### PR TITLE
- As the "Designers" use text based references,

### DIFF
--- a/Source/Krypton Components/Krypton.Docking/Krypton.Docking 2019.csproj
+++ b/Source/Krypton Components/Krypton.Docking/Krypton.Docking 2019.csproj
@@ -28,6 +28,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <!-- This may not be neded, as this dll does not have "designers" -->
         <Reference Include="System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="$(TargetFramework.StartsWith('net4'))">
             <SpecificVersion>True</SpecificVersion>
             <Version>4.0.0.0</Version>

--- a/Source/Krypton Components/Krypton.Navigator/Krypton.Navigator 2019.csproj
+++ b/Source/Krypton Components/Krypton.Navigator/Krypton.Navigator 2019.csproj
@@ -32,14 +32,6 @@
             <SpecificVersion>True</SpecificVersion>
             <Version>4.0.0.0</Version>
         </Reference>
-        <Reference Include="System.Design, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="$(TargetFramework.StartsWith('net5'))">
-            <SpecificVersion>True</SpecificVersion>
-            <Version>5.0.0.0</Version>
-        </Reference>
-        <Reference Include="System.Design, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="$(TargetFramework.StartsWith('net6'))">
-            <SpecificVersion>True</SpecificVersion>
-            <Version>6.0.0.0</Version>
-        </Reference>
         <Reference Include="System.Design" Condition="'$(TargetFramework)' == 'net35'">
             <!--TODO: Need to specify version here-->
             <!--<Version>6.0.0.0</Version>-->

--- a/Source/Krypton Components/Krypton.Ribbon/Krypton.Ribbon 2019.csproj
+++ b/Source/Krypton Components/Krypton.Ribbon/Krypton.Ribbon 2019.csproj
@@ -32,14 +32,6 @@
             <SpecificVersion>True</SpecificVersion>
             <Version>4.0.0.0</Version>
         </Reference>
-        <Reference Include="System.Design, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="$(TargetFramework.StartsWith('net5'))">
-            <SpecificVersion>True</SpecificVersion>
-            <Version>5.0.0.0</Version>
-        </Reference>
-        <Reference Include="System.Design, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="$(TargetFramework.StartsWith('net6'))">
-            <SpecificVersion>True</SpecificVersion>
-            <Version>6.0.0.0</Version>
-        </Reference>
         <Reference Include="System.Design" Condition="'$(TargetFramework)' == 'net35'">
             <!--TODO: Need to specify version here-->
             <!--<Version>6.0.0.0</Version>-->

--- a/Source/Krypton Components/Krypton.Toolkit/Krypton.Toolkit 2019.csproj
+++ b/Source/Krypton Components/Krypton.Toolkit/Krypton.Toolkit 2019.csproj
@@ -29,14 +29,6 @@
             <SpecificVersion>True</SpecificVersion>
             <Version>4.0.0.0</Version>
         </Reference>
-        <Reference Include="System.Design, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="$(TargetFramework.StartsWith('net5'))">
-            <SpecificVersion>True</SpecificVersion>
-            <Version>5.0.0.0</Version>
-        </Reference>
-        <Reference Include="System.Design, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="$(TargetFramework.StartsWith('net6'))">
-            <SpecificVersion>True</SpecificVersion>
-            <Version>6.0.0.0</Version>
-        </Reference>
         <Reference Include="System.Design" Condition="'$(TargetFramework)' == 'net35'">
             <!--TODO: Need to specify version here-->
             <!--<Version>6.0.0.0</Version>-->

--- a/Source/Krypton Components/Krypton.Workspace/Krypton.Workspace 2019.csproj
+++ b/Source/Krypton Components/Krypton.Workspace/Krypton.Workspace 2019.csproj
@@ -32,14 +32,6 @@
             <SpecificVersion>True</SpecificVersion>
             <Version>4.0.0.0</Version>
         </Reference>
-        <Reference Include="System.Design, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="$(TargetFramework.StartsWith('net5'))">
-            <SpecificVersion>True</SpecificVersion>
-            <Version>5.0.0.0</Version>
-        </Reference>
-        <Reference Include="System.Design, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="$(TargetFramework.StartsWith('net6'))">
-            <SpecificVersion>True</SpecificVersion>
-            <Version>6.0.0.0</Version>
-        </Reference>
         <Reference Include="System.Design" Condition="'$(TargetFramework)' == 'net35'">
             <!--TODO: Need to specify version here-->
             <!--<Version>6.0.0.0</Version>-->


### PR DESCRIPTION
- As the "Designers" use text based references,
- then only need to include dlls derived from `ParentControlDesigner`
resolves #92