### PR TITLE
- If tooltip not set in designer, then do not display the kryptonDefault

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -1,6 +1,7 @@
 # <img src="https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/Krypton.png"> Standard Toolkit - ChangeLog
 
 ## 2022-02-01 - Build 2202 - February 2022
+* Fixed [#520](https://github.com/Krypton-Suite/Standard-Toolkit/issues/520), KTooltips default to using the KryptonIcon when nothing is set by the developer
 * Fixed some minor issues regarding some dark themes
 * Fixed minor batch script bugs
 * Fixed tracking colours in `Office 2010 - Black (Dark Mode)`

--- a/Source/Krypton Components/Krypton.Toolkit/Values/ToolTipValues.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/ToolTipValues.cs
@@ -40,6 +40,10 @@ namespace Krypton.Toolkit
             ResetEnableToolTips();
             ResetToolTipStyle();
             ResetToolTipPosition();
+            ResetImage();
+            ResetImageTransparentColor();
+            ResetHeading();
+            ResetDescription();
         }
 
         /// <summary>
@@ -50,6 +54,8 @@ namespace Krypton.Toolkit
         public bool EnableToolTips { get; set; }
 
         private bool ShouldSerializeEnableToolTips() => EnableToolTips;
+
+        protected override Image GetImageDefault() => null;
 
         /// <summary>
         /// 


### PR DESCRIPTION
Fixes #520

Still a lot of warning for 2019 build:
![image](https://user-images.githubusercontent.com/2418812/145674535-c59b6115-011c-4e06-a6f2-646d67582501.png)
