### PR TITLE
- Handle the Culture, and also remove the trailing decimal point when …

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
@@ -13,6 +13,7 @@
 // ReSharper disable MemberCanBePrivate.Local
 // ReSharper disable UnusedMember.Local
 
+// ReSharper disable MemberCanBeProtected.Global
 namespace Krypton.Toolkit
 {
     /// <summary>
@@ -66,21 +67,6 @@ namespace Krypton.Toolkit
             }
             #endregion
 
-            #region Public
-
-            /// <summary>
-            /// Gets or sets whether the control displays trailing zeroes.
-            /// </summary>
-            [Category("Behavior")]
-            [Description("Indicates whether the control will display traling zeroes, When decimals are in play.")]
-            [DefaultValue(false)]
-            public bool TrailingZeroes
-            {
-                get;
-                set;
-            }
-            #endregion
-
             #region MouseOver
             /// <summary>
             /// Gets and sets if the mouse is currently over the combo box.
@@ -111,7 +97,6 @@ namespace Krypton.Toolkit
             #endregion
 
             #region Protected
-
             /// <summary>
             /// Process Windows-based messages.
             /// </summary>
@@ -429,21 +414,26 @@ namespace Krypton.Toolkit
                                     };
 
                                     Rectangle rectangle = new(rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top);
-                                    rectangle = CommonHelper.ApplyPadding(VisualOrientation.Top, rectangle,
-                                        states.Content.GetContentPadding(state));
+                                    rectangle = CommonHelper.ApplyPadding(VisualOrientation.Top, rectangle, states.Content.GetContentPadding(state));
 
                                     // Draw using a solid brush
                                     var text = _internalNumericUpDown.Text;
                                     if (!NumericUpDown.TrailingZeroes && NumericUpDown.AllowDecimals)
                                     {
-                                        text = text.TrimEnd('0');
+                                        // Got ot deal with culture formatting, and also the override to include `ThousandsSeparator`
+                                        var textInvariantAsRequested = _internalNumericUpDown.Value.ToString('F' + _internalNumericUpDown.DecimalPlaces.ToString(CultureInfo.InvariantCulture), (IFormatProvider) CultureInfo.CurrentCulture);
+                                        var textInvariantAsTrimmed = _internalNumericUpDown.Value.ToString(@"0.#########################", CultureInfo.InvariantCulture);
+                                        var lengthToRemove = textInvariantAsRequested.Length - textInvariantAsTrimmed.Length;
+                                        if (lengthToRemove > 0)
+                                        {
+                                            text = text.Substring(0, text.Length - lengthToRemove);
+                                        }
                                     }
 
                                     try
                                     {
                                         using SolidBrush foreBrush = new(states.Content.GetContentShortTextColor1(state));
-                                        g.DrawString(text, states.Content.GetContentShortTextFont(state), foreBrush,
-                                            rectangle, stringFormat);
+                                        g.DrawString(text, states.Content.GetContentShortTextFont(state), foreBrush, rectangle, stringFormat);
                                     }
                                     catch (ArgumentException)
                                     {
@@ -1110,12 +1100,12 @@ namespace Krypton.Toolkit
         /// </summary>
         [Category("Behavior")]
         [Description("Indicates whether the control will display traling zeroes, when decimals are in play")]
-        [DefaultValue(false)]
+        [DefaultValue(true)]
         public bool TrailingZeroes
         {
-            get => _numericUpDown.TrailingZeroes;
-            set => _numericUpDown.TrailingZeroes = value;
-        }
+            get;
+            set;
+        } = true;
 
         /// <summary>
         /// Gets or sets a value indicating whether mnemonics will fire button spec buttons.


### PR DESCRIPTION
…numbers trimmed.

- Now works correctly if the number is only 3000 and trimming takes place.
- Respects the `ThousandsSeparator` override
Fixes #502

There are problems with the 2019 build:
![image](https://user-images.githubusercontent.com/2418812/144708112-feb2f9d5-cf7e-4ef3-a8ab-e21122089b88.png)

