### PR TITLE
Alpha themes

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
@@ -48,10 +48,16 @@ namespace Krypton.Toolkit
         /// <summary>Initializes a new instance of the <see cref="KryptonThemeComboBox" /> class.</summary>
         public KryptonThemeComboBox()
         {
-            DropDownStyle = ComboBoxStyle.DropDownList;
+            DropDownStyle = ComboBoxStyle.DropDown;
 
             ThemeManager.PropagateThemeSelector(this);
 
+            AutoCompleteCustomSource = new AutoCompleteStringCollection() { ThemeManager.ReturnThemeArray().ToString() };
+
+            AutoCompleteSource = AutoCompleteSource.CustomSource;
+
+            AutoCompleteMode = AutoCompleteMode.SuggestAppend;
+            
             if (KryptonManager == null)
             {
                 KryptonManager = new KryptonManager();

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
@@ -20,6 +20,7 @@ namespace Krypton.Toolkit
     {
         #region Instance Fields
         private KryptonManager _internalKryptonManager;
+        private readonly PaletteModeManager _paletteMode;
         #endregion
 
         #region Public
@@ -52,6 +53,9 @@ namespace Krypton.Toolkit
             ThemeManager.PropagateThemeSelector(this);
 
             Text = KryptonManager.GlobalPaletteMode.ToString();
+
+            // Store the current GlobalPaletteMode, so we don't run into any issues
+            _paletteMode = KryptonManager.GlobalPaletteMode;
         }
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
@@ -52,6 +52,11 @@ namespace Krypton.Toolkit
 
             ThemeManager.PropagateThemeSelector(this);
 
+            if (KryptonManager == null)
+            {
+                KryptonManager = new KryptonManager();
+            }
+
             Text = KryptonManager.GlobalPaletteMode.ToString();
 
             // Store the current GlobalPaletteMode, so we don't run into any issues
@@ -64,7 +69,7 @@ namespace Krypton.Toolkit
         /// <param name="e">An EventArgs containing the event data.</param>
         protected override void OnSelectedIndexChanged(EventArgs e)
         {
-            ThemeManager.ApplyGlobalTheme(_internalKryptonManager, ThemeManager.ApplyThemeMode(Text)); // TODO: Protect the current value to prevent conflict
+            ThemeManager.ApplyTheme(Text, KryptonManager); // TODO: Protect the current value to prevent conflict
 
             base.OnSelectedIndexChanged(e);
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonButtonActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonButtonActionList.cs
@@ -257,7 +257,6 @@ namespace Krypton.Toolkit
                 actions.Add(new DesignerActionPropertyItem("PaletteMode", "Palette", "Visuals", "Palette applied to drawing"));
                 actions.Add(new DesignerActionHeaderItem("UAC Elevation"));
                 actions.Add(new DesignerActionPropertyItem("UseAsUACElevatedButton", "Use as an UAC Elevated Button", "UAC Elevation", "Use this button to elevate a process."));
-                actions.Add(new DesignerActionPropertyItem("ProcessToElevate", "Process to Elevate", "UAC Elevation", "The process to elevate."));
             }
 
             return actions;

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/ThemeManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/ThemeManager.cs
@@ -551,6 +551,13 @@ namespace Krypton.Toolkit
 
             return modeManager;
         }
+
+        /// <summary>Returns the theme array.</summary>
+        /// <returns>
+        ///   <br />
+        /// </returns>
+        public static string[] ReturnThemeArray() => _supportedThemes;
+
         #endregion
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/ThemeManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/ThemeManager.cs
@@ -141,7 +141,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="themeName">Name of the theme.</param>
         /// <param name="manager">The manager.</param>
-        private static void ApplyTheme(string themeName, KryptonManager manager)
+        public static void ApplyTheme(string themeName, KryptonManager manager)
         {
             switch (themeName)
             {


### PR DESCRIPTION
- Fixed `KryptonButtonActionList`
- `KryptonThemeComboBox` now works... yay! (Possibly need to set the text to 'readonly')
- Need help to discover why sparkle dark/light modes aren't being applied by the KManager