### PR TITLE
- When WrapMode is enabled, then also change the mode of the Grid to …

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -1,6 +1,7 @@
 # <img src="https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/Krypton.png"> Standard Toolkit - Changelog
 
 ## 2022-01-05 - Build 2201 - January 2022
+* Fixed [#453](https://github.com/Krypton-Suite/Standard-Toolkit/issues/453), KryptonDataGridView's cell cannot display multiple lines when DefaultCellStyle.WrapMode set true
 * Fixed [#499](https://github.com/Krypton-Suite/Standard-Toolkit/issues/499), `KDataGridView` Cell Borders
 * Fixed [#502](https://github.com/Krypton-Suite/Standard-Toolkit/issues/502),KNumericUpDowner, when told to display 1 decimal place, does not display a 0 when needed
 * Fixed [#491](https://github.com/Krypton-Suite/Standard-Toolkit/issues/491), Krypton.Toolkit.KryptonMessageBox wrong form height when YesNo or AbortRetryIgnore buttons selected (thanks to [mbsysde99](https://github.com/mbsysde99))

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/ButtonController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/ButtonController.cs
@@ -726,11 +726,11 @@ namespace Krypton.Toolkit
         protected void UpdateTargetState(Control c)
         {
             // Check we have a valid control to convert coordinates against
-            if ((c != null) && !c.IsDisposed)
+            if (c is { IsDisposed: false })
             {
                 // Ensure control is inside a visible top level form
                 Form f = c.FindForm();
-                if ((f != null) && f.Visible)
+                if (f is { Visible: true })
                 {
                     UpdateTargetState(c.PointToClient(Control.MousePosition));
                     return;

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/MenuImageSelectController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/MenuImageSelectController.cs
@@ -459,11 +459,11 @@ namespace Krypton.Toolkit
         protected void UpdateTargetState(Control c)
         {
             // Check we have a valid control to convert coordinates against
-            if ((c != null) && !c.IsDisposed)
+            if (c is { IsDisposed: false })
             {
                 // Ensure control is inside a visible top level form
                 Form f = c.FindForm();
-                if ((f != null) && f.Visible)
+                if (f is { Visible: true })
                 {
                     UpdateTargetState(c.PointToClient(Control.MousePosition));
                     return;

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/MonthCalendarController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/MonthCalendarController.cs
@@ -252,7 +252,7 @@ namespace Krypton.Toolkit
                 // Only interested in left mouse being released
                 if (button == MouseButtons.Left)
                 {
-                    if ((_monthCalendar != null) && _monthCalendar.AutoClose && (_months.Provider != null))
+                    if (_monthCalendar is { AutoClose: true } && (_months.Provider != null))
                     {
                         // If the mouse was pressed down on a day entry, then we close down on mouse up
                         if (_selectionStart != DateTime.MinValue)
@@ -399,20 +399,20 @@ namespace Krypton.Toolkit
                     break;
                 case Keys.Enter:
                 case Keys.Space:
-                    if ((_monthCalendar != null) && _monthCalendar.AutoClose && (_months.Provider != null))
-                    {
-                        // Is the menu capable of being closed?
-                        if (_months.Provider.ProviderCanCloseMenu)
+                    if (_monthCalendar is { AutoClose: true } && _months.Provider is
                         {
-                            // Ask the original context menu definition, if we can close
-                            CancelEventArgs cea = new();
-                            _months.Provider.OnClosing(cea);
+                            ProviderCanCloseMenu: true
+                        })
+                        // Is the menu capable of being closed?
+                    {
+                        // Ask the original context menu definition, if we can close
+                        CancelEventArgs cea = new();
+                        _months.Provider.OnClosing(cea);
 
-                            if (!cea.Cancel)
-                            {
-                                // Close the menu from display and pass in the item clicked as the reason
-                                _months.Provider.OnClose(new CloseReasonEventArgs(ToolStripDropDownCloseReason.Keyboard));
-                            }
+                        if (!cea.Cancel)
+                        {
+                            // Close the menu from display and pass in the item clicked as the reason
+                            _months.Provider.OnClose(new CloseReasonEventArgs(ToolStripDropDownCloseReason.Keyboard));
                         }
                     }
                     break;

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/TooltipController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/TooltipController.cs
@@ -124,7 +124,7 @@ namespace Krypton.Toolkit
         /// Should the left mouse down be ignored when present on a visual form border area.
         /// </summary>
         public bool IgnoreVisualFormLeftButtonDown =>
-            _targetController != null && _targetController.IgnoreVisualFormLeftButtonDown;
+            _targetController is { IgnoreVisualFormLeftButtonDown: true };
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonBreadCrumb.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonBreadCrumb.cs
@@ -681,7 +681,7 @@ namespace Krypton.Toolkit
             {
                 // Do not show tooltips when the form we are in does not have focus
                 Form topForm = FindForm();
-                if ((topForm != null) && !topForm.ContainsFocus)
+                if (topForm is { ContainsFocus: false })
                 {
                     return;
                 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -2991,7 +2991,7 @@ namespace Krypton.Toolkit
             {
                 // Do not show tooltips when the form we are in does not have focus
                 Form topForm = FindForm();
-                if ((topForm != null) && !topForm.ContainsFocus)
+                if (topForm is { ContainsFocus: false })
                 {
                     return;
                 }
@@ -3063,8 +3063,7 @@ namespace Krypton.Toolkit
 
         private VisualPopupToolTip GetToolTip()
         {
-            if (_toolTip != null
-                && !_toolTip.IsDisposed
+            if (_toolTip is { IsDisposed: false }
                 )
             {
                 return _toolTip;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -2354,7 +2354,7 @@ namespace Krypton.Toolkit
             if (_miGCI == null)
             {
                 // Cache access to the internal method 'GetCellInternal'
-                _miGCI = typeof(DataGridView).GetMethod("GetCellInternal", BindingFlags.Instance |
+                _miGCI = typeof(DataGridView).GetMethod(@"GetCellInternal", BindingFlags.Instance |
                                                                            BindingFlags.NonPublic |
                                                                            BindingFlags.GetField);
             }
@@ -2368,7 +2368,7 @@ namespace Krypton.Toolkit
             if (_miGTTT == null)
             {
                 // Cache access to the internal get property 'GetToolTipText'
-                _miGTTT = typeof(DataGridViewCell).GetMethod("GetToolTipText", BindingFlags.Instance |
+                _miGTTT = typeof(DataGridViewCell).GetMethod(@"GetToolTipText", BindingFlags.Instance |
                                                                                BindingFlags.NonPublic |
                                                                                BindingFlags.GetField);
             }
@@ -2389,7 +2389,7 @@ namespace Krypton.Toolkit
             if (_miGET == null)
             {
                 // Cache access to the internal get property 'GetErrorText'
-                _miGET = typeof(DataGridViewCell).GetMethod("GetErrorText", BindingFlags.Instance |
+                _miGET = typeof(DataGridViewCell).GetMethod(@"GetErrorText", BindingFlags.Instance |
                                                                             BindingFlags.NonPublic |
                                                                             BindingFlags.GetField);
             }
@@ -2410,7 +2410,7 @@ namespace Krypton.Toolkit
             if (_piCML == null)
             {
                 // Cache access to the internal get property 'CurrentMouseLocation'
-                _piCML = typeof(DataGridViewCell).GetProperty("CurrentMouseLocation", BindingFlags.Instance |
+                _piCML = typeof(DataGridViewCell).GetProperty(@"CurrentMouseLocation", BindingFlags.Instance |
                                                                                       BindingFlags.NonPublic |
                                                                                       BindingFlags.GetField);
             }
@@ -2425,7 +2425,7 @@ namespace Krypton.Toolkit
             if (_miGPW == null)
             {
                 // Cache access to the internal method 'GetPreferredWidth' of cells
-                _miGPW = typeof(DataGridViewCell).GetMethod("GetPreferredWidth", BindingFlags.Instance |
+                _miGPW = typeof(DataGridViewCell).GetMethod(@"GetPreferredWidth", BindingFlags.Instance |
                                                                                  BindingFlags.NonPublic |
                                                                                  BindingFlags.GetField);
             }
@@ -2439,7 +2439,7 @@ namespace Krypton.Toolkit
             if (_miGPH == null)
             {
                 // Cache access to the internal method 'GetPreferredHeight' of cells
-                _miGPH = typeof(DataGridViewCell).GetMethod("GetPreferredHeight", BindingFlags.Instance |
+                _miGPH = typeof(DataGridViewCell).GetMethod(@"GetPreferredHeight", BindingFlags.Instance |
                                                                                   BindingFlags.NonPublic |
                                                                                   BindingFlags.GetField);
             }
@@ -2453,7 +2453,7 @@ namespace Krypton.Toolkit
             if (_miATT == null)
             {
                 // Cache access to the internal get property 'ActivateToolTip'
-                _miATT = typeof(DataGridView).GetMethod("ActivateToolTip", BindingFlags.Instance |
+                _miATT = typeof(DataGridView).GetMethod(@"ActivateToolTip", BindingFlags.Instance |
                                                                            BindingFlags.NonPublic |
                                                                            BindingFlags.GetField);
             }
@@ -2466,7 +2466,7 @@ namespace Krypton.Toolkit
             if (toolTipText.Length > 0x120)
             {
                 StringBuilder builder = new(toolTipText.Substring(0, 0x100), 0x103);
-                builder.Append("...");
+                builder.Append(@"...");
                 return builder.ToString();
             }
             return toolTipText;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewButtonCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewButtonCell.cs
@@ -142,7 +142,7 @@ namespace Krypton.Toolkit
                 }
 
                 // Update the display text
-                if ((kDGV.Columns[ColumnIndex] is KryptonDataGridViewButtonColumn col) && col.UseColumnTextForButtonValue && !kDGV.Rows[rowIndex].IsNewRow)
+                if ((kDGV.Columns[ColumnIndex] is KryptonDataGridViewButtonColumn { UseColumnTextForButtonValue: true } col) && !kDGV.Rows[rowIndex].IsNewRow)
                 {
                     _shortTextValue.ShortText = col.Text;
                 }
@@ -246,7 +246,10 @@ namespace Krypton.Toolkit
                     }
 
                     // Update the display text
-                    if ((kDgv.Columns[ColumnIndex] is KryptonDataGridViewButtonColumn col) && col.UseColumnTextForButtonValue && !kDgv.Rows[rowIndex].IsNewRow)
+                    if ((kDgv.Columns[ColumnIndex] is KryptonDataGridViewButtonColumn
+                        {
+                            UseColumnTextForButtonValue: true
+                        } col) && !kDgv.Rows[rowIndex].IsNewRow)
                     {
                         _shortTextValue.ShortText = col.Text;
                     }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewButtonColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewButtonColumn.cs
@@ -129,7 +129,10 @@ namespace Krypton.Toolkit
                             var count = rows.Count;
                             for (var i = 0; i < count; i++)
                             {
-                                if ((rows.SharedRow(i).Cells[Index] is KryptonDataGridViewButtonCell cell) && cell.UseColumnTextForButtonValue)
+                                if ((rows.SharedRow(i).Cells[Index] is KryptonDataGridViewButtonCell
+                                    {
+                                        UseColumnTextForButtonValue: true
+                                    }))
                                 {
                                     ColumnCommonChange(Index);
                                     return;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewCheckBoxColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewCheckBoxColumn.cs
@@ -229,15 +229,13 @@ namespace Krypton.Toolkit
                     }
 
                     if (value 
-                        && DefaultCellStyle.NullValue is bool b 
-                        && !b
+                        && DefaultCellStyle.NullValue is bool and false
                         )
                     {
                         DefaultCellStyle.NullValue = CheckState.Indeterminate;
                     }
                     else if (!value 
-                             && (DefaultCellStyle.NullValue is CheckState state) 
-                             && (state == CheckState.Indeterminate)
+                             && (DefaultCellStyle.NullValue is CheckState and CheckState.Indeterminate)
                              )
                     {
                         DefaultCellStyle.NullValue = false;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxCell.cs
@@ -481,7 +481,7 @@ namespace Krypton.Toolkit
 
         private void OnCommonChange()
         {
-            if ((DataGridView != null) && !DataGridView.IsDisposed && !DataGridView.Disposing)
+            if (DataGridView is { IsDisposed: false, Disposing: false })
             {
                 if (RowIndex == -1)
                 {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDateTimePickerCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDateTimePickerCell.cs
@@ -761,7 +761,7 @@ namespace Krypton.Toolkit
 
         private void OnCommonChange()
         {
-            if ((DataGridView != null) && !DataGridView.IsDisposed && !DataGridView.Disposing)
+            if (DataGridView is { IsDisposed: false, Disposing: false })
             {
                 if (RowIndex == -1)
                 {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownCell.cs
@@ -246,7 +246,7 @@ namespace Krypton.Toolkit
 
         private void OnCommonChange()
         {
-            if ((DataGridView != null) && !DataGridView.IsDisposed && !DataGridView.Disposing)
+            if (DataGridView is { IsDisposed: false, Disposing: false })
             {
                 if (RowIndex == -1)
                 {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewLinkCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewLinkCell.cs
@@ -131,7 +131,10 @@ namespace Krypton.Toolkit
                 }
                 else
                 {
-                    if ((kDGV.Columns[ColumnIndex] is KryptonDataGridViewButtonColumn col) && col.UseColumnTextForButtonValue && !kDGV.Rows[rowIndex].IsNewRow)
+                    if ((kDGV.Columns[ColumnIndex] is KryptonDataGridViewButtonColumn
+                        {
+                            UseColumnTextForButtonValue: true
+                        } col) && !kDGV.Rows[rowIndex].IsNewRow)
                     {
                         _shortTextValue.ShortText = col.Text;
                     }
@@ -210,7 +213,10 @@ namespace Krypton.Toolkit
                     }
                     else
                     {
-                        if ((kDgv.Columns[ColumnIndex] is KryptonDataGridViewButtonColumn col) && col.UseColumnTextForButtonValue && !kDgv.Rows[rowIndex].IsNewRow)
+                        if ((kDgv.Columns[ColumnIndex] is KryptonDataGridViewButtonColumn
+                            {
+                                UseColumnTextForButtonValue: true
+                            } col) && !kDgv.Rows[rowIndex].IsNewRow)
                         {
                             _shortTextValue.ShortText = col.Text;
                         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewLinkColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewLinkColumn.cs
@@ -116,7 +116,10 @@ namespace Krypton.Toolkit
                             var count = rows.Count;
                             for (var i = 0; i < count; i++)
                             {
-                                if ((rows.SharedRow(i).Cells[Index] is KryptonDataGridViewLinkCell cell) && cell.UseColumnTextForLinkValue)
+                                if ((rows.SharedRow(i).Cells[Index] is KryptonDataGridViewLinkCell
+                                    {
+                                        UseColumnTextForLinkValue: true
+                                    }))
                                 {
                                     ColumnCommonChange(Index);
                                     return;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewMaskedTextBoxCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewMaskedTextBoxCell.cs
@@ -495,14 +495,7 @@ namespace Krypton.Toolkit
                     }
                 }
 
-                if (initialFormattedValue is not string initialFormattedValueStr)
-                {
-                    maskedTextBox.Text = string.Empty;
-                }
-                else
-                {
-                    maskedTextBox.Text = initialFormattedValueStr;
-                }
+                maskedTextBox.Text = initialFormattedValue is not string initialFormattedValueStr ? string.Empty : initialFormattedValueStr;
             }
         }
 
@@ -572,6 +565,7 @@ namespace Krypton.Toolkit
 
             return preferredSize;
         }
+
         #endregion
 
         #region Private
@@ -611,7 +605,7 @@ namespace Krypton.Toolkit
 
         private void OnCommonChange()
         {
-            if ((DataGridView != null) && !DataGridView.IsDisposed && !DataGridView.Disposing)
+            if (DataGridView is { IsDisposed: false, Disposing: false })
             {
                 if (RowIndex == -1)
                 {
@@ -791,5 +785,6 @@ namespace Krypton.Toolkit
             }
         }
         #endregion
+
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewNumericUpDownCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewNumericUpDownCell.cs
@@ -347,7 +347,7 @@ namespace Krypton.Toolkit
             }
 
             return (char.IsDigit((char)e.KeyCode) ||
-                    ((e.KeyCode >= Keys.NumPad0) && (e.KeyCode <= Keys.NumPad9)) ||
+                    e.KeyCode is >= Keys.NumPad0 and <= Keys.NumPad9 ||
                     (negativeSignKey == e.KeyCode) ||
                     (Keys.Subtract == e.KeyCode)) &&
                    !e.Shift && !e.Alt && !e.Control;
@@ -504,7 +504,7 @@ namespace Krypton.Toolkit
 
         private void OnCommonChange()
         {
-            if ((DataGridView != null) && !DataGridView.IsDisposed && !DataGridView.Disposing)
+            if (DataGridView is { IsDisposed: false, Disposing: false })
             {
                 if (RowIndex == -1)
                 {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxColumn.cs
@@ -91,6 +91,7 @@ namespace Krypton.Toolkit
 
             base.Dispose(disposing);
         }
+        
         #endregion
 
         #region Public
@@ -154,6 +155,45 @@ namespace Krypton.Toolkit
                 }
 
                 base.CellTemplate = value;
+            }
+        }
+
+        /// <summary>
+        /// Make sure that when the style is set that the datagrid respects the values
+        /// </summary>
+        [Browsable(true)]
+        [Category("Appearance")]
+        [Description("DataGridView Column DefaultCell Style\r\nIf you set wrap mode, then this will ensure the DataRows are set to display the wrapped text!")]
+        public override DataGridViewCellStyle DefaultCellStyle
+        {
+            get => base.DefaultCellStyle;
+
+            set
+            {
+                base.DefaultCellStyle = value;
+                if ((value.WrapMode != DataGridViewTriState.True)
+                    || DataGridView == null)
+                {
+                    return;
+                }
+                // https://stackoverflow.com/questions/16514352/multiple-lines-in-a-datagridview-cell/16514393
+                switch (DataGridView.AutoSizeRowsMode)
+                {
+                    case DataGridViewAutoSizeRowsMode.AllCells:
+                    case DataGridViewAutoSizeRowsMode.AllCellsExceptHeaders:
+                    case DataGridViewAutoSizeRowsMode.DisplayedCells:
+                    case DataGridViewAutoSizeRowsMode.DisplayedCellsExceptHeaders:
+                        break;
+                    case DataGridViewAutoSizeRowsMode.AllHeaders:
+                        DataGridView.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.DisplayedCells;
+                        break;
+                    case DataGridViewAutoSizeRowsMode.DisplayedHeaders:
+                        DataGridView.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.DisplayedCells;
+                        break;
+                    case DataGridViewAutoSizeRowsMode.None:
+                        DataGridView.AutoSizeRowsMode = DataGridViewAutoSizeRowsMode.DisplayedCellsExceptHeaders;
+                        break;
+                }
             }
         }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDateTimePicker.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDateTimePicker.cs
@@ -2058,7 +2058,7 @@ namespace Krypton.Toolkit
             {
                 // Do not show tooltips when the form we are in does not have focus
                 Form topForm = FindForm();
-                if ((topForm != null) && !topForm.ContainsFocus)
+                if (topForm is { ContainsFocus: false })
                 {
                     return;
                 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
@@ -1332,8 +1332,8 @@ namespace Krypton.Toolkit
                 ? _fixedActive.Value
                 : DesignMode || AlwaysActive ||
                   ContainsFocus || _mouseOver || _domainUpDown.MouseOver ||
-                  ((_subclassEdit != null) && _subclassEdit.MouseOver) ||
-                  ((_subclassButtons != null) && _subclassButtons.MouseOver);
+                  _subclassEdit is { MouseOver: true } ||
+                  _subclassButtons is { MouseOver: true };
 
         /// <summary>
         /// Sets input focus to the control.
@@ -1952,7 +1952,7 @@ namespace Krypton.Toolkit
             {
                 // Do not show tooltips when the form we are in does not have focus
                 Form topForm = FindForm();
-                if ((topForm != null) && !topForm.ContainsFocus)
+                if (topForm is { ContainsFocus: false })
                 {
                     return;
                 }
@@ -2027,8 +2027,8 @@ namespace Krypton.Toolkit
         {
             // Find new tracking mouse change state
             var tracking = _domainUpDown.MouseOver ||
-                           ((_subclassEdit != null) && _subclassEdit.MouseOver) ||
-                           ((_subclassButtons != null) && _subclassButtons.MouseOver);
+                           _subclassEdit is { MouseOver: true } ||
+                           _subclassButtons is { MouseOver: true };
 
             // Change in tracking state?
             if (tracking != _trackingMouseEnter)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -1452,12 +1452,7 @@ namespace Krypton.Toolkit
         }
 
         internal bool StatusStripMerging => _allowStatusStripMerge &&
-                                             (_statusStrip != null) &&
-                                             _statusStrip.Visible &&
-                                             (_statusStrip.Dock == DockStyle.Bottom) &&
-                                             (_statusStrip.Bottom == ClientRectangle.Bottom) &&
-                                             (_statusStrip.RenderMode == ToolStripRenderMode.ManagerRenderMode) &&
-                                             (ToolStripManager.Renderer is KryptonOffice2007Renderer or KryptonSparkleRenderer);
+                                            _statusStrip is { Visible: true, Dock: DockStyle.Bottom } && (_statusStrip.Bottom == ClientRectangle.Bottom) && (_statusStrip.RenderMode == ToolStripRenderMode.ManagerRenderMode) && (ToolStripManager.Renderer is KryptonOffice2007Renderer or KryptonSparkleRenderer);
 
         private void MonitorStatusStrip(StatusStrip statusStrip)
         {
@@ -1489,7 +1484,7 @@ namespace Krypton.Toolkit
             {
                 // Do not show tooltips when the form we are in does not have focus
                 Form topForm = FindForm();
-                if ((topForm != null) && !topForm.ContainsFocus)
+                if (topForm is { ContainsFocus: false })
                 {
                     return;
                 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonHeader.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonHeader.cs
@@ -522,7 +522,7 @@ namespace Krypton.Toolkit
             {
                 // Do not show tooltips when the form we are in does not have focus
                 Form topForm = FindForm();
-                if ((topForm != null) && !topForm.ContainsFocus)
+                if (topForm is { ContainsFocus: false })
                 {
                     return;
                 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonHeaderGroup.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonHeaderGroup.cs
@@ -1066,7 +1066,7 @@ namespace Krypton.Toolkit
             {
                 // Do not show tooltips when the form we are in does not have focus
                 Form topForm = FindForm();
-                if ((topForm != null) && !topForm.ContainsFocus)
+                if (topForm is { ContainsFocus: false })
                 {
                     return;
                 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs
@@ -1845,7 +1845,7 @@ namespace Krypton.Toolkit
             {
                 // Do not show tooltips when the form we are in does not have focus
                 Form topForm = FindForm();
-                if ((topForm != null) && !topForm.ContainsFocus)
+                if (topForm is { ContainsFocus: false })
                 {
                     return;
                 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
@@ -1437,8 +1437,8 @@ namespace Krypton.Toolkit
                 ? _fixedActive.Value
                 : DesignMode || AlwaysActive ||
                   ContainsFocus || _mouseOver || _numericUpDown.MouseOver ||
-                  ((_subclassEdit != null) && _subclassEdit.MouseOver) ||
-                  ((_subclassButtons != null) && _subclassButtons.MouseOver);
+                  _subclassEdit is { MouseOver: true } ||
+                  _subclassButtons is { MouseOver: true };
 
         /// <summary>
         /// Sets input focus to the control.
@@ -2065,7 +2065,7 @@ namespace Krypton.Toolkit
             {
                 // Do not show tooltips when the form we are in does not have focus
                 Form topForm = FindForm();
-                if ((topForm != null) && !topForm.ContainsFocus)
+                if (topForm is { ContainsFocus: false })
                 {
                     return;
                 }
@@ -2140,8 +2140,8 @@ namespace Krypton.Toolkit
         {
             // Find new tracking mouse change state
             var tracking = _numericUpDown.MouseOver ||
-                           ((_subclassEdit != null) && _subclassEdit.MouseOver) ||
-                           ((_subclassButtons != null) && _subclassButtons.MouseOver);
+                           _subclassEdit is { MouseOver: true } ||
+                           _subclassButtons is { MouseOver: true };
 
             // Change in tracking state?
             if (tracking != _trackingMouseEnter)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
@@ -2197,7 +2197,7 @@ namespace Krypton.Toolkit
             {
                 // Do not show tooltips when the form we are in does not have focus
                 Form topForm = FindForm();
-                if ((topForm != null) && !topForm.ContainsFocus)
+                if (topForm is { ContainsFocus: false })
                 {
                     return;
                 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
@@ -94,7 +94,6 @@ namespace Krypton.Toolkit
             #endregion
 
             #region Protected
-            public override Size GetPreferredSize(Size proposedSize) => base.GetPreferredSize(proposedSize);
 
             /// <summary>
             /// Process Windows-based messages.
@@ -1862,7 +1861,7 @@ namespace Krypton.Toolkit
             {
                 // Do not show tooltips when the form we are in does not have focus
                 Form topForm = FindForm();
-                if ((topForm != null) && !topForm.ContainsFocus)
+                if (topForm is { ContainsFocus: false })
                 {
                     return;
                 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
@@ -1684,7 +1684,7 @@ namespace Krypton.Toolkit
             // If we moused down on a active view element
             // Ask the controller if the mouse down should be ignored by wnd proc processing
             IMouseController controller = ViewManager.ActiveView?.FindMouseController();
-            return (controller != null) && controller.IgnoreVisualFormLeftButtonDown;
+            return controller is { IgnoreVisualFormLeftButtonDown: true };
         }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPopupManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPopupManager.cs
@@ -139,7 +139,7 @@ namespace Krypton.Toolkit
             Debug.Assert(_suspended == 0);
 
             // The popup control must be valid
-            if ((popup != null) && !popup.IsDisposed && popup.IsHandleCreated)
+            if (popup is { IsDisposed: false, IsHandleCreated: true })
             {
                 // Cannot start tracking when a popup menu is alive
                 if (_suspended == 0)
@@ -734,14 +734,14 @@ namespace Krypton.Toolkit
 
         private bool IsKeyOrMouseMessage(ref Message m)
         {
-            if ((m.Msg >= PI.WM_.MOUSEMOVE) && (m.Msg <= PI.WM_.MOUSEWHEEL))
+            if (m.Msg is >= PI.WM_.MOUSEMOVE and <= PI.WM_.MOUSEWHEEL)
             {
                 return true;
             }
 
-            return (m.Msg >= PI.WM_.NCMOUSEMOVE) && (m.Msg <= PI.WM_.NCMBUTTONDBLCLK)
+            return m.Msg is >= PI.WM_.NCMOUSEMOVE and <= PI.WM_.NCMBUTTONDBLCLK
                 ? true
-                : (m.Msg >= PI.WM_.KEYDOWN) && (m.Msg <= PI.WM_.KEYLAST);
+                : m.Msg is >= PI.WM_.KEYDOWN and <= PI.WM_.KEYLAST;
         }
 
         private void FilterMessages(bool filter)

--- a/Source/Krypton Components/Krypton.Toolkit/General/ControlObscurer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/ControlObscurer.cs
@@ -99,7 +99,7 @@ namespace Krypton.Toolkit
         public ScreenObscurer(Form f, bool designMode)
         {
             // Check the incoming form is valid
-            if ((f != null) && !f.IsDisposed && !designMode)
+            if (f is { IsDisposed: false } && !designMode)
             {
                 // First time needed, create the top level obscurer window
                 if (_obscurer == null)
@@ -123,7 +123,7 @@ namespace Krypton.Toolkit
         public ScreenObscurer(Control c, bool designMode)
         {
             // Check the incoming control is valid
-            if ((c != null) && !c.IsDisposed && !designMode)
+            if (c is { IsDisposed: false } && !designMode)
             {
                 // First time needed, create the top level obscurer window
                 if (_obscurer == null)
@@ -146,7 +146,7 @@ namespace Krypton.Toolkit
         public void Cover(Form f)
         {
             // Check the incoming form is valid
-            if ((f != null) && !f.IsDisposed)
+            if (f is { IsDisposed: false })
             {
                 // Show over top of the provided form
                 _obscurer?.ShowForm(f.Bounds);
@@ -160,7 +160,7 @@ namespace Krypton.Toolkit
         public void Cover(Control c)
         {
             // Check the incoming control is valid
-            if ((c != null) && !c.IsDisposed)
+            if (c is { IsDisposed: false })
             {
                 // Show over top of the provided control
                 _obscurer?.ShowForm(c.RectangleToScreen(c.ClientRectangle));

--- a/Source/Krypton Components/Krypton.Toolkit/General/ModalWaitDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/ModalWaitDialog.cs
@@ -133,8 +133,8 @@ namespace Krypton.Toolkit
         public bool PreFilterMessage(ref Message m)
         {
             // Prevent mouse messages from activating any application windows
-            if (((m.Msg >= 0x0200) && (m.Msg <= 0x0209)) ||
-                ((m.Msg >= 0x00A0) && (m.Msg <= 0x00A9)))
+            if (m.Msg is >= 0x0200 and <= 0x0209 ||
+                m.Msg is >= 0x00A0 and <= 0x00A9)
             {
                 // Discover target control for message
                 if (FromHandle(m.HWnd) != null)

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteContentInheritNode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteContentInheritNode.cs
@@ -217,7 +217,7 @@ namespace Krypton.Toolkit
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
         public override Font GetContentLongTextFont(PaletteState state) =>
-            (TreeNode is KryptonTreeNode kryptonNode) && (kryptonNode.LongNodeFont != null)
+            (TreeNode is KryptonTreeNode { LongNodeFont: { } } kryptonNode)
                 ? kryptonNode.LongNodeFont
                 : _inherit.GetContentLongTextFont(state);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonOffice2010Renderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonOffice2010Renderer.cs
@@ -567,7 +567,7 @@ namespace Krypton.Toolkit
                             e.TextColor = KCT.MenuItemText;
                             break;
                         default:
-                            if ((e.Item is ToolStripButton button) && button.Checked)
+                            if ((e.Item is ToolStripButton { Checked: true }))
                             {
                                 e.TextColor = KCT.MenuItemText;
                             }

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonOffice2013Renderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonOffice2013Renderer.cs
@@ -570,7 +570,7 @@ namespace Krypton.Toolkit
                     {
                         e.TextColor = KCT.MenuItemText;
                     }
-                    else if ((e.Item is ToolStripButton button) && button.Checked)
+                    else if ((e.Item is ToolStripButton { Checked: true }))
                     {
                         e.TextColor = KCT.MenuItemText;
                     }

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonOffice365Renderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonOffice365Renderer.cs
@@ -569,7 +569,7 @@ namespace Krypton.Toolkit
                     {
                         e.TextColor = KCT.MenuItemText;
                     }
-                    else if ((e.Item is ToolStripButton button) && button.Checked)
+                    else if ((e.Item is ToolStripButton { Checked: true }))
                     {
                         e.TextColor = KCT.MenuItemText;
                     }

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
@@ -5817,7 +5817,7 @@ namespace Krypton.Toolkit
             var shortText = contentValues.GetShortText();
 
             // Is there any text to be drawn?
-            if ((shortText != null) && (shortText.Length > 0))
+            if (shortText is { Length: > 0 })
             {
                 // If the text is not allowed to span multiple lines
                 if (paletteContent.GetContentShortTextMultiLine(state) == InheritBool.False)
@@ -5902,7 +5902,7 @@ namespace Krypton.Toolkit
             var longText = contentValues.GetLongText();
 
             // Is there any text to be drawn?
-            if ((longText != null) && (longText.Length > 0))
+            if (longText is { Length: > 0 })
             {
                 // If the text is not allowed to span multiple lines
                 if (paletteContent.GetContentLongTextMultiLine(state) == InheritBool.False)

--- a/Source/Krypton Components/Krypton.Toolkit/Values/BlurValues.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/BlurValues.cs
@@ -124,8 +124,7 @@ namespace Krypton.Toolkit
             set
             {
                 if (Math.Abs(_opacity - value) > 0.001
-                    && 0 <= value
-                    && value <= 100
+                    && value is >= 0 and <= 100
                 )
                 {
                     _opacity = value;

--- a/Source/Krypton Components/Krypton.Toolkit/Values/ShadowValues.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/ShadowValues.cs
@@ -157,8 +157,7 @@ namespace Krypton.Toolkit
             set
             {
                 if (Math.Abs(_blurDistance - value) > 0.001
-                    && 0 <= value
-                    && value <= 100
+                    && value is >= 0 and <= 100
                     )
                 {
                     _blurDistance = value;
@@ -213,8 +212,7 @@ namespace Krypton.Toolkit
             set
             {
                 if (Math.Abs(_opacity - value) > 0.001
-                    && 0 <= value
-                    && value <= 100
+                    && value is >= 0 and <= 100
                 )
                 {
                     _opacity = value;

--- a/Source/Krypton Components/Krypton.Toolkit/View Base/ViewContextMenuManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Base/ViewContextMenuManager.cs
@@ -849,7 +849,7 @@ namespace Krypton.Toolkit
                     }
 
                     // If we still have a target and it has a sub menu
-                    if ((_target != null) && _target.HasSubMenu)
+                    if (_target is { HasSubMenu: true })
                     {
                         // Remember we told the target to show any sub menu
                         _targetSubMenu = _target;

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawDateTimeText.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawDateTimeText.cs
@@ -398,7 +398,7 @@ namespace Krypton.Toolkit
                         }
 
                         // Keep the digit if there is just a single '1' or '0' digit that might be start of two digit month
-                        if ((_inputDigits.Length > 1) || ((_inputDigits.Length == 1) && (monthNumber > 1) && (monthNumber < 10)))
+                        if ((_inputDigits.Length > 1) || ((_inputDigits.Length == 1) && monthNumber is > 1 and < 10))
                         {
                             // Do we need to shift to the next field?
                             if ((_inputDigits.Length == 2) && _dateTimePicker.AutoShift)
@@ -1016,7 +1016,7 @@ namespace Krypton.Toolkit
                     case "M":
                     case "MM":
                         var monthNumber = int.Parse(digits);
-                        if ((monthNumber <= 12) && (monthNumber > 0))
+                        if (monthNumber is <= 12 and > 0)
                         {
                             dt = dt.AddMonths(monthNumber - dt.Month);
                         }
@@ -1043,7 +1043,7 @@ namespace Krypton.Toolkit
                 if (FragFormat.StartsWith("h") || FragFormat.StartsWith("H"))
                 {
                     var hoursNumber = int.Parse(digits);
-                    if ((hoursNumber < 24) && (hoursNumber >= 0))
+                    if (hoursNumber is < 24 and >= 0)
                     {
                         dt = dt.AddHours(hoursNumber - dt.Hour);
                     }
@@ -1051,7 +1051,7 @@ namespace Krypton.Toolkit
                 else if (FragFormat.StartsWith("m"))
                 {
                     var minutesNumber = int.Parse(digits);
-                    if ((minutesNumber < 60) && (minutesNumber >= 0))
+                    if (minutesNumber is < 60 and >= 0)
                     {
                         dt = dt.AddMinutes(minutesNumber - dt.Minute);
                     }
@@ -1059,7 +1059,7 @@ namespace Krypton.Toolkit
                 else if (FragFormat.StartsWith("s"))
                 {
                     var secondsNumber = int.Parse(digits);
-                    if ((secondsNumber < 60) && (secondsNumber >= 0))
+                    if (secondsNumber is < 60 and >= 0)
                     {
                         dt = dt.AddSeconds(secondsNumber - dt.Second);
                     }

--- a/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutMonths.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutMonths.cs
@@ -649,7 +649,7 @@ namespace Krypton.Toolkit
             }
 
             // Is the menu capable of being closed?
-            if (CloseOnTodayClick && (Provider != null) && Provider.ProviderCanCloseMenu)
+            if (CloseOnTodayClick && Provider is { ProviderCanCloseMenu: true })
             {
                 // Ask the original context menu definition, if we can close
                 CancelEventArgs cea = new();
@@ -793,7 +793,7 @@ namespace Krypton.Toolkit
             {
                 // Do not show tooltips when the form we are in does not have focus
                 Form topForm = Calendar.CalendarControl.FindForm();
-                if ((topForm != null) && !topForm.ContainsFocus)
+                if (topForm is { ContainsFocus: false })
                 {
                     return;
                 }


### PR DESCRIPTION
…display them

- Enable scoll bar in edit control
Note: 2 files for the above are `KryptonDataGridViewTextBoxColumn.cs` and `KryptonDataGridViewTextBoxColumn.cs`
![image](https://user-images.githubusercontent.com/2418812/144748684-13c7896f-87f5-486b-a70f-457e9a6b29bf.png)

- Apply ReSharper style
Fixes: #453

![image](https://user-images.githubusercontent.com/2418812/144748688-da72919f-d110-48e5-8727-00bd1fe362d4.png)
