### PR TITLE
- Initialise `RightToLeftLayout` at the correct "time"

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMessageBoxForm.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMessageBoxForm.Designer.cs
@@ -195,7 +195,6 @@ namespace Krypton.Toolkit
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "KryptonMessageBoxForm";
-            this.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMessageBoxForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMessageBoxForm.cs
@@ -61,6 +61,8 @@ namespace Krypton.Toolkit
             // Create the form contents
             InitializeComponent();
 
+            RightToLeftLayout = _options.HasFlag(MessageBoxOptions.RtlReading);
+
             // Update contents to match requirements
             UpdateText();
             UpdateIcon();
@@ -88,10 +90,10 @@ namespace Krypton.Toolkit
             _helpInfo = helpInfo;
             _showOwner = showOwner;
 
-            RightToLeftLayout = _options.HasFlag(MessageBoxOptions.RtlReading);
-
             // Create the form contents
             InitializeComponent();
+
+            RightToLeftLayout = _options.HasFlag(MessageBoxOptions.RtlReading);
 
             // Update contents to match requirements
             UpdateText();


### PR DESCRIPTION
- Remove rogue setting in designer
fixes https://github.com/Krypton-Suite/Theme-Palettes/issues/14

![image](https://user-images.githubusercontent.com/2418812/134399027-58c45104-92f4-4586-b006-9fd5b97728a1.png)
