### PR TITLE
- Remove visibility of `internal` class (That has to be `public`) on `KryptonDataGridViewIconColumn`

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ These packages only support .NET Framework >= 4.5, .NET Core 3.1 and .NET 6.
 =======
 
 ## 2021-08-01 Build 2108 - August 2021 (Canary)
+* Remove the internal class Called `KryptonDataGridViewIconColumn` from design use #27
+- Put back the removed `CLSCompliant` and `ComVisible` assembly flags for backwards compatibility
+- Update the projects to comply/use the latest analysers
+* _Something to do with TreeGridViews_
+* _Scollbars_
+* RichTextBox now allows CueHint Text
+* ComboBox now allows CueHint Text
 * New logo for both canary and stable builds
 * Fixed [#138](https://github.com/Krypton-Suite/Standard-Toolkit/issues/138), `KryptonListView` throws a `System.Resources.MissingManifestResourceException`
     - If you want a standard List then use ListBox or CheckedListBox

--- a/Source/Krypton Components/Krypton.Docking/Global/GlobalDeclarations.cs
+++ b/Source/Krypton Components/Krypton.Docking/Global/GlobalDeclarations.cs
@@ -24,7 +24,6 @@ global using System.IO;
 global using System.Linq;
 global using System.Reflection;
 global using System.Runtime.InteropServices;
-global using System.Security.Permissions;
 global using System.Text;
 global using System.Threading;
 global using System.Windows.Forms;
@@ -33,3 +32,12 @@ global using System.Xml;
 global using Krypton.Navigator;
 global using Krypton.Toolkit;
 global using Krypton.Workspace;
+
+using System.Runtime.CompilerServices;
+
+[assembly: CLSCompliant(true)]
+[assembly: ComVisible(false)]
+[assembly: Dependency("System", LoadHint.Always)]
+[assembly: Dependency("System.Drawing", LoadHint.Always)]
+[assembly: Dependency("System.Windows.Forms", LoadHint.Always)]
+[assembly: Dependency("Krypton.Toolkit", LoadHint.Always)]

--- a/Source/Krypton Components/Krypton.Docking/Krypton.Docking 2019.csproj
+++ b/Source/Krypton Components/Krypton.Docking/Krypton.Docking 2019.csproj
@@ -15,13 +15,16 @@
         <OutputType>Library</OutputType>
         <RootNamespace>Krypton.Docking</RootNamespace>
         <AssemblyName>Krypton.Docking</AssemblyName>
-        <StartupObject></StartupObject>
         <SignAssembly>false</SignAssembly>
         <AssemblyOriginatorKeyFile>StrongKrypton.snk</AssemblyOriginatorKeyFile>
         <ApplicationIcon>Krypton.ico</ApplicationIcon>
+        <DelaySign>false</DelaySign>
         <UseWindowsForms>true</UseWindowsForms>
         <LangVersion>preview</LangVersion>
         <PlatformTarget>AnyCPU</PlatformTarget>
+        <EnableNETAnalyzers>true</EnableNETAnalyzers>
+        <AnalysisLevel>latest</AnalysisLevel>
+        <NeutralLanguage>en</NeutralLanguage>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Source/Krypton Components/Krypton.Docking/Krypton.Docking 2019.csproj.DotSettings
+++ b/Source/Krypton Components/Krypton.Docking/Krypton.Docking 2019.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp100</s:String></wpf:ResourceDictionary>

--- a/Source/Krypton Components/Krypton.Navigator/Global/GlobalDeclarations.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Global/GlobalDeclarations.cs
@@ -32,3 +32,12 @@ global using System.Windows.Forms;
 global using System.Windows.Forms.Design;
 
 global using Krypton.Toolkit;
+
+using System.Runtime.CompilerServices;
+
+[assembly: CLSCompliant(true)]
+[assembly: ComVisible(false)]
+[assembly: Dependency("System", LoadHint.Always)]
+[assembly: Dependency("System.Drawing", LoadHint.Always)]
+[assembly: Dependency("System.Windows.Forms", LoadHint.Always)]
+[assembly: Dependency("Krypton.Toolkit", LoadHint.Always)]

--- a/Source/Krypton Components/Krypton.Navigator/Krypton.Navigator 2019.csproj
+++ b/Source/Krypton Components/Krypton.Navigator/Krypton.Navigator 2019.csproj
@@ -22,6 +22,9 @@
         <UseWindowsForms>true</UseWindowsForms>
         <LangVersion>preview</LangVersion>
         <PlatformTarget>AnyCPU</PlatformTarget>
+        <EnableNETAnalyzers>true</EnableNETAnalyzers>
+        <AnalysisLevel>latest</AnalysisLevel>
+        <NeutralLanguage>en</NeutralLanguage>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Source/Krypton Components/Krypton.Navigator/Krypton.Navigator 2019.csproj.DotSettings
+++ b/Source/Krypton Components/Krypton.Navigator/Krypton.Navigator 2019.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp100</s:String></wpf:ResourceDictionary>

--- a/Source/Krypton Components/Krypton.Ribbon/Global/GlobalDeclarations.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Global/GlobalDeclarations.cs
@@ -27,11 +27,18 @@ global using System.Globalization;
 global using System.IO;
 global using System.Reflection;
 global using System.Runtime.InteropServices;
-global using System.Security.Permissions;
 global using System.Text;
-global using System.Threading;
 global using System.Windows.Forms;
 global using System.Windows.Forms.Design;
 global using System.Windows.Forms.VisualStyles;
 
 global using Krypton.Toolkit;
+
+using System.Runtime.CompilerServices;
+
+[assembly: CLSCompliant(true)]
+[assembly: ComVisible(false)]
+[assembly: Dependency("System", LoadHint.Always)]
+[assembly: Dependency("System.Drawing", LoadHint.Always)]
+[assembly: Dependency("System.Windows.Forms", LoadHint.Always)]
+[assembly: Dependency("Krypton.Toolkit", LoadHint.Always)]

--- a/Source/Krypton Components/Krypton.Ribbon/Krypton.Ribbon 2019.csproj
+++ b/Source/Krypton Components/Krypton.Ribbon/Krypton.Ribbon 2019.csproj
@@ -22,6 +22,9 @@
         <UseWindowsForms>true</UseWindowsForms>
         <LangVersion>preview</LangVersion>
         <PlatformTarget>AnyCPU</PlatformTarget>
+        <EnableNETAnalyzers>true</EnableNETAnalyzers>
+        <AnalysisLevel>latest</AnalysisLevel>
+        <NeutralLanguage>en</NeutralLanguage>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Source/Krypton Components/Krypton.Ribbon/Krypton.Ribbon 2019.csproj.DotSettings
+++ b/Source/Krypton Components/Krypton.Ribbon/Krypton.Ribbon 2019.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp100</s:String></wpf:ResourceDictionary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -389,7 +389,7 @@ namespace Krypton.Toolkit
                                 // Exclude border from being drawn, we need to take off another 2 pixels from all edges
                                 PI.IntersectClipRect(hdc, rect.left + 2, rect.top + 2, rect.right - 2, rect.bottom - 2);
 
-                                if (!_kryptonComboBox.CueHint.IsDefault
+                                if (!MissingFrameWorkAPIs.IsNullOrWhiteSpace(_kryptonComboBox.CueHint.CueHintText)
                                     && string.IsNullOrEmpty(_kryptonComboBox.Text)
                                 )
                                 {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewIconColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewIconColumn.cs
@@ -90,7 +90,7 @@ namespace Krypton.Toolkit
         }
     }
 
-    public class KryptonDataGridViewIconColumn : DataGridViewColumn, IIconCell
+    public abstract class KryptonDataGridViewIconColumn : DataGridViewColumn, IIconCell
     {
         #region Instance Fields
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
@@ -211,7 +211,7 @@ namespace Krypton.Toolkit
                         base.WndProc(ref m);
                         break;
                     case PI.WM_.PAINT:
-                        if (!string.IsNullOrWhiteSpace(_kryptonRichTextBox.CueHint.CueHintText)
+                        if (!MissingFrameWorkAPIs.IsNullOrWhiteSpace(_kryptonRichTextBox.CueHint.CueHintText)
                             && (_kryptonRichTextBox.TextLength == 0)
                         )
                         {
@@ -2331,7 +2331,7 @@ namespace Krypton.Toolkit
 
         private void OnRichTextBoxTextChanged(object sender, EventArgs e)
         {
-            if (!string.IsNullOrWhiteSpace(CueHint.CueHintText)
+            if (!MissingFrameWorkAPIs.IsNullOrWhiteSpace(CueHint.CueHintText)
                 && TextLength <= 1)
             {
                 // Needed to prevent character turds being left behind

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
@@ -155,7 +155,7 @@ namespace Krypton.Toolkit
                             Size borderSize = SystemInformation.BorderSize;
                             rect.left -= (borderSize.Width + 1);
 
-                            if (!_kryptonTextBox.CueHint.IsDefault
+                            if (!MissingFrameWorkAPIs.IsNullOrWhiteSpace(_kryptonTextBox.CueHint.CueHintText)
                                 && string.IsNullOrEmpty(_kryptonTextBox.Text)
                             )
                             {

--- a/Source/Krypton Components/Krypton.Toolkit/General/CommonHelper.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/CommonHelper.cs
@@ -1142,7 +1142,7 @@ namespace Krypton.Toolkit
         public static Control GetControlWithFocus(Control control)
         {
             // Does the provided control have the focus?
-            if (control.Focused && !(control is IContainedInputControl))
+            if (control.Focused && control is not IContainedInputControl)
             {
                 return control;
             }

--- a/Source/Krypton Components/Krypton.Toolkit/Global/GlobalDeclarations.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Global/GlobalDeclarations.cs
@@ -35,7 +35,6 @@ global using System.Runtime.InteropServices;
 global using System.Runtime.Serialization;
 global using System.Runtime.Serialization.Formatters.Binary;
 global using System.Security;
-global using System.Security.Permissions;
 global using System.Security.Principal;
 global using System.Text;
 global using System.Text.RegularExpressions;
@@ -45,9 +44,17 @@ global using System.Windows.Forms.Design;
 global using System.Windows.Forms.Design.Behavior;
 global using System.Windows.Forms.VisualStyles;
 global using System.Xml;
-global using System.Xml.Serialization;
 
 global using Krypton.Toolkit.Global;
 global using Krypton.Toolkit.Properties;
 
 global using Microsoft.Win32;
+
+
+[assembly: CLSCompliant(true)]
+[assembly: ComVisible(false)]
+[assembly: Dependency("System", LoadHint.Always)]
+[assembly: Dependency("System.Drawing", LoadHint.Always)]
+[assembly: Dependency("System.Windows.Forms", LoadHint.Always)]
+[assembly: Dependency("Krypton.Toolkit", LoadHint.Always)]
+

--- a/Source/Krypton Components/Krypton.Toolkit/Krypton.Toolkit 2019.csproj.DotSettings
+++ b/Source/Krypton Components/Krypton.Toolkit/Krypton.Toolkit 2019.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp100</s:String></wpf:ResourceDictionary>

--- a/Source/Krypton Components/Krypton.Workspace/Global/GlobalDeclarations.cs
+++ b/Source/Krypton Components/Krypton.Workspace/Global/GlobalDeclarations.cs
@@ -22,7 +22,6 @@ global using System.Drawing;
 global using System.Drawing.Design;
 global using System.Globalization;
 global using System.IO;
-global using System.Reflection;
 global using System.Runtime.InteropServices;
 global using System.Text;
 global using System.Threading;
@@ -32,3 +31,12 @@ global using System.Xml;
 
 global using Krypton.Navigator;
 global using Krypton.Toolkit;
+
+using System.Runtime.CompilerServices;
+
+[assembly: CLSCompliant(true)]
+[assembly: ComVisible(false)]
+[assembly: Dependency("System", LoadHint.Always)]
+[assembly: Dependency("System.Drawing", LoadHint.Always)]
+[assembly: Dependency("System.Windows.Forms", LoadHint.Always)]
+[assembly: Dependency("Krypton.Toolkit", LoadHint.Always)]

--- a/Source/Krypton Components/Krypton.Workspace/Krypton.Workspace 2019.csproj
+++ b/Source/Krypton Components/Krypton.Workspace/Krypton.Workspace 2019.csproj
@@ -22,6 +22,9 @@
         <UseWindowsForms>true</UseWindowsForms>
         <LangVersion>preview</LangVersion>
         <PlatformTarget>AnyCPU</PlatformTarget>
+        <EnableNETAnalyzers>true</EnableNETAnalyzers>
+        <AnalysisLevel>latest</AnalysisLevel>
+        <NeutralLanguage>en</NeutralLanguage>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Source/Krypton Components/Krypton.Workspace/Krypton.Workspace 2019.csproj.DotSettings
+++ b/Source/Krypton Components/Krypton.Workspace/Krypton.Workspace 2019.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp100</s:String></wpf:ResourceDictionary>


### PR DESCRIPTION
- Remove visibility of `internal` class (That has to be `public`) on `KryptonDataGridViewIconColumn`
- Put back the removed `CLSCompliant` and `ComVisible` assembly flags for backwards compatibility
- Update the projects to comply/use the latest analysers

Fixes #27