### PR TITLE
- Make `IsInitialized` and `IsInitializing` hidden from the Designers…

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -1,6 +1,7 @@
 # <img src="https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/Krypton.png"> Standard Toolkit - ChangeLog
 
 ## 2022-02-01 - Build 2202 - February 2022
+* Fixed [#525](https://github.com/Krypton-Suite/Standard-Toolkit/issues/525), Undesired behaviour in KryptonGroupBox
 * Fixed [#520](https://github.com/Krypton-Suite/Standard-Toolkit/issues/520), KTooltips default to using the KryptonIcon when nothing is set by the developer
 * Fixed some minor issues regarding some dark themes
 * Fixed minor batch script bugs

--- a/Source/Krypton Components/Krypton.Toolkit/AccurateText/AccurateText.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/AccurateText/AccurateText.cs
@@ -153,7 +153,7 @@ namespace Krypton.Toolkit
             }
 
             // Replace tab characters with a fixed four spaces
-            text = text.Replace("\t", "    ");
+            text = text.Replace("\t", @"    ");
 
             // Perform actual measure of the text
             using GraphicsTextHint graphicsHint = new(g, hint);
@@ -283,7 +283,7 @@ namespace Krypton.Toolkit
                             //    DrawCompositionGlowingText(g, memento.Text, memento.Font, rect, state,
                             //        (state == PaletteState.Disabled)
                             //            ? Color.FromArgb(170, 170, 170)
-                            //            : ContrastColor(AccentColorService.GetColorByTypeName("ImmersiveSystemAccent")),
+                            //            : ContrastColor(AccentColorService.GetColorByTypeName(@"ImmersiveSystemAccent")),
                             //        true);
                             //}
                             //else

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpec.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpec.cs
@@ -54,15 +54,15 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Occurs whenever a button specification property has changed.
         /// </summary>
-        [Category("Action")]
-        [Description("Occurs when the component is clicked.")]
+        [Category(@"Action")]
+        [Description(@"Occurs when the component is clicked.")]
         public event EventHandler Click;
 
         /// <summary>
         /// Occurs whenever a button specification property has changed.
         /// </summary>
-        [Category("ButtonSpec")]
-        [Description("Occurs when a button specification property has changed.")]
+        [Category(@"ButtonSpec")]
+        [Description(@"Occurs when a button specification property has changed.")]
         public event PropertyChangedEventHandler ButtonSpecPropertyChanged;
         #endregion
 
@@ -174,8 +174,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the button image.
         /// </summary>
         [Localizable(true)]
-        [Category("Appearance")]
-        [Description("Button image.")]
+        [Category(@"Appearance")]
+        [Description(@"Button image.")]
         public Image Image
         {
             get => _image;
@@ -206,8 +206,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the button image.
         /// </summary>
         [Localizable(true)]
-        [Category("Appearance")]
-        [Description("Button image transparent color.")]
+        [Category(@"Appearance")]
+        [Description(@"Button image transparent color.")]
         [KryptonDefaultColor()]
         public Color ImageTransparentColor
         {
@@ -238,8 +238,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the state specific images for the button.
         /// </summary>
-        [Category("Appearance")]
-        [Description("State specific images for the button.")]
+        [Category(@"Appearance")]
+        [Description(@"State specific images for the button.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public ButtonImageStates ImageStates => _imageStates;
 
@@ -252,9 +252,9 @@ namespace Krypton.Toolkit
         /// Gets and sets the button text.
         /// </summary>
         [Localizable(true)]
-        [Category("Appearance")]
-        [Description("Button text.")]
-        [Editor("System.ComponentModel.Design.MultilineStringEditor", typeof(UITypeEditor))]
+        [Category(@"Appearance")]
+        [Description(@"Button text.")]
+        [Editor(@"System.ComponentModel.Design.MultilineStringEditor", typeof(UITypeEditor))]
         public string Text
         {
             get => _text;
@@ -285,9 +285,9 @@ namespace Krypton.Toolkit
         /// Gets and sets the button extra text.
         /// </summary>
         [Localizable(true)]
-        [Category("Appearance")]
-        [Description("Button extra text.")]
-        [Editor("System.ComponentModel.Design.MultilineStringEditor", typeof(UITypeEditor))]
+        [Category(@"Appearance")]
+        [Description(@"Button extra text.")]
+        [Editor(@"System.ComponentModel.Design.MultilineStringEditor", typeof(UITypeEditor))]
         public string ExtraText
         {
             get => _extraText;
@@ -318,8 +318,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the button tooltip image.
         /// </summary>
         [Localizable(true)]
-        [Category("ToolTip")]
-        [Description("Button tooltip image.")]
+        [Category(@"ToolTip")]
+        [Description(@"Button tooltip image.")]
         [DefaultValue(null)]
         public Image ToolTipImage
         {
@@ -351,8 +351,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the tooltip image transparent color.
         /// </summary>
         [Localizable(true)]
-        [Category("ToolTip")]
-        [Description("Button image transparent color.")]
+        [Category(@"ToolTip")]
+        [Description(@"Button image transparent color.")]
         [KryptonDefaultColor()]
         public Color ToolTipImageTransparentColor
         {
@@ -384,10 +384,10 @@ namespace Krypton.Toolkit
         /// Gets and sets the button title tooltip text.
         /// </summary>
         [Localizable(true)]
-        [Category("ToolTip")]
-        [Description("Button tooltip title text.")]
-        [Editor("System.ComponentModel.Design.MultilineStringEditor", typeof(UITypeEditor))]
-        [DefaultValue("")]
+        [Category(@"ToolTip")]
+        [Description(@"Button tooltip title text.")]
+        [Editor(@"System.ComponentModel.Design.MultilineStringEditor", typeof(UITypeEditor))]
+        [DefaultValue(@"")]
         public string ToolTipTitle
         {
             get => _toolTipTitle;
@@ -418,10 +418,10 @@ namespace Krypton.Toolkit
         /// Gets and sets the button body tooltip text.
         /// </summary>
         [Localizable(true)]
-        [Category("ToolTip")]
-        [Description("Button tooltip body text.")]
-        [Editor("System.ComponentModel.Design.MultilineStringEditor", typeof(UITypeEditor))]
-        [DefaultValue("")]
+        [Category(@"ToolTip")]
+        [Description(@"Button tooltip body text.")]
+        [Editor(@"System.ComponentModel.Design.MultilineStringEditor", typeof(UITypeEditor))]
+        [DefaultValue(@"")]
         public string ToolTipBody
         {
             get => _toolTipBody;
@@ -451,8 +451,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the tooltip label style.
         /// </summary>
-        [Category("ToolTip")]
-        [Description("Button tooltip label style.")]
+        [Category(@"ToolTip")]
+        [Description(@"Button tooltip label style.")]
         [DefaultValue(typeof(LabelStyle), "Tooltip")]
         public LabelStyle ToolTipStyle { get; set; }
 
@@ -471,8 +471,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the unique name of the ButtonSpec.
         /// </summary>
-        [Category("Data")]
-        [Description("The unique name of the ButtonSpec.")]
+        [Category(@"Data")]
+        [Description(@"The unique name of the ButtonSpec.")]
         public string UniqueName { get; set; }
 
         /// <summary>
@@ -489,8 +489,8 @@ namespace Krypton.Toolkit
         /// Gets and sets if the button image be inherited if defined as null.
         /// </summary>
         [Localizable(true)]
-        [Category("Inherit")]
-        [Description("Should button image be inherited if defined as null.")]
+        [Category(@"Inherit")]
+        [Description(@"Should button image be inherited if defined as null.")]
         [DefaultValue(true)]
         public bool AllowInheritImage
         {
@@ -520,8 +520,8 @@ namespace Krypton.Toolkit
         /// Gets and sets if the button text be inherited if defined as empty.
         /// </summary>
         [Localizable(true)]
-        [Category("Inherit")]
-        [Description("Should button text be inherited if defined as empty.")]
+        [Category(@"Inherit")]
+        [Description(@"Should button text be inherited if defined as empty.")]
         [DefaultValue(true)]
         public bool AllowInheritText
         {
@@ -551,8 +551,8 @@ namespace Krypton.Toolkit
         /// Gets and sets if the button extra text be inherited if defined as empty.
         /// </summary>
         [Localizable(true)]
-        [Category("Inherit")]
-        [Description("Should button extra text be inherited if defined as empty.")]
+        [Category(@"Inherit")]
+        [Description(@"Should button extra text be inherited if defined as empty.")]
         [DefaultValue(true)]
         public bool AllowInheritExtraText
         {
@@ -582,8 +582,8 @@ namespace Krypton.Toolkit
         /// Gets and sets if the button tooltip title be inherited if defined as empty.
         /// </summary>
         [Localizable(true)]
-        [Category("Inherit")]
-        [Description("Should button tooltip title text be inherited if defined as empty.")]
+        [Category(@"Inherit")]
+        [Description(@"Should button tooltip title text be inherited if defined as empty.")]
         [DefaultValue(true)]
         public bool AllowInheritToolTipTitle
         {
@@ -623,8 +623,8 @@ namespace Krypton.Toolkit
         /// Gets and sets image color to remap to container foreground.
         /// </summary>
         [Localizable(true)]
-        [Category("Appearance")]
-        [Description("Image color to remap to container foreground.")]
+        [Category(@"Appearance")]
+        [Description(@"Image color to remap to container foreground.")]
         [KryptonDefaultColor()]
         public Color ColorMap
         {
@@ -656,8 +656,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the button style.
         /// </summary>
         [Localizable(true)]
-        [Category("Behavior")]
-        [Description("Button style.")]
+        [Category(@"Behavior")]
+        [Description(@"Button style.")]
         [DefaultValue(typeof(PaletteButtonStyle), "Inherit")]
         public PaletteButtonStyle Style
         {
@@ -686,8 +686,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the button orientation.
         /// </summary>
         [Localizable(true)]
-        [Category("Behavior")]
-        [Description("Defines the button orientation.")]
+        [Category(@"Behavior")]
+        [Description(@"Defines the button orientation.")]
         [RefreshProperties(RefreshProperties.All)]
         public PaletteButtonOrientation Orientation
         {
@@ -719,8 +719,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the header edge to display the button against.
         /// </summary>
         [Localizable(true)]
-        [Category("Behavior")]
-        [Description("The header edge to display the button against.")]
+        [Category(@"Behavior")]
+        [Description(@"The header edge to display the button against.")]
         [RefreshProperties(RefreshProperties.All)]
         public PaletteRelativeEdgeAlign Edge
         {
@@ -749,8 +749,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the context menu strip for the button.
         /// </summary>
         [Localizable(true)]
-        [Category("Behavior")]
-        [Description("ContextMenuStrip to show when the button is pressed.")]
+        [Category(@"Behavior")]
+        [Description(@"ContextMenuStrip to show when the button is pressed.")]
         [RefreshProperties(RefreshProperties.All)]
         [DefaultValue(null)]
         public ContextMenuStrip ContextMenuStrip { get; set; }
@@ -762,8 +762,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the krypton context menu for the button.
         /// </summary>
         [Localizable(true)]
-        [Category("Behavior")]
-        [Description("KryptonContextMenu to show when the button is pressed.")]
+        [Category(@"Behavior")]
+        [Description(@"KryptonContextMenu to show when the button is pressed.")]
         [RefreshProperties(RefreshProperties.All)]
         [DefaultValue(null)]
         public KryptonContextMenu KryptonContextMenu { get; set; }
@@ -774,8 +774,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the associated KryptonCommand.
         /// </summary>
-        [Category("Behavior")]
-        [Description("Command associated with the button.")]
+        [Category(@"Behavior")]
+        [Description(@"Command associated with the button.")]
         [RefreshProperties(RefreshProperties.All)]
         [DefaultValue(null)]
         public virtual KryptonCommand KryptonCommand
@@ -817,8 +817,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets user-defined data associated with the object.
         /// </summary>
-        [Category("Data")]
-        [Description("User-defined data associated with the object.")]
+        [Category(@"Data")]
+        [Description(@"User-defined data associated with the object.")]
         [TypeConverter(typeof(StringConverter))]
         [DefaultValue(null)]
         public object Tag { get; set; }

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecAny.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecAny.cs
@@ -72,8 +72,8 @@ namespace Krypton.Toolkit
         /// Gets and sets if the button should be shown.
         /// </summary>
         [Localizable(true)]
-        [Category("Behavior")]
-        [Description("Should the button be shown.")]
+        [Category(@"Behavior")]
+        [Description(@"Should the button be shown.")]
         [RefreshProperties(RefreshProperties.All)]
         [DefaultValue(true)]
         public bool Visible
@@ -104,8 +104,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the button enabled state.
         /// </summary>
         [Localizable(true)]
-        [Category("Behavior")]
-        [Description("Defines the button enabled state.")]
+        [Category(@"Behavior")]
+        [Description(@"Defines the button enabled state.")]
         [RefreshProperties(RefreshProperties.All)]
         [DefaultValue(typeof(ButtonEnabled), "Container")]
         public ButtonEnabled Enabled
@@ -136,8 +136,8 @@ namespace Krypton.Toolkit
         /// Gets and sets if the button is checked or capable of being checked.
         /// </summary>
         [Localizable(true)]
-        [Category("Behavior")]
-        [Description("Defines if the button is checked or capable of being checked.")]
+        [Category(@"Behavior")]
+        [Description(@"Defines if the button is checked or capable of being checked.")]
         [RefreshProperties(RefreshProperties.All)]
         [DefaultValue(typeof(ButtonCheckState), "NotCheckButton")]
         public ButtonCheckState Checked
@@ -167,8 +167,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the associated KryptonCommand.
         /// </summary>
-        [Category("Behavior")]
-        [Description("Command associated with the button.")]
+        [Category(@"Behavior")]
+        [Description(@"Command associated with the button.")]
         [RefreshProperties(RefreshProperties.All)]
         [DefaultValue(null)]
         public override KryptonCommand KryptonCommand
@@ -202,8 +202,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the button type.
         /// </summary>
         [Localizable(true)]
-        [Category("Behavior")]
-        [Description("Defines the type of button specification.")]
+        [Category(@"Behavior")]
+        [Description(@"Defines the type of button specification.")]
         [RefreshProperties(RefreshProperties.All)]
         [DefaultValue(typeof(PaletteButtonSpecStyle), "Generic")]
         public PaletteButtonSpecStyle Type

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecCollection.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecCollection.cs
@@ -216,7 +216,7 @@ namespace Krypton.Toolkit
         {
             get => _specs[index];
 
-            set => throw new NotImplementedException("Cannot set a collection index with a new value");
+            set => throw new NotImplementedException(@"Cannot set a collection index with a new value");
         }
         #endregion
 
@@ -292,7 +292,7 @@ namespace Krypton.Toolkit
         {
             get => _specs[index];
 
-            set => throw new NotImplementedException("Cannot set a collection index with a new value");
+            set => throw new NotImplementedException(@"Cannot set a collection index with a new value");
         }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecFormWindowClose.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecFormWindowClose.cs
@@ -83,7 +83,7 @@ namespace Krypton.Toolkit
                     MouseEventArgs mea = (MouseEventArgs)e;
                     if (GetView().ClientRectangle.Contains(mea.Location))
                     {
-                        PropertyInfo pi = typeof(Form).GetProperty("CloseReason",
+                        PropertyInfo pi = typeof(Form).GetProperty(@"CloseReason",
                                                                     BindingFlags.Instance |
                                                                     BindingFlags.SetProperty |
                                                                     BindingFlags.NonPublic);

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecHeaderGroup.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecHeaderGroup.cs
@@ -45,8 +45,8 @@ namespace Krypton.Toolkit
         /// Gets and sets if the button header location.
         /// </summary>
         [Localizable(true)]
-        [Category("Visuals")]
-        [Description("Defines header location for the button.")]
+        [Category(@"Visuals")]
+        [Description(@"Defines header location for the button.")]
         [RefreshProperties(RefreshProperties.All)]
         [DefaultValue(typeof(HeaderLocation), "PrimaryHeader")]
         public HeaderLocation HeaderLocation

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecRemapByContentBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecRemapByContentBase.cs
@@ -137,8 +137,7 @@ namespace Krypton.Toolkit
             if (PaletteContent != null)
             {
                 // We only override the normal/disabled states
-                if ((state == PaletteState.Normal) ||
-                    (state == PaletteState.Disabled))
+                if (state is PaletteState.Normal or PaletteState.Disabled)
                 {
                     // ReSharper disable RedundantBaseQualifier
                     // Get the color map from the button spec

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuHeading.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuHeading.cs
@@ -18,9 +18,9 @@ namespace Krypton.Toolkit
     /// </summary>
     [ToolboxItem(false)]
     [ToolboxBitmap(typeof(KryptonContextMenuHeading), "ToolboxBitmaps.KryptonContextMenuHeading.bmp")]
-    [DesignerCategory("code")]
+    [DesignerCategory(@"code")]
     [DesignTimeVisible(false)]
-    [DefaultProperty("Text")]
+    [DefaultProperty(@"Text")]
     public class KryptonContextMenuHeading : KryptonContextMenuItemBase
     {
         #region Instance Fields
@@ -36,7 +36,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the KryptonContextMenuHeading class.
         /// </summary>
         public KryptonContextMenuHeading()
-            : this("Heading")
+            : this(@"Heading")
         {
         }
 
@@ -112,11 +112,11 @@ namespace Krypton.Toolkit
         /// Gets and sets the heading menu item text.
         /// </summary>
         [KryptonPersist]
-        [Category("Appearance")]
-        [Description("Heading menu item text.")]
-        [Editor("System.ComponentModel.Design.MultilineStringEditor", typeof(UITypeEditor))]
+        [Category(@"Appearance")]
+        [Description(@"Heading menu item text.")]
+        [Editor(@"System.ComponentModel.Design.MultilineStringEditor", typeof(UITypeEditor))]
         [Localizable(true)]
-        [DefaultValue("Heading")]
+        [DefaultValue(@"Heading")]
         public string Text
         {
             get => _text;
@@ -135,9 +135,9 @@ namespace Krypton.Toolkit
         /// Gets and sets the heading menu item extra text.
         /// </summary>
         [KryptonPersist]
-        [Category("Appearance")]
-        [Description("Heading menu item extra text.")]
-        [Editor("System.ComponentModel.Design.MultilineStringEditor", typeof(UITypeEditor))]
+        [Category(@"Appearance")]
+        [Description(@"Heading menu item extra text.")]
+        [Editor(@"System.ComponentModel.Design.MultilineStringEditor", typeof(UITypeEditor))]
         [Localizable(true)]
         [DefaultValue(null)]
         public string ExtraText
@@ -158,8 +158,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the heading menu item image.
         /// </summary>
         [KryptonPersist]
-        [Category("Appearance")]
-        [Description("Heading menu item image.")]
+        [Category(@"Appearance")]
+        [Description(@"Heading menu item image.")]
         [Localizable(true)]
         [DefaultValue(null)]
         public Image Image
@@ -180,8 +180,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the heading image color to make transparent.
         /// </summary>
         [KryptonPersist]
-        [Category("Appearance")]
-        [Description("Heading image color to make transparent.")]
+        [Category(@"Appearance")]
+        [Description(@"Heading image color to make transparent.")]
         [Localizable(true)]
         public Color ImageTransparentColor
         {
@@ -203,8 +203,8 @@ namespace Krypton.Toolkit
         /// Gets access to the header instance specific appearance values.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Overrides for defining header instance specific appearance values.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining header instance specific appearance values.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteTripleRedirect StateNormal { get; }
 

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuImageSelect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuImageSelect.cs
@@ -18,10 +18,10 @@ namespace Krypton.Toolkit
     /// </summary>
     [ToolboxItem(false)]
     [ToolboxBitmap(typeof(KryptonContextMenuImageSelect), "ToolboxBitmaps.KryptonContextMenuImageSelect.bmp")]
-    [DesignerCategory("code")]
+    [DesignerCategory(@"code")]
     [DesignTimeVisible(false)]
-    [DefaultProperty("ImageList")]
-    [DefaultEvent("SelectedIndexChanged")]
+    [DefaultProperty(@"ImageList")]
+    [DefaultEvent(@"SelectedIndexChanged")]
     public class KryptonContextMenuImageSelect : KryptonContextMenuItemBase
     {
         #region Instance Fields
@@ -43,22 +43,22 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Occurs when the value of the SelectedIndex property changes.
         /// </summary>
-        [Category("Property Changed")]
-        [Description("Occurs when the value of the SelectedIndex property changes.")]
+        [Category(@"Property Changed")]
+        [Description(@"Occurs when the value of the SelectedIndex property changes.")]
         public event EventHandler SelectedIndexChanged;
 
         /// <summary>
         /// Occurs when the user is tracking over a color.
         /// </summary>
-        [Category("Action")]
-        [Description("Occurs when user is tracking over an image.")]
+        [Category(@"Action")]
+        [Description(@"Occurs when user is tracking over an image.")]
         public event EventHandler<ImageSelectEventArgs> TrackingImage;
 
         /// <summary>
         /// Occurs when the value of the SelectedIndex property changes.
         /// </summary>
-        [Category("Action")]
-        [Description("Occurs when an image is clicked.")]
+        [Category(@"Action")]
+        [Description(@"Occurs when an image is clicked.")]
         public event EventHandler Click;
 
         #endregion
@@ -137,8 +137,8 @@ namespace Krypton.Toolkit
         /// Gets and sets padding around the image selection area.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("Padding used around the image selection area.")]
+        [Category(@"Behavior")]
+        [Description(@"Padding used around the image selection area.")]
         [DefaultValue(typeof(Padding), "2,2,2,2")]
         public Padding Padding
         {
@@ -158,8 +158,8 @@ namespace Krypton.Toolkit
         /// Gets and sets if selecting an image automatically closes the context menu.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("Indicates if selecting an image automatically closes the context menu.")]
+        [Category(@"Behavior")]
+        [Description(@"Indicates if selecting an image automatically closes the context menu.")]
         [DefaultValue(true)]
         public bool AutoClose
         {
@@ -179,8 +179,8 @@ namespace Krypton.Toolkit
         /// Gets access to the collection of images for display and selection.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("The index of the selected image.")]
+        [Category(@"Behavior")]
+        [Description(@"The index of the selected image.")]
         [DefaultValue(-1)]
         public int SelectedIndex
         {
@@ -200,8 +200,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the button style used for each image item.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Button style used for each image item.")]
+        [Category(@"Visuals")]
+        [Description(@"Button style used for each image item.")]
         [DefaultValue(typeof(ButtonStyle), "LowProfile")]
         public ButtonStyle ButtonStyle
         {
@@ -221,8 +221,8 @@ namespace Krypton.Toolkit
         /// Gets access to the collection of images for display and selection.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("Collection of images for display and selection.")]
+        [Category(@"Behavior")]
+        [Description(@"Collection of images for display and selection.")]
         [DefaultValue(null)]
         public ImageList ImageList
         {
@@ -242,8 +242,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the index of first image in the ImageList for display.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("Index of first image in the ImageList for display.")]
+        [Category(@"Behavior")]
+        [Description(@"Index of first image in the ImageList for display.")]
         [DefaultValue(-1)]
         public int ImageIndexStart
         {
@@ -263,8 +263,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the index of last image in the ImageList for display.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("Index of last image in the ImageList for display.")]
+        [Category(@"Behavior")]
+        [Description(@"Index of last image in the ImageList for display.")]
         [DefaultValue(-1)]
         public int ImageIndexEnd
         {
@@ -284,8 +284,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the number of items to place on each display line.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("Number of items to place on each display line.")]
+        [Category(@"Behavior")]
+        [Description(@"Number of items to place on each display line.")]
         [DefaultValue(5)]
         public int LineItems
         {

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuItem.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuItem.cs
@@ -18,11 +18,11 @@ namespace Krypton.Toolkit
     /// </summary>
     [ToolboxItem(false)]
     [ToolboxBitmap(typeof(KryptonContextMenuItem), "ToolboxBitmaps.KryptonContextMenuItem.bmp")]
-    [Designer("Krypton.Toolkit.KryptonContextMenuItemDesigner, Krypton.Toolkit")]
-    [DesignerCategory("code")]
+    [Designer(@"Krypton.Toolkit.KryptonContextMenuItemDesigner, Krypton.Toolkit")]
+    [DesignerCategory(@"code")]
     [DesignTimeVisible(false)]
-    [DefaultProperty("Text")]
-    [DefaultEvent("Click")]
+    [DefaultProperty(@"Text")]
+    [DefaultEvent(@"Click")]
     public class KryptonContextMenuItem : KryptonContextMenuItemBase
     {
         #region Instance Fields
@@ -47,22 +47,22 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Occurs when the menu item is clicked.
         /// </summary>
-        [Category("Action")]
-        [Description("Occurs when the menu item is clicked.")]
+        [Category(@"Action")]
+        [Description(@"Occurs when the menu item is clicked.")]
         public event EventHandler Click;
 
         /// <summary>
         /// Occurs when the menu item is clicked.
         /// </summary>
-        [Category("Property Changed")]
-        [Description("Occurs when the checked property changes.")]
+        [Category(@"Property Changed")]
+        [Description(@"Occurs when the checked property changes.")]
         public event EventHandler CheckedChanged;
 
         /// <summary>
         /// Occurs when the menu item is clicked.
         /// </summary>
-        [Category("Property Changed")]
-        [Description("Occurs when the check state property changes.")]
+        [Category(@"Property Changed")]
+        [Description(@"Occurs when the check state property changes.")]
         public event EventHandler CheckStateChanged;
         #endregion
 
@@ -71,7 +71,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the KryptonContextMenuItem class.
         /// </summary>
         public KryptonContextMenuItem()
-            : this("Menu Item", null, null, Keys.None)
+            : this(@"Menu Item", null, null, Keys.None)
         {
         }
 
@@ -226,10 +226,10 @@ namespace Krypton.Toolkit
         /// Gets and sets the standard menu item text.
         /// </summary>
         [KryptonPersist]
-        [Category("Appearance")]
-        [Description("Standard menu item text.")]
-        [Editor("System.ComponentModel.Design.MultilineStringEditor", typeof(UITypeEditor))]
-        [DefaultValue("MenuItem")]
+        [Category(@"Appearance")]
+        [Description(@"Standard menu item text.")]
+        [Editor(@"System.ComponentModel.Design.MultilineStringEditor", typeof(UITypeEditor))]
+        [DefaultValue(@"MenuItem")]
         [Localizable(true)]
         [Bindable(true)]
         public string Text
@@ -250,10 +250,10 @@ namespace Krypton.Toolkit
         /// Gets and sets the standard menu item extra text.
         /// </summary>
         [KryptonPersist]
-        [Category("Appearance")]
-        [Description("Standard menu item extra text.")]
-        [Editor("System.ComponentModel.Design.MultilineStringEditor", typeof(UITypeEditor))]
-        [DefaultValue("")]
+        [Category(@"Appearance")]
+        [Description(@"Standard menu item extra text.")]
+        [Editor(@"System.ComponentModel.Design.MultilineStringEditor", typeof(UITypeEditor))]
+        [DefaultValue(@"")]
         [Localizable(true)]
         [Bindable(true)]
         public string ExtraText
@@ -274,8 +274,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the standard menu item image.
         /// </summary>
         [KryptonPersist]
-        [Category("Appearance")]
-        [Description("Standard menu item image.")]
+        [Category(@"Appearance")]
+        [Description(@"Standard menu item image.")]
         [DefaultValue(null)]
         [Localizable(true)]
         [Bindable(true)]
@@ -297,8 +297,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the heading image color to make transparent.
         /// </summary>
         [KryptonPersist]
-        [Category("Appearance")]
-        [Description("Heading image color to make transparent.")]
+        [Category(@"Appearance")]
+        [Description(@"Heading image color to make transparent.")]
         [Localizable(true)]
         [Bindable(true)]
         public Color ImageTransparentColor
@@ -321,8 +321,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the shortcut key combination associated with the menu item.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("The shortcut key combination associated with the menu item.")]
+        [Category(@"Behavior")]
+        [Description(@"The shortcut key combination associated with the menu item.")]
         [DefaultValue(typeof(Keys), "None")]
         [Localizable(true)]
         public Keys ShortcutKeys
@@ -343,8 +343,8 @@ namespace Krypton.Toolkit
         /// Gets and sets if clicking the menu item automatically closes the context menu.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("Indicates if clicking the menu item automatically closes the context menu.")]
+        [Category(@"Behavior")]
+        [Description(@"Indicates if clicking the menu item automatically closes the context menu.")]
         [DefaultValue(true)]
         public bool AutoClose
         {
@@ -364,8 +364,8 @@ namespace Krypton.Toolkit
         /// Gets and sets whether the menu item toggles checked state when clicked.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("Indicates whether the menu item toggles checked state when clicked.")]
+        [Category(@"Behavior")]
+        [Description(@"Indicates whether the menu item toggles checked state when clicked.")]
         [DefaultValue(false)]
         public bool SplitSubMenu
         {
@@ -385,8 +385,8 @@ namespace Krypton.Toolkit
         /// Gets and sets if the shortcut display text is shown.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("Determines if the shortcut display text is shown.")]
+        [Category(@"Behavior")]
+        [Description(@"Determines if the shortcut display text is shown.")]
         [DefaultValue(false)]
         public bool CheckOnClick
         {
@@ -406,8 +406,8 @@ namespace Krypton.Toolkit
         /// Gets and sets if the shortcut display text is shown.
         /// </summary>
         [KryptonPersist]
-        [Category("Appearance")]
-        [Description("Determines if the shortcut display text is shown.")]
+        [Category(@"Appearance")]
+        [Description(@"Determines if the shortcut display text is shown.")]
         [DefaultValue(true)]
         [Localizable(true)]
         public bool ShowShortcutKeys
@@ -428,8 +428,8 @@ namespace Krypton.Toolkit
         /// Gets and sets if the large image is used from the attached KryptonCommand.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("Determines if the large image is used from the attached KryptonCommand.")]
+        [Category(@"Behavior")]
+        [Description(@"Determines if the large image is used from the attached KryptonCommand.")]
         [DefaultValue(false)]
         public bool LargeKryptonCommandImage
         {
@@ -449,9 +449,9 @@ namespace Krypton.Toolkit
         /// Gets and sets the display text to use in preference to the shortcut key setting.
         /// </summary>
         [KryptonPersist]
-        [Category("Appearance")]
-        [Description("Display text to use in preference to the shortcut key setting.")]
-        [DefaultValue("")]
+        [Category(@"Appearance")]
+        [Description(@"Display text to use in preference to the shortcut key setting.")]
+        [DefaultValue(@"")]
         [Localizable(true)]
         public string ShortcutKeyDisplayString
         {
@@ -471,8 +471,8 @@ namespace Krypton.Toolkit
         /// Gets and sets if the menu item is in the checked state.
         /// </summary>
         [KryptonPersist]
-        [Category("Appearance")]
-        [Description("Indicates if the menu item is in the checked state.")]
+        [Category(@"Appearance")]
+        [Description(@"Indicates if the menu item is in the checked state.")]
         [RefreshProperties(RefreshProperties.All)]
         [DefaultValue(false)]
         [Bindable(true)]
@@ -511,8 +511,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the checked state of the menu item.
         /// </summary>
         [KryptonPersist]
-        [Category("Appearance")]
-        [Description("Indicates the checked state of the menu item.")]
+        [Category(@"Appearance")]
+        [Description(@"Indicates the checked state of the menu item.")]
         [RefreshProperties(RefreshProperties.All)]
         [DefaultValue(typeof(CheckState), "Unchecked")]
         [Bindable(true)]
@@ -543,8 +543,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Collection of sub-menu items for display.
         /// </summary>
-        [Category("Data")]
-        [Description("Collection of sub-menu items.")]
+        [Category(@"Data")]
+        [Description(@"Collection of sub-menu items.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         [Editor(@"Krypton.Toolkit.KryptonContextMenuCollectionEditor, Krypton.Toolkit", typeof(UITypeEditor))]
         public KryptonContextMenuCollection Items { get; }
@@ -553,8 +553,8 @@ namespace Krypton.Toolkit
         /// Gets and sets if the menu item is enabled.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("Indicates whether the menu item is enabled.")]
+        [Category(@"Behavior")]
+        [Description(@"Indicates whether the menu item is enabled.")]
         [DefaultValue(true)]
         [Bindable(true)]
         public bool Enabled
@@ -575,8 +575,8 @@ namespace Krypton.Toolkit
         /// Gets access to the menu item disabled appearance values.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Overrides for defining menu item disabled appearance values.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining menu item disabled appearance values.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteContextMenuItemState StateDisabled { get; }
 
@@ -586,8 +586,8 @@ namespace Krypton.Toolkit
         /// Gets access to the menu item normal appearance values.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Overrides for defining menu item normal appearance values.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining menu item normal appearance values.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteContextMenuItemState StateNormal { get; }
 
@@ -597,8 +597,8 @@ namespace Krypton.Toolkit
         /// Gets access to the menu item normal appearance values.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Overrides for defining menu item checked appearance values.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining menu item checked appearance values.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteContextMenuItemStateChecked StateChecked { get; }
 
@@ -608,8 +608,8 @@ namespace Krypton.Toolkit
         /// Gets access to the menu item highlight appearance values.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Overrides for defining menu item highlight appearance values.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining menu item highlight appearance values.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteContextMenuItemStateHighlight StateHighlight { get; }
 
@@ -619,8 +619,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the associated KryptonCommand.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("Command associated with the menu item.")]
+        [Category(@"Behavior")]
+        [Description(@"Command associated with the menu item.")]
         [DefaultValue(null)]
         public virtual KryptonCommand KryptonCommand
         {

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuItemBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuItemBase.cs
@@ -27,8 +27,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Occurs when a property has changed value.
         /// </summary>
-        [Category("Property Changed")]
-        [Description("Occurs when the value of property has changed.")]
+        [Category(@"Property Changed")]
+        [Description(@"Occurs when the value of property has changed.")]
         public event PropertyChangedEventHandler PropertyChanged;
         #endregion
 
@@ -81,8 +81,8 @@ namespace Krypton.Toolkit
         /// Gets and sets user-defined data associated with the object.
         /// </summary>
         [KryptonPersist]
-        [Category("Data")]
-        [Description("User-defined data associated with the object.")]
+        [Category(@"Data")]
+        [Description(@"User-defined data associated with the object.")]
         [TypeConverter(typeof(StringConverter))]
         [DefaultValue(null)]
         [Bindable(true)]
@@ -92,8 +92,8 @@ namespace Krypton.Toolkit
         /// Gets and sets if the item is visible in the context menu.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("Determines if the item is visible in the context menu.")]
+        [Category(@"Behavior")]
+        [Description(@"Determines if the item is visible in the context menu.")]
         [DefaultValue(true)]
         [Bindable(true)]
         public bool Visible

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuItems.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuItems.cs
@@ -18,10 +18,10 @@ namespace Krypton.Toolkit
     /// </summary>
     [ToolboxItem(false)]
     [ToolboxBitmap(typeof(KryptonContextMenuItems), "ToolboxBitmaps.KryptonContextMenuItems.bmp")]
-    [Designer("Krypton.Toolkit.KryptonContextMenuItemsDesigner, Krypton.Toolkit")]
-    [DesignerCategory("code")]
+    [Designer(@"Krypton.Toolkit.KryptonContextMenuItemsDesigner, Krypton.Toolkit")]
+    [DesignerCategory(@"code")]
     [DesignTimeVisible(false)]
-    [DefaultProperty("Items")]
+    [DefaultProperty(@"Items")]
     public class KryptonContextMenuItems : KryptonContextMenuItemBase
     {
         #region Instance Fields
@@ -119,8 +119,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Collection of standard menu items.
         /// </summary>
-        [Category("Data")]
-        [Description("Collection of standard menu items.")]
+        [Category(@"Data")]
+        [Description(@"Collection of standard menu items.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         [Editor(@"Krypton.Toolkit.KryptonContextMenuItemCollectionEditor, Krypton.Toolkit", typeof(UITypeEditor))]
         public KryptonContextMenuItemCollection Items { get; }
@@ -129,8 +129,8 @@ namespace Krypton.Toolkit
         /// Gets and sets if the collection appears as standard or alternate items.
         /// </summary>
         [KryptonPersist]
-        [Category("Appearance")]
-        [Description("Determines if collection appears as standard or alternate items.")]
+        [Category(@"Appearance")]
+        [Description(@"Determines if collection appears as standard or alternate items.")]
         [DefaultValue(true)]
         public bool StandardStyle
         {
@@ -150,8 +150,8 @@ namespace Krypton.Toolkit
         /// Gets and sets if the an image column is provided for background of images.
         /// </summary>
         [KryptonPersist]
-        [Category("Appearance")]
-        [Description("Determines if an image column is provided for background of images.")]
+        [Category(@"Appearance")]
+        [Description(@"Determines if an image column is provided for background of images.")]
         [DefaultValue(true)]
         public bool ImageColumn
         {
@@ -171,8 +171,8 @@ namespace Krypton.Toolkit
         /// Gets access to the image column specific appearance values.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Overrides for defining image column specific appearance values.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining image column specific appearance values.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteDoubleRedirect StateNormal { get; }
 

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuLinkLabel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuLinkLabel.cs
@@ -18,10 +18,10 @@ namespace Krypton.Toolkit
     /// </summary>
     [ToolboxItem(false)]
     [ToolboxBitmap(typeof(KryptonContextMenuLinkLabel), "ToolboxBitmaps.KryptonLinkLabel.bmp")]
-    [DesignerCategory("code")]
+    [DesignerCategory(@"code")]
     [DesignTimeVisible(false)]
-    [DefaultProperty("Text")]
-    [DefaultEvent("Click")]
+    [DefaultProperty(@"Text")]
+    [DefaultEvent(@"Click")]
     public class KryptonContextMenuLinkLabel : KryptonContextMenuItemBase
     {
         #region Instance Fields
@@ -46,8 +46,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Occurs when the link label item is clicked.
         /// </summary>
-        [Category("Action")]
-        [Description("Occurs when the link label item is clicked.")]
+        [Category(@"Action")]
+        [Description(@"Occurs when the link label item is clicked.")]
         public event EventHandler Click;
         #endregion
 
@@ -56,7 +56,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the KryptonContextMenuLinkLabel class.
         /// </summary>
         public KryptonContextMenuLinkLabel()
-            : this("LinkLabel")
+            : this(@"LinkLabel")
         {
         }
 
@@ -149,8 +149,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the link label style.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Link label style.")]
+        [Category(@"Visuals")]
+        [Description(@"Link label style.")]
         [DefaultValue(typeof(LabelStyle), "NormalPanel")]
         public LabelStyle LabelStyle
         {
@@ -171,8 +171,8 @@ namespace Krypton.Toolkit
         /// Gets and sets a value that determines the underline behavior of the link label.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Determines the underline behavior of the link label.")]
+        [Category(@"Visuals")]
+        [Description(@"Determines the underline behavior of the link label.")]
         [DefaultValue(typeof(KryptonLinkBehavior), "Always Underline")]
         public KryptonLinkBehavior LinkBehavior
         {
@@ -192,8 +192,8 @@ namespace Krypton.Toolkit
         /// Gets and sets a value indicating if the label has been visited.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Indicates if the hyperlink has been visited already.")]
+        [Category(@"Visuals")]
+        [Description(@"Indicates if the hyperlink has been visited already.")]
         [DefaultValue(false)]
         public bool LinkVisited
         {
@@ -213,8 +213,8 @@ namespace Krypton.Toolkit
         /// Gets and sets if clicking the link label automatically closes the context menu.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("Indicates if clicking the link label automatically closes the context menu.")]
+        [Category(@"Behavior")]
+        [Description(@"Indicates if clicking the link label automatically closes the context menu.")]
         [DefaultValue(true)]
         public bool AutoClose
         {
@@ -234,9 +234,9 @@ namespace Krypton.Toolkit
         /// Gets and sets the link label text.
         /// </summary>
         [KryptonPersist]
-        [Category("Appearance")]
-        [Description("Main link label text.")]
-        [DefaultValue("LinkLabel")]
+        [Category(@"Appearance")]
+        [Description(@"Main link label text.")]
+        [DefaultValue(@"LinkLabel")]
         [Localizable(true)]
         public string Text
         {
@@ -256,8 +256,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the link label extra text.
         /// </summary>
         [KryptonPersist]
-        [Category("Appearance")]
-        [Description("Link label extra text.")]
+        [Category(@"Appearance")]
+        [Description(@"Link label extra text.")]
         [DefaultValue(null)]
         [Localizable(true)]
         public string ExtraText
@@ -278,8 +278,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the link label image.
         /// </summary>
         [KryptonPersist]
-        [Category("Appearance")]
-        [Description("Link label image.")]
+        [Category(@"Appearance")]
+        [Description(@"Link label image.")]
         [DefaultValue(null)]
         [Localizable(true)]
         public Image Image
@@ -300,8 +300,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the link label image color to make transparent.
         /// </summary>
         [KryptonPersist]
-        [Category("Appearance")]
-        [Description("Link label image color to make transparent.")]
+        [Category(@"Appearance")]
+        [Description(@"Link label image color to make transparent.")]
         [Localizable(true)]
         public Color ImageTransparentColor
         {
@@ -323,8 +323,8 @@ namespace Krypton.Toolkit
         /// Gets access to the link label normal instance specific appearance values.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Overrides for defining link label normal instance specific appearance values.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining link label normal instance specific appearance values.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteContent StateNormal { get; }
 
@@ -334,8 +334,8 @@ namespace Krypton.Toolkit
         /// Gets access to the pressed link label appearance entries.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Overrides for defining pressed link label appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining pressed link label appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteContent OverridePressed { get; }
 
@@ -345,8 +345,8 @@ namespace Krypton.Toolkit
         /// Gets access to the link label appearance when it has focus.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Overrides for defining link label appearance when it has focus.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining link label appearance when it has focus.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteContent OverrideFocus { get; }
 
@@ -356,8 +356,8 @@ namespace Krypton.Toolkit
         /// Gets access to normal state modifications when link label has been visited.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Overrides for modifying normal state when link label has been visited.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for modifying normal state when link label has been visited.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteContent OverrideVisited { get; }
 
@@ -367,8 +367,8 @@ namespace Krypton.Toolkit
         /// Gets access to normal state modifications when link label has not been visited.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Overrides for modifying normal state when link label has not been visited.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for modifying normal state when link label has not been visited.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteContent OverrideNotVisited { get; }
 
@@ -378,8 +378,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the associated KryptonCommand.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("Command associated with the menu check box.")]
+        [Category(@"Behavior")]
+        [Description(@"Command associated with the menu check box.")]
         [DefaultValue(null)]
         public virtual KryptonCommand KryptonCommand
         {

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuMonthCalendar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuMonthCalendar.cs
@@ -18,10 +18,10 @@ namespace Krypton.Toolkit
     /// </summary>
     [ToolboxItem(false)]
     [ToolboxBitmap(typeof(KryptonContextMenuMonthCalendar), "ToolboxBitmaps.KryptonMonthCalendar.bmp")]
-    [DesignerCategory("code")]
+    [DesignerCategory(@"code")]
     [DesignTimeVisible(false)]
-    [DefaultEvent("DateChanged")]
-    [DefaultProperty("SelectionRange")]
+    [DefaultEvent(@"DateChanged")]
+    [DefaultProperty(@"SelectionRange")]
     public class KryptonContextMenuMonthCalendar : KryptonContextMenuItemBase
     {
         #region Static Fields
@@ -74,22 +74,22 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Occurs when the selected date changes.
         /// </summary>
-        [Category("Action")]
-        [Description("Occurs when the selected date changes.")]
+        [Category(@"Action")]
+        [Description(@"Occurs when the selected date changes.")]
         public event DateRangeEventHandler DateChanged;
 
         /// <summary>
         /// Occurs when the selected start date changes.
         /// </summary>
-        [Category("Property Changed")]
-        [Description("Occurs when the selected start date changes.")]
+        [Category(@"Property Changed")]
+        [Description(@"Occurs when the selected start date changes.")]
         public event EventHandler SelectionStartChanged;
 
         /// <summary>
         /// Occurs when the selected end date changes.
         /// </summary>
-        [Category("Property Changed")]
-        [Description("Occurs when the selected end date changes.")]
+        [Category(@"Property Changed")]
+        [Description(@"Occurs when the selected end date changes.")]
         public event EventHandler SelectionEndChanged;
         #endregion
 
@@ -216,8 +216,8 @@ namespace Krypton.Toolkit
         /// Gets and sets if selecting a day automatically closes the context menu.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("Indicates if selecting a day closes the context menu.")]
+        [Category(@"Behavior")]
+        [Description(@"Indicates if selecting a day closes the context menu.")]
         [DefaultValue(true)]
         public bool AutoClose
         {
@@ -237,8 +237,8 @@ namespace Krypton.Toolkit
         /// Gets and sets if clicking the Today button closes the drop down menu.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("Indicates if clicking the Today button closes the drop down menu.")]
+        [Category(@"Behavior")]
+        [Description(@"Indicates if clicking the Today button closes the drop down menu.")]
         [DefaultValue(false)]
         public bool CloseOnTodayClick
         {
@@ -258,8 +258,8 @@ namespace Krypton.Toolkit
         /// Gets and sets if the radio button is enabled.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("Indicates whether the month calendar is enabled.")]
+        [Category(@"Behavior")]
+        [Description(@"Indicates whether the month calendar is enabled.")]
         [DefaultValue(true)]
         [Bindable(true)]
         public bool Enabled
@@ -280,8 +280,8 @@ namespace Krypton.Toolkit
         /// Gets or sets the number of months to scroll when next/prev buttons are used.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("Number of months to scroll when next/prev buttons are used.")]
+        [Category(@"Behavior")]
+        [Description(@"Number of months to scroll when next/prev buttons are used.")]
         [DefaultValue(0)]
         public int ScrollChange
         {
@@ -303,8 +303,8 @@ namespace Krypton.Toolkit
         /// Gets or sets today's date.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("Today's date.")]
+        [Category(@"Behavior")]
+        [Description(@"Today's date.")]
         public DateTime TodayDate
         {
             get => _todayDate;
@@ -333,7 +333,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [KryptonPersist]
         [Localizable(true)]
-        [Description("Indicates which annual dates should be boldface.")]
+        [Description(@"Indicates which annual dates should be boldface.")]
         public DateTime[] AnnuallyBoldedDates
         {
             get => _annualDates.ToArray();
@@ -372,7 +372,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [KryptonPersist]
         [Localizable(true)]
-        [Description("Indicates which monthly dates should be boldface.")]
+        [Description(@"Indicates which monthly dates should be boldface.")]
         public DateTime[] MonthlyBoldedDates
         {
             get => _monthlyDates.ToArray();
@@ -410,7 +410,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [KryptonPersist]
         [Localizable(true)]
-        [Description("Indicates which dates should be boldface.")]
+        [Description(@"Indicates which dates should be boldface.")]
         public DateTime[] BoldedDates
         {
             get => BoldedDatesList.ToArray();
@@ -439,8 +439,8 @@ namespace Krypton.Toolkit
         /// Gets or sets the minimum allowable date.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("Minimum allowable date.")]
+        [Category(@"Behavior")]
+        [Description(@"Minimum allowable date.")]
         [RefreshProperties(RefreshProperties.All)]
         public DateTime MinDate
         {
@@ -478,8 +478,8 @@ namespace Krypton.Toolkit
         /// Gets or sets the maximum allowable date.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("Maximum allowable date.")]
+        [Category(@"Behavior")]
+        [Description(@"Maximum allowable date.")]
         [RefreshProperties(RefreshProperties.All)]
         public DateTime MaxDate
         {
@@ -517,8 +517,8 @@ namespace Krypton.Toolkit
         /// Gets or sets the maximum number of days that can be selected in a month calendar control.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("Maximum number of days that can be selected.")]
+        [Category(@"Behavior")]
+        [Description(@"Maximum number of days that can be selected.")]
         [RefreshProperties(RefreshProperties.All)]
         [DefaultValue(7)]
         public int MaxSelectionCount
@@ -545,8 +545,8 @@ namespace Krypton.Toolkit
         /// Gets or sets the start date of the selected range of dates.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("Start date of the selected range of dates.")]
+        [Category(@"Behavior")]
+        [Description(@"Start date of the selected range of dates.")]
         [RefreshProperties(RefreshProperties.All)]
         [Browsable(true)]
         public DateTime SelectionStart
@@ -598,8 +598,8 @@ namespace Krypton.Toolkit
         /// Gets or sets the end date of the selected range of dates.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("End date of the selected range of dates.")]
+        [Category(@"Behavior")]
+        [Description(@"End date of the selected range of dates.")]
         [RefreshProperties(RefreshProperties.All)]
         [Bindable(true)]
         public DateTime SelectionEnd
@@ -651,8 +651,8 @@ namespace Krypton.Toolkit
         /// Gets or sets the selected range of dates for a month calendar control.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("Specifies the selected range of dates.")]
+        [Category(@"Behavior")]
+        [Description(@"Specifies the selected range of dates.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [RefreshProperties(RefreshProperties.All)]
         [Bindable(true)]
@@ -673,9 +673,9 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets the today date format string.
         /// </summary>
-        [Category("Behavior")]
-        [Description("The today format string used to format the date displayed in the today button.")]
-        [DefaultValue("d")]
+        [Category(@"Behavior")]
+        [Description(@"The today format string used to format the date displayed in the today button.")]
+        [DefaultValue(@"d")]
         [RefreshProperties(RefreshProperties.Repaint)]
         [Localizable(true)]
         public string TodayFormat
@@ -696,9 +696,9 @@ namespace Krypton.Toolkit
         /// Gets or sets the label text for todays text. 
         /// </summary>
         [KryptonPersist]
-        [Category("Appearance")]
-        [Description("Text used as label for todays date.")]
-        [DefaultValue("Today:")]
+        [Category(@"Appearance")]
+        [Description(@"Text used as label for todays date.")]
+        [DefaultValue(@"Today:")]
         [Localizable(true)]
         public string TodayText
         {
@@ -725,8 +725,8 @@ namespace Krypton.Toolkit
         /// Gets or sets the number of columns and rows of months displayed. 
         /// </summary>
         [KryptonPersist]
-        [Category("Appearance")]
-        [Description("Specifies the number of rows and columns of months displayed.")]
+        [Category(@"Appearance")]
+        [Description(@"Specifies the number of rows and columns of months displayed.")]
         [DefaultValue(typeof(Size), "1,1")]
         [Localizable(true)]
         public Size CalendarDimensions
@@ -757,8 +757,8 @@ namespace Krypton.Toolkit
         /// First day of the week.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("First day of the week.")]
+        [Category(@"Behavior")]
+        [Description(@"First day of the week.")]
         [Localizable(true)]
         public Day FirstDayOfWeek
         {
@@ -785,8 +785,8 @@ namespace Krypton.Toolkit
         /// Gets and sets if the control will display todays date.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("Indicates whether this month calendar will display todays date.")]
+        [Category(@"Behavior")]
+        [Description(@"Indicates whether this month calendar will display todays date.")]
         [DefaultValue(true)]
         public bool ShowToday
         {
@@ -806,8 +806,8 @@ namespace Krypton.Toolkit
         /// Gets and sets if the control will circle the today date.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("Indicates whether this month calendar will circle the today date.")]
+        [Category(@"Behavior")]
+        [Description(@"Indicates whether this month calendar will circle the today date.")]
         [DefaultValue(true)]
         public bool ShowTodayCircle
         {
@@ -827,8 +827,8 @@ namespace Krypton.Toolkit
         /// Gets and sets if week numbers to the left of each row.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("Indicates whether this month calendar will display week numbers to the left of each row.")]
+        [Category(@"Behavior")]
+        [Description(@"Indicates whether this month calendar will display week numbers to the left of each row.")]
         [DefaultValue(false)]
         public bool ShowWeekNumbers
         {
@@ -848,8 +848,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the header style for the month calendar.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Header style for the month calendar.")]
+        [Category(@"Visuals")]
+        [Description(@"Header style for the month calendar.")]
         [DefaultValue(typeof(HeaderStyle), "Calendar")]
         public HeaderStyle HeaderStyle
         {
@@ -872,8 +872,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the content style for the day entries.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Content style for the day entries.")]
+        [Category(@"Visuals")]
+        [Description(@"Content style for the day entries.")]
         [DefaultValue(typeof(ButtonStyle), "Calendar Day")]
         public ButtonStyle DayStyle
         {
@@ -904,8 +904,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the content style for the day of week labels.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Content style for the day of week labels.")]
+        [Category(@"Visuals")]
+        [Description(@"Content style for the day of week labels.")]
         [DefaultValue(typeof(ButtonStyle), "CalendarDay")]
         public ButtonStyle DayOfWeekStyle
         {
@@ -933,8 +933,8 @@ namespace Krypton.Toolkit
         /// Gets access to the day appearance when it has focus.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Overrides for defining month calendar appearance when it has focus.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining month calendar appearance when it has focus.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteMonthCalendarStateRedirect OverrideFocus { get; }
 
@@ -944,8 +944,8 @@ namespace Krypton.Toolkit
         /// Gets access to the day appearance when it is bolded.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Overrides for defining month calendar appearance when it is bolded.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining month calendar appearance when it is bolded.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteMonthCalendarStateRedirect OverrideBolded { get; }
 
@@ -955,8 +955,8 @@ namespace Krypton.Toolkit
         /// Gets access to the day appearance when it is todays.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Overrides for defining month calendar appearance when it is today.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining month calendar appearance when it is today.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteMonthCalendarStateRedirect OverrideToday { get; }
 
@@ -966,8 +966,8 @@ namespace Krypton.Toolkit
         /// Gets access to the common month calendar appearance that other states can override.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Overrides for defining common month calendar appearance that other states can override.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining common month calendar appearance that other states can override.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteMonthCalendarRedirect StateCommon { get; }
 
@@ -977,8 +977,8 @@ namespace Krypton.Toolkit
         /// Gets access to the month calendar disabled appearance entries.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Overrides for defining month calendar disabled appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining month calendar disabled appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteMonthCalendarDoubleState StateDisabled { get; }
 
@@ -988,8 +988,8 @@ namespace Krypton.Toolkit
         /// Gets access to the month calendar normal appearance entries.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Overrides for defining month calendar normal appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining month calendar normal appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteMonthCalendarDoubleState StateNormal { get; }
 
@@ -999,8 +999,8 @@ namespace Krypton.Toolkit
         /// Gets access to the tracking month calendar appearance entries.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Overrides for defining tracking month calendar appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining tracking month calendar appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteMonthCalendarState StateTracking { get; }
 
@@ -1010,8 +1010,8 @@ namespace Krypton.Toolkit
         /// Gets access to the pressed month calendar appearance entries.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Overrides for defining pressed month calendar appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining pressed month calendar appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteMonthCalendarState StatePressed { get; }
 
@@ -1021,8 +1021,8 @@ namespace Krypton.Toolkit
         /// Gets access to the checked normal month calendar appearance entries.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Overrides for defining checked normal month calendar appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining checked normal month calendar appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteMonthCalendarState StateCheckedNormal { get; }
 
@@ -1032,8 +1032,8 @@ namespace Krypton.Toolkit
         /// Gets access to the checked tracking month calendar appearance entries.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Overrides for defining checked tracking month calendar appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining checked tracking month calendar appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteMonthCalendarState StateCheckedTracking { get; }
 
@@ -1043,8 +1043,8 @@ namespace Krypton.Toolkit
         /// Gets access to the checked pressed month calendar appearance entries.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Overrides for defining checked pressed month calendar appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining checked pressed month calendar appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteMonthCalendarState StateCheckedPressed { get; }
 
@@ -1204,22 +1204,22 @@ namespace Krypton.Toolkit
         {
             if (start.Ticks > _maxDate.Ticks)
             {
-                throw new ArgumentOutOfRangeException("Start date provided is greater than the maximum date.");
+                throw new ArgumentOutOfRangeException(@"Start date provided is greater than the maximum date.");
             }
 
             if (start.Ticks < _minDate.Ticks)
             {
-                throw new ArgumentOutOfRangeException("Start date provided is less than the minimum date.");
+                throw new ArgumentOutOfRangeException(@"Start date provided is less than the minimum date.");
             }
 
             if (end.Ticks > _maxDate.Ticks)
             {
-                throw new ArgumentOutOfRangeException("End date provided is greater than the maximum date.");
+                throw new ArgumentOutOfRangeException(@"End date provided is greater than the maximum date.");
             }
 
             if (end.Ticks < _minDate.Ticks)
             {
-                throw new ArgumentOutOfRangeException("End date provided is less than the minimum date.");
+                throw new ArgumentOutOfRangeException(@"End date provided is less than the minimum date.");
             }
 
             if (start > end)

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuRadioButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuRadioButton.cs
@@ -18,10 +18,10 @@ namespace Krypton.Toolkit
     /// </summary>
     [ToolboxItem(false)]
     [ToolboxBitmap(typeof(KryptonContextMenuRadioButton), "ToolboxBitmaps.KryptonRadioButton.bmp")]
-    [DesignerCategory("code")]
+    [DesignerCategory(@"code")]
     [DesignTimeVisible(false)]
-    [DefaultProperty("Text")]
-    [DefaultEvent("CheckedChanged")]
+    [DefaultProperty(@"Text")]
+    [DefaultEvent(@"CheckedChanged")]
     public class KryptonContextMenuRadioButton : KryptonContextMenuItemBase
     {
         #region Instance Fields
@@ -41,15 +41,15 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Occurs when the radio button is clicked.
         /// </summary>
-        [Category("Action")]
-        [Description("Occurs when the radio button is clicked.")]
+        [Category(@"Action")]
+        [Description(@"Occurs when the radio button is clicked.")]
         public event EventHandler Click;
 
         /// <summary>
         /// Occurs when the value of the Checked property has changed.
         /// </summary>
-        [Category("Misc")]
-        [Description("Occurs whenever the Checked property has changed.")]
+        [Category(@"Misc")]
+        [Description(@"Occurs whenever the Checked property has changed.")]
         public event EventHandler CheckedChanged;
         #endregion
 
@@ -58,7 +58,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the KryptonContextMenuRadioButton class.
         /// </summary>
         public KryptonContextMenuRadioButton()
-            : this("RadioButton")
+            : this(@"RadioButton")
         {
         }
 
@@ -145,8 +145,8 @@ namespace Krypton.Toolkit
         /// Gets and sets if clicking the radio button automatically closes the context menu.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("Indicates if clicking the cradio button automatically closes the context menu.")]
+        [Category(@"Behavior")]
+        [Description(@"Indicates if clicking the cradio button automatically closes the context menu.")]
         [DefaultValue(false)]
         public bool AutoClose
         {
@@ -166,9 +166,9 @@ namespace Krypton.Toolkit
         /// Gets and sets the radio button text.
         /// </summary>
         [KryptonPersist]
-        [Category("Appearance")]
-        [Description("Main radio button text.")]
-        [DefaultValue("RadioButton")]
+        [Category(@"Appearance")]
+        [Description(@"Main radio button text.")]
+        [DefaultValue(@"RadioButton")]
         [Localizable(true)]
         public string Text
         {
@@ -188,8 +188,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the radio button extra text.
         /// </summary>
         [KryptonPersist]
-        [Category("Appearance")]
-        [Description("Radio button extra text.")]
+        [Category(@"Appearance")]
+        [Description(@"Radio button extra text.")]
         [DefaultValue(null)]
         [Localizable(true)]
         public string ExtraText
@@ -210,8 +210,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the radio button image.
         /// </summary>
         [KryptonPersist]
-        [Category("Appearance")]
-        [Description("Radio button image.")]
+        [Category(@"Appearance")]
+        [Description(@"Radio button image.")]
         [DefaultValue(null)]
         [Localizable(true)]
         public Image Image
@@ -232,8 +232,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the radio button image color to make transparent.
         /// </summary>
         [KryptonPersist]
-        [Category("Appearance")]
-        [Description("Radio button image color to make transparent.")]
+        [Category(@"Appearance")]
+        [Description(@"Radio button image color to make transparent.")]
         [Localizable(true)]
         public Color ImageTransparentColor
         {
@@ -255,8 +255,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the radio button label style.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Radio button label style.")]
+        [Category(@"Visuals")]
+        [Description(@"Radio button label style.")]
         [DefaultValue(typeof(LabelStyle), "NormalPanel")]
         public LabelStyle LabelStyle
         {
@@ -277,8 +277,8 @@ namespace Krypton.Toolkit
         /// Gets access to the image value overrides.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Image value overrides.")]
+        [Category(@"Visuals")]
+        [Description(@"Image value overrides.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public RadioButtonImages Images { get; }
 
@@ -288,8 +288,8 @@ namespace Krypton.Toolkit
         /// Gets and sets if the radio button is enabled.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("Indicates whether the radio button is enabled.")]
+        [Category(@"Behavior")]
+        [Description(@"Indicates whether the radio button is enabled.")]
         [DefaultValue(true)]
         [Bindable(true)]
         public bool Enabled
@@ -310,8 +310,8 @@ namespace Krypton.Toolkit
         /// Gets or sets a value indicating if the component is in the checked state.
         /// </summary>
         [KryptonPersist]
-        [Category("Appearance")]
-        [Description("Indicates if the component is in the checked state.")]
+        [Category(@"Appearance")]
+        [Description(@"Indicates if the component is in the checked state.")]
         [DefaultValue(false)]
         [Bindable(true)]
         public bool Checked
@@ -333,8 +333,8 @@ namespace Krypton.Toolkit
         /// Gets or sets a value indicating if the radio button is automatically changed state when clicked. 
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("Causes the radio button to automatically change state when clicked.")]
+        [Category(@"Behavior")]
+        [Description(@"Causes the radio button to automatically change state when clicked.")]
         [DefaultValue(true)]
         public bool AutoCheck
         {
@@ -354,8 +354,8 @@ namespace Krypton.Toolkit
         /// Gets access to the common radio button appearance that other states can override.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Overrides for defining common radio button appearance that other states can override.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining common radio button appearance that other states can override.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteContent StateCommon { get; }
 
@@ -365,8 +365,8 @@ namespace Krypton.Toolkit
         /// Gets access to the disabled radio button appearance entries.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Overrides for defining disabled radio button appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining disabled radio button appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteContent StateDisabled { get; }
 
@@ -376,8 +376,8 @@ namespace Krypton.Toolkit
         /// Gets access to the normal radio button appearance entries.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Overrides for defining normal radio button appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining normal radio button appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteContent StateNormal { get; }
 
@@ -387,8 +387,8 @@ namespace Krypton.Toolkit
         /// Gets access to the radio button appearance when it has focus.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Overrides for defining radio button appearance when it has focus.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining radio button appearance when it has focus.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteContent OverrideFocus { get; }
 

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuSeparator.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuSeparator.cs
@@ -18,9 +18,9 @@ namespace Krypton.Toolkit
     /// </summary>
     [ToolboxItem(false)]
     [ToolboxBitmap(typeof(KryptonContextMenuSeparator), "ToolboxBitmaps.KryptonContextMenuSeparator.bmp")]
-    [DesignerCategory("code")]
+    [DesignerCategory(@"code")]
     [DesignTimeVisible(false)]
-    [DefaultProperty("Horizontal")]
+    [DefaultProperty(@"Horizontal")]
     public class KryptonContextMenuSeparator : KryptonContextMenuItemBase
     {
         #region Instance Fields
@@ -129,8 +129,8 @@ namespace Krypton.Toolkit
         /// Gets and sets if the separator is a horizontal or vertical break.
         /// </summary>
         [KryptonPersist]
-        [Category("Behavior")]
-        [Description("Is this a horizontal or vertical break in the menu.")]
+        [Category(@"Behavior")]
+        [Description(@"Is this a horizontal or vertical break in the menu.")]
         [DefaultValue(true)]
         public bool Horizontal
         {
@@ -150,8 +150,8 @@ namespace Krypton.Toolkit
         /// Gets access to the separator instance specific appearance values.
         /// </summary>
         [KryptonPersist]
-        [Category("Visuals")]
-        [Description("Overrides for defining separator instance specific appearance values.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining separator instance specific appearance values.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteDoubleRedirect StateNormal { get; }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/ButtonController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/ButtonController.cs
@@ -388,8 +388,7 @@ namespace Krypton.Toolkit
                             }
 
                             // Only if the button is still pressed, do we generate a click
-                            if ((Target.ElementState == PaletteState.Pressed) ||
-                                (Target.ElementState == (PaletteState.Pressed | PaletteState.Checked)))
+                            if (Target.ElementState is PaletteState.Pressed or (PaletteState.Pressed | PaletteState.Checked))
                             {
                                 if (!_fixedPressed)
                                 {
@@ -566,7 +565,7 @@ namespace Krypton.Toolkit
             }
 
             // If the user pressed the escape key
-            if ((e.KeyCode == Keys.Escape) || (e.KeyCode == Keys.Space))
+            if (e.KeyCode is Keys.Escape or Keys.Space)
             {
                 // If we are capturing mouse input
                 if (Captured)

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/CheckBoxController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/CheckBoxController.cs
@@ -272,7 +272,7 @@ namespace Krypton.Toolkit
             }
 
             // If the user pressed the escape key
-            if ((e.KeyCode == Keys.Escape) || (e.KeyCode == Keys.Space))
+            if (e.KeyCode is Keys.Escape or Keys.Space)
             {
                 // If we are capturing mouse input
                 if (_captured)

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/RadioButtonController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/RadioButtonController.cs
@@ -269,7 +269,7 @@ namespace Krypton.Toolkit
             }
 
             // If the user pressed the escape key
-            if ((e.KeyCode == Keys.Escape) || (e.KeyCode == Keys.Space))
+            if (e.KeyCode is Keys.Escape or Keys.Space)
             {
                 // If we are capturing mouse input
                 if (_captured)

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/SeparatorController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/SeparatorController.cs
@@ -698,7 +698,7 @@ namespace Krypton.Toolkit
             }
 
             // We allow all non-keyboard messages
-            if ((m.Msg < 0x100) || (m.Msg > 0x108))
+            if (m.Msg is < 0x100 or > 0x108)
             {
                 return false;
             }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonBorderEdge.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonBorderEdge.cs
@@ -18,11 +18,11 @@ namespace Krypton.Toolkit
     /// </summary>
     [ToolboxItem(true)]
     [ToolboxBitmap(typeof(KryptonBorderEdge), "ToolboxBitmaps.KryptonBorderEdge.bmp")]
-    [DefaultEvent("Paint")]
-    [DefaultProperty("Orientation")]
-    [Designer("Krypton.Toolkit.KryptonBorderEdgeDesigner, Krypton.Toolkit")]
-    [DesignerCategory("code")]
-    [Description("Displays a vertical or horizontal border edge.")]
+    [DefaultEvent(@"Paint")]
+    [DefaultProperty(@"Orientation")]
+    [Designer(@"Krypton.Toolkit.KryptonBorderEdgeDesigner, Krypton.Toolkit")]
+    [DesignerCategory(@"code")]
+    [Description(@"Displays a vertical or horizontal border edge.")]
     public class KryptonBorderEdge : VisualControlBase
     {
         #region Instance Fields
@@ -154,8 +154,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the auto size mode.
         /// </summary>
-        [Category("Layout")]
-        [Description("Specifies if the control grows and shrinks to fit the contents exactly.")]
+        [Category(@"Layout")]
+        [Description(@"Specifies if the control grows and shrinks to fit the contents exactly.")]
         [DefaultValue(typeof(AutoSizeMode), "GrowAndShrink")]
         public AutoSizeMode AutoSizeMode
         {
@@ -184,8 +184,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the border style.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Border style.")]
+        [Category(@"Visuals")]
+        [Description(@"Border style.")]
         public PaletteBorderStyle BorderStyle
         {
             get => _borderRedirect.Style;
@@ -210,8 +210,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the orientation of the border edge used to determine sizing.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Orientation of border edge used to determine sizing.")]
+        [Category(@"Visuals")]
+        [Description(@"Orientation of border edge used to determine sizing.")]
         [DefaultValue(typeof(Orientation), "Horizontal")]
         public virtual Orientation Orientation
         {
@@ -230,8 +230,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the common border edge appearance that other states can override.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining common border edge appearance that other states can override.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining common border edge appearance that other states can override.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteBorderEdgeRedirect StateCommon { get; }
 
@@ -240,8 +240,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the disabled border edge appearance.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining disabled border edge appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining disabled border edge appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteBorderEdge StateDisabled { get; }
 
@@ -250,8 +250,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the normal border edge appearance.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining normal border edge appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining normal border edge appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteBorderEdge StateNormal { get; }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonBreadCrumb.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonBreadCrumb.cs
@@ -195,7 +195,8 @@ namespace Krypton.Toolkit
         /// Gets a value indicating if the control is initialized.
         /// </summary>
         [Browsable(false)]
-        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool IsInitialized
         {
             [DebuggerStepThrough]
@@ -207,7 +208,8 @@ namespace Krypton.Toolkit
         /// Gets a value indicating if the control is initialized.
         /// </summary>
         [Browsable(false)]
-        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool IsInitializing
         {
             [DebuggerStepThrough]

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonBreadCrumbItem.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonBreadCrumbItem.cs
@@ -46,7 +46,7 @@ namespace Krypton.Toolkit
             /// <summary>
             /// Gets the item with the provided unique name.
             /// </summary>
-            /// <param name="name">Name of the ribbon tab instance.</param>
+            /// <param name=(@"Name")>Name of the ribbon tab instance.</param>
             /// <returns>Item at specified index.</returns>
             public override KryptonBreadCrumbItem this[string name]
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonButton.cs
@@ -19,11 +19,11 @@ namespace Krypton.Toolkit
     /// </summary>
     [ToolboxItem(true)]
     [ToolboxBitmap(typeof(KryptonButton), "ToolboxBitmaps.KryptonButton.bmp")]
-    [DefaultEvent("Click")]
-    [DefaultProperty("Text")]
-    [DesignerCategory("code")]
-    [Description("Raises an event when the user clicks it.")]
-    [Designer("Krypton.Toolkit.KryptonButtonDesigner, Krypton.Toolkit")]
+    [DefaultEvent(@"Click")]
+    [DefaultProperty(@"Text")]
+    [DesignerCategory(@"code")]
+    [Description(@"Raises an event when the user clicks it.")]
+    [Designer(@"Krypton.Toolkit.KryptonButtonDesigner, Krypton.Toolkit")]
 
     public class KryptonButton : VisualSimpleBase, IButtonControl, IContentValues
     {
@@ -44,8 +44,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Occurs when the value of the KryptonCommand property changes.
         /// </summary>
-        [Category("Property Changed")]
-        [Description("Occurs when the value of the KryptonCommand property changes.")]
+        [Category(@"Property Changed")]
+        [Description(@"Occurs when the value of the KryptonCommand property changes.")]
         public event EventHandler KryptonCommandChanged;
         #endregion
 
@@ -152,7 +152,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets the text associated with this control. 
         /// </summary>
-        [Editor("System.ComponentModel.Design.MultilineStringEditor", typeof(UITypeEditor))]
+        [Editor(@"System.ComponentModel.Design.MultilineStringEditor", typeof(UITypeEditor))]
         public override string Text
         {
             get => Values.Text;
@@ -174,8 +174,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the visual orientation of the control.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Visual orientation of the control.")]
+        [Category(@"Visuals")]
+        [Description(@"Visual orientation of the control.")]
         [DefaultValue(typeof(VisualOrientation), "Top")]
         public virtual VisualOrientation Orientation
         {
@@ -198,8 +198,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the button style.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Button style.")]
+        [Category(@"Visuals")]
+        [Description(@"Button style.")]
         public ButtonStyle ButtonStyle
         {
             get => _style;
@@ -223,7 +223,7 @@ namespace Krypton.Toolkit
         }
 
         [DefaultValue(false), 
-         Description("If set to true, the text will pair up with the equivalent KryptonManager's dialog button text result. (Note: You'll lose any previous text)")]
+         Description(@"If set to true, the text will pair up with the equivalent KryptonManager's dialog button text result. (Note: You'll lose any previous text)")]
         public bool UseAsADialogButton 
         { 
             get => _useAsDialogButton; 
@@ -231,7 +231,7 @@ namespace Krypton.Toolkit
         }
 
         [DefaultValue(false), 
-         Description("Transforms the button into a UAC elevated button.")]
+         Description(@"Transforms the button into a UAC elevated button.")]
         public bool UseAsUACElevationButton 
         { 
             get => _useAsUACElevationButton; 
@@ -245,8 +245,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the button content.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Button values")]
+        [Category(@"Visuals")]
+        [Description(@"Button values")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public ButtonValues Values { get; }
 
@@ -255,8 +255,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the common button appearance that other states can override.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining common button appearance that other states can override.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining common button appearance that other states can override.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteTripleRedirect StateCommon { get; }
 
@@ -265,8 +265,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the disabled button appearance entries.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining disabled button appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining disabled button appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteTriple StateDisabled { get; }
 
@@ -275,8 +275,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the normal button appearance entries.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining normal button appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining normal button appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteTriple StateNormal { get; }
 
@@ -285,8 +285,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the hot tracking button appearance entries.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining hot tracking button appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining hot tracking button appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteTriple StateTracking { get; }
 
@@ -295,8 +295,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the pressed button appearance entries.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining pressed button appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining pressed button appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteTriple StatePressed { get; }
 
@@ -305,8 +305,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the normal button appearance when default.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining normal button appearance when default.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining normal button appearance when default.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteTripleRedirect OverrideDefault { get; }
 
@@ -315,8 +315,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the button appearance when it has focus.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining button appearance when it has focus.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining button appearance when it has focus.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteTripleRedirect OverrideFocus { get; }
 
@@ -325,16 +325,16 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets the value returned to the parent form when the button is clicked.
         /// </summary>
-        [Category("Behavior")]
-        [Description("The dialog-box result produced in a modal form by clicking the button.")]
+        [Category(@"Behavior")]
+        [Description(@"The dialog-box result produced in a modal form by clicking the button.")]
         [DefaultValue(typeof(DialogResult), "None")]
         public DialogResult DialogResult { get; set; }
 
         /// <summary>
         /// Gets and sets the associated KryptonCommand.
         /// </summary>
-        [Category("Behavior")]
-        [Description("Command associated with the button.")]
+        [Category(@"Behavior")]
+        [Description(@"Command associated with the button.")]
         [DefaultValue(null)]
         public virtual IKryptonCommand KryptonCommand
         {
@@ -403,8 +403,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets a value indicating whether an ampersand is included in the text of the control. 
         /// </summary>
-        [Category("Appearance")]
-        [Description("When true the first character after an ampersand will be used as a mnemonic.")]
+        [Category(@"Appearance")]
+        [Description(@"When true the first character after an ampersand will be used as a mnemonic.")]
         [DefaultValue(true)]
         public bool UseMnemonic
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckButton.cs
@@ -18,11 +18,11 @@ namespace Krypton.Toolkit
     /// </summary>
     [ToolboxItem(true)]
     [ToolboxBitmap(typeof(KryptonCheckButton), "ToolboxBitmaps.KryptonCheckButton.bmp")]
-    [DefaultEvent("Click")]
-    [DefaultProperty("Text")]
-    [Designer("Krypton.Toolkit.KryptonCheckButtonDesigner, Krypton.Toolkit")]
-    [DesignerCategory("code")]
-    [Description("Toggles checked state when user clicks button.")]
+    [DefaultEvent(@"Click")]
+    [DefaultProperty(@"Text")]
+    [Designer(@"Krypton.Toolkit.KryptonCheckButtonDesigner, Krypton.Toolkit")]
+    [DesignerCategory(@"code")]
+    [Description(@"Toggles checked state when user clicks button.")]
     public class KryptonCheckButton : KryptonButton
     {
         #region Instance Fields
@@ -39,15 +39,15 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Occurs when the value of the Checked property is about to change.
         /// </summary>
-        [Category("Property Changing")]
-        [Description("Occurs whenever the Checked property is about to change.")]
+        [Category(@"Property Changing")]
+        [Description(@"Occurs whenever the Checked property is about to change.")]
         public event CancelEventHandler CheckedChanging;
 
         /// <summary>
         /// Occurs when the value of the Checked property has changed.
         /// </summary>
-        [Category("Property Changed")]
-        [Description("Occurs whenever the Checked property has changed.")]
+        [Category(@"Property Changed")]
+        [Description(@"Occurs whenever the Checked property has changed.")]
         public event EventHandler CheckedChanged;
         #endregion
 
@@ -79,8 +79,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the normal checked button appearance entries.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining normal checked button appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining normal checked button appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteTriple StateCheckedNormal { get; }
 
@@ -89,8 +89,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the hot tracking checked button appearance entries.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining hot tracking checked button appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining hot tracking checked button appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteTriple StateCheckedTracking { get; }
 
@@ -99,8 +99,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the pressed checked button appearance entries.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining pressed checked button appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining pressed checked button appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteTriple StateCheckedPressed { get; }
 
@@ -109,8 +109,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets a value indicating whether the KryptonCheckButton is in the checked state. 
         /// </summary>
-        [Category("Appearance")]
-        [Description("Indicates whether the control is in the checked state.")]
+        [Category(@"Appearance")]
+        [Description(@"Indicates whether the control is in the checked state.")]
         [DefaultValue(false)]
         [Bindable(true)]
         public bool Checked
@@ -144,8 +144,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets a value indicating whether the user can uncheck the button when in the checked state.
         /// </summary>
-        [Category("Behavior")]
-        [Description("Indicates whether the user can uncheck the button when in the checked state.")]
+        [Category(@"Behavior")]
+        [Description(@"Indicates whether the user can uncheck the button when in the checked state.")]
         [DefaultValue(true)]
         public bool AllowUncheck
         {
@@ -156,8 +156,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the associated KryptonCommand.
         /// </summary>
-        [Category("Behavior")]
-        [Description("Command associated with the check button.")]
+        [Category(@"Behavior")]
+        [Description(@"Command associated with the check button.")]
         [DefaultValue(null)]
         public override IKryptonCommand KryptonCommand
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckSet.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckSet.cs
@@ -18,11 +18,11 @@ namespace Krypton.Toolkit
     /// </summary>
     [ToolboxItem(true)]
     [ToolboxBitmap(typeof(KryptonCheckSet), "ToolboxBitmaps.KryptonCheckSet.bmp")]
-    [DefaultEvent("CheckedButtonChanged")]
-    [DefaultProperty("CheckButtons")]
-    [DesignerCategory("code")]
-    [Designer("Krypton.Toolkit.KryptonCheckSetDesigner, Krypton.Toolkit")]
-    [Description("Provide exclusive checked logic for a set of KryptonCheckButton controls.")]
+    [DefaultEvent(@"CheckedButtonChanged")]
+    [DefaultProperty(@"CheckButtons")]
+    [DesignerCategory(@"code")]
+    [Designer(@"Krypton.Toolkit.KryptonCheckSetDesigner, Krypton.Toolkit")]
+    [Description(@"Provide exclusive checked logic for a set of KryptonCheckButton controls.")]
     public class KryptonCheckSet : Component,
                                    ISupportInitialize
     {
@@ -67,7 +67,7 @@ namespace Krypton.Toolkit
 
                 if (Contains(checkButton))
                 {
-                    throw new ArgumentException("Reference already exists in the collection");
+                    throw new ArgumentException(@"Reference already exists in the collection");
                 }
 
                 // ReSharper disable RedundantBaseQualifier
@@ -120,7 +120,7 @@ namespace Krypton.Toolkit
 
                 if (Contains(checkButton))
                 {
-                    throw new ArgumentException("Reference already in collection");
+                    throw new ArgumentException(@"Reference already in collection");
                 }
 
                 // ReSharper disable RedundantBaseQualifier
@@ -145,7 +145,7 @@ namespace Krypton.Toolkit
 
                 if (!Contains(checkButton))
                 {
-                    throw new ArgumentException("No matching reference to remove");
+                    throw new ArgumentException(@"No matching reference to remove");
                 }
 
                 // ReSharper disable RedundantBaseQualifier
@@ -240,8 +240,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Occurs when the value of the CheckedButton property has changed.
         /// </summary>
-        [Category("Property Changed")]
-        [Description("Occurs whenever the CheckedButton property has changed.")]
+        [Category(@"Property Changed")]
+        [Description(@"Occurs whenever the CheckedButton property has changed.")]
         public event EventHandler CheckedButtonChanged;
         #endregion
 
@@ -310,8 +310,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets a value indicating if the checked button is allowed to be unchecked.
         /// </summary>
-        [Category("Behavior")]
-        [Description("Is the current checked button allowed to be unchecked.")]
+        [Category(@"Behavior")]
+        [Description(@"Is the current checked button allowed to be unchecked.")]
         [DefaultValue(false)]
         public bool AllowUncheck { get; set; }
 
@@ -319,8 +319,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the currently checked button in the set.
         /// </summary>
         [Bindable(true)]
-        [Category("Appearance")]
-        [Description("Determine which of the associated buttons is checked.")]
+        [Category(@"Appearance")]
+        [Description(@"Determine which of the associated buttons is checked.")]
         [RefreshProperties(RefreshProperties.All)]
         [TypeConverter(typeof(KryptonCheckedButtonConverter))]
         [DefaultValue(null)]
@@ -366,8 +366,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the index of the checked button.
         /// </summary>
         [Bindable(true)]
-        [Category("Appearance")]
-        [Description("Determine the index of the checked button.")]
+        [Category(@"Appearance")]
+        [Description(@"Determine the index of the checked button.")]
         [RefreshProperties(RefreshProperties.All)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [DefaultValue(-1)]
@@ -391,8 +391,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the collection of KryptonCheckButton referencs.
         /// </summary>
-        [Category("Behavior")]
-        [Description("Determine which of the associated buttons is checked.")]
+        [Category(@"Behavior")]
+        [Description(@"Determine which of the associated buttons is checked.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         [Editor(@"Krypton.Toolkit.KryptonCheckButtonCollectionEditor, Krypton.Toolkit", typeof(UITypeEditor))]
         [RefreshProperties(RefreshProperties.All)]

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckedListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckedListBox.cs
@@ -18,12 +18,12 @@ namespace Krypton.Toolkit
     /// </summary>
     [ToolboxItem(true)]
     [ToolboxBitmap(typeof(KryptonCheckedListBox), "ToolboxBitmaps.KryptonCheckedListBox.bmp")]
-    [DefaultEvent("SelectedIndexChanged")]
-    [DefaultProperty("Items")]
-    [DefaultBindingProperty("SelectedValue")]
-    [Designer("Krypton.Toolkit.KryptonCheckedListBoxDesigner, Krypton.Toolkit")]
-    [DesignerCategory("code")]
-    [Description("Represents a checked list box control that allows single or multiple item selection.")]
+    [DefaultEvent(@"SelectedIndexChanged")]
+    [DefaultProperty(@"Items")]
+    [DefaultBindingProperty(@"SelectedValue")]
+    [Designer(@"Krypton.Toolkit.KryptonCheckedListBoxDesigner, Krypton.Toolkit")]
+    [DesignerCategory(@"code")]
+    [Description(@"Represents a checked list box control that allows single or multiple item selection.")]
     public class KryptonCheckedListBox : VisualControlBase,
                                          IContainedInputControl
     {
@@ -128,20 +128,20 @@ namespace Krypton.Toolkit
                     return InnerArrayIndexOfIdentifier(entryObject, 0);
                 }
 
-                set => throw new NotSupportedException("Read Only Collection");
+                set => throw new NotSupportedException(@"Read Only Collection");
             }
             #endregion
 
             #region Private
-            int IList.Add(object value) => throw new NotSupportedException("Read Only Collection");
+            int IList.Add(object value) => throw new NotSupportedException(@"Read Only Collection");
 
-            void IList.Clear() => throw new NotSupportedException("Read Only Collection");
+            void IList.Clear() => throw new NotSupportedException(@"Read Only Collection");
 
-            void IList.Insert(int index, object value) => throw new NotSupportedException("Read Only Collection");
+            void IList.Insert(int index, object value) => throw new NotSupportedException(@"Read Only Collection");
 
-            void IList.Remove(object value) => throw new NotSupportedException("Read Only Collection");
+            void IList.Remove(object value) => throw new NotSupportedException(@"Read Only Collection");
 
-            void IList.RemoveAt(int index) => throw new NotSupportedException("Read Only Collection");
+            void IList.RemoveAt(int index) => throw new NotSupportedException(@"Read Only Collection");
 
             bool ICollection.IsSynchronized => false;
 
@@ -248,7 +248,7 @@ namespace Krypton.Toolkit
             public object this[int index]
             {
                 get => InnerArrayGetItem(index, _anyItemMask);
-                set => throw new NotSupportedException("Read Only Collection");
+                set => throw new NotSupportedException(@"Read Only Collection");
             }
             #endregion
 
@@ -288,15 +288,15 @@ namespace Krypton.Toolkit
             #endregion
 
             #region Private
-            int IList.Add(object value) => throw new NotSupportedException("Read Only Collection");
+            int IList.Add(object value) => throw new NotSupportedException(@"Read Only Collection");
 
-            void IList.Clear() => throw new NotSupportedException("Read Only Collection");
+            void IList.Clear() => throw new NotSupportedException(@"Read Only Collection");
 
-            void IList.Insert(int index, object value) => throw new NotSupportedException("Read Only Collection");
+            void IList.Insert(int index, object value) => throw new NotSupportedException(@"Read Only Collection");
 
-            void IList.Remove(object value) => throw new NotSupportedException("Read Only Collection");
+            void IList.Remove(object value) => throw new NotSupportedException(@"Read Only Collection");
 
-            void IList.RemoveAt(int index) => throw new NotSupportedException("Read Only Collection");
+            void IList.RemoveAt(int index) => throw new NotSupportedException(@"Read Only Collection");
 
             bool ICollection.IsSynchronized => false;
 
@@ -405,8 +405,8 @@ namespace Krypton.Toolkit
             #region Identity
             static InternalCheckedListBox()
             {
-                LBC_GETCHECKSTATE = PI.RegisterWindowMessage("LBC_GETCHECKSTATE");
-                LBC_SETCHECKSTATE = PI.RegisterWindowMessage("LBC_SETCHECKSTATE");
+                LBC_GETCHECKSTATE = PI.RegisterWindowMessage(@"LBC_GETCHECKSTATE");
+                LBC_SETCHECKSTATE = PI.RegisterWindowMessage(@"LBC_SETCHECKSTATE");
             }
 
             /// <summary>
@@ -715,7 +715,7 @@ namespace Krypton.Toolkit
                     // First time around we need to use reflection to grab inner array
                     if (_innerArray == null)
                     {
-                        PropertyInfo pi = typeof(ObjectCollection).GetProperty("InnerArray",
+                        PropertyInfo pi = typeof(ObjectCollection).GetProperty(@"InnerArray",
                                                                                         BindingFlags.Instance |
                                                                                         BindingFlags.NonPublic |
                                                                                         BindingFlags.GetField);
@@ -731,7 +731,7 @@ namespace Krypton.Toolkit
             {
                 if (_miGetCount == null)
                 {
-                    _miGetCount = InnerArray.GetType().GetMethod("GetCount", new Type[] { typeof(int) }, null);
+                    _miGetCount = InnerArray.GetType().GetMethod(@"GetCount", new Type[] { typeof(int) }, null);
                 }
 
                 return (int)_miGetCount.Invoke(InnerArray, new object[] { stateMask });
@@ -741,7 +741,7 @@ namespace Krypton.Toolkit
             {
                 if (_miIndexOf == null)
                 {
-                    _miIndexOf = InnerArray.GetType().GetMethod("IndexOf", new Type[] { typeof(object), typeof(int) }, null);
+                    _miIndexOf = InnerArray.GetType().GetMethod(@"IndexOf", new Type[] { typeof(object), typeof(int) }, null);
                 }
 
                 return (int)_miIndexOf.Invoke(InnerArray, new object[] { item, stateMask });
@@ -751,7 +751,7 @@ namespace Krypton.Toolkit
             {
                 if (_miIndexOfIdentifier == null)
                 {
-                    _miIndexOfIdentifier = InnerArray.GetType().GetMethod("IndexOfIdentifier", new Type[] { typeof(object), typeof(int) }, null);
+                    _miIndexOfIdentifier = InnerArray.GetType().GetMethod(@"IndexOfIdentifier", new Type[] { typeof(object), typeof(int) }, null);
                 }
 
                 return (int)_miIndexOfIdentifier.Invoke(InnerArray, new object[] { identifier, stateMask });
@@ -761,7 +761,7 @@ namespace Krypton.Toolkit
             {
                 if (_miGetItem == null)
                 {
-                    _miGetItem = InnerArray.GetType().GetMethod("GetItem", new Type[] { typeof(int), typeof(int) }, null);
+                    _miGetItem = InnerArray.GetType().GetMethod(@"GetItem", new Type[] { typeof(int), typeof(int) }, null);
                 }
 
                 return _miGetItem.Invoke(InnerArray, new object[] { index, stateMask });
@@ -771,7 +771,7 @@ namespace Krypton.Toolkit
             {
                 if (_miGetEntryObject == null)
                 {
-                    _miGetEntryObject = InnerArray.GetType().GetMethod("GetEntryObject", BindingFlags.NonPublic | BindingFlags.Instance);
+                    _miGetEntryObject = InnerArray.GetType().GetMethod(@"GetEntryObject", BindingFlags.NonPublic | BindingFlags.Instance);
                 }
 
                 return _miGetEntryObject.Invoke(InnerArray, new object[] { index, stateMask });
@@ -781,7 +781,7 @@ namespace Krypton.Toolkit
             {
                 if (_miGetState == null)
                 {
-                    _miGetState = InnerArray.GetType().GetMethod("GetState", new Type[] { typeof(int), typeof(int) }, null);
+                    _miGetState = InnerArray.GetType().GetMethod(@"GetState", new Type[] { typeof(int), typeof(int) }, null);
                 }
 
                 return (bool)_miGetState.Invoke(InnerArray, new object[] { index, stateMask });
@@ -791,7 +791,7 @@ namespace Krypton.Toolkit
             {
                 if (_miSetState == null)
                 {
-                    _miSetState = InnerArray.GetType().GetMethod("SetState", new Type[] { typeof(int), typeof(int), typeof(bool) }, null);
+                    _miSetState = InnerArray.GetType().GetMethod(@"SetState", new Type[] { typeof(int), typeof(int), typeof(bool) }, null);
                 }
 
                 _miSetState.Invoke(InnerArray, new object[] { index, stateMask, value });
@@ -801,7 +801,7 @@ namespace Krypton.Toolkit
             {
                 if (_miGetEnumerator == null)
                 {
-                    _miGetEnumerator = InnerArray.GetType().GetMethod("GetEnumerator", new Type[] { typeof(int), typeof(bool) }, null);
+                    _miGetEnumerator = InnerArray.GetType().GetMethod(@"GetEnumerator", new Type[] { typeof(int), typeof(bool) }, null);
                 }
 
                 return (IEnumerator)_miGetEnumerator.Invoke(InnerArray, new object[] { stateMask, anyBit });
@@ -964,50 +964,50 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Occurs when the property of a control is bound to a data value. 
         /// </summary>
-        [Description("Occurs when the property of a control is bound to a data value.")]
-        [Category("Property Changed")]
+        [Description(@"Occurs when the property of a control is bound to a data value.")]
+        [Category(@"Property Changed")]
         public event EventHandler Format;
 
         /// <summary>
         /// Occurs when the value of the FormatInfo property changes.
         /// </summary>
-        [Description("Occurs when the value of the FormatInfo property changes.")]
-        [Category("Property Changed")]
+        [Description(@"Occurs when the value of the FormatInfo property changes.")]
+        [Category(@"Property Changed")]
         public event EventHandler FormatInfoChanged;
 
         /// <summary>
         /// Occurs when the value of the FormatString property changes.
         /// </summary>
-        [Description("Occurs when the value of the FormatString property changes.")]
-        [Category("Property Changed")]
+        [Description(@"Occurs when the value of the FormatString property changes.")]
+        [Category(@"Property Changed")]
         public event EventHandler FormatStringChanged;
 
         /// <summary>
         /// Occurs when the value of the FormattingEnabled property changes.
         /// </summary>
-        [Description("Occurs when the value of the FormattingEnabled property changes.")]
-        [Category("Property Changed")]
+        [Description(@"Occurs when the value of the FormattingEnabled property changes.")]
+        [Category(@"Property Changed")]
         public event EventHandler FormattingEnabledChanged;
 
         /// <summary>
         /// Occurs when the value of the SelectedValue property changes.
         /// </summary>
-        [Description("Occurs when the value of the SelectedValue property changes.")]
-        [Category("Property Changed")]
+        [Description(@"Occurs when the value of the SelectedValue property changes.")]
+        [Category(@"Property Changed")]
         public event EventHandler SelectedValueChanged;
 
         /// <summary>
         /// Occurs when the value of the SelectedIndex property changes.
         /// </summary>
-        [Description("Occurs when the value of the SelectedIndex property changes.")]
-        [Category("Behavior")]
+        [Description(@"Occurs when the value of the SelectedIndex property changes.")]
+        [Category(@"Behavior")]
         public event EventHandler SelectedIndexChanged;
 
         /// <summary>
         /// Occurs when the value of the SelectedIndex property changes.
         /// </summary>
-        [Description("Indicates that an item is about to have its check state changed. The value is not updated until after the event occurs.")]
-        [Category("Behavior")]
+        [Description(@"Indicates that an item is about to have its check state changed. The value is not updated until after the event occurs.")]
+        [Category(@"Behavior")]
         public event ItemCheckEventHandler ItemCheck;
 
         /// <summary>
@@ -1062,16 +1062,16 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Occurs when the mouse enters the control.
         /// </summary>
-        [Description("Raises the TrackMouseEnter event in the wrapped control.")]
-        [Category("Mouse")]
+        [Description(@"Raises the TrackMouseEnter event in the wrapped control.")]
+        [Category(@"Mouse")]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public event EventHandler TrackMouseEnter;
 
         /// <summary>
         /// Occurs when the mouse leaves the control.
         /// </summary>
-        [Description("Raises the TrackMouseLeave event in the wrapped control.")]
-        [Category("Mouse")]
+        [Description(@"Raises the TrackMouseLeave event in the wrapped control.")]
+        [Category(@"Mouse")]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public event EventHandler TrackMouseLeave;
         #endregion
@@ -1314,7 +1314,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the value of the selected item in the list control, or selects the item in the list control that contains the specified value.
         /// </summary>
-        [Category("Data")]
+        [Category(@"Data")]
         [Bindable(true)]
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
@@ -1365,8 +1365,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the button style.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Item style.")]
+        [Category(@"Visuals")]
+        [Description(@"Item style.")]
         public ButtonStyle ItemStyle
         {
             get => _style;
@@ -1394,8 +1394,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets the width by which the horizontal scroll bar of a KryptonCheckedListBox can scroll. 
         /// </summary>
-        [Category("Behavior")]
-        [Description("The width, in pixels, by which a list box can be scrolled horizontally. Only valid HorizontalScrollbar is true.")]
+        [Category(@"Behavior")]
+        [Description(@"The width, in pixels, by which a list box can be scrolled horizontally. Only valid HorizontalScrollbar is true.")]
         [Localizable(true)]
         [DefaultValue(0)]
         public virtual int HorizontalExtent
@@ -1407,8 +1407,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets a value indicating whether a horizontal scroll bar is displayed in the control. 
         /// </summary>
-        [Category("Behavior")]
-        [Description("Indicates whether the KryptonCheckedListBox will display a horizontal scrollbar for items beyond the right edge of the KryptonCheckedListBox.")]
+        [Category(@"Behavior")]
+        [Description(@"Indicates whether the KryptonCheckedListBox will display a horizontal scrollbar for items beyond the right edge of the KryptonCheckedListBox.")]
         [Localizable(true)]
         [DefaultValue(false)]
         public virtual bool HorizontalScrollbar
@@ -1420,8 +1420,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets a value indicating whether the vertical scroll bar is shown at all times. 
         /// </summary>
-        [Category("Behavior")]
-        [Description("Indicates if the list box should always have a scroll bar present, regardless of how many items are present.")]
+        [Category(@"Behavior")]
+        [Description(@"Indicates if the list box should always have a scroll bar present, regardless of how many items are present.")]
         [Localizable(true)]
         [DefaultValue(false)]
         public virtual bool ScrollAlwaysVisible
@@ -1433,16 +1433,16 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets a value indicating whether the check box should be toggled when an item is selected.
         /// </summary>
-        [Category("Behavior")]
-        [Description("Indicates whether the check box should be toggled when an item is selected.")]
+        [Category(@"Behavior")]
+        [Description(@"Indicates whether the check box should be toggled when an item is selected.")]
         [DefaultValue(false)]
         public bool CheckOnClick { get; set; }
 
         /// <summary>
         /// Gets or sets the selection mode of the KryptonCheckedListBox control.
         /// </summary>
-        [Category("Behavior")]
-        [Description("Indicates if the checked list box is to be single-select or not selectable. (Multi## not supported)")]
+        [Category(@"Behavior")]
+        [Description(@"Indicates if the checked list box is to be single-select or not selectable. (Multi## not supported)")]
         [DefaultValue(typeof(CheckedSelectionMode), "One")]
         public virtual CheckedSelectionMode SelectionMode
         {
@@ -1458,8 +1458,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets a value indicating whether the items in the KryptonCheckedListBox are sorted alphabetically.
         /// </summary>
-        [Category("Behavior")]
-        [Description("Controls whether the list is sorted.")]
+        [Category(@"Behavior")]
+        [Description(@"Controls whether the list is sorted.")]
         [DefaultValue(false)]
         public virtual bool Sorted
         {
@@ -1470,9 +1470,9 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the items of the KryptonCheckedListBox. 
         /// </summary>
-        [Category("Data")]
-        [Description("The items in the KryptonCheckedListBox.")]
-        [Editor("System.Windows.Forms.Design.ListControlStringCollectionEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
+        [Category(@"Data")]
+        [Description(@"The items in the KryptonCheckedListBox.")]
+        [Editor(@"System.Windows.Forms.Design.ListControlStringCollectionEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         [MergableProperty(false)]
         [Localizable(true)]
@@ -1496,10 +1496,10 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets the format specifier characters that indicate how a value is to be displayed.
         /// </summary>
-        [Description("The format specifier characters that indicate how a value is to be displayed.")]
-        [Editor("System.Windows.Forms.Design.FormatStringEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
+        [Description(@"The format specifier characters that indicate how a value is to be displayed.")]
+        [Editor(@"System.Windows.Forms.Design.FormatStringEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
         [MergableProperty(false)]
-        [DefaultValue("")]
+        [DefaultValue(@"")]
         public string FormatString
         {
             get => _listBox.FormatString;
@@ -1509,7 +1509,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets if this property is true, the value of FormatString is used to convert the value of DisplayMember into a value that can be displayed.
         /// </summary>
-        [Description("If this property is true, the value of FormatString is used to convert the value of DisplayMember into a value that can be displayed.")]
+        [Description(@"If this property is true, the value of FormatString is used to convert the value of DisplayMember into a value that can be displayed.")]
         [DefaultValue(false)]
         public bool FormattingEnabled
         {
@@ -1520,8 +1520,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the background style.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Style used to draw the background.")]
+        [Category(@"Visuals")]
+        [Description(@"Style used to draw the background.")]
         public PaletteBackStyle BackStyle
         {
             get => StateCommon.BackStyle;
@@ -1547,8 +1547,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the border style.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Style used to draw the border.")]
+        [Category(@"Visuals")]
+        [Description(@"Style used to draw the border.")]
         public PaletteBorderStyle BorderStyle
         {
             get => StateCommon.BorderStyle;
@@ -1574,8 +1574,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the item appearance when it has focus.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining item appearance when it has focus.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining item appearance when it has focus.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteListItemTripleRedirect OverrideFocus { get; }
 
@@ -1584,8 +1584,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the check box image value overrides.
         /// </summary>
-        [Category("Visuals")]
-        [Description("CheckBox image value overrides.")]
+        [Category(@"Visuals")]
+        [Description(@"CheckBox image value overrides.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public CheckBoxImages Images { get; }
 
@@ -1594,8 +1594,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the common appearance entries that other states can override.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining common appearance that other states can override.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining common appearance that other states can override.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteListStateRedirect StateCommon { get; }
 
@@ -1604,8 +1604,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the disabled appearance entries.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining disabled appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining disabled appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteListState StateDisabled { get; }
 
@@ -1614,8 +1614,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the normal appearance entries.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining normal appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining normal appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteListState StateNormal { get; }
 
@@ -1624,8 +1624,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the active appearance entries.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining active appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining active appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteDouble StateActive { get; }
 
@@ -1634,8 +1634,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the hot tracking item appearance entries.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining hot tracking item appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining hot tracking item appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteListItemTriple StateTracking { get; }
 
@@ -1644,8 +1644,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the pressed item appearance entries.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining pressed item appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining pressed item appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteListItemTriple StatePressed { get; }
 
@@ -1654,8 +1654,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the normal checked item appearance entries.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining normal checked item appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining normal checked item appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteListItemTriple StateCheckedNormal { get; }
 
@@ -1664,8 +1664,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the hot tracking checked item appearance entries.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining hot tracking checked item appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining hot tracking checked item appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteListItemTriple StateCheckedTracking { get; }
 
@@ -1674,8 +1674,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the pressed checked item appearance entries.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining pressed checked item appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining pressed checked item appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteListItemTriple StateCheckedPressed { get; }
 
@@ -1684,8 +1684,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets Determines if the control is always active or only when the mouse is over the control or has focus.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Determines if the control is always active or only when the mouse is over the control or has focus.")]
+        [Category(@"Visuals")]
+        [Description(@"Determines if the control is always active or only when the mouse is over the control or has focus.")]
         [DefaultValue(true)]
         public bool AlwaysActive
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonColorButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonColorButton.cs
@@ -18,11 +18,11 @@ namespace Krypton.Toolkit
     /// </summary>
     [ToolboxItem(true)]
     [ToolboxBitmap(typeof(KryptonColorButton), "ToolboxBitmaps.KryptonColorButton.bmp")]
-    [DefaultEvent("SelectedColorChanged")]
-    [DefaultProperty("SelectedColor")]
-    [Designer("Krypton.Toolkit.KryptonColorButtonDesigner, Krypton.Toolkit")]
-    [DesignerCategory("code")]
-    [Description("Raises an event when the user clicks it.")]
+    [DefaultEvent(@"SelectedColorChanged")]
+    [DefaultProperty(@"SelectedColor")]
+    [Designer(@"Krypton.Toolkit.KryptonColorButtonDesigner, Krypton.Toolkit")]
+    [DesignerCategory(@"code")]
+    [Description(@"Raises an event when the user clicks it.")]
     public class KryptonColorButton : VisualSimpleBase, IButtonControl, IContentValues
     {
         #region Instance Fields
@@ -69,36 +69,36 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Occurs when the drop down portion of the color button is pressed.
         /// </summary>
-        [Category("Action")]
-        [Description("Occurs when the drop down portion of the color button is pressed.")]
+        [Category(@"Action")]
+        [Description(@"Occurs when the drop down portion of the color button is pressed.")]
         public event EventHandler<ContextPositionMenuArgs> DropDown;
 
         /// <summary>
         /// Occurs when the value of the KryptonCommand property changes.
         /// </summary>
-        [Category("Property Changed")]
-        [Description("Occurs when the value of the KryptonCommand property changes.")]
+        [Category(@"Property Changed")]
+        [Description(@"Occurs when the value of the KryptonCommand property changes.")]
         public event EventHandler KryptonCommandChanged;
 
         /// <summary>
         /// Occurs when the SelectedColor property changes value.
         /// </summary>
-        [Category("Property Changed")]
-        [Description("Occurs when the SelectedColor property changes value.")]
+        [Category(@"Property Changed")]
+        [Description(@"Occurs when the SelectedColor property changes value.")]
         public event EventHandler<ColorEventArgs> SelectedColorChanged;
 
         /// <summary>
         /// Occurs when the user is tracking over a color.
         /// </summary>
-        [Category("Action")]
-        [Description("Occurs when user is tracking over a color.")]
+        [Category(@"Action")]
+        [Description(@"Occurs when user is tracking over a color.")]
         public event EventHandler<ColorEventArgs> TrackingColor;
 
         /// <summary>
         /// Occurs when the user selects the more colors option.
         /// </summary>
-        [Category("Action")]
-        [Description("Occurs when user selects the more colors option.")]
+        [Category(@"Action")]
+        [Description(@"Occurs when user selects the more colors option.")]
         public event CancelEventHandler MoreColors;
         #endregion
 
@@ -135,20 +135,20 @@ namespace Krypton.Toolkit
             // Create the context menu items
             _kryptonContextMenu = new KryptonContextMenu();
             _separatorTheme = new KryptonContextMenuSeparator();
-            _headingTheme = new KryptonContextMenuHeading("Theme Colors");
+            _headingTheme = new KryptonContextMenuHeading(@"Theme Colors");
             _colorsTheme = new KryptonContextMenuColorColumns(ColorScheme.OfficeThemes);
             _separatorStandard = new KryptonContextMenuSeparator();
-            _headingStandard = new KryptonContextMenuHeading("Standard Colors");
+            _headingStandard = new KryptonContextMenuHeading(@"Standard Colors");
             _colorsStandard = new KryptonContextMenuColorColumns(ColorScheme.OfficeStandard);
             _separatorRecent = new KryptonContextMenuSeparator();
-            _headingRecent = new KryptonContextMenuHeading("Recent Colors");
+            _headingRecent = new KryptonContextMenuHeading(@"Recent Colors");
             _colorsRecent = new KryptonContextMenuColorColumns(ColorScheme.None);
             _separatorNoColor = new KryptonContextMenuSeparator();
-            _itemNoColor = new KryptonContextMenuItem("&No Color", Resources.GenericImageResources.ButtonNoColor, OnClickNoColor);
+            _itemNoColor = new KryptonContextMenuItem(@"&No Color", Resources.GenericImageResources.ButtonNoColor, OnClickNoColor);
             _itemsNoColor = new KryptonContextMenuItems();
             _itemsNoColor.Items.Add(_itemNoColor);
             _separatorMoreColors = new KryptonContextMenuSeparator();
-            _itemMoreColors = new KryptonContextMenuItem("&More Colors...", OnClickMoreColors);
+            _itemMoreColors = new KryptonContextMenuItem(@"&More Colors...", OnClickMoreColors);
             _itemsMoreColors = new KryptonContextMenuItems();
             _itemsMoreColors.Items.Add(_itemMoreColors);
             _kryptonContextMenu.Items.AddRange(new KryptonContextMenuItemBase[] { _separatorTheme, _headingTheme, _colorsTheme,
@@ -271,7 +271,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets the text associated with this control. 
         /// </summary>
-        [Editor("System.ComponentModel.Design.MultilineStringEditor", typeof(UITypeEditor))]
+        [Editor(@"System.ComponentModel.Design.MultilineStringEditor", typeof(UITypeEditor))]
         public override string Text
         {
             get => Values.Text;
@@ -317,72 +317,72 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the maximum number of recent colors to store and display.
         /// </summary>
-        [Category("Behavior")]
-        [Description("Determine the maximum number of recent colors to store and display.")]
+        [Category(@"Behavior")]
+        [Description(@"Determine the maximum number of recent colors to store and display.")]
         [DefaultValue(10)]
         public int MaxRecentColors { get; set; }
 
         /// <summary>
         /// Gets and sets the visible state of the themes color set.
         /// </summary>
-        [Category("Behavior")]
-        [Description("Determine the visible state of the themes color set.")]
+        [Category(@"Behavior")]
+        [Description(@"Determine the visible state of the themes color set.")]
         [DefaultValue(true)]
         public bool VisibleThemes { get; set; }
 
         /// <summary>
         /// Gets and sets the visible state of the standard color set.
         /// </summary>
-        [Category("Behavior")]
-        [Description("Determine the visible state of the standard color set.")]
+        [Category(@"Behavior")]
+        [Description(@"Determine the visible state of the standard color set.")]
         [DefaultValue(true)]
         public bool VisibleStandard { get; set; }
 
         /// <summary>
         /// Gets and sets the visible state of the recent color set.
         /// </summary>
-        [Category("Behavior")]
-        [Description("Determine the visible state of the recent color set.")]
+        [Category(@"Behavior")]
+        [Description(@"Determine the visible state of the recent color set.")]
         [DefaultValue(true)]
         public bool VisibleRecent { get; set; }
 
         /// <summary>
         /// Gets and sets the visible state of the no color menu item.
         /// </summary>
-        [Category("Behavior")]
-        [Description("Determine if the 'No Color' menu item is used.")]
+        [Category(@"Behavior")]
+        [Description(@"Determine if the 'No Color' menu item is used.")]
         [DefaultValue(true)]
         public bool VisibleNoColor { get; set; }
 
         /// <summary>
         /// Gets and sets the visible state of the more colors menu item.
         /// </summary>
-        [Category("Behavior")]
-        [Description("Determine if the 'More Colors...' menu item is used.")]
+        [Category(@"Behavior")]
+        [Description(@"Determine if the 'More Colors...' menu item is used.")]
         [DefaultValue(true)]
         public bool VisibleMoreColors { get; set; }
 
         /// <summary>
         /// Gets and sets if the recent colors should be automatically updated.
         /// </summary>
-        [Category("Behavior")]
-        [Description("Should recent colors be automatically updated.")]
+        [Category(@"Behavior")]
+        [Description(@"Should recent colors be automatically updated.")]
         [DefaultValue(true)]
         public bool AutoRecentColors { get; set; }
 
         /// <summary>
         /// Gets and sets the color scheme for the themes color set.
         /// </summary>
-        [Category("Behavior")]
-        [Description("Color scheme to use for the themes color set.")]
+        [Category(@"Behavior")]
+        [Description(@"Color scheme to use for the themes color set.")]
         [DefaultValue(typeof(ColorScheme), "OfficeThemes")]
         public ColorScheme SchemeThemes { get; set; }
 
         /// <summary>
         /// Gets and sets the color scheme for the standard color set.
         /// </summary>
-        [Category("Behavior")]
-        [Description("Color scheme to use for the standard color set.")]
+        [Category(@"Behavior")]
+        [Description(@"Color scheme to use for the standard color set.")]
         [DefaultValue(typeof(ColorScheme), "OfficeStandard")]
         public ColorScheme SchemeStandard { get; set; }
 
@@ -390,8 +390,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the selected color.
         /// </summary>
         [Bindable(true)]
-        [Category("Appearance")]
-        [Description("Selected color.")]
+        [Category(@"Appearance")]
+        [Description(@"Selected color.")]
         [DefaultValue(typeof(Color), "Red")]
         public Color SelectedColor
         {
@@ -414,8 +414,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the selected color block when selected color is empty.
         /// </summary>
         [Bindable(true)]
-        [Category("Appearance")]
-        [Description("Border color of selected block when selected color is empty.")]
+        [Category(@"Appearance")]
+        [Description(@"Border color of selected block when selected color is empty.")]
         [DefaultValue(typeof(Color), "DarkGray")]
         public Color EmptyBorderColor
         {
@@ -436,8 +436,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the selected color drawing rectangle.
         /// </summary>
         [Bindable(true)]
-        [Category("Appearance")]
-        [Description("Selected color drawing rectangle.")]
+        [Category(@"Appearance")]
+        [Description(@"Selected color drawing rectangle.")]
         [DefaultValue(typeof(Rectangle), "0,12,16,4")]
         public Rectangle SelectedRect
         {
@@ -455,8 +455,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the visual orientation of the control.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Visual orientation of the control.")]
+        [Category(@"Visuals")]
+        [Description(@"Visual orientation of the control.")]
         [DefaultValue(typeof(VisualOrientation), "Top")]
         public virtual VisualOrientation ButtonOrientation
         {
@@ -475,8 +475,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the position of the drop arrow within the color button.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Position of the drop arrow within the color button.")]
+        [Category(@"Visuals")]
+        [Description(@"Position of the drop arrow within the color button.")]
         [DefaultValue(typeof(VisualOrientation), "Right")]
         public virtual VisualOrientation DropDownPosition
         {
@@ -495,8 +495,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the orientation of the drop arrow within the color button.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Orientation of the drop arrow within the color button.")]
+        [Category(@"Visuals")]
+        [Description(@"Orientation of the drop arrow within the color button.")]
         [DefaultValue(typeof(VisualOrientation), "Bottom")]
         public virtual VisualOrientation DropDownOrientation
         {
@@ -534,8 +534,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets if the color button works as a splitter or as a drop down.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Determine if color button acts as a splitter or just a drop down.")]
+        [Category(@"Visuals")]
+        [Description(@"Determine if color button acts as a splitter or just a drop down.")]
         [DefaultValue(true)]
         public virtual bool Splitter
         {
@@ -554,8 +554,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the color button style.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Color button style.")]
+        [Category(@"Visuals")]
+        [Description(@"Color button style.")]
         public ButtonStyle ButtonStyle
         {
             get => _style;
@@ -581,8 +581,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the color button content.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Color button values")]
+        [Category(@"Visuals")]
+        [Description(@"Color button values")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public ColorButtonValues Values { get; }
 
@@ -591,8 +591,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the image value overrides.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Image value overrides.")]
+        [Category(@"Visuals")]
+        [Description(@"Image value overrides.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public DropDownButtonImages Images { get; }
 
@@ -601,16 +601,16 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the context menu display strings.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Context menu display strings.")]
+        [Category(@"Visuals")]
+        [Description(@"Context menu display strings.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteColorButtonStrings Strings { get; }
 
         /// <summary>
         /// Gets access to the common color button appearance that other states can override.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining common color button appearance that other states can override.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining common color button appearance that other states can override.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteTripleRedirect StateCommon { get; }
 
@@ -619,8 +619,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the disabled color button appearance entries.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining disabled color button appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining disabled color button appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteTriple StateDisabled { get; }
 
@@ -629,8 +629,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the normal color button appearance entries.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining normal color button appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining normal color button appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteTriple StateNormal { get; }
 
@@ -639,8 +639,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the hot tracking color button appearance entries.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining hot tracking color button appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining hot tracking color button appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteTriple StateTracking { get; }
 
@@ -649,8 +649,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the pressed color button appearance entries.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining pressed color button appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining pressed color button appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteTriple StatePressed { get; }
 
@@ -659,8 +659,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the normal color button appearance when default.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining normal color button appearance when default.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining normal color button appearance when default.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteTripleRedirect OverrideDefault { get; }
 
@@ -669,8 +669,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the color button appearance when it has focus.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining color button appearance when it has focus.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining color button appearance when it has focus.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteTripleRedirect OverrideFocus { get; }
 
@@ -679,16 +679,16 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets the value returned to the parent form when the color button is clicked.
         /// </summary>
-        [Category("Behavior")]
-        [Description("The dialog-box result produced in a modal form by clicking the color button.")]
+        [Category(@"Behavior")]
+        [Description(@"The dialog-box result produced in a modal form by clicking the color button.")]
         [DefaultValue(typeof(DialogResult), "None")]
         public DialogResult DialogResult { get; set; }
 
         /// <summary>
         /// Gets and sets the associated KryptonCommand.
         /// </summary>
-        [Category("Behavior")]
-        [Description("Command associated with the color button.")]
+        [Category(@"Behavior")]
+        [Description(@"Command associated with the color button.")]
         [DefaultValue(null)]
         public virtual KryptonCommand KryptonCommand
         {
@@ -768,8 +768,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets a value indicating whether an ampersand is included in the text of the control. 
         /// </summary>
-        [Category("Appearance")]
-        [Description("When true the first character after an ampersand will be used as a mnemonic.")]
+        [Category(@"Appearance")]
+        [Description(@"When true the first character after an ampersand will be used as a mnemonic.")]
         [DefaultValue(true)]
         public bool UseMnemonic
         {
@@ -817,7 +817,7 @@ namespace Krypton.Toolkit
             set => base.ImeMode = value;
         }
 
-        [DefaultValue(true), Description("Full color dialog.")]
+        [DefaultValue(true), Description(@"Full color dialog.")]
         public bool AllowFullOpen
         {
             get => _allowFullOpen;
@@ -1386,8 +1386,7 @@ namespace Krypton.Toolkit
                     }
 
                     // We do not consider existing separators
-                    if (!((item is KryptonContextMenuSeparator) ||
-                          (item is KryptonContextMenuHeading)))
+                    if (!(item is KryptonContextMenuSeparator or KryptonContextMenuHeading))
                     {
                         // If the previous item is visible, then make the parameter visible
                         if (item.Visible)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -18,13 +18,13 @@ namespace Krypton.Toolkit
     /// </summary>
     [ToolboxItem(true)]
     [ToolboxBitmap(typeof(KryptonComboBox), "ToolboxBitmaps.KryptonComboBox.bmp")]
-    [DefaultEvent("SelectedIndexChanged")]
-    [DefaultProperty("Text")]
-    [DefaultBindingProperty("Text")]
-    [LookupBindingProperties("DataSource", "DisplayMember", "ValueMember", "SelectedValue")]
-    [Designer("Krypton.Toolkit.KryptonComboBoxDesigner, Krypton.Toolkit")]
-    [DesignerCategory("code")]
-    [Description("Displays an editable textbox with a drop-down list of permitted values.")]
+    [DefaultEvent(@"SelectedIndexChanged")]
+    [DefaultProperty(@"Text")]
+    [DefaultBindingProperty(@"Text")]
+    [LookupBindingProperties(@"DataSource", @"DisplayMember", @"ValueMember", @"SelectedValue")]
+    [Designer(@"Krypton.Toolkit.KryptonComboBoxDesigner, Krypton.Toolkit")]
+    [DesignerCategory(@"code")]
+    [Description(@"Displays an editable textbox with a drop-down list of permitted values.")]
     public class KryptonComboBox : VisualControlBase,
                                    IContainedInputControl,
                                    ISupportInitializeNotification
@@ -478,8 +478,8 @@ namespace Krypton.Toolkit
             /// Raises the TrackMouseEnter event.
             /// </summary>
             /// <param name="e">An EventArgs containing the event data.</param>
-            [Description("Raises the TrackMouseEnter event in the wrapped control.")]
-            [Category("Mouse")]
+            [Description(@"Raises the TrackMouseEnter event in the wrapped control.")]
+            [Category(@"Mouse")]
             [EditorBrowsable(EditorBrowsableState.Advanced)]
             protected virtual void OnTrackMouseEnter(EventArgs e) => TrackMouseEnter?.Invoke(this, e);
 
@@ -831,142 +831,142 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Occurs when [draw item].
         /// </summary>
-        [Category("Behavior")]
-        [Description("Occurs when an item needs to be Drawn.")]
+        [Category(@"Behavior")]
+        [Description(@"Occurs when an item needs to be Drawn.")]
         public event DrawItemEventHandler DrawItem;
 
         /// <summary>
         /// Occurs when the control is initialized.
         /// </summary>
-        [Category("Behavior")]
-        [Description("Occurs when the control has been fully initialized.")]
+        [Category(@"Behavior")]
+        [Description(@"Occurs when the control has been fully initialized.")]
         public event EventHandler Initialized;
 
         /// <summary>
         /// Occurs when the drop-down portion of the KryptonComboBox is shown.
         /// </summary>
-        [Description("Occurs when the drop-down portion of the KryptonComboBox is shown.")]
-        [Category("Behavior")]
+        [Description(@"Occurs when the drop-down portion of the KryptonComboBox is shown.")]
+        [Category(@"Behavior")]
         public event EventHandler DropDown;
 
         /// <summary>
         /// Indicates that the drop-down portion of the KryptonComboBox has closed.
         /// </summary>
-        [Description("Indicates that the drop-down portion of the KryptonComboBox has closed.")]
-        [Category("Behavior")]
+        [Description(@"Indicates that the drop-down portion of the KryptonComboBox has closed.")]
+        [Category(@"Behavior")]
         public event EventHandler DropDownClosed;
 
         /// <summary>
         /// Occurs when the value of the DropDownStyle property changed.
         /// </summary>
-        [Description("Occurs when the value of the DropDownStyle property changed.")]
-        [Category("Behavior")]
+        [Description(@"Occurs when the value of the DropDownStyle property changed.")]
+        [Category(@"Behavior")]
         public event EventHandler DropDownStyleChanged;
 
         /// <summary>
         /// Occurs when the value of the SelectedIndex property changes.
         /// </summary>
-        [Description("Occurs when the value of the SelectedIndex property changes.")]
-        [Category("Behavior")]
+        [Description(@"Occurs when the value of the SelectedIndex property changes.")]
+        [Category(@"Behavior")]
         public event EventHandler SelectedIndexChanged;
 
         /// <summary>
         /// Occurs when an item is chosen from the drop-down list and the drop-down list is closed.
         /// </summary>
-        [Description("Occurs when an item is chosen from the drop-down list and the drop-down list is closed.")]
-        [Category("Behavior")]
+        [Description(@"Occurs when an item is chosen from the drop-down list and the drop-down list is closed.")]
+        [Category(@"Behavior")]
         public event EventHandler SelectionChangeCommitted;
 
         /// <summary>
         /// Occurs when the value of the DataSource property changed.
         /// </summary>
-        [Description("Occurs when the value of the DataSource property changed.")]
-        [Category("PropertyChanged")]
+        [Description(@"Occurs when the value of the DataSource property changed.")]
+        [Category(@"PropertyChanged")]
         public event EventHandler DataSourceChanged;
 
         /// <summary>
         /// Occurs when the value of the DisplayMember property changed.
         /// </summary>
-        [Description("Occurs when the value of the DisplayMember property changed.")]
-        [Category("PropertyChanged")]
+        [Description(@"Occurs when the value of the DisplayMember property changed.")]
+        [Category(@"PropertyChanged")]
         public event EventHandler DisplayMemberChanged;
 
         /// <summary>
         /// Occurs when the list format has changed.
         /// </summary>
-        [Description("Occurs when the list format has changed.")]
-        [Category("PropertyChanged")]
+        [Description(@"Occurs when the list format has changed.")]
+        [Category(@"PropertyChanged")]
         public event ListControlConvertEventHandler Format;
 
         /// <summary>
         /// Occurs when the value of the FormatInfo property changed.
         /// </summary>
-        [Description("Occurs when the value of the FormatInfo property changed.")]
-        [Category("PropertyChanged")]
+        [Description(@"Occurs when the value of the FormatInfo property changed.")]
+        [Category(@"PropertyChanged")]
         public event EventHandler FormatInfoChanged;
 
         /// <summary>
         /// Occurs when the value of the FormatString property changed.
         /// </summary>
-        [Description("Occurs when the value of the FormatString property changed.")]
-        [Category("PropertyChanged")]
+        [Description(@"Occurs when the value of the FormatString property changed.")]
+        [Category(@"PropertyChanged")]
         public event EventHandler FormatStringChanged;
 
         /// <summary>
         /// Occurs when the value of the FormattingEnabled property changed.
         /// </summary>
-        [Description("Occurs when the value of the FormattingEnabled property changed.")]
-        [Category("PropertyChanged")]
+        [Description(@"Occurs when the value of the FormattingEnabled property changed.")]
+        [Category(@"PropertyChanged")]
         public event EventHandler FormattingEnabledChanged;
 
         /// <summary>
         /// Occurs when the value of the SelectedValue property changed.
         /// </summary>
-        [Description("Occurs when the value of the SelectedValue property changed.")]
-        [Category("PropertyChanged")]
+        [Description(@"Occurs when the value of the SelectedValue property changed.")]
+        [Category(@"PropertyChanged")]
         public event EventHandler SelectedValueChanged;
 
         /// <summary>
         /// Occurs when the value of the ValueMember property changed.
         /// </summary>
-        [Description("Occurs when the value of the ValueMember property changed.")]
-        [Category("PropertyChanged")]
+        [Description(@"Occurs when the value of the ValueMember property changed.")]
+        [Category(@"PropertyChanged")]
         public event EventHandler ValueMemberChanged;
 
         /// <summary>
         /// Occurs when the KryptonComboBox text has changed.
         /// </summary>
-        [Description("Occurs when the KryptonComboBox text has changed.")]
-        [Category("Behavior")]
+        [Description(@"Occurs when the KryptonComboBox text has changed.")]
+        [Category(@"Behavior")]
         public event EventHandler TextUpdate;
 
         /// <summary>
         /// Occurs when the hovered selection changed.
         /// </summary>
-        [Description("Occurs when the hovered selection changed.")]
-        [Category("Behavior")]
+        [Description(@"Occurs when the hovered selection changed.")]
+        [Category(@"Behavior")]
         public event EventHandler<HoveredSelectionChangedEventArgs> HoveredSelectionChanged;
 
         /// <summary>
         /// Occurs when the <see cref="KryptonComboBox"/> wants to display a tooltip.
         /// </summary>
-        [Description("Occurs when the KryptonComboBox wants to display a tooltip.")]
-        [Category("Behavior")]
+        [Description(@"Occurs when the KryptonComboBox wants to display a tooltip.")]
+        [Category(@"Behavior")]
         public event EventHandler<ToolTipNeededEventArgs> ToolTipNeeded;
 
         /// <summary>
         /// Occurs when the mouse enters the control.
         /// </summary>
-        [Description("Raises the TrackMouseEnter event in the wrapped control.")]
-        [Category("Mouse")]
+        [Description(@"Raises the TrackMouseEnter event in the wrapped control.")]
+        [Category(@"Mouse")]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public event EventHandler TrackMouseEnter;
 
         /// <summary>
         /// Occurs when the mouse leaves the control.
         /// </summary>
-        [Description("Raises the TrackMouseLeave event in the wrapped control.")]
-        [Category("Mouse")]
+        [Description(@"Raises the TrackMouseLeave event in the wrapped control.")]
+        [Category(@"Mouse")]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public event EventHandler TrackMouseLeave;
 
@@ -1183,8 +1183,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the common textbox appearance entries that other states can override.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Set a watermark/prompt message for the user.")]
+        [Category(@"Visuals")]
+        [Description(@"Set a watermark/prompt message for the user.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteCueHintText CueHint { get; }
 
@@ -1221,7 +1221,8 @@ namespace Krypton.Toolkit
         /// Gets a value indicating if the control is initialized.
         /// </summary>
         [Browsable(false)]
-        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool IsInitialized
         {
             [DebuggerStepThrough]
@@ -1233,7 +1234,8 @@ namespace Krypton.Toolkit
         /// Gets a value indicating if the control is initialized.
         /// </summary>
         [Browsable(false)]
-        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool IsInitializing
         {
             [DebuggerStepThrough]
@@ -1252,7 +1254,7 @@ namespace Krypton.Toolkit
 
         /// <summary>Gets or sets the draw mode of the combobox.</summary>
         /// <value>The draw mode of the combobox.</value>
-        [Description("Gets or sets the draw mode of the combobox.")]
+        [Description(@"Gets or sets the draw mode of the combobox.")]
         public DrawMode DrawMode
         {
             get => _comboBox.DrawMode;
@@ -1424,10 +1426,10 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the value member.
         /// </summary>
-        [Category("Data")]
-        [Description("Indicates the property to use as the actual value of the items in the control.")]
-        [Editor("System.Windows.Forms.Design.DataMemberFieldEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
-        [DefaultValue("")]
+        [Category(@"Data")]
+        [Description(@"Indicates the property to use as the actual value of the items in the control.")]
+        [Editor(@"System.Windows.Forms.Design.DataMemberFieldEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
+        [DefaultValue(@"")]
         public string ValueMember
         {
             get => _comboBox.ValueMember;
@@ -1437,8 +1439,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the list that this control will use to gets its items.
         /// </summary>
-        [Category("Data")]
-        [Description("Indicates the list that this control will use to gets its items.")]
+        [Category(@"Data")]
+        [Description(@"Indicates the list that this control will use to gets its items.")]
         [AttributeProvider(typeof(IListSource))]
         [RefreshProperties(RefreshProperties.Repaint)]
         [DefaultValue(null)]
@@ -1451,11 +1453,11 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the property to display for the items in this control.
         /// </summary>
-        [Category("Data")]
-        [Description("Indicates the property to display for the items in this control.")]
-        [TypeConverter("System.Windows.Forms.Design.DataMemberFieldConverter, " + AssemblyRef.SystemWinformsDesign)]
-        [Editor("System.Windows.Forms.Design.DataMemberFieldEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
-        [DefaultValue("")]
+        [Category(@"Data")]
+        [Description(@"Indicates the property to display for the items in this control.")]
+        [TypeConverter(@"System.Windows.Forms.Design.DataMemberFieldConverter, " + AssemblyRef.SystemWinformsDesign)]
+        [Editor(@"System.Windows.Forms.Design.DataMemberFieldEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
+        [DefaultValue(@"")]
         public string DisplayMember
         {
             get => _comboBox.DisplayMember;
@@ -1499,8 +1501,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets a value indicating whether mnemonics will fire button spec buttons.
         /// </summary>
-        [Category("Appearance")]
-        [Description("Defines if mnemonic characters generate click events for button specs.")]
+        [Category(@"Appearance")]
+        [Description(@"Defines if mnemonic characters generate click events for button specs.")]
         [DefaultValue(true)]
         public bool UseMnemonic
         {
@@ -1519,8 +1521,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets Determines if the control is always active or only when the mouse is over the control or has focus.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Determines if the control is always active or only when the mouse is over the control or has focus.")]
+        [Category(@"Visuals")]
+        [Description(@"Determines if the control is always active or only when the mouse is over the control or has focus.")]
         [DefaultValue(true)]
         public bool AlwaysActive
         {
@@ -1539,8 +1541,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the appearance and functionality of the KryptonComboBox.
         /// </summary>
-        [Category("Appearance")]
-        [Description("Controls the appearance and functionality of the KryptonComboBox.")]
+        [Category(@"Appearance")]
+        [Description(@"Controls the appearance and functionality of the KryptonComboBox.")]
         [Editor(@"Krypton.Toolkit.OverrideComboBoxStyleDropDownStyle", typeof(UITypeEditor))]
         [DefaultValue(typeof(ComboBoxStyle), "DropDown")]
         [RefreshProperties(RefreshProperties.Repaint)]
@@ -1564,7 +1566,7 @@ namespace Krypton.Toolkit
         }
 
         /// <summary />
-        [Category("Behavior")]
+        [Category(@"Behavior")]
         [DefaultValue(true)]
         [Description(@"Determines if the ComboBox Items are shown in full")]
         public bool IntegralHeight
@@ -1576,8 +1578,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the height, in pixels, of the drop down box in a KryptonComboBox.
         /// </summary>
-        [Category("Behavior")]
-        [Description("The height, in pixels, of the drop down box in a KryptonComboBox.")]
+        [Category(@"Behavior")]
+        [Description(@"The height, in pixels, of the drop down box in a KryptonComboBox.")]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [DefaultValue(200)]
         [Browsable(true)]
@@ -1590,8 +1592,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the width, in pixels, of the drop down box in a KryptonComboBox.
         /// </summary>
-        [Category("Behavior")]
-        [Description("The width, in pixels, of the drop down box in a KryptonComboBox.")]
+        [Category(@"Behavior")]
+        [Description(@"The width, in pixels, of the drop down box in a KryptonComboBox.")]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Browsable(true)]
         public int DropDownWidth
@@ -1603,8 +1605,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the height, in pixels, of items in an owner-draw KryptonComboBox.
         /// </summary>
-        [Category("Behavior")]
-        [Description("Do not use this property, it is provided for backwards compatability only.")]
+        [Category(@"Behavior")]
+        [Description(@"Do not use this property, it is provided for backwards compatability only.")]
         [Localizable(true)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -1622,8 +1624,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the maximum number of entries to display in the drop-down list.
         /// </summary>
-        [Category("Behavior")]
-        [Description("The maximum number of entries to display in the drop-down list.")]
+        [Category(@"Behavior")]
+        [Description(@"The maximum number of entries to display in the drop-down list.")]
         [Localizable(true)]
         [DefaultValue(8)]
         public int MaxDropDownItems
@@ -1635,8 +1637,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets the maximum number of characters that can be entered into the edit control.
         /// </summary>
-        [Category("Behavior")]
-        [Description("Specifies the maximum number of characters that can be entered into the edit control.")]
+        [Category(@"Behavior")]
+        [Description(@"Specifies the maximum number of characters that can be entered into the edit control.")]
         [DefaultValue(0)]
         [Localizable(true)]
         public int MaxLength
@@ -1648,8 +1650,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets whether the items in the list portion of the KryptonComboBox are sorted.
         /// </summary>
-        [Category("Behavior")]
-        [Description("Specifies whether the items in the list portion of the KryptonComboBox are sorted.")]
+        [Category(@"Behavior")]
+        [Description(@"Specifies whether the items in the list portion of the KryptonComboBox are sorted.")]
         [DefaultValue(false)]
         public bool Sorted
         {
@@ -1660,9 +1662,9 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets the items in the KryptonComboBox.
         /// </summary>
-        [Category("Data")]
-        [Description("The items in the KryptonComboBox.")]
-        [Editor("System.Windows.Forms.Design.ListControlStringCollectionEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
+        [Category(@"Data")]
+        [Description(@"The items in the KryptonComboBox.")]
+        [Editor(@"System.Windows.Forms.Design.ListControlStringCollectionEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         [MergableProperty(false)]
         [Localizable(true)]
@@ -1671,8 +1673,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the input control style.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Input control style.")]
+        [Category(@"Visuals")]
+        [Description(@"Input control style.")]
         public InputControlStyle InputControlStyle
         {
             get => _inputControlStyle;
@@ -1698,8 +1700,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the item style.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Item style.")]
+        [Category(@"Visuals")]
+        [Description(@"Item style.")]
         public ButtonStyle ItemStyle
         {
             get => _style;
@@ -1725,8 +1727,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the drop button style.
         /// </summary>
-        [Category("Visuals")]
-        [Description("DropButton style.")]
+        [Category(@"Visuals")]
+        [Description(@"DropButton style.")]
         public ButtonStyle DropButtonStyle
         {
             get => _dropButtonStyle;
@@ -1751,8 +1753,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the drop button style.
         /// </summary>
-        [Category("Visuals")]
-        [Description("DropButton style.")]
+        [Category(@"Visuals")]
+        [Description(@"DropButton style.")]
         public PaletteBackStyle DropBackStyle
         {
             get => _dropBackStyle;
@@ -1778,32 +1780,32 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets a value indicating if tooltips should be displayed for button specs.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Should tooltips be displayed for button specs.")]
+        [Category(@"Visuals")]
+        [Description(@"Should tooltips be displayed for button specs.")]
         [DefaultValue(false)]
         public bool AllowButtonSpecToolTips { get; set; }
 
         /// <summary>
         /// Gets and sets a value indicating if button spec tooltips should remove the parent tooltip.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Should button spec tooltips should remove the parent tooltip")]
+        [Category(@"Visuals")]
+        [Description(@"Should button spec tooltips should remove the parent tooltip")]
         [DefaultValue(false)]
         public bool AllowButtonSpecToolTipPriority { get; set; }
 
         /// <summary>
         /// Gets the collection of button specifications.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Collection of button specifications.")]
+        [Category(@"Visuals")]
+        [Description(@"Collection of button specifications.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public ComboBoxButtonSpecCollection ButtonSpecs { get; }
 
         /// <summary>
         /// Gets or sets the StringCollection to use when the AutoCompleteSource property is set to CustomSource.
         /// </summary>
-        [Description("The StringCollection to use when the AutoCompleteSource property is set to CustomSource.")]
-        [Editor("System.Windows.Forms.Design.ListControlStringCollectionEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
+        [Description(@"The StringCollection to use when the AutoCompleteSource property is set to CustomSource.")]
+        [Editor(@"System.Windows.Forms.Design.ListControlStringCollectionEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Localizable(true)]
@@ -1817,7 +1819,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets the text completion behavior of the combobox.
         /// </summary>
-        [Description("Indicates the text completion behavior of the combobox.")]
+        [Description(@"Indicates the text completion behavior of the combobox.")]
         [DefaultValue(typeof(AutoCompleteMode), "None")]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Browsable(true)]
@@ -1831,7 +1833,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets the autocomplete source, which can be one of the values from AutoCompleteSource enumeration.
         /// </summary>
-        [Description("The autocomplete source, which can be one of the values from AutoCompleteSource enumeration.")]
+        [Description(@"The autocomplete source, which can be one of the values from AutoCompleteSource enumeration.")]
         [DefaultValue(typeof(AutoCompleteSource), "None")]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Browsable(true)]
@@ -1845,10 +1847,10 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets the format specifier characters that indicate how a value is to be displayed.
         /// </summary>
-        [Description("The format specifier characters that indicate how a value is to be displayed.")]
-        [Editor("System.Windows.Forms.Design.FormatStringEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
+        [Description(@"The format specifier characters that indicate how a value is to be displayed.")]
+        [Editor(@"System.Windows.Forms.Design.FormatStringEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
         [MergableProperty(false)]
-        [DefaultValue("")]
+        [DefaultValue(@"")]
         public string FormatString
         {
             get => _comboBox.FormatString;
@@ -1858,7 +1860,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets if this property is true, the value of FormatString is used to convert the value of DisplayMember into a value that can be displayed.
         /// </summary>
-        [Description("If this property is true, the value of FormatString is used to convert the value of DisplayMember into a value that can be displayed.")]
+        [Description(@"If this property is true, the value of FormatString is used to convert the value of DisplayMember into a value that can be displayed.")]
         [DefaultValue(false)]
         public bool FormattingEnabled
         {
@@ -1869,8 +1871,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the common combobox appearance entries that other states can override.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining common combobox appearance that other states can override.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining common combobox appearance that other states can override.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteComboBoxRedirect StateCommon { get; }
 
@@ -1879,8 +1881,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the disabled combobox appearance entries.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining disabled combobox appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining disabled combobox appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteComboBoxStates StateDisabled { get; }
 
@@ -1889,8 +1891,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the normal combobox appearance entries.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining normal combobox appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining normal combobox appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteComboBoxStates StateNormal { get; }
 
@@ -1899,8 +1901,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the active combobox appearance entries.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining active combobox appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining active combobox appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteComboBoxJustComboStates StateActive { get; }
 
@@ -1909,8 +1911,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the tracking combobox appearance entries.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining tracking combobox appearance.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining tracking combobox appearance.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteComboBoxJustItemStates StateTracking { get; }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCommand.cs
@@ -400,7 +400,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the item with the provided name.
         /// </summary>
-        /// <param name="name">Name to find.</param>
+        /// <param name=(@"Name")>Name to find.</param>
         /// <returns>Item with matching name.</returns>
         public override KryptonCommand this[string name]
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonContextMenu.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonContextMenu.cs
@@ -18,11 +18,11 @@ namespace Krypton.Toolkit
     /// </summary>
     [ToolboxItem(true)]
     [ToolboxBitmap(typeof(KryptonContextMenu), "ToolboxBitmaps.KryptonContextMenu.bmp")]
-    [DefaultEvent("Opening")]
-    [DefaultProperty("PaletteMode")]
-    [DesignerCategory("code")]
-    [Designer("Krypton.Toolkit.KryptonContextMenuDesigner, Krypton.Toolkit")]
-    [Description("Displays a shortcut menu in popup window.")]
+    [DefaultEvent(@"Opening")]
+    [DefaultProperty(@"PaletteMode")]
+    [DesignerCategory(@"code")]
+    [Designer(@"Krypton.Toolkit.KryptonContextMenuDesigner, Krypton.Toolkit")]
+    [Description(@"Displays a shortcut menu in popup window.")]
     public class KryptonContextMenu : Component
     {
         #region Instance Fields
@@ -37,29 +37,29 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Occurs when the context menu is opening.
         /// </summary>
-        [Category("Action")]
-        [Description("Occurs when context menu is opening but not displayed as yet.")]
+        [Category(@"Action")]
+        [Description(@"Occurs when context menu is opening but not displayed as yet.")]
         public event CancelEventHandler Opening;
 
         /// <summary>
         /// Occurs when the context menu is opened.
         /// </summary>
-        [Category("Action")]
-        [Description("Occurs when the context menu is fully opened for display.")]
+        [Category(@"Action")]
+        [Description(@"Occurs when the context menu is fully opened for display.")]
         public event EventHandler Opened;
 
         /// <summary>
         /// Occurs when the context menu is about to close.
         /// </summary>
-        [Category("Action")]
-        [Description("Occurs when the context menu is about to close.")]
+        [Category(@"Action")]
+        [Description(@"Occurs when the context menu is about to close.")]
         public event CancelEventHandler Closing;
 
         /// <summary>
         /// Occurs when the context menu has been closed.
         /// </summary>
-        [Category("Action")]
-        [Description("Occurs when the context menu has been closed.")]
+        [Category(@"Action")]
+        [Description(@"Occurs when the context menu has been closed.")]
         public event ToolStripDropDownClosedEventHandler Closed;
         #endregion
 
@@ -110,8 +110,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the image value overrides.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Image value overrides.")]
+        [Category(@"Visuals")]
+        [Description(@"Image value overrides.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public ContextMenuImages Images { get; }
 
@@ -120,8 +120,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the common context menu appearance entries that other states can override.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining common context menu appearance that other states can override.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining common context menu appearance that other states can override.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteContextMenuRedirect StateCommon { get; }
 
@@ -130,8 +130,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the context menu disabled appearance values.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining context menu disabled appearance values.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining context menu disabled appearance values.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteContextMenuItemState StateDisabled { get; }
 
@@ -140,8 +140,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the context menu normal appearance values.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for context menu item normal appearance values.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for context menu item normal appearance values.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteContextMenuItemState StateNormal { get; }
 
@@ -150,8 +150,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the context menu normal appearance values.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining context menu checked appearance values.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining context menu checked appearance values.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteContextMenuItemStateChecked StateChecked { get; }
 
@@ -160,8 +160,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the context menu highlight appearance values.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Overrides for defining context menu highlight appearance values.")]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining context menu highlight appearance values.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteContextMenuItemStateHighlight StateHighlight { get; }
 
@@ -170,16 +170,16 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Collection of menu items for display.
         /// </summary>
-        [Category("Data")]
-        [Description("Collection of menu items.")]
+        [Category(@"Data")]
+        [Description(@"Collection of menu items.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public KryptonContextMenuCollection Items { get; }
 
         /// <summary>
         /// Gets and sets user-defined data associated with the object.
         /// </summary>
-        [Category("Data")]
-        [Description("User-defined data associated with the object.")]
+        [Category(@"Data")]
+        [Description(@"User-defined data associated with the object.")]
         [TypeConverter(typeof(StringConverter))]
         [Bindable(true)]
         public object Tag { get; set; }
@@ -196,8 +196,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets if the context menu is enabled.
         /// </summary>
-        [Category("Behavior")]
-        [Description("Indicates whether the context menu is enabled.")]
+        [Category(@"Behavior")]
+        [Description(@"Indicates whether the context menu is enabled.")]
         [DefaultValue(true)]
         [Bindable(true)]
         public bool Enabled { get; set; }
@@ -205,8 +205,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets the palette to be applied.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Palette applied to drawing.")]
+        [Category(@"Visuals")]
+        [Description(@"Palette applied to drawing.")]
         public PaletteMode PaletteMode
         {
             [DebuggerStepThrough]
@@ -227,8 +227,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the custom palette implementation.
         /// </summary>
-        [Category("Visuals")]
-        [Description("Custom palette applied to drawing.")]
+        [Category(@"Visuals")]
+        [Description(@"Custom palette applied to drawing.")]
         [DefaultValue(null)]
         public IPalette Palette
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewButtonCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewButtonCell.cs
@@ -61,7 +61,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the button style.
         /// </summary>
-        [Category("Appearance")]
+        [Category(@"Appearance")]
         [DefaultValue(typeof(ButtonStyle), "Standalone")]
         public ButtonStyle ButtonStyle
         {
@@ -352,7 +352,7 @@ namespace Krypton.Toolkit
                 if (_piButtonState == null)
                 {
                     // Cache access to the internal get property 'ButtonState'
-                    _piButtonState = typeof(DataGridViewButtonCell).GetProperty("ButtonState", BindingFlags.Instance |
+                    _piButtonState = typeof(DataGridViewButtonCell).GetProperty(@"ButtonState", BindingFlags.Instance |
                                                                                                BindingFlags.NonPublic |
                                                                                                BindingFlags.GetField);
 
@@ -371,7 +371,7 @@ namespace Krypton.Toolkit
                 if (_fiMouseInContentBounds == null)
                 {
                     // Cache field info about the internal 'mouseInContentBounds' instance
-                    _fiMouseInContentBounds = typeof(DataGridViewButtonCell).GetField("mouseInContentBounds", BindingFlags.Static |
+                    _fiMouseInContentBounds = typeof(DataGridViewButtonCell).GetField(@"mouseInContentBounds", BindingFlags.Static |
                                                                                                               BindingFlags.NonPublic |
                                                                                                               BindingFlags.GetField);
                 }
@@ -389,7 +389,7 @@ namespace Krypton.Toolkit
                 if (_piMouseEnteredCellAddress == null)
                 {
                     // Cache access to the internal get property 'MouseEnteredCellAddress'
-                    _piMouseEnteredCellAddress = typeof(DataGridView).GetProperty("MouseEnteredCellAddress", BindingFlags.Instance |
+                    _piMouseEnteredCellAddress = typeof(DataGridView).GetProperty(@"MouseEnteredCellAddress", BindingFlags.Instance |
                                                                                                              BindingFlags.NonPublic |
                                                                                                              BindingFlags.GetField);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewButtonColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewButtonColumn.cs
@@ -49,13 +49,13 @@ namespace Krypton.Toolkit
         public override string ToString()
         {
             StringBuilder builder = new(0x40);
-            builder.Append("KryptonDataGridViewButtonColumn { Name=");
+            builder.Append(@"KryptonDataGridViewButtonColumn { Name=");
             // ReSharper disable RedundantBaseQualifier
             builder.Append(base.Name);
-            builder.Append(", Index=");
+            builder.Append(@", Index=");
             builder.Append(base.Index.ToString(CultureInfo.CurrentCulture));
             // ReSharper restore RedundantBaseQualifier
-            builder.Append(" }");
+            builder.Append(@" }");
             return builder.ToString();
         }
 
@@ -86,7 +86,7 @@ namespace Krypton.Toolkit
             {
                 if ((value != null) && value is not KryptonDataGridViewButtonCell)
                 {
-                    throw new InvalidCastException("Can only assign a object of type KryptonDataGridViewButtonCell");
+                    throw new InvalidCastException(@"Can only assign a object of type KryptonDataGridViewButtonCell");
                 }
 
                 base.CellTemplate = value;
@@ -97,7 +97,7 @@ namespace Krypton.Toolkit
         /// Gets or sets the column's default cell style.
         /// </summary>
         [Browsable(true)]
-        [Category("Appearance")]
+        [Category(@"Appearance")]
         public override DataGridViewCellStyle DefaultCellStyle
         {
             get => base.DefaultCellStyle;
@@ -107,7 +107,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets the default text displayed on the button cell.
         /// </summary>
-        [Category("Appearance")]
+        [Category(@"Appearance")]
         [DefaultValue(null)]
         public string Text
         {
@@ -148,13 +148,13 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets a value indicating whether the Text property value is displayed as the button text for cells in this column.
         /// </summary>
-        [Category("Appearance")]
+        [Category(@"Appearance")]
         [DefaultValue(false)]
         public bool UseColumnTextForButtonValue
         {
             get =>
                 CellTemplate == null
-                    ? throw new InvalidOperationException("KryptonDataGridViewButtonColumn cell template required")
+                    ? throw new InvalidOperationException(@"KryptonDataGridViewButtonColumn cell template required")
                     : ((KryptonDataGridViewButtonCell)CellTemplate).UseColumnTextForButtonValue;
 
             set
@@ -183,13 +183,13 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets a value indicating whether the Text property value is displayed as the button text for cells in this column.
         /// </summary>
-        [Category("Appearance")]
+        [Category(@"Appearance")]
         [DefaultValue(typeof(ButtonStyle), "Standalone")]
         public ButtonStyle ButtonStyle
         {
             get =>
                 CellTemplate == null
-                    ? throw new InvalidOperationException("KryptonDataGridViewButtonColumn cell template required")
+                    ? throw new InvalidOperationException(@"KryptonDataGridViewButtonColumn cell template required")
                     : ((KryptonDataGridViewButtonCell)CellTemplate).ButtonStyle;
 
             set
@@ -240,7 +240,7 @@ namespace Krypton.Toolkit
             if (_miColumnCommonChange == null)
             {
                 // Cache access to the internal method 'OnColumnCommonChange'
-                _miColumnCommonChange = typeof(DataGridView).GetMethod("OnColumnCommonChange", BindingFlags.Instance |
+                _miColumnCommonChange = typeof(DataGridView).GetMethod(@"OnColumnCommonChange", BindingFlags.Instance |
                                                                                                BindingFlags.NonPublic |
                                                                                                BindingFlags.GetField);
 
@@ -255,7 +255,7 @@ namespace Krypton.Toolkit
             if (_piUseColumnTextForButtonValueInternal == null)
             {
                 // Cache access to the internal property sette 'UseColumnTextForButtonValueInternal'
-                _piUseColumnTextForButtonValueInternal = typeof(DataGridViewButtonCell).GetProperty("UseColumnTextForButtonValueInternal", BindingFlags.Instance |
+                _piUseColumnTextForButtonValueInternal = typeof(DataGridViewButtonCell).GetProperty(@"UseColumnTextForButtonValueInternal", BindingFlags.Instance |
                                                                                                                                            BindingFlags.NonPublic |
                                                                                                                                            BindingFlags.SetProperty);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewCheckBoxCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewCheckBoxCell.cs
@@ -264,7 +264,7 @@ namespace Krypton.Toolkit
                 if (_piButtonState == null)
                 {
                     // Cache access to the internal get property 'ButtonState'
-                    _piButtonState = typeof(DataGridViewCheckBoxCell).GetProperty("ButtonState", BindingFlags.Instance |
+                    _piButtonState = typeof(DataGridViewCheckBoxCell).GetProperty(@"ButtonState", BindingFlags.Instance |
                                                                                                  BindingFlags.NonPublic |
                                                                                                  BindingFlags.GetField);
 
@@ -283,7 +283,7 @@ namespace Krypton.Toolkit
                 if (_fiMouseInContentBounds == null)
                 {
                     // Cache field info about the internal 'mouseInContentBounds' instance
-                    _fiMouseInContentBounds = typeof(DataGridViewCheckBoxCell).GetField("mouseInContentBounds", BindingFlags.Static |
+                    _fiMouseInContentBounds = typeof(DataGridViewCheckBoxCell).GetField(@"mouseInContentBounds", BindingFlags.Static |
                                                                                                                 BindingFlags.NonPublic |
                                                                                                                 BindingFlags.GetField);
                 }
@@ -301,7 +301,7 @@ namespace Krypton.Toolkit
                 if (_piMouseEnteredCellAddress == null)
                 {
                     // Cache access to the internal get property 'MouseEnteredCellAddress'
-                    _piMouseEnteredCellAddress = typeof(DataGridView).GetProperty("MouseEnteredCellAddress", BindingFlags.Instance |
+                    _piMouseEnteredCellAddress = typeof(DataGridView).GetProperty(@"MouseEnteredCellAddress", BindingFlags.Instance |
                                                                                                              BindingFlags.NonPublic |
                                                                                                              BindingFlags.GetField);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewCheckBoxColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewCheckBoxColumn.cs
@@ -60,13 +60,13 @@ namespace Krypton.Toolkit
         public override string ToString()
         {
             StringBuilder builder = new(0x40);
-            builder.Append("KryptonDataGridViewCheckBoxColumn { Name=");
+            builder.Append(@"KryptonDataGridViewCheckBoxColumn { Name=");
             // ReSharper disable RedundantBaseQualifier
             builder.Append(base.Name);
-            builder.Append(", Index=");
+            builder.Append(@", Index=");
             builder.Append(base.Index.ToString(CultureInfo.CurrentCulture));
             // ReSharper restore RedundantBaseQualifier
-            builder.Append(" }");
+            builder.Append(@" }");
             return builder.ToString();
         }
         #endregion
@@ -85,7 +85,7 @@ namespace Krypton.Toolkit
             {
                 if ((value != null) && value is not KryptonDataGridViewCheckBoxCell)
                 {
-                    throw new InvalidCastException("Can only assign a object of type KryptonDataGridViewCheckBoxCell");
+                    throw new InvalidCastException(@"Can only assign a object of type KryptonDataGridViewCheckBoxCell");
                 }
 
                 base.CellTemplate = value;
@@ -95,14 +95,14 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets the underlying value corresponding to a cell value of false, which appears as an unchecked box.
         /// </summary>
-        [Category("Data")]
-        [DefaultValue("")]
+        [Category(@"Data")]
+        [DefaultValue(@"")]
         [TypeConverter(typeof(StringConverter))]
         public object FalseValue
         {
             get =>
                 CheckBoxCellTemplate == null
-                    ? throw new InvalidOperationException("KryptonDataGridViewCheckBoxColumn cell template required")
+                    ? throw new InvalidOperationException(@"KryptonDataGridViewCheckBoxColumn cell template required")
                     : CheckBoxCellTemplate.FalseValue;
             set
             {
@@ -130,14 +130,14 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets the underlying value corresponding to an indeterminate or a null reference (Nothing in Visual Basic) cell value, which appears as a disabled checkbox.
         /// </summary>
-        [Category("Data")]
-        [DefaultValue("")]
+        [Category(@"Data")]
+        [DefaultValue(@"")]
         [TypeConverter(typeof(StringConverter))]
         public object IndeterminateValue
         {
             get =>
                 CheckBoxCellTemplate == null
-                    ? throw new InvalidOperationException("KryptonDataGridViewCheckBoxColumn cell template required")
+                    ? throw new InvalidOperationException(@"KryptonDataGridViewCheckBoxColumn cell template required")
                     : CheckBoxCellTemplate.IndeterminateValue;
             set
             {
@@ -165,14 +165,14 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets the underlying value corresponding to a cell value of true, which appears as a checked box.
         /// </summary>
-        [Category("Data")]
-        [DefaultValue("")]
+        [Category(@"Data")]
+        [DefaultValue(@"")]
         [TypeConverter(typeof(StringConverter))]
         public object TrueValue
         {
             get =>
                 CheckBoxCellTemplate == null
-                    ? throw new InvalidOperationException("KryptonDataGridViewCheckBoxColumn cell template required")
+                    ? throw new InvalidOperationException(@"KryptonDataGridViewCheckBoxColumn cell template required")
                     : CheckBoxCellTemplate.TrueValue;
             set
             {
@@ -200,13 +200,13 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets a value indicating whether the hosted check box cells will allow three check states rather than two.
         /// </summary>
-        [Category("Behavior")]
+        [Category(@"Behavior")]
         [DefaultValue(false)]
         public bool ThreeState
         {
             get =>
                 CheckBoxCellTemplate == null
-                    ? throw new InvalidOperationException("KryptonDataGridViewCheckBoxColumn cell template required")
+                    ? throw new InvalidOperationException(@"KryptonDataGridViewCheckBoxColumn cell template required")
                     : CheckBoxCellTemplate.ThreeState;
             set
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxCell.cs
@@ -225,7 +225,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// The DisplayMember property replicates the one from the KryptonComboBox control
         /// </summary>
-        [DefaultValue("")]
+        [DefaultValue(@"")]
         public string DisplayMember
         {
             get => _displayMember;
@@ -243,7 +243,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// The ValueMember property replicates the one from the KryptonComboBox control
         /// </summary>
-        [DefaultValue("")]
+        [DefaultValue(@"")]
         public string ValueMember
         {
             get => _valueMember;
@@ -261,8 +261,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the list that this control will use to gets its items.
         /// </summary>
-        [Category("Data")]
-        [Description("Indicates the list that this control will use to gets its items.")]
+        [Category(@"Data")]
+        [Description(@"Indicates the list that this control will use to gets its items.")]
         [AttributeProvider(typeof(IListSource))]
         [RefreshProperties(RefreshProperties.Repaint)]
         [DefaultValue(null)]
@@ -288,7 +288,7 @@ namespace Krypton.Toolkit
             DataGridView dataGridView = DataGridView;
             if (dataGridView?.EditingControl == null)
             {
-                throw new InvalidOperationException("Cell is detached or its grid has no editing control.");
+                throw new InvalidOperationException(@"Cell is detached or its grid has no editing control.");
             }
 
             if (dataGridView.EditingControl is KryptonComboBox comboBox)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxColumn.cs
@@ -17,7 +17,7 @@ namespace Krypton.Toolkit
     /// <summary>
     /// Hosts a collection of KryptonDataGridViewComboBoxCell cells.
     /// </summary>
-    [Designer("Krypton.Toolkit.KryptonComboBoxColumnDesigner, Krypton.Toolkit")]
+    [Designer(@"Krypton.Toolkit.KryptonComboBoxColumnDesigner, Krypton.Toolkit")]
     [ToolboxBitmap(typeof(KryptonDataGridViewComboBoxColumn), "ToolboxBitmaps.KryptonComboBox.bmp")]
     public class KryptonDataGridViewComboBoxColumn : KryptonDataGridViewIconColumn
     {
@@ -50,13 +50,13 @@ namespace Krypton.Toolkit
         public override string ToString()
         {
             StringBuilder builder = new(0x40);
-            builder.Append("KryptonDataGridViewComboBoxColumn { Name=");
+            builder.Append(@"KryptonDataGridViewComboBoxColumn { Name=");
             // ReSharper disable RedundantBaseQualifier
             builder.Append(base.Name);
-            builder.Append(", Index=");
+            builder.Append(@", Index=");
             builder.Append(base.Index.ToString(CultureInfo.CurrentCulture));
             // ReSharper restore RedundantBaseQualifier
-            builder.Append(" }");
+            builder.Append(@" }");
             return builder.ToString();
         }
 
@@ -116,18 +116,18 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the collection of the button specifications.
         /// </summary>
-        [Category("Data")]
-        [Description("Set of extra button specs to appear with control.")]
+        [Category(@"Data")]
+        [Description(@"Set of extra button specs to appear with control.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public DataGridViewColumnSpecCollection ButtonSpecs { get; }
 
         /// <summary>
         /// Gets the collection of allowable items of the domain up down.
         /// </summary>
-        [Category("Data")]
-        [Description("The allowable items of the domain up down.")]
+        [Category(@"Data")]
+        [Description(@"The allowable items of the domain up down.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-        [Editor("System.Windows.Forms.Design.StringCollectionEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
+        [Editor(@"System.Windows.Forms.Design.StringCollectionEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
         [Localizable(true)]
         public List<object> Items { get; }
 
@@ -136,8 +136,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the appearance and functionality of the KryptonComboBox.
         /// </summary>
-        [Category("Appearance")]
-        [Description("Controls the appearance and functionality of the KryptonComboBox.")]
+        [Category(@"Appearance")]
+        [Description(@"Controls the appearance and functionality of the KryptonComboBox.")]
         [DefaultValue(typeof(ComboBoxStyle), "DropDown")]
         [RefreshProperties(RefreshProperties.Repaint)]
         public ComboBoxStyle DropDownStyle
@@ -180,8 +180,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the maximum number of entries to display in the drop-down list.
         /// </summary>
-        [Category("Behavior")]
-        [Description("The maximum number of entries to display in the drop-down list.")]
+        [Category(@"Behavior")]
+        [Description(@"The maximum number of entries to display in the drop-down list.")]
         [Localizable(true)]
         [DefaultValue(8)]
         public int MaxDropDownItems
@@ -224,8 +224,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the height, in pixels, of the drop down box in a KryptonComboBox.
         /// </summary>
-        [Category("Behavior")]
-        [Description("The height, in pixels, of the drop down box in a KryptonComboBox.")]
+        [Category(@"Behavior")]
+        [Description(@"The height, in pixels, of the drop down box in a KryptonComboBox.")]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [DefaultValue(200)]
         [Browsable(true)]
@@ -269,8 +269,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the width, in pixels, of the drop down box in a KryptonComboBox.
         /// </summary>
-        [Category("Behavior")]
-        [Description("The width, in pixels, of the drop down box in a KryptonComboBox.")]
+        [Category(@"Behavior")]
+        [Description(@"The width, in pixels, of the drop down box in a KryptonComboBox.")]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Browsable(true)]
         public int DropDownWidth
@@ -313,8 +313,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets the StringCollection to use when the AutoCompleteSource property is set to CustomSource.
         /// </summary>
-        [Description("The StringCollection to use when the AutoCompleteSource property is set to CustomSource.")]
-        [Editor("System.Windows.Forms.Design.ListControlStringCollectionEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
+        [Description(@"The StringCollection to use when the AutoCompleteSource property is set to CustomSource.")]
+        [Editor(@"System.Windows.Forms.Design.ListControlStringCollectionEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Localizable(true)]
@@ -326,7 +326,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets the text completion behavior of the combobox.
         /// </summary>
-        [Description("Indicates the text completion behavior of the combobox.")]
+        [Description(@"Indicates the text completion behavior of the combobox.")]
         [DefaultValue(typeof(AutoCompleteMode), "None")]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Browsable(true)]
@@ -370,7 +370,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets the autocomplete source, which can be one of the values from AutoCompleteSource enumeration.
         /// </summary>
-        [Description("The autocomplete source, which can be one of the values from AutoCompleteSource enumeration.")]
+        [Description(@"The autocomplete source, which can be one of the values from AutoCompleteSource enumeration.")]
         [DefaultValue(typeof(AutoCompleteSource), "None")]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Browsable(true)]
@@ -414,23 +414,23 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the appearance and functionality of the KryptonComboBox.
         /// </summary>
-        [Category("Data")]
-        [Description("Indicates the property to display for the items in this control.")]
-        [TypeConverter("System.Windows.Forms.Design.DataMemberFieldConverter, " + AssemblyRef.SystemWinformsDesign)]
-        [Editor("System.Windows.Forms.Design.DataMemberFieldEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
-        [DefaultValue("")]
+        [Category(@"Data")]
+        [Description(@"Indicates the property to display for the items in this control.")]
+        [TypeConverter(@"System.Windows.Forms.Design.DataMemberFieldConverter, " + AssemblyRef.SystemWinformsDesign)]
+        [Editor(@"System.Windows.Forms.Design.DataMemberFieldEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
+        [DefaultValue(@"")]
         public string DisplayMember
         {
             get =>
                 ComboBoxCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
+                    ? throw new InvalidOperationException(@"Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
                     : ComboBoxCellTemplate.DisplayMember;
 
             set
             {
                 if (ComboBoxCellTemplate == null)
                 {
-                    throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
+                    throw new InvalidOperationException(@"Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
                 }
 
                 // Update the template cell so that subsequent cloned cells use the new value.
@@ -459,16 +459,16 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the appearance and functionality of the KryptonComboBox.
         /// </summary>
-        [Category("Data")]
-        [Description("Indicates the property to display for the items in this control.")]
-        [TypeConverter("System.Windows.Forms.Design.DataMemberFieldConverter, " + AssemblyRef.SystemWinformsDesign)]
-        [Editor("System.Windows.Forms.Design.DataMemberFieldEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
-        [DefaultValue("")]
+        [Category(@"Data")]
+        [Description(@"Indicates the property to display for the items in this control.")]
+        [TypeConverter(@"System.Windows.Forms.Design.DataMemberFieldConverter, " + AssemblyRef.SystemWinformsDesign)]
+        [Editor(@"System.Windows.Forms.Design.DataMemberFieldEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
+        [DefaultValue(@"")]
         public string ValueMember
         {
             get =>
                 ComboBoxCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
+                    ? throw new InvalidOperationException(@"Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
                     : ComboBoxCellTemplate.ValueMember;
 
             set
@@ -503,10 +503,10 @@ namespace Krypton.Toolkit
         /// <summary>
         /// "Indicates the Datasource for the items in this control.
         /// </summary>
-        [Category("Data")]
-        [Description("Indicates the Datasource for the items in this control.")]
-        [TypeConverter("System.Windows.Forms.Design.DataSourceConverter, " + AssemblyRef.SystemDesign)]
-        [Editor("System.Windows.Forms.Design.DataSourceListEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
+        [Category(@"Data")]
+        [Description(@"Indicates the Datasource for the items in this control.")]
+        [TypeConverter(@"System.Windows.Forms.Design.DataSourceConverter, " + AssemblyRef.SystemDesign)]
+        [Editor(@"System.Windows.Forms.Design.DataSourceListEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
         public object DataSource
         {
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownCell.cs
@@ -75,7 +75,7 @@ namespace Krypton.Toolkit
             DataGridView dataGridView = DataGridView;
             if (dataGridView?.EditingControl == null)
             {
-                throw new InvalidOperationException("Cell is detached or its grid has no editing control.");
+                throw new InvalidOperationException(@"Cell is detached or its grid has no editing control.");
             }
 
             if (dataGridView.EditingControl is KryptonDomainUpDown domainUpDown)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownColumn.cs
@@ -16,7 +16,7 @@ namespace Krypton.Toolkit
     /// <summary>
     /// Hosts a collection of KryptonDataGridViewDomainUpDownCell cells.
     /// </summary>
-    [Designer("Krypton.Toolkit.KryptonDomainUpDownColumnDesigner, Krypton.Toolkit")]
+    [Designer(@"Krypton.Toolkit.KryptonDomainUpDownColumnDesigner, Krypton.Toolkit")]
     [ToolboxBitmap(typeof(KryptonDataGridViewDomainUpDownColumn), "ToolboxBitmaps.KryptonDomainUpDown.bmp")]
     public class KryptonDataGridViewDomainUpDownColumn : KryptonDataGridViewIconColumn
     {
@@ -48,13 +48,13 @@ namespace Krypton.Toolkit
         public override string ToString()
         {
             StringBuilder builder = new(0x40);
-            builder.Append("KryptonDataGridViewDomainUpDownColumn { Name=");
+            builder.Append(@"KryptonDataGridViewDomainUpDownColumn { Name=");
             // ReSharper disable RedundantBaseQualifier
             builder.Append(base.Name);
-            builder.Append(", Index=");
+            builder.Append(@", Index=");
             builder.Append(base.Index.ToString(CultureInfo.CurrentCulture));
             // ReSharper restore RedundantBaseQualifier
-            builder.Append(" }");
+            builder.Append(@" }");
             return builder.ToString();
         }
 
@@ -98,7 +98,7 @@ namespace Krypton.Toolkit
             {
                 if ((value != null) && (value is not KryptonDataGridViewDomainUpDownCell cell))
                 {
-                    throw new InvalidCastException("Value provided for CellTemplate must be of type KryptonDataGridViewDomainUpDownCell or derive from it.");
+                    throw new InvalidCastException(@"Value provided for CellTemplate must be of type KryptonDataGridViewDomainUpDownCell or derive from it.");
                 }
 
                 base.CellTemplate = value;
@@ -108,18 +108,18 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the collection of the button specifications.
         /// </summary>
-        [Category("Data")]
-        [Description("Set of extra button specs to appear with control.")]
+        [Category(@"Data")]
+        [Description(@"Set of extra button specs to appear with control.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public DataGridViewColumnSpecCollection ButtonSpecs { get; }
 
         /// <summary>
         /// Gets the collection of allowable items of the domain up down.
         /// </summary>
-        [Category("Data")]
-        [Description("The allowable items of the domain up down.")]
+        [Category(@"Data")]
+        [Description(@"The allowable items of the domain up down.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-        [Editor("System.Windows.Forms.Design.StringCollectionEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
+        [Editor(@"System.Windows.Forms.Design.StringCollectionEditor, " + AssemblyRef.SystemDesign, typeof(UITypeEditor))]
         public StringCollection Items { get; }
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewNumericUpDownCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewNumericUpDownCell.cs
@@ -129,9 +129,9 @@ namespace Krypton.Toolkit
 
             set
             {
-                if ((value < 0) || (value > 99))
+                if (value is < 0 or > 99)
                 {
-                    throw new ArgumentOutOfRangeException("The DecimalPlaces property cannot be smaller than 0 or larger than 99.");
+                    throw new ArgumentOutOfRangeException(@"The DecimalPlaces property cannot be smaller than 0 or larger than 99.");
                 }
 
                 if (_decimalPlaces != value)
@@ -170,7 +170,7 @@ namespace Krypton.Toolkit
             {
                 if (value < (decimal)0.0)
                 {
-                    throw new ArgumentOutOfRangeException("The Increment property cannot be smaller than 0.");
+                    throw new ArgumentOutOfRangeException(@"The Increment property cannot be smaller than 0.");
                 }
 
                 SetIncrement(RowIndex, value);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDateTimePicker.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDateTimePicker.cs
@@ -616,7 +616,7 @@ namespace Krypton.Toolkit
             set
             {
                 // We only allow a null/DBNull (as a way of setting no value) or a DateTime value
-                if ((value == null) || (value is DBNull) || (value is DateTime))
+                if (value is null or DBNull or DateTime)
                 {
                     // Only interested in changes of value
                     if (_rawDateTime != value)
@@ -625,7 +625,7 @@ namespace Krypton.Toolkit
                         _userSetDateTime = true;
 
                         // Update the checkbox to reflect the value
-                        if ((_rawDateTime == null) || (_rawDateTime is DBNull))
+                        if (_rawDateTime is null or DBNull)
                         {
                             _rawDateTime = DBNull.Value;
                             InternalViewDrawCheckBox.CheckState = CheckState.Unchecked;
@@ -867,12 +867,12 @@ namespace Krypton.Toolkit
                 {
                     if (value < EffectiveMinDate(_minDateTime))
                     {
-                        throw new ArgumentOutOfRangeException("Date provided is less than the minimum supported date.");
+                        throw new ArgumentOutOfRangeException(@"Date provided is less than the minimum supported date.");
                     }
 
                     if (value > DateTimePicker.MaximumDateTime)
                     {
-                        throw new ArgumentOutOfRangeException("Date provided is greater than the maximum supported date.");
+                        throw new ArgumentOutOfRangeException(@"Date provided is greater than the maximum supported date.");
                     }
 
                     _maxDateTime = value;
@@ -920,12 +920,12 @@ namespace Krypton.Toolkit
                 {
                     if (value > EffectiveMaxDate(_maxDateTime))
                     {
-                        throw new ArgumentOutOfRangeException("Date provided is greater than the maximum supported date.");
+                        throw new ArgumentOutOfRangeException(@"Date provided is greater than the maximum supported date.");
                     }
 
                     if (value < DateTimePicker.MinimumDateTime)
                     {
-                        throw new ArgumentOutOfRangeException("Date provided is less than the minimum supported date.");
+                        throw new ArgumentOutOfRangeException(@"Date provided is less than the minimum supported date.");
                     }
 
                     _minDateTime = value;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonGroupBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonGroupBox.cs
@@ -641,7 +641,7 @@ namespace Krypton.Toolkit
             // are not added correctly when inside a TabControl. Bonkers but true.
             if (!_ignoreLayout)
             {
-                // Let base class calulcate fill rectangle
+                // Let base class calculate fill rectangle
                 base.OnLayout(levent);
 
                 // Only use layout logic if control is fully initialized or if being forced

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMonthCalendar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMonthCalendar.cs
@@ -306,12 +306,12 @@ namespace Krypton.Toolkit
                 {
                     if (value > EffectiveMaxDate(_maxDate))
                     {
-                        throw new ArgumentOutOfRangeException("Date provided is greater than the maximum supported date.");
+                        throw new ArgumentOutOfRangeException(@"Date provided is greater than the maximum supported date.");
                     }
 
                     if (value < DateTimePicker.MinimumDateTime)
                     {
-                        throw new ArgumentOutOfRangeException("Date provided is less than the minimum supported date.");
+                        throw new ArgumentOutOfRangeException(@"Date provided is less than the minimum supported date.");
                     }
 
                     _minDate = value;
@@ -506,12 +506,12 @@ namespace Krypton.Toolkit
                 {
                     if (value < EffectiveMinDate(_minDate))
                     {
-                        throw new ArgumentOutOfRangeException("Date provided is less than the minimum supported date.");
+                        throw new ArgumentOutOfRangeException(@"Date provided is less than the minimum supported date.");
                     }
 
                     if (value > DateTimePicker.MaximumDateTime)
                     {
-                        throw new ArgumentOutOfRangeException("Date provided is greater than the maximum supported date.");
+                        throw new ArgumentOutOfRangeException(@"Date provided is greater than the maximum supported date.");
                     }
 
                     _maxDate = value;
@@ -541,7 +541,7 @@ namespace Krypton.Toolkit
             {
                 if (value < 1)
                 {
-                    throw new ArgumentOutOfRangeException("MaxSelectionCount cannot be less than zero.");
+                    throw new ArgumentOutOfRangeException(@"MaxSelectionCount cannot be less than zero.");
                 }
 
                 if (value != _maxSelectionCount)
@@ -570,12 +570,12 @@ namespace Krypton.Toolkit
                 {
                     if (value > _maxDate)
                     {
-                        throw new ArgumentOutOfRangeException("Date provided is greater than the maximum date.");
+                        throw new ArgumentOutOfRangeException(@"Date provided is greater than the maximum date.");
                     }
 
                     if (value < _minDate)
                     {
-                        throw new ArgumentOutOfRangeException("Date provided is less than the minimum date.");
+                        throw new ArgumentOutOfRangeException(@"Date provided is less than the minimum date.");
                     }
 
                     DateTime endDate = _selectionEnd;
@@ -620,12 +620,12 @@ namespace Krypton.Toolkit
                 {
                     if (value > _maxDate)
                     {
-                        throw new ArgumentOutOfRangeException("Date provided is greater than the maximum date.");
+                        throw new ArgumentOutOfRangeException(@"Date provided is greater than the maximum date.");
                     }
 
                     if (value < _minDate)
                     {
-                        throw new ArgumentOutOfRangeException("Date provided is less than the minimum date.");
+                        throw new ArgumentOutOfRangeException(@"Date provided is less than the minimum date.");
                     }
 
                     DateTime startDate = _selectionStart;
@@ -692,12 +692,12 @@ namespace Krypton.Toolkit
                 {
                     if (value.Width < 1)
                     {
-                        throw new ArgumentOutOfRangeException("CalendarDimension Width must be greater than 0");
+                        throw new ArgumentOutOfRangeException(@"CalendarDimension Width must be greater than 0");
                     }
 
                     if (value.Height < 1)
                     {
-                        throw new ArgumentOutOfRangeException("CalendarDimension Height must be greater than 0");
+                        throw new ArgumentOutOfRangeException(@"CalendarDimension Height must be greater than 0");
                     }
 
                     _dimensions = value;
@@ -1218,22 +1218,22 @@ namespace Krypton.Toolkit
         {
             if (start.Ticks > _maxDate.Ticks)
             {
-                throw new ArgumentOutOfRangeException("Start date provided is greater than the maximum date.");
+                throw new ArgumentOutOfRangeException(@"Start date provided is greater than the maximum date.");
             }
 
             if (start.Ticks < _minDate.Ticks)
             {
-                throw new ArgumentOutOfRangeException("Start date provided is less than the minimum date.");
+                throw new ArgumentOutOfRangeException(@"Start date provided is less than the minimum date.");
             }
 
             if (end.Ticks > _maxDate.Ticks)
             {
-                throw new ArgumentOutOfRangeException("End date provided is greater than the maximum date.");
+                throw new ArgumentOutOfRangeException(@"End date provided is greater than the maximum date.");
             }
 
             if (end.Ticks < _minDate.Ticks)
             {
-                throw new ArgumentOutOfRangeException("End date provided is less than the minimum date.");
+                throw new ArgumentOutOfRangeException(@"End date provided is less than the minimum date.");
             }
 
             if (start > end)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPalette.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPalette.cs
@@ -2004,7 +2004,7 @@ namespace Krypton.Toolkit
                 _suspendCount--;
 
                 // If an immediate drawing update is required and updates have just been enabled
-                if (updateNow && (_suspendCount == 0))
+                if (updateNow && _suspendCount == 0)
                 {
                     OnPalettePaint(this, new PaletteLayoutEventArgs(true, true));
                     OnButtonSpecChanged(this, EventArgs.Empty);
@@ -2637,7 +2637,7 @@ namespace Krypton.Toolkit
                     IPalette tempPalette = _basePalette;
 
                     // Find the new palette mode based on the incoming value
-                    _basePaletteMode = (value == null) ? PaletteMode.Office365Blue : PaletteMode.Custom;
+                    _basePaletteMode = value == null ? PaletteMode.Office365Blue : PaletteMode.Custom;
                     _basePalette = value;
 
                     // If the new value creates a circular reference
@@ -2745,7 +2745,7 @@ namespace Krypton.Toolkit
                 if (_baseRenderer != value)
                 {
                     // Find the new renderer mode based on the incoming value
-                    _baseRenderMode = (value == null) ? RendererMode.Inherit : RendererMode.Custom;
+                    _baseRenderMode = value == null ? RendererMode.Inherit : RendererMode.Custom;
                     _baseRenderer = value;
 
                     // Fire events to indicate a change in palette values
@@ -3147,7 +3147,7 @@ namespace Krypton.Toolkit
                 // having a version number the loading of older version is easier
                 XmlElement root = doc.CreateElement("KryptonPalette");
                 root.SetAttribute("Version", _paletteVersion.ToString());
-                root.SetAttribute("Generated", DateTime.Now.ToLongDateString() + ", " + DateTime.Now.ToShortTimeString());
+                root.SetAttribute("Generated", DateTime.Now.ToLongDateString() + ", @" + DateTime.Now.ToShortTimeString());
                 doc.AppendChild(root);
 
                 // Add two children, one for storing actual palette values the other for cached images
@@ -3249,7 +3249,7 @@ namespace Krypton.Toolkit
 
                                             // We ignore conversion of a Font of value (none) because instead
                                             // of providing null it returns a default font value
-                                            if ((valueType != nameof(Font)) || (valueValue != @"(none)"))
+                                            if (valueType != nameof(Font) || valueValue != @"(none)")
                                             {
                                                 // We need the type converter to create a string representation
                                                 TypeConverter converter = TypeDescriptor.GetConverter(StringToType(valueType));
@@ -3273,7 +3273,7 @@ namespace Krypton.Toolkit
         private void ImportImagesFromElement(XmlElement element, ImageReverseDictionary imageCache)
         {
             // Get all nodes storing images
-            XmlNodeList images = element.SelectNodes("Image");
+            XmlNodeList images = element.SelectNodes(@"Image");
 
             // Load each image node entry in turn
             if (images != null)
@@ -3284,10 +3284,10 @@ namespace Krypton.Toolkit
                     XmlElement imageElement = (XmlElement)image;
 
                     // Check the element is the expected type and has the required data
-                    if ((imageElement != null) &&
+                    if (imageElement != null &&
                         imageElement.HasAttribute(@"Name") &&
-                        (imageElement.ChildNodes.Count == 1) &&
-                        (imageElement.ChildNodes[0].NodeType == XmlNodeType.CDATA))
+                        imageElement.ChildNodes.Count == 1 &&
+                        imageElement.ChildNodes[0].NodeType == XmlNodeType.CDATA)
                     {
                         try
                         {
@@ -3367,7 +3367,7 @@ namespace Krypton.Toolkit
                                         PropertyDescriptor propertyIsDefault = TypeDescriptor.GetProperties(childObj)[@"IsDefault"];
 
                                         // All compound objects are expected to have an 'IsDefault' returning a boolean
-                                        if ((propertyIsDefault != null) && (propertyIsDefault.PropertyType == typeof(bool)))
+                                        if (propertyIsDefault != null && propertyIsDefault.PropertyType == typeof(bool))
                                         {
                                             // If the object 'IsDefault' then no need to persist it
                                             if ((bool)propertyIsDefault.GetValue(childObj))
@@ -3496,7 +3496,7 @@ namespace Krypton.Toolkit
 
                     // Create and add a new xml element
                     XmlElement imageElement = doc.CreateElement(@"Image");
-                    imageElement.SetAttribute("Name", entry.Value);
+                    imageElement.SetAttribute(@"Name", entry.Value);
                     element.AppendChild(imageElement);
 
                     // Set the image data into a CDATA section
@@ -3539,7 +3539,7 @@ namespace Krypton.Toolkit
                                     PropertyDescriptor propertyIsDefault = TypeDescriptor.GetProperties(childObj)[@"IsDefault"];
 
                                     // All compound objects are expected to have an 'IsDefault' returning a boolean
-                                    if ((propertyIsDefault != null) && (propertyIsDefault.PropertyType == typeof(bool)))
+                                    if (propertyIsDefault != null && propertyIsDefault.PropertyType == typeof(bool))
                                     {
                                         // If the object 'IsDefault' then no need to reset it
                                         if ((bool)propertyIsDefault.GetValue(childObj))

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonSeparator.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonSeparator.cs
@@ -363,7 +363,7 @@ namespace Krypton.Toolkit
                     // Cannot assign a value of less than zero
                     if (value < 0)
                     {
-                        throw new ArgumentOutOfRangeException("SplitterWidth", "Value cannot be less than zero");
+                        throw new ArgumentOutOfRangeException(@"SplitterWidth", @"Value cannot be less than zero");
                     }
 
                     // Use new width of the splitter area

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonSplitContainer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonSplitContainer.cs
@@ -326,7 +326,7 @@ namespace Krypton.Toolkit
                     // Cannot assign a value of less than zero
                     if (value < 0)
                     {
-                        throw new ArgumentOutOfRangeException("Panel1MinSize", "Value cannot be less than zero");
+                        throw new ArgumentOutOfRangeException(@"Panel1MinSize", @"Value cannot be less than zero");
                     }
 
                     // Use the new minimum size
@@ -430,7 +430,7 @@ namespace Krypton.Toolkit
                     // Cannot assign a value of less than zero
                     if (value < 0)
                     {
-                        throw new ArgumentOutOfRangeException("Panel2MinSize", "Value cannot be less than zero");
+                        throw new ArgumentOutOfRangeException(@"Panel2MinSize", @"Value cannot be less than zero");
                     }
 
                     // Use the new minimum size
@@ -674,7 +674,7 @@ namespace Krypton.Toolkit
                     // Cannot assign a value of less than zero
                     if (value < 0)
                     {
-                        throw new ArgumentOutOfRangeException("SplitterWidth", "Value cannot be less than zero");
+                        throw new ArgumentOutOfRangeException(@"SplitterWidth", @"Value cannot be less than zero");
                     }
 
                     // Use new width of the splitter area
@@ -714,7 +714,7 @@ namespace Krypton.Toolkit
                     // Cannot assign a value of less than zero
                     if (value < 1)
                     {
-                        throw new ArgumentOutOfRangeException("SplitterIncrement", "Value cannot be less than one");
+                        throw new ArgumentOutOfRangeException(@"SplitterIncrement", @"Value cannot be less than one");
                     }
 
                     // Remember new value for use when moving the splitter

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialogCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialogCommand.cs
@@ -326,7 +326,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the item with the provided name.
         /// </summary>
-        /// <param name="name">Name to find.</param>
+        /// <param name=(@"Name")>Name to find.</param>
         /// <returns>Item with matching name.</returns>
         public override KryptonTaskDialogCommand this[string name]
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContainerControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContainerControl.cs
@@ -84,7 +84,8 @@ namespace Krypton.Toolkit
         /// Gets a value indicating if the control is initialized.
         /// </summary>
         [Browsable(false)]
-        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool IsInitialized
         {
             [DebuggerStepThrough]
@@ -96,7 +97,8 @@ namespace Krypton.Toolkit
         /// Gets a value indicating if the control is initialized.
         /// </summary>
         [Browsable(false)]
-        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool IsInitializing
         {
             [DebuggerStepThrough]

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContextMenu.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContextMenu.cs
@@ -224,8 +224,7 @@ namespace Krypton.Toolkit
                 if ((screenPt.X + preferredSize.Width) > workingArea.Right)
                 {
                     // ...and we tried to position afterwards
-                    if ((horz == KryptonContextMenuPositionH.After) ||
-                        (horz == KryptonContextMenuPositionH.Left))
+                    if (horz is KryptonContextMenuPositionH.After or KryptonContextMenuPositionH.Left)
                     {
                         // Then switch to positioning before
                         horz = KryptonContextMenuPositionH.Before;
@@ -237,8 +236,7 @@ namespace Krypton.Toolkit
                 if (screenPt.X < workingArea.X)
                 {
                     // ...and we tried to position before
-                    if ((horz == KryptonContextMenuPositionH.Before) ||
-                        (horz == KryptonContextMenuPositionH.Right))
+                    if (horz is KryptonContextMenuPositionH.Before or KryptonContextMenuPositionH.Right)
                     {
                         // Then switch to positioning after
                         horz = KryptonContextMenuPositionH.After;
@@ -250,8 +248,7 @@ namespace Krypton.Toolkit
                 if ((screenPt.Y + preferredSize.Height) > workingArea.Bottom)
                 {
                     // ...and we tried to position downwards
-                    if ((vert == KryptonContextMenuPositionV.Below) ||
-                        (vert == KryptonContextMenuPositionV.Top))
+                    if (vert is KryptonContextMenuPositionV.Below or KryptonContextMenuPositionV.Top)
                     {
                         // Then switch to positoning upwards
                         vert = KryptonContextMenuPositionV.Bottom;
@@ -263,8 +260,7 @@ namespace Krypton.Toolkit
                 if (screenPt.Y < workingArea.Y)
                 {
                     // ...and we tried to position upwards
-                    if ((vert == KryptonContextMenuPositionV.Above) ||
-                        (vert == KryptonContextMenuPositionV.Bottom))
+                    if (vert is KryptonContextMenuPositionV.Above or KryptonContextMenuPositionV.Bottom)
                     {
                         // Then switch to positoning downwards
                         vert = KryptonContextMenuPositionV.Top;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualControl.cs
@@ -87,7 +87,8 @@ namespace Krypton.Toolkit
         /// Gets a value indicating if the control is initialized.
         /// </summary>
         [Browsable(false)]
-        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool IsInitialized
         {
             [DebuggerStepThrough]
@@ -99,7 +100,8 @@ namespace Krypton.Toolkit
         /// Gets a value indicating if the control is initialized.
         /// </summary>
         [Browsable(false)]
-        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool IsInitializing
         {
             [DebuggerStepThrough]

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
@@ -210,7 +210,7 @@ namespace Krypton.Toolkit
                                 if (!ApplyComposition)
                                 {
                                     // Remove any theme that is currently drawing chrome
-                                    PI.SetWindowTheme(Handle, "", "");
+                                    PI.SetWindowTheme(Handle, "", @"");
                                 }
                                 else
                                 {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPanel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPanel.cs
@@ -208,7 +208,8 @@ namespace Krypton.Toolkit
         /// Gets a value indicating if the control is initialized.
         /// </summary>
         [Browsable(false)]
-        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool IsInitialized
         {
             [DebuggerStepThrough]
@@ -220,7 +221,8 @@ namespace Krypton.Toolkit
         /// Gets a value indicating if the control is initialized.
         /// </summary>
         [Browsable(false)]
-        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool IsInitializing
         {
             [DebuggerStepThrough]

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualTaskDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualTaskDialog.cs
@@ -204,7 +204,7 @@ namespace Krypton.Toolkit
             {
                 _messageContent.Text = string.Empty;
             }
-            else if (_content.Length - _content.Replace("\n", "").Length > 20)
+            else if (_content.Length - _content.Replace("\n", @"").Length > 20)
             {
                 _messageContentMultiline.Text = _content;
                 _messageContentMultiline.Visible = true;

--- a/Source/Krypton Components/Krypton.Toolkit/Converters/DateTimeNullableConverter.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Converters/DateTimeNullableConverter.cs
@@ -43,7 +43,7 @@ namespace Krypton.Toolkit
             if (value is string)
             {
                 var stringValue = value.ToString().ToLower();
-                if ((stringValue == "dbnull") || (stringValue == "null") || (stringValue == "nothing"))
+                if (stringValue is "dbnull" or "null" or "nothing")
                 {
                     return DBNull.Value;
                 }

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonBorderEdgeActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonBorderEdgeActionList.cs
@@ -134,14 +134,14 @@ namespace Krypton.Toolkit
             if (_borderEdge != null)
             {
                 // Add our own action to the end
-                actions.Add(new DesignerActionHeaderItem("Appearance"));
-                actions.Add(new DesignerActionPropertyItem("BorderStyle", "Border style", "Appearance", "Border style"));
-                actions.Add(new DesignerActionHeaderItem("Layout"));
-                actions.Add(new DesignerActionPropertyItem("AutoSize", "AutoSize", "Layout", "Determines whether the control resizes based on its contents."));
-                actions.Add(new DesignerActionPropertyItem("Dock", "Dock", "Layout", "Determines how the control is sized with its parent."));
+                actions.Add(new DesignerActionHeaderItem(@"Appearance"));
+                actions.Add(new DesignerActionPropertyItem(@"BorderStyle", @"Border style", @"Appearance", @"Border style"));
+                actions.Add(new DesignerActionHeaderItem(@"Layout"));
+                actions.Add(new DesignerActionPropertyItem(@"AutoSize", @"AutoSize", @"Layout", @"Determines whether the control resizes based on its contents."));
+                actions.Add(new DesignerActionPropertyItem(@"Dock", @"Dock", @"Layout", @"Determines how the control is sized with its parent."));
                 actions.Add(new KryptonDesignerActionItem(new DesignerVerb(_action, OnOrientationClick), "Layout"));
-                actions.Add(new DesignerActionHeaderItem("Visuals"));
-                actions.Add(new DesignerActionPropertyItem("PaletteMode", "Palette", "Visuals", "Palette applied to drawing"));
+                actions.Add(new DesignerActionHeaderItem(@"Visuals"));
+                actions.Add(new DesignerActionPropertyItem(@"PaletteMode", @"Palette", @"Visuals", @"Palette applied to drawing"));
             }
 
             return actions;
@@ -157,7 +157,7 @@ namespace Krypton.Toolkit
             if (sender is DesignerVerb verb)
             {
                 // Decide on the new orientation required
-                Orientation orientation = verb.Text.Equals("Horizontal border orientation") ? Orientation.Horizontal : Orientation.Vertical;
+                Orientation orientation = verb.Text.Equals(@"Horizontal border orientation") ? Orientation.Horizontal : Orientation.Vertical;
 
                 // Decide on the next action to take given the new setting
                 _action = orientation == Orientation.Vertical ? "Horizontal border orientation" : "Vertical border orientation";

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonBreadCrumbActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonBreadCrumbActionList.cs
@@ -120,12 +120,12 @@ namespace Krypton.Toolkit
             if (_breadCrumb != null)
             {
                 // Add the list of bread crumb specific actions
-                actions.Add(new DesignerActionHeaderItem("Appearance"));
-                actions.Add(new DesignerActionPropertyItem("ControlBackStyle", "Back Style", "Appearance", "Background drawing style."));
-                actions.Add(new DesignerActionPropertyItem("ControlBorderStyle", "Border Style", "Appearance", "Border drawing style."));
-                actions.Add(new DesignerActionPropertyItem("CrumbButtonStyle", "Crumb Style", "Appearance", "Crumb drawing style."));
-                actions.Add(new DesignerActionHeaderItem("Visuals"));
-                actions.Add(new DesignerActionPropertyItem("PaletteMode", "Palette", "Visuals", "Palette applied to drawing"));
+                actions.Add(new DesignerActionHeaderItem(@"Appearance"));
+                actions.Add(new DesignerActionPropertyItem(@"ControlBackStyle", @"Back Style", @"Appearance", @"Background drawing style."));
+                actions.Add(new DesignerActionPropertyItem(@"ControlBorderStyle", @"Border Style", @"Appearance", @"Border drawing style."));
+                actions.Add(new DesignerActionPropertyItem(@"CrumbButtonStyle", @"Crumb Style", @"Appearance", @"Crumb drawing style."));
+                actions.Add(new DesignerActionHeaderItem(@"Visuals"));
+                actions.Add(new DesignerActionPropertyItem(@"PaletteMode", @"Palette", @"Visuals", @"Palette applied to drawing"));
             }
             
             return actions;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonButtonActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonButtonActionList.cs
@@ -259,23 +259,23 @@ namespace Krypton.Toolkit
             if (_button != null)
             {
                 // Add the list of button specific actions
-                actions.Add(new DesignerActionHeaderItem("Appearance"));
-                actions.Add(new DesignerActionPropertyItem("ButtonStyle", "Style", "Appearance", "Button style"));
-                actions.Add(new DesignerActionPropertyItem("ContextMenuStrip", "Context Menu Strip", "Appearance", "The context menu strip for the control."));
-                actions.Add(new DesignerActionPropertyItem("KryptonContextMenu", "Krypton Context Menu", "Appearance",
+                actions.Add(new DesignerActionHeaderItem(@"Appearance"));
+                actions.Add(new DesignerActionPropertyItem(@"ButtonStyle", @"Style", @"Appearance", @"Button style"));
+                actions.Add(new DesignerActionPropertyItem(@"ContextMenuStrip", @"Context Menu Strip", @"Appearance", @"The context menu strip for the control."));
+                actions.Add(new DesignerActionPropertyItem(@"KryptonContextMenu", @"Krypton Context Menu", @"Appearance",
                     "The krypton context menu strip for the control."));
-                actions.Add(new DesignerActionPropertyItem("Orientation", "Orientation", "Appearance", "Button orientation"));
-                actions.Add(new DesignerActionPropertyItem("ShortTextFont", "Short Text Font", "Appearance", "The short text font."));
-                actions.Add(new DesignerActionPropertyItem("LongTextFont", "Long Text Font", "Appearance", "The long text font."));
-                actions.Add(new DesignerActionPropertyItem("CornerRadius", "Corner Rounding Radius", "Appearance", "The corner rounding radius of the control."));
-                actions.Add(new DesignerActionHeaderItem("Values"));
-                actions.Add(new DesignerActionPropertyItem("Text", "Text", "Values", "Button text"));
-                actions.Add(new DesignerActionPropertyItem("ExtraText", "ExtraText", "Values", "Button extra text"));
-                actions.Add(new DesignerActionPropertyItem("Image", "Image", "Values", "Button image"));
-                actions.Add(new DesignerActionHeaderItem("Visuals"));
-                actions.Add(new DesignerActionPropertyItem("PaletteMode", "Palette", "Visuals", "Palette applied to drawing"));
-                actions.Add(new DesignerActionHeaderItem("UAC Elevation"));
-                actions.Add(new DesignerActionPropertyItem("UseAsUACElevatedButton", "Use as an UAC Elevated Button", "UAC Elevation", "Use this button to elevate a process."));
+                actions.Add(new DesignerActionPropertyItem(@"Orientation", @"Orientation", @"Appearance", @"Button orientation"));
+                actions.Add(new DesignerActionPropertyItem(@"ShortTextFont", @"Short Text Font", @"Appearance", @"The short text font."));
+                actions.Add(new DesignerActionPropertyItem(@"LongTextFont", @"Long Text Font", @"Appearance", @"The long text font."));
+                actions.Add(new DesignerActionPropertyItem(@"CornerRadius", @"Corner Rounding Radius", @"Appearance", @"The corner rounding radius of the control."));
+                actions.Add(new DesignerActionHeaderItem(@"Values"));
+                actions.Add(new DesignerActionPropertyItem(@"Text", @"Text", @"Values", @"Button text"));
+                actions.Add(new DesignerActionPropertyItem(@"ExtraText", @"ExtraText", @"Values", @"Button extra text"));
+                actions.Add(new DesignerActionPropertyItem(@"Image", @"Image", @"Values", @"Button image"));
+                actions.Add(new DesignerActionHeaderItem(@"Visuals"));
+                actions.Add(new DesignerActionPropertyItem(@"PaletteMode", @"Palette", @"Visuals", @"Palette applied to drawing"));
+                actions.Add(new DesignerActionHeaderItem(@"UAC Elevation"));
+                actions.Add(new DesignerActionPropertyItem(@"UseAsUACElevatedButton", @"Use as an UAC Elevated Button", @"UAC Elevation", @"Use this button to elevate a process."));
             }
 
             return actions;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonCheckBoxActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonCheckBoxActionList.cs
@@ -307,24 +307,24 @@ namespace Krypton.Toolkit
             if (_checkBox != null)
             {
                 // Add the list of checkbox specific actions
-                actions.Add(new DesignerActionHeaderItem("Operation"));
-                actions.Add(new DesignerActionPropertyItem("Checked", "Checked", "Operation", "Checked state"));
-                actions.Add(new DesignerActionPropertyItem("AutoCheck", "AutoCheck", "Operation", "AutoCheck of other instances."));
-                actions.Add(new DesignerActionPropertyItem("ThreeState", "ThreeState", "Operation", "ThreeState setting"));
-                actions.Add(new DesignerActionHeaderItem("Appearance"));
-                actions.Add(new DesignerActionPropertyItem("LabelStyle", "Style", "Appearance", "Label style"));
-                actions.Add(new DesignerActionPropertyItem("Orientation", "Orientation", "Appearance", "Visual orientation"));
-                actions.Add(new DesignerActionPropertyItem("ShortTextFont", "Short Text Font", "Appearance", "The short text font."));
-                actions.Add(new DesignerActionPropertyItem("ShortTextTrim", "Short Text Trim", "Appearance", "The trim mode of the short text."));
-                actions.Add(new DesignerActionPropertyItem("LongTextFont", "Long Text Font", "Appearance", "The long text font."));
-                actions.Add(new DesignerActionPropertyItem("LongTextTrim", "Long Text Trim", "Appearance", "The trim mode of the long text."));
-                actions.Add(new DesignerActionPropertyItem("ContextMenuStrip", "Context Menu Strip", "Appearance", "The context menu strip for the control."));
-                actions.Add(new DesignerActionHeaderItem("Values"));
-                actions.Add(new DesignerActionPropertyItem("Text", "Text", "Values", "Checkbox text"));
-                actions.Add(new DesignerActionPropertyItem("ExtraText", "ExtraText", "Values", "Checkbox extra text"));
-                actions.Add(new DesignerActionPropertyItem("Image", "Image", "Values", "Checkbox image"));
-                actions.Add(new DesignerActionHeaderItem("Visuals"));
-                actions.Add(new DesignerActionPropertyItem("PaletteMode", "Palette", "Visuals", "Palette applied to drawing"));
+                actions.Add(new DesignerActionHeaderItem(@"Operation"));
+                actions.Add(new DesignerActionPropertyItem(@"Checked", @"Checked", @"Operation", @"Checked state"));
+                actions.Add(new DesignerActionPropertyItem(@"AutoCheck", @"AutoCheck", @"Operation", @"AutoCheck of other instances."));
+                actions.Add(new DesignerActionPropertyItem(@"ThreeState", @"ThreeState", @"Operation", @"ThreeState setting"));
+                actions.Add(new DesignerActionHeaderItem(@"Appearance"));
+                actions.Add(new DesignerActionPropertyItem(@"LabelStyle", @"Style", @"Appearance", @"Label style"));
+                actions.Add(new DesignerActionPropertyItem(@"Orientation", @"Orientation", @"Appearance", @"Visual orientation"));
+                actions.Add(new DesignerActionPropertyItem(@"ShortTextFont", @"Short Text Font", @"Appearance", @"The short text font."));
+                actions.Add(new DesignerActionPropertyItem(@"ShortTextTrim", @"Short Text Trim", @"Appearance", @"The trim mode of the short text."));
+                actions.Add(new DesignerActionPropertyItem(@"LongTextFont", @"Long Text Font", @"Appearance", @"The long text font."));
+                actions.Add(new DesignerActionPropertyItem(@"LongTextTrim", @"Long Text Trim", @"Appearance", @"The trim mode of the long text."));
+                actions.Add(new DesignerActionPropertyItem(@"ContextMenuStrip", @"Context Menu Strip", @"Appearance", @"The context menu strip for the control."));
+                actions.Add(new DesignerActionHeaderItem(@"Values"));
+                actions.Add(new DesignerActionPropertyItem(@"Text", @"Text", @"Values", @"Checkbox text"));
+                actions.Add(new DesignerActionPropertyItem(@"ExtraText", @"ExtraText", @"Values", @"Checkbox extra text"));
+                actions.Add(new DesignerActionPropertyItem(@"Image", @"Image", @"Values", @"Checkbox image"));
+                actions.Add(new DesignerActionHeaderItem(@"Visuals"));
+                actions.Add(new DesignerActionPropertyItem(@"PaletteMode", @"Palette", @"Visuals", @"Palette applied to drawing"));
             }
 
             return actions;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonCheckButtonActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonCheckButtonActionList.cs
@@ -84,16 +84,16 @@ namespace Krypton.Toolkit
             if (_checkButton != null)
             {
                 // Add the list of button specific actions
-                actions.Add(new DesignerActionHeaderItem("Appearance"));
+                actions.Add(new DesignerActionHeaderItem(@"Appearance"));
                 actions.Add(new KryptonDesignerActionItem(new DesignerVerb(_action, OnCheckedClick), "Appearance"));
-                actions.Add(new DesignerActionPropertyItem("ButtonStyle", "Style", "Appearance", "Button style"));
-                actions.Add(new DesignerActionPropertyItem("Orientation", "Orientation", "Appearance", "Button orientation"));
-                actions.Add(new DesignerActionHeaderItem("Values"));
-                actions.Add(new DesignerActionPropertyItem("Text", "Text", "Values", "Button text"));
-                actions.Add(new DesignerActionPropertyItem("ExtraText", "ExtraText", "Values", "Button extra text"));
-                actions.Add(new DesignerActionPropertyItem("Image", "Image", "Values", "Button image"));
-                actions.Add(new DesignerActionHeaderItem("Visuals"));
-                actions.Add(new DesignerActionPropertyItem("PaletteMode", "Palette", "Visuals", "Palette applied to drawing"));
+                actions.Add(new DesignerActionPropertyItem(@"ButtonStyle", @"Style", @"Appearance", @"Button style"));
+                actions.Add(new DesignerActionPropertyItem(@"Orientation", @"Orientation", @"Appearance", @"Button orientation"));
+                actions.Add(new DesignerActionHeaderItem(@"Values"));
+                actions.Add(new DesignerActionPropertyItem(@"Text", @"Text", @"Values", @"Button text"));
+                actions.Add(new DesignerActionPropertyItem(@"ExtraText", @"ExtraText", @"Values", @"Button extra text"));
+                actions.Add(new DesignerActionPropertyItem(@"Image", @"Image", @"Values", @"Button image"));
+                actions.Add(new DesignerActionHeaderItem(@"Visuals"));
+                actions.Add(new DesignerActionPropertyItem(@"PaletteMode", @"Palette", @"Visuals", @"Palette applied to drawing"));
             }
 
             return actions;
@@ -109,7 +109,7 @@ namespace Krypton.Toolkit
             if (sender is DesignerVerb verb)
             {
                 // Decide on the new orientation required
-                var isChecked = verb.Text.Equals("Uncheck the button");
+                var isChecked = verb.Text.Equals(@"Uncheck the button");
 
                 // Decide on the next action to take given the new setting
                 _action = isChecked ? "Uncheck the button" : "Check the button";

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonCheckedListBoxActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonCheckedListBoxActionList.cs
@@ -240,20 +240,20 @@ namespace Krypton.Toolkit
             if (_checkedListBox != null)
             {
                 // Add the list of list box specific actions
-                actions.Add(new DesignerActionHeaderItem("Appearance"));
-                actions.Add(new DesignerActionPropertyItem("BackStyle", "Back Style", "Appearance", "Style used to draw background."));
-                actions.Add(new DesignerActionPropertyItem("BorderStyle", "Border Style", "Appearance", "Style used to draw the border."));
-                actions.Add(new DesignerActionPropertyItem("ContextMenuStrip", "Context Menu Strip", "Appearance", "The context menu strip for the control."));
-                actions.Add(new DesignerActionPropertyItem("ItemStyle", "Item Style", "Appearance", "How to display list items."));
-                actions.Add(new DesignerActionPropertyItem("ShortTextFont", "Short Text Font", "Appearance", "The short text font."));
-                actions.Add(new DesignerActionPropertyItem("LongTextFont", "Long Text Font", "Appearance", "The long text font."));
-                actions.Add(new DesignerActionPropertyItem("CornerRadius", "Corner Rounding Radius", "Appearance", "The corner rounding radius of the control."));
-                actions.Add(new DesignerActionHeaderItem("Behavior"));
-                actions.Add(new DesignerActionPropertyItem("SelectionMode", "Selection Mode", "Behavior", "Determines the selection mode."));
-                actions.Add(new DesignerActionPropertyItem("Sorted", "Sorted", "Behavior", "Should items be sorted according to string."));
-                actions.Add(new DesignerActionPropertyItem("CheckOnClick", "CheckOnClick", "Behavior", "Should clicking an item toggle its checked state."));
-                actions.Add(new DesignerActionHeaderItem("Visuals"));
-                actions.Add(new DesignerActionPropertyItem("PaletteMode", "Palette", "Visuals", "Palette applied to drawing"));
+                actions.Add(new DesignerActionHeaderItem(@"Appearance"));
+                actions.Add(new DesignerActionPropertyItem(@"BackStyle", @"Back Style", @"Appearance", @"Style used to draw background."));
+                actions.Add(new DesignerActionPropertyItem(@"BorderStyle", @"Border Style", @"Appearance", @"Style used to draw the border."));
+                actions.Add(new DesignerActionPropertyItem(@"ContextMenuStrip", @"Context Menu Strip", @"Appearance", @"The context menu strip for the control."));
+                actions.Add(new DesignerActionPropertyItem(@"ItemStyle", @"Item Style", @"Appearance", @"How to display list items."));
+                actions.Add(new DesignerActionPropertyItem(@"ShortTextFont", @"Short Text Font", @"Appearance", @"The short text font."));
+                actions.Add(new DesignerActionPropertyItem(@"LongTextFont", @"Long Text Font", @"Appearance", @"The long text font."));
+                actions.Add(new DesignerActionPropertyItem(@"CornerRadius", @"Corner Rounding Radius", @"Appearance", @"The corner rounding radius of the control."));
+                actions.Add(new DesignerActionHeaderItem(@"Behavior"));
+                actions.Add(new DesignerActionPropertyItem(@"SelectionMode", @"Selection Mode", @"Behavior", @"Determines the selection mode."));
+                actions.Add(new DesignerActionPropertyItem(@"Sorted", @"Sorted", @"Behavior", @"Should items be sorted according to string."));
+                actions.Add(new DesignerActionPropertyItem(@"CheckOnClick", @"CheckOnClick", @"Behavior", @"Should clicking an item toggle its checked state."));
+                actions.Add(new DesignerActionHeaderItem(@"Visuals"));
+                actions.Add(new DesignerActionPropertyItem(@"PaletteMode", @"Palette", @"Visuals", @"Palette applied to drawing"));
             }
 
             return actions;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonColorButtonActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonColorButtonActionList.cs
@@ -304,24 +304,24 @@ namespace Krypton.Toolkit
             if (_colorButton != null)
             {
                 // Add the list of button specific actions
-                actions.Add(new DesignerActionHeaderItem("Appearance"));
-                actions.Add(new DesignerActionPropertyItem("Splitter", "Splitter", "Appearance", "Splitter of DropDown"));
-                actions.Add(new DesignerActionPropertyItem("ButtonStyle", "ButtonStyle", "Appearance", "Button style"));
-                actions.Add(new DesignerActionPropertyItem("ButtonOrientation", "ButtonOrientation", "Appearance", "Button orientation"));
-                actions.Add(new DesignerActionPropertyItem("DropDownPosition", "DropDownPosition", "Appearance", "DropDown position"));
-                actions.Add(new DesignerActionPropertyItem("DropDownOrientation", "DropDownOrientation", "Appearance", "DropDown orientation"));
-                actions.Add(new DesignerActionPropertyItem("ShortTextFont", "Short Text Font", "Appearance", "The short text font."));
-                actions.Add(new DesignerActionPropertyItem("LongTextFont", "Long Text Font", "Appearance", "The long text font."));
-                actions.Add(new DesignerActionPropertyItem("CornerRadius", "Corner Rounding Radius", "Appearance", "The corner rounding radius of the control."));
-                actions.Add(new DesignerActionHeaderItem("Values"));
-                actions.Add(new DesignerActionPropertyItem("Text", "Text", "Values", "Button text"));
-                actions.Add(new DesignerActionPropertyItem("ExtraText", "ExtraText", "Values", "Button extra text"));
-                actions.Add(new DesignerActionPropertyItem("Image", "Image", "Values", "Button image"));
-                actions.Add(new DesignerActionPropertyItem("SelectedColour", "Selected Colour", "Values", "The selected colour."));
-                actions.Add(new DesignerActionPropertyItem("AllowFullOpen", "Allow Full Open", "Values", "Allows the color dialog to fully open."));
-                actions.Add(new DesignerActionPropertyItem("SelectedRect", "SelectedRect", "Visuals", "Selected color drawing rectangle."));
-                actions.Add(new DesignerActionHeaderItem("Visuals"));
-                actions.Add(new DesignerActionPropertyItem("PaletteMode", "Palette", "Visuals", "Palette applied to drawing"));
+                actions.Add(new DesignerActionHeaderItem(@"Appearance"));
+                actions.Add(new DesignerActionPropertyItem(@"Splitter", @"Splitter", @"Appearance", @"Splitter of DropDown"));
+                actions.Add(new DesignerActionPropertyItem(@"ButtonStyle", @"ButtonStyle", @"Appearance", @"Button style"));
+                actions.Add(new DesignerActionPropertyItem(@"ButtonOrientation", @"ButtonOrientation", @"Appearance", @"Button orientation"));
+                actions.Add(new DesignerActionPropertyItem(@"DropDownPosition", @"DropDownPosition", @"Appearance", @"DropDown position"));
+                actions.Add(new DesignerActionPropertyItem(@"DropDownOrientation", @"DropDownOrientation", @"Appearance", @"DropDown orientation"));
+                actions.Add(new DesignerActionPropertyItem(@"ShortTextFont", @"Short Text Font", @"Appearance", @"The short text font."));
+                actions.Add(new DesignerActionPropertyItem(@"LongTextFont", @"Long Text Font", @"Appearance", @"The long text font."));
+                actions.Add(new DesignerActionPropertyItem(@"CornerRadius", @"Corner Rounding Radius", @"Appearance", @"The corner rounding radius of the control."));
+                actions.Add(new DesignerActionHeaderItem(@"Values"));
+                actions.Add(new DesignerActionPropertyItem(@"Text", @"Text", @"Values", @"Button text"));
+                actions.Add(new DesignerActionPropertyItem(@"ExtraText", @"ExtraText", @"Values", @"Button extra text"));
+                actions.Add(new DesignerActionPropertyItem(@"Image", @"Image", @"Values", @"Button image"));
+                actions.Add(new DesignerActionPropertyItem(@"SelectedColour", @"Selected Colour", @"Values", @"The selected colour."));
+                actions.Add(new DesignerActionPropertyItem(@"AllowFullOpen", @"Allow Full Open", @"Values", @"Allows the color dialog to fully open."));
+                actions.Add(new DesignerActionPropertyItem(@"SelectedRect", @"SelectedRect", @"Visuals", @"Selected color drawing rectangle."));
+                actions.Add(new DesignerActionHeaderItem(@"Visuals"));
+                actions.Add(new DesignerActionPropertyItem(@"PaletteMode", @"Palette", @"Visuals", @"Palette applied to drawing"));
             }
 
             return actions;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonComboBoxActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonComboBoxActionList.cs
@@ -155,14 +155,14 @@ namespace Krypton.Toolkit
             if (_comboBox != null)
             {
                 // Add the list of label specific actions
-                actions.Add(new DesignerActionHeaderItem("Appearance"));
-                actions.Add(new DesignerActionPropertyItem("ContextMenuStrip", "Context Menu Strip", "Appearance", "The context menu strip for the control."));
-                actions.Add(new DesignerActionPropertyItem("DropDownStyle", "Drop Down Style", "Appearance", "The combobox drop down style."));
-                actions.Add(new DesignerActionPropertyItem("InputControlStyle", "Style", "Appearance", "ComboBox display style."));
-                actions.Add(new DesignerActionPropertyItem("Font", "Font", "Appearance", "The font for the combobox."));
-                actions.Add(new DesignerActionPropertyItem("CornerRadius", "Corner Rounding Radius", "Appearance", "The corner rounding radius of the control."));
-                actions.Add(new DesignerActionHeaderItem("Visuals"));
-                actions.Add(new DesignerActionPropertyItem("PaletteMode", "Palette", "Visuals", "Palette applied to drawing"));
+                actions.Add(new DesignerActionHeaderItem(@"Appearance"));
+                actions.Add(new DesignerActionPropertyItem(@"ContextMenuStrip", @"Context Menu Strip", @"Appearance", @"The context menu strip for the control."));
+                actions.Add(new DesignerActionPropertyItem(@"DropDownStyle", @"Drop Down Style", @"Appearance", @"The combobox drop down style."));
+                actions.Add(new DesignerActionPropertyItem(@"InputControlStyle", @"Style", @"Appearance", @"ComboBox display style."));
+                actions.Add(new DesignerActionPropertyItem(@"Font", @"Font", @"Appearance", @"The font for the combobox."));
+                actions.Add(new DesignerActionPropertyItem(@"CornerRadius", @"Corner Rounding Radius", @"Appearance", @"The corner rounding radius of the control."));
+                actions.Add(new DesignerActionHeaderItem(@"Visuals"));
+                actions.Add(new DesignerActionPropertyItem(@"PaletteMode", @"Palette", @"Visuals", @"Palette applied to drawing"));
             }
 
             return actions;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonContextMenuActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonContextMenuActionList.cs
@@ -50,8 +50,8 @@ namespace Krypton.Toolkit
             if (_contextMenu != null)
             {
                 // Add the list of panel specific actions
-                actions.Add(new DesignerActionHeaderItem("Visuals"));
-                actions.Add(new DesignerActionPropertyItem("PaletteMode", "Palette", "Visuals", "Palette applied to drawing"));
+                actions.Add(new DesignerActionHeaderItem(@"Visuals"));
+                actions.Add(new DesignerActionPropertyItem(@"PaletteMode", @"Palette", @"Visuals", @"Palette applied to drawing"));
             }
 
             return actions;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonDateTimePickerActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonDateTimePickerActionList.cs
@@ -187,16 +187,16 @@ namespace Krypton.Toolkit
             if (_dateTimePicker != null)
             {
                 // Add the list of bread crumb specific actions
-                actions.Add(new DesignerActionHeaderItem("Appearance"));
-                actions.Add(new DesignerActionPropertyItem("ContextMenuStrip", "Context Menu Strip", "Appearance", "The context menu strip for the control."));
-                actions.Add(new DesignerActionPropertyItem("Format", "Format", "Appearance", "Decide what to display in the edit portion of the control"));
-                actions.Add(new DesignerActionPropertyItem("ShowUpDown", "ShowUpDown", "Appearance", "Display up and down buttons for modifying dates and times"));
-                actions.Add(new DesignerActionPropertyItem("ShowCheckBox", "ShowCheckBox", "Appearance", "Display a check box allowing the user to set the value is null"));
-                actions.Add(new DesignerActionPropertyItem("Checked", "Checked", "Appearance", "Is the current value null"));
-                actions.Add(new DesignerActionPropertyItem("Font", "Font", "Appearance", "The font for the date time picker."));
-                actions.Add(new DesignerActionPropertyItem("CornerRadius", "Corner Rounding Radius", "Appearance", "The corner rounding radius of the control."));
-                actions.Add(new DesignerActionHeaderItem("Visuals"));
-                actions.Add(new DesignerActionPropertyItem("PaletteMode", "Palette", "Visuals", "Palette applied to drawing"));
+                actions.Add(new DesignerActionHeaderItem(@"Appearance"));
+                actions.Add(new DesignerActionPropertyItem(@"ContextMenuStrip", @"Context Menu Strip", @"Appearance", @"The context menu strip for the control."));
+                actions.Add(new DesignerActionPropertyItem(@"Format", @"Format", @"Appearance", @"Decide what to display in the edit portion of the control"));
+                actions.Add(new DesignerActionPropertyItem(@"ShowUpDown", @"ShowUpDown", @"Appearance", @"Display up and down buttons for modifying dates and times"));
+                actions.Add(new DesignerActionPropertyItem(@"ShowCheckBox", @"ShowCheckBox", @"Appearance", @"Display a check box allowing the user to set the value is null"));
+                actions.Add(new DesignerActionPropertyItem(@"Checked", @"Checked", @"Appearance", @"Is the current value null"));
+                actions.Add(new DesignerActionPropertyItem(@"Font", @"Font", @"Appearance", @"The font for the date time picker."));
+                actions.Add(new DesignerActionPropertyItem(@"CornerRadius", @"Corner Rounding Radius", @"Appearance", @"The corner rounding radius of the control."));
+                actions.Add(new DesignerActionHeaderItem(@"Visuals"));
+                actions.Add(new DesignerActionPropertyItem(@"PaletteMode", @"Palette", @"Visuals", @"Palette applied to drawing"));
             }
 
             return actions;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonDomainUpDownActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonDomainUpDownActionList.cs
@@ -136,13 +136,13 @@ namespace Krypton.Toolkit
             if (_domainUpDown != null)
             {
                 // Add the list of label specific actions
-                actions.Add(new DesignerActionHeaderItem("Appearance"));
-                actions.Add(new DesignerActionPropertyItem("ContextMenuStrip", "Context Menu Strip", "Appearance", "The context menu strip for the control."));
-                actions.Add(new DesignerActionPropertyItem("InputControlStyle", "Style", "Appearance", "DomainUpDown display style."));
-                actions.Add(new DesignerActionPropertyItem("Font", "Font", "Appearance", "The font for the domain up down."));
-                actions.Add(new DesignerActionPropertyItem("CornerRadius", "Corner Rounding Radius", "Appearance", "The corner rounding radius of the control."));
-                actions.Add(new DesignerActionHeaderItem("Visuals"));
-                actions.Add(new DesignerActionPropertyItem("PaletteMode", "Palette", "Visuals", "Palette applied to drawing"));
+                actions.Add(new DesignerActionHeaderItem(@"Appearance"));
+                actions.Add(new DesignerActionPropertyItem(@"ContextMenuStrip", @"Context Menu Strip", @"Appearance", @"The context menu strip for the control."));
+                actions.Add(new DesignerActionPropertyItem(@"InputControlStyle", @"Style", @"Appearance", @"DomainUpDown display style."));
+                actions.Add(new DesignerActionPropertyItem(@"Font", @"Font", @"Appearance", @"The font for the domain up down."));
+                actions.Add(new DesignerActionPropertyItem(@"CornerRadius", @"Corner Rounding Radius", @"Appearance", @"The corner rounding radius of the control."));
+                actions.Add(new DesignerActionHeaderItem(@"Visuals"));
+                actions.Add(new DesignerActionPropertyItem(@"PaletteMode", @"Palette", @"Visuals", @"Palette applied to drawing"));
             }
 
             return actions;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonDropButtonActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonDropButtonActionList.cs
@@ -274,22 +274,22 @@ namespace Krypton.Toolkit
             if (_dropButton != null)
             {
                 // Add the list of button specific actions
-                actions.Add(new DesignerActionHeaderItem("Appearance"));
-                actions.Add(new DesignerActionPropertyItem("Splitter", "Splitter", "Appearance", "Splitter of DropDown"));
-                actions.Add(new DesignerActionPropertyItem("ButtonStyle", "ButtonStyle", "Appearance", "Button style"));
-                actions.Add(new DesignerActionPropertyItem("ButtonOrientation", "ButtonOrientation", "Appearance", "Button orientation"));
-                actions.Add(new DesignerActionPropertyItem("ContextMenuStrip", "Context Menu Strip", "Appearance", "The context menu strip for the control."));
-                actions.Add(new DesignerActionPropertyItem("DropDownPosition", "DropDownPosition", "Appearance", "DropDown position"));
-                actions.Add(new DesignerActionPropertyItem("DropDownOrientation", "DropDownOrientation", "Appearance", "DropDown orientation"));
-                actions.Add(new DesignerActionPropertyItem("ShortTextFont", "Short Text Font", "Appearance", "The short text font."));
-                actions.Add(new DesignerActionPropertyItem("LongTextFont", "Long Text Font", "Appearance", "The long text font."));
-                actions.Add(new DesignerActionPropertyItem("CornerRadius", "Corner Rounding Radius", "Appearance", "The corner rounding radius of the control."));
-                actions.Add(new DesignerActionHeaderItem("Values"));
-                actions.Add(new DesignerActionPropertyItem("Text", "Text", "Values", "Button text"));
-                actions.Add(new DesignerActionPropertyItem("ExtraText", "ExtraText", "Values", "Button extra text"));
-                actions.Add(new DesignerActionPropertyItem("Image", "Image", "Values", "Button image"));
-                actions.Add(new DesignerActionHeaderItem("Visuals"));
-                actions.Add(new DesignerActionPropertyItem("PaletteMode", "Palette", "Visuals", "Palette applied to drawing"));
+                actions.Add(new DesignerActionHeaderItem(@"Appearance"));
+                actions.Add(new DesignerActionPropertyItem(@"Splitter", @"Splitter", @"Appearance", @"Splitter of DropDown"));
+                actions.Add(new DesignerActionPropertyItem(@"ButtonStyle", @"ButtonStyle", @"Appearance", @"Button style"));
+                actions.Add(new DesignerActionPropertyItem(@"ButtonOrientation", @"ButtonOrientation", @"Appearance", @"Button orientation"));
+                actions.Add(new DesignerActionPropertyItem(@"ContextMenuStrip", @"Context Menu Strip", @"Appearance", @"The context menu strip for the control."));
+                actions.Add(new DesignerActionPropertyItem(@"DropDownPosition", @"DropDownPosition", @"Appearance", @"DropDown position"));
+                actions.Add(new DesignerActionPropertyItem(@"DropDownOrientation", @"DropDownOrientation", @"Appearance", @"DropDown orientation"));
+                actions.Add(new DesignerActionPropertyItem(@"ShortTextFont", @"Short Text Font", @"Appearance", @"The short text font."));
+                actions.Add(new DesignerActionPropertyItem(@"LongTextFont", @"Long Text Font", @"Appearance", @"The long text font."));
+                actions.Add(new DesignerActionPropertyItem(@"CornerRadius", @"Corner Rounding Radius", @"Appearance", @"The corner rounding radius of the control."));
+                actions.Add(new DesignerActionHeaderItem(@"Values"));
+                actions.Add(new DesignerActionPropertyItem(@"Text", @"Text", @"Values", @"Button text"));
+                actions.Add(new DesignerActionPropertyItem(@"ExtraText", @"ExtraText", @"Values", @"Button extra text"));
+                actions.Add(new DesignerActionPropertyItem(@"Image", @"Image", @"Values", @"Button image"));
+                actions.Add(new DesignerActionHeaderItem(@"Visuals"));
+                actions.Add(new DesignerActionPropertyItem(@"PaletteMode", @"Palette", @"Visuals", @"Palette applied to drawing"));
             }
 
             return actions;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonGroupActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonGroupActionList.cs
@@ -103,11 +103,11 @@ namespace Krypton.Toolkit
             if (_group != null)
             {
                 // Add the list of panel specific actions
-                actions.Add(new DesignerActionHeaderItem("Appearance"));
-                actions.Add(new DesignerActionPropertyItem("GroupBackStyle", "Back style", "Appearance", "Background style"));
-                actions.Add(new DesignerActionPropertyItem("GroupBorderStyle", "Border style", "Appearance", "Border style"));
-                actions.Add(new DesignerActionHeaderItem("Visuals"));
-                actions.Add(new DesignerActionPropertyItem("PaletteMode", "Palette", "Visuals", "Palette applied to drawing"));
+                actions.Add(new DesignerActionHeaderItem(@"Appearance"));
+                actions.Add(new DesignerActionPropertyItem(@"GroupBackStyle", @"Back style", @"Appearance", @"Background style"));
+                actions.Add(new DesignerActionPropertyItem(@"GroupBorderStyle", @"Border style", @"Appearance", @"Border style"));
+                actions.Add(new DesignerActionHeaderItem(@"Visuals"));
+                actions.Add(new DesignerActionPropertyItem(@"PaletteMode", @"Palette", @"Visuals", @"Palette applied to drawing"));
             }
             
             return actions;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonGroupBoxActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonGroupBoxActionList.cs
@@ -239,20 +239,20 @@ namespace Krypton.Toolkit
             if (_groupBox != null)
             {
                 // Add the list of panel specific actions
-                actions.Add(new DesignerActionHeaderItem("Appearance"));
-                actions.Add(new DesignerActionPropertyItem("GroupBackStyle", "Back style", "Appearance", "Background style"));
-                actions.Add(new DesignerActionPropertyItem("GroupBorderStyle", "Border style", "Appearance", "Border style"));
-                actions.Add(new DesignerActionPropertyItem("CaptionStyle", "Caption style", "Appearance", "Caption style"));
-                actions.Add(new DesignerActionPropertyItem("CaptionEdge", "Caption edge", "Appearance", "Caption edge"));
-                actions.Add(new DesignerActionPropertyItem("CaptionOverlap", "Caption overlap", "Appearance", "Caption overlap"));
-                actions.Add(new DesignerActionPropertyItem("ShortTextFont", "Short Text Font", "Appearance", "The short text font."));
-                actions.Add(new DesignerActionPropertyItem("LongTextFont", "Long Text Font", "Appearance", "The long text font."));
-                actions.Add(new DesignerActionHeaderItem("Visuals"));
-                actions.Add(new DesignerActionPropertyItem("PaletteMode", "Palette", "Visuals", "Palette applied to drawing"));
-                actions.Add(new DesignerActionHeaderItem("Values"));
-                actions.Add(new DesignerActionPropertyItem("Description", "Description", "Values", "The header description text."));
-                actions.Add(new DesignerActionPropertyItem("Heading", "Heading", "Values", "The heading text."));
-                actions.Add(new DesignerActionPropertyItem("Image", "Image", "Values", "The heading image."));
+                actions.Add(new DesignerActionHeaderItem(@"Appearance"));
+                actions.Add(new DesignerActionPropertyItem(@"GroupBackStyle", @"Back style", @"Appearance", @"Background style"));
+                actions.Add(new DesignerActionPropertyItem(@"GroupBorderStyle", @"Border style", @"Appearance", @"Border style"));
+                actions.Add(new DesignerActionPropertyItem(@"CaptionStyle", @"Caption style", @"Appearance", @"Caption style"));
+                actions.Add(new DesignerActionPropertyItem(@"CaptionEdge", @"Caption edge", @"Appearance", @"Caption edge"));
+                actions.Add(new DesignerActionPropertyItem(@"CaptionOverlap", @"Caption overlap", @"Appearance", @"Caption overlap"));
+                actions.Add(new DesignerActionPropertyItem(@"ShortTextFont", @"Short Text Font", @"Appearance", @"The short text font."));
+                actions.Add(new DesignerActionPropertyItem(@"LongTextFont", @"Long Text Font", @"Appearance", @"The long text font."));
+                actions.Add(new DesignerActionHeaderItem(@"Visuals"));
+                actions.Add(new DesignerActionPropertyItem(@"PaletteMode", @"Palette", @"Visuals", @"Palette applied to drawing"));
+                actions.Add(new DesignerActionHeaderItem(@"Values"));
+                actions.Add(new DesignerActionPropertyItem(@"Description", @"Description", @"Values", @"The header description text."));
+                actions.Add(new DesignerActionPropertyItem(@"Heading", @"Heading", @"Values", @"The heading text."));
+                actions.Add(new DesignerActionPropertyItem(@"Image", @"Image", @"Values", @"The heading image."));
             }
 
             return actions;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonHeaderActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonHeaderActionList.cs
@@ -154,15 +154,15 @@ namespace Krypton.Toolkit
             if (_header != null)
             {
                 // Add the list of header specific actions
-                actions.Add(new DesignerActionHeaderItem("Appearance"));
-                actions.Add(new DesignerActionPropertyItem("HeaderStyle", "Style", "Appearance", "Header style"));
-                actions.Add(new DesignerActionPropertyItem("Orientation", "Orientation", "Appearance", "Header orientation"));
-                actions.Add(new DesignerActionHeaderItem("Values"));
-                actions.Add(new DesignerActionPropertyItem("Heading", "Heading", "Values", "Heading text"));
-                actions.Add(new DesignerActionPropertyItem("Description", "Description", "Values", "Header description text"));
-                actions.Add(new DesignerActionPropertyItem("Image", "Image", "Values", "Heading image"));
-                actions.Add(new DesignerActionHeaderItem("Visuals"));
-                actions.Add(new DesignerActionPropertyItem("PaletteMode", "Palette", "Visuals", "Palette applied to drawing"));
+                actions.Add(new DesignerActionHeaderItem(@"Appearance"));
+                actions.Add(new DesignerActionPropertyItem(@"HeaderStyle", @"Style", @"Appearance", @"Header style"));
+                actions.Add(new DesignerActionPropertyItem(@"Orientation", @"Orientation", @"Appearance", @"Header orientation"));
+                actions.Add(new DesignerActionHeaderItem(@"Values"));
+                actions.Add(new DesignerActionPropertyItem(@"Heading", @"Heading", @"Values", @"Heading text"));
+                actions.Add(new DesignerActionPropertyItem(@"Description", @"Description", @"Values", @"Header description text"));
+                actions.Add(new DesignerActionPropertyItem(@"Image", @"Image", @"Values", @"Heading image"));
+                actions.Add(new DesignerActionHeaderItem(@"Visuals"));
+                actions.Add(new DesignerActionPropertyItem(@"PaletteMode", @"Palette", @"Visuals", @"Palette applied to drawing"));
             }
             
             return actions;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonHeaderGroupActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonHeaderGroupActionList.cs
@@ -187,19 +187,19 @@ namespace Krypton.Toolkit
                 _visible2 = new DesignerVerb(_text2, OnVisibleClick);
 
                 // Add the list of panel specific actions
-                actions.Add(new DesignerActionHeaderItem("Appearance"));
-                actions.Add(new DesignerActionPropertyItem("GroupBackStyle", "Back style", "Appearance", "Background style"));
-                actions.Add(new DesignerActionPropertyItem("GroupBorderStyle", "Border style", "Appearance", "Border style"));
-                actions.Add(new DesignerActionHeaderItem("Primary Header"));
+                actions.Add(new DesignerActionHeaderItem(@"Appearance"));
+                actions.Add(new DesignerActionPropertyItem(@"GroupBackStyle", @"Back style", @"Appearance", @"Background style"));
+                actions.Add(new DesignerActionPropertyItem(@"GroupBorderStyle", @"Border style", @"Appearance", @"Border style"));
+                actions.Add(new DesignerActionHeaderItem(@"Primary Header"));
                 actions.Add(new KryptonDesignerActionItem(_visible1, "Primary Header"));
-                actions.Add(new DesignerActionPropertyItem("HeaderStylePrimary", "Style", "Primary Header", "Primary header style"));
-                actions.Add(new DesignerActionPropertyItem("HeaderPositionPrimary", "Position", "Primary Header", "Primary header position"));
-                actions.Add(new DesignerActionHeaderItem("Secondary Header"));
+                actions.Add(new DesignerActionPropertyItem(@"HeaderStylePrimary", @"Style", @"Primary Header", @"Primary header style"));
+                actions.Add(new DesignerActionPropertyItem(@"HeaderPositionPrimary", @"Position", @"Primary Header", @"Primary header position"));
+                actions.Add(new DesignerActionHeaderItem(@"Secondary Header"));
                 actions.Add(new KryptonDesignerActionItem(_visible2, "Secondary Header"));
-                actions.Add(new DesignerActionPropertyItem("HeaderStyleSecondary", "Style", "Secondary Header", "Secondary header style"));
-                actions.Add(new DesignerActionPropertyItem("HeaderPositionSecondary", "Position", "Secondary Header", "Secondary header position"));
-                actions.Add(new DesignerActionHeaderItem("Visuals"));
-                actions.Add(new DesignerActionPropertyItem("PaletteMode", "Palette", "Visuals", "Palette applied to drawing"));
+                actions.Add(new DesignerActionPropertyItem(@"HeaderStyleSecondary", @"Style", @"Secondary Header", @"Secondary header style"));
+                actions.Add(new DesignerActionPropertyItem(@"HeaderPositionSecondary", @"Position", @"Secondary Header", @"Secondary header position"));
+                actions.Add(new DesignerActionHeaderItem(@"Visuals"));
+                actions.Add(new DesignerActionPropertyItem(@"PaletteMode", @"Palette", @"Visuals", @"Palette applied to drawing"));
             }
 
             return actions;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonLabelActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonLabelActionList.cs
@@ -188,17 +188,17 @@ namespace Krypton.Toolkit
             if (_label != null)
             {
                 // Add the list of label specific actions
-                actions.Add(new DesignerActionHeaderItem("Appearance"));
-                actions.Add(new DesignerActionPropertyItem("LabelStyle", "Style", "Appearance", "Label style"));
-                actions.Add(new DesignerActionPropertyItem("Orientation", "Orientation", "Appearance", "Visual orientation"));
-                actions.Add(new DesignerActionPropertyItem("ShortTextFont", "Short Text Font", "Appearance", "The short text font."));
-                actions.Add(new DesignerActionPropertyItem("LongTextFont", "Long Text Font", "Appearance", "The long text font."));
-                actions.Add(new DesignerActionHeaderItem("Values"));
-                actions.Add(new DesignerActionPropertyItem("Text", "Text", "Values", "Label text"));
-                actions.Add(new DesignerActionPropertyItem("ExtraText", "ExtraText", "Values", "Label extra text"));
-                actions.Add(new DesignerActionPropertyItem("Image", "Image", "Values", "Label image"));
-                actions.Add(new DesignerActionHeaderItem("Visuals"));
-                actions.Add(new DesignerActionPropertyItem("PaletteMode", "Palette", "Visuals", "Palette applied to drawing"));
+                actions.Add(new DesignerActionHeaderItem(@"Appearance"));
+                actions.Add(new DesignerActionPropertyItem(@"LabelStyle", @"Style", @"Appearance", @"Label style"));
+                actions.Add(new DesignerActionPropertyItem(@"Orientation", @"Orientation", @"Appearance", @"Visual orientation"));
+                actions.Add(new DesignerActionPropertyItem(@"ShortTextFont", @"Short Text Font", @"Appearance", @"The short text font."));
+                actions.Add(new DesignerActionPropertyItem(@"LongTextFont", @"Long Text Font", @"Appearance", @"The long text font."));
+                actions.Add(new DesignerActionHeaderItem(@"Values"));
+                actions.Add(new DesignerActionPropertyItem(@"Text", @"Text", @"Values", @"Label text"));
+                actions.Add(new DesignerActionPropertyItem(@"ExtraText", @"ExtraText", @"Values", @"Label extra text"));
+                actions.Add(new DesignerActionPropertyItem(@"Image", @"Image", @"Values", @"Label image"));
+                actions.Add(new DesignerActionHeaderItem(@"Visuals"));
+                actions.Add(new DesignerActionPropertyItem(@"PaletteMode", @"Palette", @"Visuals", @"Palette applied to drawing"));
             }
 
             return actions;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonLinkLabelActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonLinkLabelActionList.cs
@@ -230,19 +230,19 @@ namespace Krypton.Toolkit
             if (_linkLabel != null)
             {
                 // Add the list of label specific actions
-                actions.Add(new DesignerActionHeaderItem("Appearance"));
-                actions.Add(new DesignerActionPropertyItem("LabelStyle", "Style", "Appearance", "Label style"));
-                actions.Add(new DesignerActionPropertyItem("Orientation", "Orientation", "Appearance", "Visual orientation"));
-                actions.Add(new DesignerActionPropertyItem("LinkBehavior", "Link Behavior", "Appearance", "Underline behavior"));
+                actions.Add(new DesignerActionHeaderItem(@"Appearance"));
+                actions.Add(new DesignerActionPropertyItem(@"LabelStyle", @"Style", @"Appearance", @"Label style"));
+                actions.Add(new DesignerActionPropertyItem(@"Orientation", @"Orientation", @"Appearance", @"Visual orientation"));
+                actions.Add(new DesignerActionPropertyItem(@"LinkBehavior", @"Link Behavior", @"Appearance", @"Underline behavior"));
                 actions.Add(new KryptonDesignerActionItem(new DesignerVerb(_action, OnLinkVisitedClick), "Appearance"));
-                actions.Add(new DesignerActionPropertyItem("ShortTextFont", "Short Text Font", "Appearance", "The short text font."));
-                actions.Add(new DesignerActionPropertyItem("LongTextFont", "Long Text Font", "Appearance", "The long text font."));
-                actions.Add(new DesignerActionHeaderItem("Values"));
-                actions.Add(new DesignerActionPropertyItem("Text", "Text", "Values", "Label text"));
-                actions.Add(new DesignerActionPropertyItem("ExtraText", "ExtraText", "Values", "Label extra text"));
-                actions.Add(new DesignerActionPropertyItem("Image", "Image", "Values", "Label image"));
-                actions.Add(new DesignerActionHeaderItem("Visuals"));
-                actions.Add(new DesignerActionPropertyItem("PaletteMode", "Palette", "Visuals", "Palette applied to drawing"));
+                actions.Add(new DesignerActionPropertyItem(@"ShortTextFont", @"Short Text Font", @"Appearance", @"The short text font."));
+                actions.Add(new DesignerActionPropertyItem(@"LongTextFont", @"Long Text Font", @"Appearance", @"The long text font."));
+                actions.Add(new DesignerActionHeaderItem(@"Values"));
+                actions.Add(new DesignerActionPropertyItem(@"Text", @"Text", @"Values", @"Label text"));
+                actions.Add(new DesignerActionPropertyItem(@"ExtraText", @"ExtraText", @"Values", @"Label extra text"));
+                actions.Add(new DesignerActionPropertyItem(@"Image", @"Image", @"Values", @"Label image"));
+                actions.Add(new DesignerActionHeaderItem(@"Visuals"));
+                actions.Add(new DesignerActionPropertyItem(@"PaletteMode", @"Palette", @"Visuals", @"Palette applied to drawing"));
             }
 
             return actions;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonListBoxActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonListBoxActionList.cs
@@ -241,20 +241,20 @@ namespace Krypton.Toolkit
             if (_listBox != null)
             {
                 // Add the list of list box specific actions
-                actions.Add(new DesignerActionHeaderItem("Appearance"));
-                actions.Add(new DesignerActionPropertyItem("BackStyle", "Back Style", "Appearance", "Style used to draw background."));
-                actions.Add(new DesignerActionPropertyItem("BorderStyle", "Border Style", "Appearance", "Style used to draw the border."));
-                actions.Add(new DesignerActionPropertyItem("ContextMenuStrip", "Context Menu Strip", "Appearance", "The context menu strip for the control."));
-                actions.Add(new DesignerActionPropertyItem("ItemStyle", "Item Style", "Appearance", "How to display list items."));
-                actions.Add(new DesignerActionPropertyItem("ShortTextFont", "Short Text Font", "Appearance", "The short text font."));
-                actions.Add(new DesignerActionPropertyItem("LongTextFont", "Long Text Font", "Appearance", "The long text font."));
-                actions.Add(new DesignerActionPropertyItem("CornerRadius", "Corner Rounding Radius", "Appearance", "The corner rounding radius of the control."));
-                actions.Add(new DesignerActionPropertyItem("ItemCornerRadius", "Item Corner Rounding Radius", "Appearance", "The corner rounding radius of the item."));
-                actions.Add(new DesignerActionHeaderItem("Behavior"));
-                actions.Add(new DesignerActionPropertyItem("SelectionMode", "Selection Mode", "Behavior", "Determines the selection mode."));
-                actions.Add(new DesignerActionPropertyItem("Sorted", "Sorted", "Behavior", "Should items be sorted according to string."));
-                actions.Add(new DesignerActionHeaderItem("Visuals"));
-                actions.Add(new DesignerActionPropertyItem("PaletteMode", "Palette", "Visuals", "Palette applied to drawing"));
+                actions.Add(new DesignerActionHeaderItem(@"Appearance"));
+                actions.Add(new DesignerActionPropertyItem(@"BackStyle", @"Back Style", @"Appearance", @"Style used to draw background."));
+                actions.Add(new DesignerActionPropertyItem(@"BorderStyle", @"Border Style", @"Appearance", @"Style used to draw the border."));
+                actions.Add(new DesignerActionPropertyItem(@"ContextMenuStrip", @"Context Menu Strip", @"Appearance", @"The context menu strip for the control."));
+                actions.Add(new DesignerActionPropertyItem(@"ItemStyle", @"Item Style", @"Appearance", @"How to display list items."));
+                actions.Add(new DesignerActionPropertyItem(@"ShortTextFont", @"Short Text Font", @"Appearance", @"The short text font."));
+                actions.Add(new DesignerActionPropertyItem(@"LongTextFont", @"Long Text Font", @"Appearance", @"The long text font."));
+                actions.Add(new DesignerActionPropertyItem(@"CornerRadius", @"Corner Rounding Radius", @"Appearance", @"The corner rounding radius of the control."));
+                actions.Add(new DesignerActionPropertyItem(@"ItemCornerRadius", @"Item Corner Rounding Radius", @"Appearance", @"The corner rounding radius of the item."));
+                actions.Add(new DesignerActionHeaderItem(@"Behavior"));
+                actions.Add(new DesignerActionPropertyItem(@"SelectionMode", @"Selection Mode", @"Behavior", @"Determines the selection mode."));
+                actions.Add(new DesignerActionPropertyItem(@"Sorted", @"Sorted", @"Behavior", @"Should items be sorted according to string."));
+                actions.Add(new DesignerActionHeaderItem(@"Visuals"));
+                actions.Add(new DesignerActionPropertyItem(@"PaletteMode", @"Palette", @"Visuals", @"Palette applied to drawing"));
             }
 
             return actions;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonListViewActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonListViewActionList.cs
@@ -136,14 +136,14 @@ namespace Krypton.Toolkit.Designers.Action_Lists
             if (_listView != null)
             {
                 // Add the list of list box specific actions
-                actions.Add(new DesignerActionHeaderItem("Appearance"));
-                actions.Add(new DesignerActionPropertyItem("BackStyle", "Back Style", "Appearance", "Style used to draw background."));
-                actions.Add(new DesignerActionPropertyItem("BorderStyle", "Border Style", "Appearance", "Style used to draw the border."));
-                actions.Add(new DesignerActionPropertyItem("ContextMenuStrip", "Context Menu Strip", "Appearance", "The context menu strip for the control."));
-                actions.Add(new DesignerActionPropertyItem("ItemStyle", "Item Style", "Appearance", "How to display list items."));
-                actions.Add(new DesignerActionPropertyItem("ShortTextFont", "Short Text Font", "Appearance", "The short text font."));
-                actions.Add(new DesignerActionHeaderItem("Behavior"));
-                actions.Add(new DesignerActionHeaderItem("Visuals"));
+                actions.Add(new DesignerActionHeaderItem(@"Appearance"));
+                actions.Add(new DesignerActionPropertyItem(@"BackStyle", @"Back Style", @"Appearance", @"Style used to draw background."));
+                actions.Add(new DesignerActionPropertyItem(@"BorderStyle", @"Border Style", @"Appearance", @"Style used to draw the border."));
+                actions.Add(new DesignerActionPropertyItem(@"ContextMenuStrip", @"Context Menu Strip", @"Appearance", @"The context menu strip for the control."));
+                actions.Add(new DesignerActionPropertyItem(@"ItemStyle", @"Item Style", @"Appearance", @"How to display list items."));
+                actions.Add(new DesignerActionPropertyItem(@"ShortTextFont", @"Short Text Font", @"Appearance", @"The short text font."));
+                actions.Add(new DesignerActionHeaderItem(@"Behavior"));
+                actions.Add(new DesignerActionHeaderItem(@"Visuals"));
             }
 
             return actions;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonManagerActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonManagerActionList.cs
@@ -69,8 +69,8 @@ namespace Krypton.Toolkit
             if (_manager != null)
             {
                 // Add the list of panel specific actions
-                actions.Add(new DesignerActionHeaderItem("Visuals"));
-                actions.Add(new DesignerActionPropertyItem("GlobalPaletteMode", "Global Palette", "Visuals", "Global palette setting"));
+                actions.Add(new DesignerActionHeaderItem(@"Visuals"));
+                actions.Add(new DesignerActionPropertyItem(@"GlobalPaletteMode", @"Global Palette", @"Visuals", @"Global palette setting"));
             }
 
             return actions;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonMaskedTextBoxActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonMaskedTextBoxActionList.cs
@@ -155,15 +155,15 @@ namespace Krypton.Toolkit
             if (_maskedTextBox != null)
             {
                 // Add the list of label specific actions
-                actions.Add(new DesignerActionHeaderItem("Appearance"));
-                actions.Add(new DesignerActionPropertyItem("ContextMenuStrip", "Context Menu Strip", "Appearance", "The context menu strip for the control."));
-                actions.Add(new DesignerActionPropertyItem("InputControlStyle", "Style", "Appearance", "TextBox display style."));
-                actions.Add(new DesignerActionPropertyItem("Font", "Font", "Appearance", "Modifies the font of the control."));
-                actions.Add(new DesignerActionPropertyItem("CornerRadius", "Corner Rounding Radius", "Appearance", "The corner rounding radius of the control."));
-                actions.Add(new DesignerActionHeaderItem("MaskedTextBox"));
-                actions.Add(new DesignerActionPropertyItem("Mask", "Mask", "MaskedTextBox", "Input mask."));
-                actions.Add(new DesignerActionHeaderItem("Visuals"));
-                actions.Add(new DesignerActionPropertyItem("PaletteMode", "Palette", "Visuals", "Palette applied to drawing"));
+                actions.Add(new DesignerActionHeaderItem(@"Appearance"));
+                actions.Add(new DesignerActionPropertyItem(@"ContextMenuStrip", @"Context Menu Strip", @"Appearance", @"The context menu strip for the control."));
+                actions.Add(new DesignerActionPropertyItem(@"InputControlStyle", @"Style", @"Appearance", @"TextBox display style."));
+                actions.Add(new DesignerActionPropertyItem(@"Font", @"Font", @"Appearance", @"Modifies the font of the control."));
+                actions.Add(new DesignerActionPropertyItem(@"CornerRadius", @"Corner Rounding Radius", @"Appearance", @"The corner rounding radius of the control."));
+                actions.Add(new DesignerActionHeaderItem(@"MaskedTextBox"));
+                actions.Add(new DesignerActionPropertyItem(@"Mask", @"Mask", @"MaskedTextBox", @"Input mask."));
+                actions.Add(new DesignerActionHeaderItem(@"Visuals"));
+                actions.Add(new DesignerActionPropertyItem(@"PaletteMode", @"Palette", @"Visuals", @"Palette applied to drawing"));
             }
 
             return actions;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonMonthCalendarActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonMonthCalendarActionList.cs
@@ -206,18 +206,18 @@ namespace Krypton.Toolkit
             if (_monthCalendar != null)
             {
                 // Add the list of bread crumb specific actions
-                actions.Add(new DesignerActionHeaderItem("Appearance"));
-                actions.Add(new DesignerActionPropertyItem("ContextMenuStrip", "Context Menu Strip", "Appearance", "The context menu strip for the control."));
-                actions.Add(new DesignerActionPropertyItem("DayShortTextFont", "Day Short Text Font", "Appearance", "The short text font."));
-                actions.Add(new DesignerActionPropertyItem("DayLongTextFont", "Day Long Text Font", "Appearance", "The long text font."));
-                actions.Add(new DesignerActionPropertyItem("CornerRadius", "Corner Rounding Radius", "Appearance", "The corner rounding radius of the control."));
-                actions.Add(new DesignerActionHeaderItem("Behavior"));
-                actions.Add(new DesignerActionPropertyItem("MaxSelectionCount", "MaxSelectionCount", "Behavior", "Maximum number of selected days"));
-                actions.Add(new DesignerActionPropertyItem("ShowToday", "ShowToday", "Behavior", "Show the today button"));
-                actions.Add(new DesignerActionPropertyItem("ShowTodayCircle", "ShowTodayCircle", "Behavior", "Show a circle around the today entry"));
-                actions.Add(new DesignerActionPropertyItem("ShowWeekNumbers", "ShowWeekNumbers", "Behavior", "Show the week numbers"));
-                actions.Add(new DesignerActionHeaderItem("Visuals"));
-                actions.Add(new DesignerActionPropertyItem("PaletteMode", "Palette", "Visuals", "Palette applied to drawing"));
+                actions.Add(new DesignerActionHeaderItem(@"Appearance"));
+                actions.Add(new DesignerActionPropertyItem(@"ContextMenuStrip", @"Context Menu Strip", @"Appearance", @"The context menu strip for the control."));
+                actions.Add(new DesignerActionPropertyItem(@"DayShortTextFont", @"Day Short Text Font", @"Appearance", @"The short text font."));
+                actions.Add(new DesignerActionPropertyItem(@"DayLongTextFont", @"Day Long Text Font", @"Appearance", @"The long text font."));
+                actions.Add(new DesignerActionPropertyItem(@"CornerRadius", @"Corner Rounding Radius", @"Appearance", @"The corner rounding radius of the control."));
+                actions.Add(new DesignerActionHeaderItem(@"Behavior"));
+                actions.Add(new DesignerActionPropertyItem(@"MaxSelectionCount", @"MaxSelectionCount", @"Behavior", @"Maximum number of selected days"));
+                actions.Add(new DesignerActionPropertyItem(@"ShowToday", @"ShowToday", @"Behavior", @"Show the today button"));
+                actions.Add(new DesignerActionPropertyItem(@"ShowTodayCircle", @"ShowTodayCircle", @"Behavior", @"Show a circle around the today entry"));
+                actions.Add(new DesignerActionPropertyItem(@"ShowWeekNumbers", @"ShowWeekNumbers", @"Behavior", @"Show the week numbers"));
+                actions.Add(new DesignerActionHeaderItem(@"Visuals"));
+                actions.Add(new DesignerActionPropertyItem(@"PaletteMode", @"Palette", @"Visuals", @"Palette applied to drawing"));
             }
 
             return actions;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonNumericUpDownActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonNumericUpDownActionList.cs
@@ -189,17 +189,17 @@ namespace Krypton.Toolkit
             if (_numericUpDown != null)
             {
                 // Add the list of label specific actions
-                actions.Add(new DesignerActionHeaderItem("Appearance"));
-                actions.Add(new DesignerActionPropertyItem("ContextMenuStrip", "Context Menu Strip", "Appearance", "The context menu strip for the control."));
-                actions.Add(new DesignerActionPropertyItem("InputControlStyle", "Style", "Appearance", "NumericUpDown display style."));
-                actions.Add(new DesignerActionPropertyItem("Font", "Font", "Appearance", "The numeric up down font."));
-                actions.Add(new DesignerActionPropertyItem("CornerRadius", "Corner Rounding Radius", "Appearance", "The corner rounding radius of the control."));
-                actions.Add(new DesignerActionHeaderItem("Data"));
-                actions.Add(new DesignerActionPropertyItem("Increment", "Increment", "Data", "NumericUpDown increment value."));
-                actions.Add(new DesignerActionPropertyItem("Maximum", "Maximum", "Data", "NumericUpDown maximum value."));
-                actions.Add(new DesignerActionPropertyItem("Minimum", "Minimum", "Data", "NumericUpDown minimum value."));
-                actions.Add(new DesignerActionHeaderItem("Visuals"));
-                actions.Add(new DesignerActionPropertyItem("PaletteMode", "Palette", "Visuals", "Palette applied to drawing"));
+                actions.Add(new DesignerActionHeaderItem(@"Appearance"));
+                actions.Add(new DesignerActionPropertyItem(@"ContextMenuStrip", @"Context Menu Strip", @"Appearance", @"The context menu strip for the control."));
+                actions.Add(new DesignerActionPropertyItem(@"InputControlStyle", @"Style", @"Appearance", @"NumericUpDown display style."));
+                actions.Add(new DesignerActionPropertyItem(@"Font", @"Font", @"Appearance", @"The numeric up down font."));
+                actions.Add(new DesignerActionPropertyItem(@"CornerRadius", @"Corner Rounding Radius", @"Appearance", @"The corner rounding radius of the control."));
+                actions.Add(new DesignerActionHeaderItem(@"Data"));
+                actions.Add(new DesignerActionPropertyItem(@"Increment", @"Increment", @"Data", @"NumericUpDown increment value."));
+                actions.Add(new DesignerActionPropertyItem(@"Maximum", @"Maximum", @"Data", @"NumericUpDown maximum value."));
+                actions.Add(new DesignerActionPropertyItem(@"Minimum", @"Minimum", @"Data", @"NumericUpDown minimum value."));
+                actions.Add(new DesignerActionHeaderItem(@"Visuals"));
+                actions.Add(new DesignerActionPropertyItem(@"PaletteMode", @"Palette", @"Visuals", @"Palette applied to drawing"));
             }
 
             return actions;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonPanelActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonPanelActionList.cs
@@ -86,10 +86,10 @@ namespace Krypton.Toolkit
             if (_panel != null)
             {
                 // Add the list of panel specific actions
-                actions.Add(new DesignerActionHeaderItem("Appearance"));
-                actions.Add(new DesignerActionPropertyItem("PanelBackStyle", "Back style", "Appearance", "Background style"));
-                actions.Add(new DesignerActionHeaderItem("Visuals"));
-                actions.Add(new DesignerActionPropertyItem("PaletteMode", "Palette", "Visuals", "Palette applied to drawing"));
+                actions.Add(new DesignerActionHeaderItem(@"Appearance"));
+                actions.Add(new DesignerActionPropertyItem(@"PanelBackStyle", @"Back style", @"Appearance", @"Background style"));
+                actions.Add(new DesignerActionHeaderItem(@"Visuals"));
+                actions.Add(new DesignerActionPropertyItem(@"PaletteMode", @"Palette", @"Visuals", @"Palette applied to drawing"));
             }
             
             return actions;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonPropertyGridActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonPropertyGridActionList.cs
@@ -89,11 +89,11 @@ namespace Krypton.Toolkit
 
             if (_propertyGrid != null)
             {
-                actions.Add(new DesignerActionHeaderItem("Appearance"));
-                actions.Add(new DesignerActionPropertyItem("PropertySort", "Property Sort", "Appearance", "Sort properties by."));
-                //actions.Add(new DesignerActionHeaderItem("Values"));
-                //actions.Add(new DesignerActionPropertyItem("SelectedObject", "Selected Object", "Values", "The object to alter."));
-                //actions.Add(new DesignerActionPropertyItem("SelectedObjects", "Selected Objects", "Values", "The objects to alter."));
+                actions.Add(new DesignerActionHeaderItem(@"Appearance"));
+                actions.Add(new DesignerActionPropertyItem(@"PropertySort", @"Property Sort", @"Appearance", @"Sort properties by."));
+                //actions.Add(new DesignerActionHeaderItem(@"Values"));
+                //actions.Add(new DesignerActionPropertyItem(@"SelectedObject", @"Selected Object", @"Values", @"The object to alter."));
+                //actions.Add(new DesignerActionPropertyItem(@"SelectedObjects", @"Selected Objects", @"Values", @"The objects to alter."));
             }
 
             return actions;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonRadioButtonActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonRadioButtonActionList.cs
@@ -222,20 +222,20 @@ namespace Krypton.Toolkit
             if (_radioButton != null)
             {
                 // Add the list of radio button specific actions
-                actions.Add(new DesignerActionHeaderItem("Operation"));
-                actions.Add(new DesignerActionPropertyItem("Checked", "Checked", "Operation", "Checked state"));
-                actions.Add(new DesignerActionPropertyItem("AutoCheck", "AutoCheck", "Operation", "AutoCheck of other instances."));
-                actions.Add(new DesignerActionHeaderItem("Appearance"));
-                actions.Add(new DesignerActionPropertyItem("LabelStyle", "Style", "Appearance", "Label style"));
-                actions.Add(new DesignerActionPropertyItem("Orientation", "Orientation", "Appearance", "Visual orientation"));
-                actions.Add(new DesignerActionPropertyItem("ShortTextFont", "Short Text Font", "Appearance", "The short text font."));
-                actions.Add(new DesignerActionPropertyItem("LongTextFont", "Long Text Font", "Appearance", "The long text font."));
-                actions.Add(new DesignerActionHeaderItem("Values"));
-                actions.Add(new DesignerActionPropertyItem("Text", "Text", "Values", "Radio button text"));
-                actions.Add(new DesignerActionPropertyItem("ExtraText", "ExtraText", "Values", "Radio button extra text"));
-                actions.Add(new DesignerActionPropertyItem("Image", "Image", "Values", "Radio button image"));
-                actions.Add(new DesignerActionHeaderItem("Visuals"));
-                actions.Add(new DesignerActionPropertyItem("PaletteMode", "Palette", "Visuals", "Palette applied to drawing"));
+                actions.Add(new DesignerActionHeaderItem(@"Operation"));
+                actions.Add(new DesignerActionPropertyItem(@"Checked", @"Checked", @"Operation", @"Checked state"));
+                actions.Add(new DesignerActionPropertyItem(@"AutoCheck", @"AutoCheck", @"Operation", @"AutoCheck of other instances."));
+                actions.Add(new DesignerActionHeaderItem(@"Appearance"));
+                actions.Add(new DesignerActionPropertyItem(@"LabelStyle", @"Style", @"Appearance", @"Label style"));
+                actions.Add(new DesignerActionPropertyItem(@"Orientation", @"Orientation", @"Appearance", @"Visual orientation"));
+                actions.Add(new DesignerActionPropertyItem(@"ShortTextFont", @"Short Text Font", @"Appearance", @"The short text font."));
+                actions.Add(new DesignerActionPropertyItem(@"LongTextFont", @"Long Text Font", @"Appearance", @"The long text font."));
+                actions.Add(new DesignerActionHeaderItem(@"Values"));
+                actions.Add(new DesignerActionPropertyItem(@"Text", @"Text", @"Values", @"Radio button text"));
+                actions.Add(new DesignerActionPropertyItem(@"ExtraText", @"ExtraText", @"Values", @"Radio button extra text"));
+                actions.Add(new DesignerActionPropertyItem(@"Image", @"Image", @"Values", @"Radio button image"));
+                actions.Add(new DesignerActionHeaderItem(@"Visuals"));
+                actions.Add(new DesignerActionPropertyItem(@"PaletteMode", @"Palette", @"Visuals", @"Palette applied to drawing"));
             }
 
             return actions;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonRichTextBoxActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonRichTextBoxActionList.cs
@@ -172,16 +172,16 @@ namespace Krypton.Toolkit
             if (_richTextBox != null)
             {
                 // Add the list of rich text box specific actions
-                actions.Add(new DesignerActionHeaderItem("Appearance"));
-                actions.Add(new DesignerActionPropertyItem("ContextMenuStrip", "Context Menu Strip", "Appearance", "The context menu strip for the control."));
-                actions.Add(new DesignerActionPropertyItem("InputControlStyle", "Style", "Appearance", "TextBox display style."));
-                actions.Add(new DesignerActionPropertyItem("Font", "Font", "Appearance", "Modifies the font of the control."));
-                actions.Add(new DesignerActionPropertyItem("CornerRadius", "Corner Rounding Radius", "Appearance", "The corner rounding radius of the control."));
-                actions.Add(new DesignerActionHeaderItem("TextBox"));
-                actions.Add(new DesignerActionPropertyItem("Multiline", "Multiline", "TextBox", "Should text span multiple lines."));
-                actions.Add(new DesignerActionPropertyItem("WordWrap", "WordWrap", "TextBox", "Should words be wrapped over multiple lines."));
-                actions.Add(new DesignerActionHeaderItem("Visuals"));
-                actions.Add(new DesignerActionPropertyItem("PaletteMode", "Palette", "Visuals", "Palette applied to drawing."));
+                actions.Add(new DesignerActionHeaderItem(@"Appearance"));
+                actions.Add(new DesignerActionPropertyItem(@"ContextMenuStrip", @"Context Menu Strip", @"Appearance", @"The context menu strip for the control."));
+                actions.Add(new DesignerActionPropertyItem(@"InputControlStyle", @"Style", @"Appearance", @"TextBox display style."));
+                actions.Add(new DesignerActionPropertyItem(@"Font", @"Font", @"Appearance", @"Modifies the font of the control."));
+                actions.Add(new DesignerActionPropertyItem(@"CornerRadius", @"Corner Rounding Radius", @"Appearance", @"The corner rounding radius of the control."));
+                actions.Add(new DesignerActionHeaderItem(@"TextBox"));
+                actions.Add(new DesignerActionPropertyItem(@"Multiline", @"Multiline", @"TextBox", @"Should text span multiple lines."));
+                actions.Add(new DesignerActionPropertyItem(@"WordWrap", @"WordWrap", @"TextBox", @"Should words be wrapped over multiple lines."));
+                actions.Add(new DesignerActionHeaderItem(@"Visuals"));
+                actions.Add(new DesignerActionPropertyItem(@"PaletteMode", @"Palette", @"Visuals", @"Palette applied to drawing."));
             }
 
             return actions;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonScrollBarActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonScrollBarActionList.cs
@@ -108,12 +108,12 @@ namespace Krypton.Toolkit
 
             if (_scrollBar != null)
             {
-                actions.Add(new DesignerActionHeaderItem("Appearance"));
-                actions.Add(new DesignerActionPropertyItem("Orientation", "Orientation", "Appearance", "The appearance of the scrollbar."));
-                actions.Add(new DesignerActionHeaderItem("Values"));
-                actions.Add(new DesignerActionPropertyItem("Maximum", "Maximum", "Values", "The maximum value that the scrollbar can accept."));
-                actions.Add(new DesignerActionPropertyItem("Minimum", "Minimum", "Values", "The minimum value that the scrollbar can accept."));
-                actions.Add(new DesignerActionPropertyItem("Value", "Value", "Values", "The current value of the scrollbar."));
+                actions.Add(new DesignerActionHeaderItem(@"Appearance"));
+                actions.Add(new DesignerActionPropertyItem(@"Orientation", @"Orientation", @"Appearance", @"The appearance of the scrollbar."));
+                actions.Add(new DesignerActionHeaderItem(@"Values"));
+                actions.Add(new DesignerActionPropertyItem(@"Maximum", @"Maximum", @"Values", @"The maximum value that the scrollbar can accept."));
+                actions.Add(new DesignerActionPropertyItem(@"Minimum", @"Minimum", @"Values", @"The minimum value that the scrollbar can accept."));
+                actions.Add(new DesignerActionPropertyItem(@"Value", @"Value", @"Values", @"The current value of the scrollbar."));
 
             }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonSeparatorActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonSeparatorActionList.cs
@@ -103,11 +103,11 @@ namespace Krypton.Toolkit
             if (_separator != null)
             {
                 // Add the list of label specific actions
-                actions.Add(new DesignerActionHeaderItem("Appearance"));
-                actions.Add(new DesignerActionPropertyItem("SeparatorStyle", "Style", "Appearance", "Separator style"));
-                actions.Add(new DesignerActionPropertyItem("Orientation", "Orientation", "Appearance", "Visual orientation"));
-                actions.Add(new DesignerActionHeaderItem("Visuals"));
-                actions.Add(new DesignerActionPropertyItem("PaletteMode", "Palette", "Visuals", "Palette applied to drawing"));
+                actions.Add(new DesignerActionHeaderItem(@"Appearance"));
+                actions.Add(new DesignerActionPropertyItem(@"SeparatorStyle", @"Style", @"Appearance", @"Separator style"));
+                actions.Add(new DesignerActionPropertyItem(@"Orientation", @"Orientation", @"Appearance", @"Visual orientation"));
+                actions.Add(new DesignerActionHeaderItem(@"Visuals"));
+                actions.Add(new DesignerActionPropertyItem(@"PaletteMode", @"Palette", @"Visuals", @"Palette applied to drawing"));
             }
             
             return actions;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonSplitContainerActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonSplitContainerActionList.cs
@@ -119,13 +119,13 @@ namespace Krypton.Toolkit
             if (_splitContainer != null)
             {
                 // Add our own action to the end
-                actions.Add(new DesignerActionHeaderItem("Appearance"));
-                actions.Add(new DesignerActionPropertyItem("ContainerBackStyle", "Back style", "Appearance", "Background style"));
-                actions.Add(new DesignerActionHeaderItem("Splitter"));
+                actions.Add(new DesignerActionHeaderItem(@"Appearance"));
+                actions.Add(new DesignerActionPropertyItem(@"ContainerBackStyle", @"Back style", @"Appearance", @"Background style"));
+                actions.Add(new DesignerActionHeaderItem(@"Splitter"));
                 actions.Add(new KryptonDesignerActionItem(new DesignerVerb(_action, OnOrientationClick), "Splitter"));
-                actions.Add(new DesignerActionPropertyItem("SeparatorStyle", "Separator style", "Splitter", "Separator style"));
-                actions.Add(new DesignerActionHeaderItem("Visuals"));
-                actions.Add(new DesignerActionPropertyItem("PaletteMode", "Palette", "Visuals", "Palette applied to drawing"));
+                actions.Add(new DesignerActionPropertyItem(@"SeparatorStyle", @"Separator style", @"Splitter", @"Separator style"));
+                actions.Add(new DesignerActionHeaderItem(@"Visuals"));
+                actions.Add(new DesignerActionPropertyItem(@"PaletteMode", @"Palette", @"Visuals", @"Palette applied to drawing"));
             }
 
             return actions;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonTextBoxActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonTextBoxActionList.cs
@@ -207,18 +207,18 @@ namespace Krypton.Toolkit
             if (_textBox != null)
             {
                 // Add the list of label specific actions
-                actions.Add(new DesignerActionHeaderItem("Appearance"));
-                actions.Add(new DesignerActionPropertyItem("ContextMenuStrip", "Context Menu Strip", "Appearance", "The context menu strip for the control."));
-                actions.Add(new DesignerActionPropertyItem("InputControlStyle", "Style", "Appearance", "TextBox display style."));
-                actions.Add(new DesignerActionPropertyItem("Font", "Font", "Appearance", "Modifies the font of the control."));
-                actions.Add(new DesignerActionPropertyItem("CornerRadius", "Corner Rounding Radius", "Appearance", "The corner rounding radius of the control."));
-                actions.Add(new DesignerActionHeaderItem("TextBox"));
-                actions.Add(new DesignerActionPropertyItem("Multiline", "Multiline", "TextBox", "Should text span multiple lines."));
-                actions.Add(new DesignerActionPropertyItem("WordWrap", "WordWrap", "TextBox", "Should words be wrapped over multiple lines."));
-                actions.Add(new DesignerActionPropertyItem("UseSystemPasswordChar", "UseSystemPasswordChar", "TextBox", "Should characters be displayed in password characters."));
-                actions.Add(new DesignerActionPropertyItem("Hint", "Hint", "TextBox", "Sets the hint string for the textbox."));
-                actions.Add(new DesignerActionHeaderItem("Visuals"));
-                actions.Add(new DesignerActionPropertyItem("PaletteMode", "Palette", "Visuals", "Palette applied to drawing"));
+                actions.Add(new DesignerActionHeaderItem(@"Appearance"));
+                actions.Add(new DesignerActionPropertyItem(@"ContextMenuStrip", @"Context Menu Strip", @"Appearance", @"The context menu strip for the control."));
+                actions.Add(new DesignerActionPropertyItem(@"InputControlStyle", @"Style", @"Appearance", @"TextBox display style."));
+                actions.Add(new DesignerActionPropertyItem(@"Font", @"Font", @"Appearance", @"Modifies the font of the control."));
+                actions.Add(new DesignerActionPropertyItem(@"CornerRadius", @"Corner Rounding Radius", @"Appearance", @"The corner rounding radius of the control."));
+                actions.Add(new DesignerActionHeaderItem(@"TextBox"));
+                actions.Add(new DesignerActionPropertyItem(@"Multiline", @"Multiline", @"TextBox", @"Should text span multiple lines."));
+                actions.Add(new DesignerActionPropertyItem(@"WordWrap", @"WordWrap", @"TextBox", @"Should words be wrapped over multiple lines."));
+                actions.Add(new DesignerActionPropertyItem(@"UseSystemPasswordChar", @"UseSystemPasswordChar", @"TextBox", @"Should characters be displayed in password characters."));
+                actions.Add(new DesignerActionPropertyItem(@"Hint", @"Hint", @"TextBox", @"Sets the hint string for the textbox."));
+                actions.Add(new DesignerActionHeaderItem(@"Visuals"));
+                actions.Add(new DesignerActionPropertyItem(@"PaletteMode", @"Palette", @"Visuals", @"Palette applied to drawing"));
             }
 
             return actions;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonTrackBarActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonTrackBarActionList.cs
@@ -187,17 +187,17 @@ namespace Krypton.Toolkit
             if (_trackBar != null)
             {
                 // Add our own action to the end
-                actions.Add(new DesignerActionHeaderItem("Layout"));
-                actions.Add(new DesignerActionPropertyItem("TickStyle", "Tick Style", "Layout", "Tick style"));
-                actions.Add(new DesignerActionPropertyItem("TrackBarSize", "TrackBar Size", "Layout", "Size of the track bar"));
+                actions.Add(new DesignerActionHeaderItem(@"Layout"));
+                actions.Add(new DesignerActionPropertyItem(@"TickStyle", @"Tick Style", @"Layout", @"Tick style"));
+                actions.Add(new DesignerActionPropertyItem(@"TrackBarSize", @"TrackBar Size", @"Layout", @"Size of the track bar"));
                 actions.Add(new KryptonDesignerActionItem(new DesignerVerb(_action, OnOrientationClick), "Layout"));
-                actions.Add(new DesignerActionHeaderItem("Values"));
-                actions.Add(new DesignerActionPropertyItem("Minimum", "Minimum", "Values", "Minium value"));
-                actions.Add(new DesignerActionPropertyItem("Maximum", "Maximum", "Values", "Maximum value"));
-                actions.Add(new DesignerActionPropertyItem("SmallChange", "Small Change", "Values", "Small change value"));
-                actions.Add(new DesignerActionPropertyItem("LargeChange", "Large Change", "Values", "Large change value"));
-                actions.Add(new DesignerActionHeaderItem("Visuals"));
-                actions.Add(new DesignerActionPropertyItem("PaletteMode", "Palette", "Visuals", "Palette applied to drawing"));
+                actions.Add(new DesignerActionHeaderItem(@"Values"));
+                actions.Add(new DesignerActionPropertyItem(@"Minimum", @"Minimum", @"Values", @"Minium value"));
+                actions.Add(new DesignerActionPropertyItem(@"Maximum", @"Maximum", @"Values", @"Maximum value"));
+                actions.Add(new DesignerActionPropertyItem(@"SmallChange", @"Small Change", @"Values", @"Small change value"));
+                actions.Add(new DesignerActionPropertyItem(@"LargeChange", @"Large Change", @"Values", @"Large change value"));
+                actions.Add(new DesignerActionHeaderItem(@"Visuals"));
+                actions.Add(new DesignerActionPropertyItem(@"PaletteMode", @"Palette", @"Visuals", @"Palette applied to drawing"));
             }
 
             return actions;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonTreeViewActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonTreeViewActionList.cs
@@ -224,19 +224,19 @@ namespace Krypton.Toolkit
             if (_treeView != null)
             {
                 // Add the list of tree view specific actions
-                actions.Add(new DesignerActionHeaderItem("Appearance"));
-                actions.Add(new DesignerActionPropertyItem("BackStyle", "Back Style", "Appearance", "Style used to draw background."));
-                actions.Add(new DesignerActionPropertyItem("BorderStyle", "Border Style", "Appearance", "Style used to draw the border."));
-                actions.Add(new DesignerActionPropertyItem("ContextMenuStrip", "Context Menu Strip", "Appearance", "The context menu strip for the control."));
-                actions.Add(new DesignerActionPropertyItem("ItemStyle", "Item Style", "Appearance", "How to display tree items."));
-                actions.Add(new DesignerActionPropertyItem("ShortTextFont", "Short Text Font", "Appearance", "The short text font."));
-                actions.Add(new DesignerActionPropertyItem("LongTextFont", "Long Text Font", "Appearance", "The long text font."));
-                actions.Add(new DesignerActionPropertyItem("CornerRadius", "Corner Rounding Radius", "Appearance", "The corner rounding radius of the control."));
-                actions.Add(new DesignerActionPropertyItem("NodeCornerRadius", "Node Corner Rounding Radius", "Appearance", "The corner rounding radius of the node."));
-                actions.Add(new DesignerActionHeaderItem("Behavior"));
-                actions.Add(new DesignerActionPropertyItem("Sorted", "Sorted", "Behavior", "Should items be sorted according to string."));
-                actions.Add(new DesignerActionHeaderItem("Visuals"));
-                actions.Add(new DesignerActionPropertyItem("PaletteMode", "Palette", "Visuals", "Palette applied to drawing"));
+                actions.Add(new DesignerActionHeaderItem(@"Appearance"));
+                actions.Add(new DesignerActionPropertyItem(@"BackStyle", @"Back Style", @"Appearance", @"Style used to draw background."));
+                actions.Add(new DesignerActionPropertyItem(@"BorderStyle", @"Border Style", @"Appearance", @"Style used to draw the border."));
+                actions.Add(new DesignerActionPropertyItem(@"ContextMenuStrip", @"Context Menu Strip", @"Appearance", @"The context menu strip for the control."));
+                actions.Add(new DesignerActionPropertyItem(@"ItemStyle", @"Item Style", @"Appearance", @"How to display tree items."));
+                actions.Add(new DesignerActionPropertyItem(@"ShortTextFont", @"Short Text Font", @"Appearance", @"The short text font."));
+                actions.Add(new DesignerActionPropertyItem(@"LongTextFont", @"Long Text Font", @"Appearance", @"The long text font."));
+                actions.Add(new DesignerActionPropertyItem(@"CornerRadius", @"Corner Rounding Radius", @"Appearance", @"The corner rounding radius of the control."));
+                actions.Add(new DesignerActionPropertyItem(@"NodeCornerRadius", @"Node Corner Rounding Radius", @"Appearance", @"The corner rounding radius of the node."));
+                actions.Add(new DesignerActionHeaderItem(@"Behavior"));
+                actions.Add(new DesignerActionPropertyItem(@"Sorted", @"Sorted", @"Behavior", @"Should items be sorted according to string."));
+                actions.Add(new DesignerActionHeaderItem(@"Visuals"));
+                actions.Add(new DesignerActionPropertyItem(@"PaletteMode", @"Palette", @"Visuals", @"Palette applied to drawing"));
             }
 
             return actions;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonWrapLabelActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonWrapLabelActionList.cs
@@ -102,11 +102,11 @@ namespace Krypton.Toolkit
             // This can be null when deleting a control instance at design time
             if (_wrapLabel != null)
             {
-                actions.Add(new DesignerActionHeaderItem("Appearance"));
-                actions.Add(new DesignerActionPropertyItem("LabelStyle", "Style", "Appearance", "Label style"));
-                actions.Add(new DesignerActionPropertyItem("Font", "Font", "Appearance", "The wrap label font."));
-                actions.Add(new DesignerActionHeaderItem("Visuals"));
-                actions.Add(new DesignerActionPropertyItem("PaletteMode", "Palette", "Visuals", "Palette applied to drawing"));
+                actions.Add(new DesignerActionHeaderItem(@"Appearance"));
+                actions.Add(new DesignerActionPropertyItem(@"LabelStyle", @"Style", @"Appearance", @"Label style"));
+                actions.Add(new DesignerActionPropertyItem(@"Font", @"Font", @"Appearance", @"The wrap label font."));
+                actions.Add(new DesignerActionHeaderItem(@"Visuals"));
+                actions.Add(new DesignerActionPropertyItem(@"PaletteMode", @"Palette", @"Visuals", @"Palette applied to drawing"));
             }
 
             return actions;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonGroupBoxDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonGroupBoxDesigner.cs
@@ -66,7 +66,9 @@ namespace Krypton.Toolkit
         /// <returns>A ControlDesigner at the specified index.</returns>
         public override ControlDesigner InternalControlDesigner(int internalControlIndex) =>
             // Get the control designer for the requested indexed child control
-            (_groupBox != null) && (internalControlIndex == 0) ? (ControlDesigner)_designerHost.GetDesigner(_groupBox.Panel) : null;
+            (_groupBox != null) && (internalControlIndex == 0) 
+                ? (ControlDesigner)_designerHost.GetDesigner(_groupBox.Panel) 
+                : null;
 
         /// <summary>
         /// Returns the number of internal control designers in the ControlDesigner.
@@ -84,7 +86,6 @@ namespace Krypton.Toolkit
                 // Create a collection of action lists
                 DesignerActionListCollection actionLists = new()
                 {
-
                     // Add the group box specific list
                     new KryptonGroupBoxActionList(this)
                 };

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonGroupDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonGroupDesigner.cs
@@ -64,7 +64,9 @@ namespace Krypton.Toolkit
         /// <returns>A ControlDesigner at the specified index.</returns>
         public override ControlDesigner InternalControlDesigner(int internalControlIndex) =>
             // Get the control designer for the requested indexed child control
-            (internalControlIndex == 0) && (_group != null) ? (ControlDesigner)_designerHost.GetDesigner(_group.Panel) : null;
+            (internalControlIndex == 0) && (_group != null) 
+                ? (ControlDesigner)_designerHost.GetDesigner(_group.Panel) 
+                : null;
 
         /// <summary>
         /// Returns the number of internal control designers in the ControlDesigner.
@@ -82,7 +84,6 @@ namespace Krypton.Toolkit
                 // Create a collection of action lists
                 DesignerActionListCollection actionLists = new()
                 {
-
                     // Add the group specific list
                     new KryptonGroupActionList(this)
                 };

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonGroupPanelDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonGroupPanelDesigner.cs
@@ -43,7 +43,7 @@ namespace Krypton.Toolkit
             if (_panel != null)
             {
                 PropertyDescriptor descriptor = TypeDescriptor.GetProperties(component)["Locked"];
-                if ((descriptor != null) && ((_panel.Parent is KryptonGroup) || (_panel.Parent is KryptonHeaderGroup)))
+                if ((descriptor != null) && (_panel.Parent is KryptonGroup or KryptonHeaderGroup))
                 {
                     descriptor.SetValue(component, true);
                 }
@@ -57,7 +57,7 @@ namespace Krypton.Toolkit
         /// <returns>true if the control managed by the specified designer can parent the control managed by this designer; otherwise, false.</returns>
         public override bool CanBeParentedTo(IDesigner parentDesigner) =>
             // We should only ever exist inside a Krypton group container
-            (parentDesigner is KryptonGroup) || (parentDesigner is KryptonHeaderGroup);
+            (parentDesigner is KryptonGroup or KryptonHeaderGroup);
 
         /// <summary>
         /// Gets the selection rules that indicate the movement capabilities of a component.
@@ -65,8 +65,7 @@ namespace Krypton.Toolkit
         public override SelectionRules SelectionRules =>
             // If the panel is inside our Krypton group container then prevent 
             // user changing the size or location of the group panel instance
-            (Control.Parent is KryptonGroup) ||
-            (Control.Parent is KryptonHeaderGroup)
+            (Control.Parent is KryptonGroup or KryptonHeaderGroup)
                 ? SelectionRules.None | SelectionRules.Locked
                 : SelectionRules.None;
 
@@ -136,22 +135,22 @@ namespace Krypton.Toolkit
         /// <param name="properties">The properties for the class of the component.</param>
         protected override void PreFilterProperties(IDictionary properties)
         {
-            // Let base clas filter properties first
+            // Let base class filter properties first
             base.PreFilterProperties(properties);
 
             // Remove the design time properties we do not want
-            properties.Remove("Modifiers");
-            properties.Remove("Locked");
-            properties.Remove("GenerateMember");
+            properties.Remove(@"Modifiers");
+            properties.Remove(@"Locked");
+            properties.Remove(@"GenerateMember");
 
-            // Scan for the 'Name' propertty
+            // Scan for the 'Name' property
             foreach (DictionaryEntry entry in properties)
             {
                 // Get the property descriptor for the entry
                 PropertyDescriptor descriptor = (PropertyDescriptor)entry.Value;
 
                 // Is this the 'Name' we are searching for?
-                if (descriptor.Name.Equals("Name") && descriptor.DesignTimeOnly)
+                if (descriptor.Name.Equals((@"Name")) && descriptor.DesignTimeOnly)
                 {
                     // Hide the 'Name' property so the user cannot modify it
                     var attributeArray = new Attribute[2] { BrowsableAttribute.No, DesignerSerializationVisibilityAttribute.Hidden };

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonSplitterPanelDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonSplitterPanelDesigner.cs
@@ -141,22 +141,22 @@ namespace Krypton.Toolkit
         /// <param name="properties">The properties for the class of the component.</param>
         protected override void PreFilterProperties(IDictionary properties)
         {
-            // Let base clas filter properties first
+            // Let base class filter properties first
             base.PreFilterProperties(properties);
 
             // Remove the design time properties we do not want
-            properties.Remove("Modifiers");
-            properties.Remove("Locked");
-            properties.Remove("GenerateMember");
+            properties.Remove(@"Modifiers");
+            properties.Remove(@"Locked");
+            properties.Remove(@"GenerateMember");
 
-            // Scan for the 'Name' propertty
+            // Scan for the 'Name' property
             foreach (DictionaryEntry entry in properties)
             {
                 // Get the property descriptor for the entry
                 PropertyDescriptor descriptor = (PropertyDescriptor)entry.Value;
 
                 // Is this the 'Name' we are searching for?
-                if (descriptor.Name.Equals("Name") && descriptor.DesignTimeOnly)
+                if (descriptor.Name.Equals((@"Name")) && descriptor.DesignTimeOnly)
                 {
                     // Hide the 'Name' property so the user cannot modify it
                     var attributeArray = new Attribute[2] { BrowsableAttribute.No, DesignerSerializationVisibilityAttribute.Hidden };

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/ScrollBarControlDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/ScrollBarControlDesigner.cs
@@ -56,15 +56,15 @@ namespace Krypton.Toolkit
         /// <param name="properties">The property dictionary.</param>
         protected override void PreFilterProperties(IDictionary properties)
         {
-            properties.Remove("Text");
-            properties.Remove("BackgroundImage");
-            properties.Remove("ForeColor");
-            properties.Remove("ImeMode");
-            properties.Remove("Padding");
-            properties.Remove("BackgroundImageLayout");
-            properties.Remove("BackColor");
-            properties.Remove("Font");
-            properties.Remove("RightToLeft");
+            properties.Remove(@"Text");
+            properties.Remove(@"BackgroundImage");
+            properties.Remove(@"ForeColor");
+            properties.Remove(@"ImeMode");
+            properties.Remove(@"Padding");
+            properties.Remove(@"BackgroundImageLayout");
+            properties.Remove(@"BackColor");
+            properties.Remove(@"Font");
+            properties.Remove(@"RightToLeft");
 
             base.PreFilterProperties(properties);
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Editors/KryptonBreadCrumbItemsEditor.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Editors/KryptonBreadCrumbItemsEditor.cs
@@ -49,7 +49,7 @@ namespace Krypton.Toolkit
                 /// <summary>
                 /// Gets and sets the short text.
                 /// </summary>
-                [Category("Appearance")]
+                [Category(@"Appearance")]
                 public string ShortText
                 {
                     get => _item.ShortText;
@@ -61,7 +61,7 @@ namespace Krypton.Toolkit
                 /// <summary>
                 /// Gets and sets the long text.
                 /// </summary>
-                [Category("Appearance")]
+                [Category(@"Appearance")]
                 public string LongText
                 {
                     get => _item.LongText;
@@ -73,7 +73,7 @@ namespace Krypton.Toolkit
                 /// <summary>
                 /// Gets and sets the image.
                 /// </summary>
-                [Category("Appearance")]
+                [Category(@"Appearance")]
                 [DefaultValue(null)]
                 public Image Image
                 {
@@ -86,7 +86,7 @@ namespace Krypton.Toolkit
                 /// <summary>
                 /// Gets and sets the image transparent color.
                 /// </summary>
-                [Category("Appearance")]
+                [Category(@"Appearance")]
                 [DefaultValue(typeof(Color), "")]
                 public Color ImageTransparentColor
                 {
@@ -99,7 +99,7 @@ namespace Krypton.Toolkit
                 /// <summary>
                 /// Gets and sets user-defined data associated with the object.
                 /// </summary>
-                [Category("Data")]
+                [Category(@"Data")]
                 [TypeConverter(typeof(StringConverter))]
                 [DefaultValue(null)]
                 public object Tag
@@ -416,7 +416,7 @@ namespace Krypton.Toolkit
                 Controls.Add(buttonMoveUp);
                 Controls.Add(treeView1);
                 Controls.Add(buttonOK);
-                Font = new Font("Tahoma", 8.25F, FontStyle.Regular, GraphicsUnit.Point, 0);
+                Font = new Font(@"Tahoma", 8.25F, FontStyle.Regular, GraphicsUnit.Point, 0);
                 MinimumSize = new Size(501, 296);
                 Name = "KryptonBreadCrumbCollectionForm";
                 StartPosition = FormStartPosition.CenterScreen;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/UX/KryptonCheckButtonCollectionForm.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/UX/KryptonCheckButtonCollectionForm.Designer.cs
@@ -103,7 +103,7 @@ namespace Krypton.Toolkit
             this.Controls.Add(this.buttonCancel);
             this.Controls.Add(this.buttonOK);
             this.Controls.Add(this.checkedListBox);
-            this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.Font = new System.Drawing.Font(@"Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.MinimumSize = new System.Drawing.Size(250, 205);
             this.Name = "KryptonCheckButtonCollectionForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;

--- a/Source/Krypton Components/Krypton.Toolkit/General/CommonHelper.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/CommonHelper.cs
@@ -498,10 +498,7 @@ namespace Krypton.Toolkit
             PaletteDrawBorders justBorders = borders & PaletteDrawBorders.All;
 
             // If borders value equals just one of the edges
-            return (justBorders == PaletteDrawBorders.Top) ||
-                   (justBorders == PaletteDrawBorders.Bottom) ||
-                   (justBorders == PaletteDrawBorders.Left) ||
-                   (justBorders == PaletteDrawBorders.Right);
+            return justBorders is PaletteDrawBorders.Top or PaletteDrawBorders.Bottom or PaletteDrawBorders.Left or PaletteDrawBorders.Right;
         }
 
         /// <summary>
@@ -560,7 +557,7 @@ namespace Krypton.Toolkit
             }
 
             // No need to change the All or None values
-            if ((borders == PaletteDrawBorders.All) || (borders == PaletteDrawBorders.None))
+            if (borders is PaletteDrawBorders.All or PaletteDrawBorders.None)
             {
                 return borders;
             }
@@ -664,7 +661,7 @@ namespace Krypton.Toolkit
             }
 
             // No need to change the All or None values
-            if ((borders == PaletteDrawBorders.All) || (borders == PaletteDrawBorders.None))
+            if (borders is PaletteDrawBorders.All or PaletteDrawBorders.None)
             {
                 return borders;
             }

--- a/Source/Krypton Components/Krypton.Toolkit/General/GlobalStrings.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/GlobalStrings.cs
@@ -94,8 +94,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the OK string used in message box buttons.
         /// </summary>
         [Localizable(true)]
-        [Category("Visuals")]
-        [Description("OK string used for message box buttons.")]
+        [Category(@"Visuals")]
+        [Description(@"OK string used for message box buttons.")]
         [DefaultValue(DEFAULT_OK)]
         [RefreshProperties(RefreshProperties.All)]
         public string OK { get; set; }
@@ -104,8 +104,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the Cancel string used in message box buttons.
         /// </summary>
         [Localizable(true)]
-        [Category("Visuals")]
-        [Description("Cancel string used for message box buttons.")]
+        [Category(@"Visuals")]
+        [Description(@"Cancel string used for message box buttons.")]
         [DefaultValue(DEFAULT_CANCEL)]
         [RefreshProperties(RefreshProperties.All)]
         public string Cancel { get; set; }
@@ -114,8 +114,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the Yes string used in message box buttons.
         /// </summary>
         [Localizable(true)]
-        [Category("Visuals")]
-        [Description("Yes string used for message box buttons.")]
+        [Category(@"Visuals")]
+        [Description(@"Yes string used for message box buttons.")]
         [DefaultValue(DEFAULT_YES)]
         [RefreshProperties(RefreshProperties.All)]
         public string Yes { get; set; }
@@ -124,8 +124,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the No string used in message box buttons.
         /// </summary>
         [Localizable(true)]
-        [Category("Visuals")]
-        [Description("No string used for message box buttons.")]
+        [Category(@"Visuals")]
+        [Description(@"No string used for message box buttons.")]
         [DefaultValue(DEFAULT_NO)]
         [RefreshProperties(RefreshProperties.All)]
         public string No { get; set; }
@@ -134,8 +134,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the Abort string used in message box buttons.
         /// </summary>
         [Localizable(true)]
-        [Category("Visuals")]
-        [Description("Abort string used for message box buttons.")]
+        [Category(@"Visuals")]
+        [Description(@"Abort string used for message box buttons.")]
         [DefaultValue(DEFAULT_ABORT)]
         [RefreshProperties(RefreshProperties.All)]
         public string Abort { get; set; }
@@ -144,8 +144,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the Retry string used in message box buttons.
         /// </summary>
         [Localizable(true)]
-        [Category("Visuals")]
-        [Description("Retry string used for message box buttons.")]
+        [Category(@"Visuals")]
+        [Description(@"Retry string used for message box buttons.")]
         [DefaultValue(DEFAULT_RETRY)]
         [RefreshProperties(RefreshProperties.All)]
         public string Retry { get; set; }
@@ -154,8 +154,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the Ignore string used in message box buttons.
         /// </summary>
         [Localizable(true)]
-        [Category("Visuals")]
-        [Description("Ignore string used for message box buttons.")]
+        [Category(@"Visuals")]
+        [Description(@"Ignore string used for message box buttons.")]
         [DefaultValue(DEFAULT_IGNORE)]
         [RefreshProperties(RefreshProperties.All)]
         public string Ignore { get; set; }
@@ -164,8 +164,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the Close string used in message box buttons.
         /// </summary>
         [Localizable(true)]
-        [Category("Visuals")]
-        [Description("Close string used for message box buttons.")]
+        [Category(@"Visuals")]
+        [Description(@"Close string used for message box buttons.")]
         [DefaultValue(DEFAULT_CLOSE)]
 
         [RefreshProperties(RefreshProperties.All)]
@@ -175,8 +175,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the Close string used in calendars.
         /// </summary>
         [Localizable(true)]
-        [Category("Visuals")]
-        [Description("Today string used for calendars.")]
+        [Category(@"Visuals")]
+        [Description(@"Today string used for calendars.")]
         [DefaultValue(DEFAULT_TODAY)]
         [RefreshProperties(RefreshProperties.All)]
         public string Today { get; set; }
@@ -185,8 +185,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the Close string used in calendars.
         /// </summary>
         [Localizable(true)]
-        [Category("Visuals")]
-        [Description("Help string used for Message Box Buttons.")]
+        [Category(@"Visuals")]
+        [Description(@"Help string used for Message Box Buttons.")]
         [DefaultValue(DEFAULT_HELP)]
         [RefreshProperties(RefreshProperties.All)]
         public string Help { get; set; }

--- a/Source/Krypton Components/Krypton.Toolkit/General/GlobalSuppressions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/GlobalSuppressions.cs
@@ -15,4 +15,4 @@
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
-[assembly: SuppressMessage("Style", "IDE0063:Use simple 'using' statement", Justification = "Prevent confusion between different framework code patterns")]
+[assembly: SuppressMessage(@"Style", @"IDE0063:Use simple 'using' statement", Justification = "Prevent confusion between different framework code patterns")]

--- a/Source/Krypton Components/Krypton.Toolkit/General/ModalWaitDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/ModalWaitDialog.cs
@@ -133,8 +133,7 @@ namespace Krypton.Toolkit
         public bool PreFilterMessage(ref Message m)
         {
             // Prevent mouse messages from activating any application windows
-            if (m.Msg is >= 0x0200 and <= 0x0209 ||
-                m.Msg is >= 0x00A0 and <= 0x00A9)
+            if (m.Msg is >= 0x0200 and <= 0x0209 or >= 0x00A0 and <= 0x00A9)
             {
                 // Discover target control for message
                 if (FromHandle(m.HWnd) != null)

--- a/Source/Krypton Components/Krypton.Toolkit/General/PlatformInvoke.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/PlatformInvoke.cs
@@ -2789,19 +2789,19 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
         internal static extern uint SetWindowLong(IntPtr hwnd, GWL_ nIndex, uint nLong);
 
         // This is aliased as a macro in 32bit Windows.
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [SuppressMessage("Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal static IntPtr SetWindowLongPtr(IntPtr hwnd, GWL_ nIndex, IntPtr dwNewLong) =>
             (8 == IntPtr.Size)
                 ? SetWindowLongPtr64(hwnd, nIndex, dwNewLong)
                 : new IntPtr(SetWindowLongPtr32(hwnd, nIndex, dwNewLong.ToInt32()));
 
-        [SuppressMessage("Microsoft.Interoperability", "CA1400:PInvokeEntryPointsShouldExist")]
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [SuppressMessage("Microsoft.Interoperability", @"CA1400:PInvokeEntryPointsShouldExist")]
+        [SuppressMessage("Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         [DllImport(@"user32.dll", EntryPoint = "SetWindowLong", SetLastError = true)]
         private static extern int SetWindowLongPtr32(IntPtr hWnd, GWL_ nIndex, int dwNewLong);
 
-        [SuppressMessage("Microsoft.Interoperability", "CA1400:PInvokeEntryPointsShouldExist")]
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [SuppressMessage("Microsoft.Interoperability", @"CA1400:PInvokeEntryPointsShouldExist")]
+        [SuppressMessage("Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         [DllImport(@"user32.dll", EntryPoint = "SetWindowLongPtr", SetLastError = true)]
         private static extern IntPtr SetWindowLongPtr64(IntPtr hWnd, GWL_ nIndex, IntPtr dwNewLong);
 
@@ -2972,12 +2972,12 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         internal static extern uint RegisterWindowMessage(string lpString);
 
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [SuppressMessage("Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         [DllImport(@"user32.dll", EntryPoint = "GetMonitorInfo", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         private static extern bool _GetMonitorInfo(IntPtr hMonitor, [In, Out] MONITORINFO lpmi);
 
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [SuppressMessage("Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal static MONITORINFO GetMonitorInfo(IntPtr hMonitor)
         {
             MONITORINFO mi = new();

--- a/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/HScrollSkin.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/HScrollSkin.cs
@@ -20,13 +20,13 @@ namespace Krypton.Toolkit
         #region "   Members   "
         //private static List<WeakReference> __ENCList = new List<WeakReference>();
 
-        [AccessedThroughProperty("_win")]
+        [AccessedThroughProperty(@"_win")]
         private Control __win;
 
-        [AccessedThroughProperty("VScrollBar1")]
+        [AccessedThroughProperty(@"VScrollBar1")]
         private KryptonScrollBar _VScrollBar1;
 
-        [AccessedThroughProperty("HScrollBar1")]
+        [AccessedThroughProperty(@"HScrollBar1")]
         private KryptonScrollBar _HScrollBar1;
 
         private IContainer components;

--- a/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/ScrollBarExtendedRenderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/ScrollBarExtendedRenderer.cs
@@ -952,8 +952,7 @@ namespace Krypton.Toolkit
             }
 
             using Image arrowIcon = (Image)GetScrollBarArrowDownBitmap().Clone();
-            if (state == ScrollBarArrowButtonState.DownDisabled
-                || state == ScrollBarArrowButtonState.UpDisabled)
+            if (state is ScrollBarArrowButtonState.DownDisabled or ScrollBarArrowButtonState.UpDisabled)
             {
                 ControlPaint.DrawImageDisabled(
                     g,

--- a/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/ScrollBarKryptonRenderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/ScrollBarKryptonRenderer.cs
@@ -971,8 +971,7 @@ namespace Krypton.Toolkit
             }
 
             using Image arrowIcon = (Image)GetScrollBarArrowDownBitmap().Clone();
-            if (state == ScrollBarArrowButtonState.DownDisabled
-                || state == ScrollBarArrowButtonState.UpDisabled)
+            if (state is ScrollBarArrowButtonState.DownDisabled or ScrollBarArrowButtonState.UpDisabled)
             {
                 ControlPaint.DrawImageDisabled(
                     g,

--- a/Source/Krypton Components/Krypton.Toolkit/General/TypedCollection.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/TypedCollection.cs
@@ -242,7 +242,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the item with the provided unique name.
         /// </summary>
-        /// <param name="name">Name of the ribbon tab instance.</param>
+        /// <param name=(@"Name")>Name of the ribbon tab instance.</param>
         /// <returns>Item at specified index.</returns>
         public virtual T this[string name] => null;
 

--- a/Source/Krypton Components/Krypton.Toolkit/General/XmlHelper.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/XmlHelper.cs
@@ -9,7 +9,7 @@
         /// Only persist the provided name/value pair as an Xml attribute if the value is not null/empty and not the default.
         /// </summary>
         /// <param name="xmlWriter">Xml writer to save information into.</param>
-        /// <param name="name">Attribute name.</param>
+        /// <param name=(@"Name")>Attribute name.</param>
         /// <param name="value">Attribute value.</param>
         /// <param name="defaultValue">Default value.</param>
         public static void TextToXmlAttribute(XmlWriter xmlWriter, string name, string value, string defaultValue = @"")
@@ -24,7 +24,7 @@
         /// Read the named attribute value but if no attribute is found then return the provided default.
         /// </summary>
         /// <param name="xmlReader">Xml reader to load information from.</param>
-        /// <param name="name">Attribute name.</param>
+        /// <param name=(@"Name")>Attribute name.</param>
         /// <param name="defaultValue">Default value.</param>
         /// <returns></returns>
         public static string XmlAttributeToText(XmlReader xmlReader, string name, string defaultValue = @"")
@@ -46,7 +46,7 @@
         /// Convert a Image to a culture invariant string value.
         /// </summary>
         /// <param name="xmlWriter">Xml writer to save information into.</param>
-        /// <param name="name">Name of image to save.</param>
+        /// <param name=(@"Name")>Name of image to save.</param>
         /// <param name="image">Image to persist.</param>
         public static void ImageToXmlCData(XmlWriter xmlWriter, string name, Bitmap image)
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Global/GlobalDeclarations.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Global/GlobalDeclarations.cs
@@ -52,7 +52,7 @@ global using Microsoft.Win32;
 
 [assembly: CLSCompliant(true)]
 [assembly: ComVisible(false)]
-[assembly: Dependency("System", LoadHint.Always)]
-[assembly: Dependency("System.Drawing", LoadHint.Always)]
-[assembly: Dependency("System.Windows.Forms", LoadHint.Always)]
+[assembly: Dependency(@"System", LoadHint.Always)]
+[assembly: Dependency(@"System.Drawing", LoadHint.Always)]
+[assembly: Dependency(@"System.Windows.Forms", LoadHint.Always)]
 

--- a/Source/Krypton Components/Krypton.Toolkit/Krypton.Toolkit 2022.sln
+++ b/Source/Krypton Components/Krypton.Toolkit/Krypton.Toolkit 2022.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31911.196
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Krypton.Toolkit 2022", "Krypton.Toolkit 2022.csproj", "{CB654B81-1E40-4026-BC33-A3B3D9A63602}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Preview|Any CPU = Preview|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CB654B81-1E40-4026-BC33-A3B3D9A63602}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CB654B81-1E40-4026-BC33-A3B3D9A63602}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CB654B81-1E40-4026-BC33-A3B3D9A63602}.Preview|Any CPU.ActiveCfg = Preview|Any CPU
+		{CB654B81-1E40-4026-BC33-A3B3D9A63602}.Preview|Any CPU.Build.0 = Preview|Any CPU
+		{CB654B81-1E40-4026-BC33-A3B3D9A63602}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CB654B81-1E40-4026-BC33-A3B3D9A63602}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {78521875-1831-4355-AEEA-2841D104AB7D}
+	EndGlobalSection
+EndGlobal

--- a/Source/Krypton Components/Krypton.Toolkit/Krypton.Toolkit 2022.sln.DotSettings
+++ b/Source/Krypton Components/Krypton.Toolkit/Krypton.Toolkit 2022.sln.DotSettings
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Coghlan/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Wagnerp/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTable2007.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTable2007.cs
@@ -856,8 +856,8 @@ namespace Krypton.Toolkit
             _statusFont?.Dispose();
 
             // Create new font using system information
-            _menuToolFont = new Font("Segoe UI", SystemFonts.MenuFont.SizeInPoints, FontStyle.Regular);
-            _statusFont = new Font("Segoe UI", SystemFonts.StatusFont.SizeInPoints, FontStyle.Regular);
+            _menuToolFont = new Font(@"Segoe UI", SystemFonts.MenuFont.SizeInPoints, FontStyle.Regular);
+            _statusFont = new Font(@"Segoe UI", SystemFonts.StatusFont.SizeInPoints, FontStyle.Regular);
         }
 
         private static void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e) =>

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTable2010.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTable2010.cs
@@ -624,8 +624,8 @@ namespace Krypton.Toolkit
             _statusFont?.Dispose();
 
             // Create new font using system information
-            _menuToolFont = new Font("Segoe UI", SystemFonts.MenuFont.SizeInPoints, FontStyle.Regular);
-            _statusFont = new Font("Segoe UI", SystemFonts.StatusFont.SizeInPoints, FontStyle.Regular);
+            _menuToolFont = new Font(@"Segoe UI", SystemFonts.MenuFont.SizeInPoints, FontStyle.Regular);
+            _statusFont = new Font(@"Segoe UI", SystemFonts.StatusFont.SizeInPoints, FontStyle.Regular);
         }
 
         private static void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e) =>

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTable2013.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTable2013.cs
@@ -626,8 +626,8 @@ namespace Krypton.Toolkit
             _statusFont?.Dispose();
 
             // Create new font using system information
-            _menuToolFont = new Font("Segoe UI", SystemFonts.MenuFont.SizeInPoints, FontStyle.Regular);
-            _statusFont = new Font("Segoe UI", SystemFonts.StatusFont.SizeInPoints, FontStyle.Regular);
+            _menuToolFont = new Font(@"Segoe UI", SystemFonts.MenuFont.SizeInPoints, FontStyle.Regular);
+            _statusFont = new Font(@"Segoe UI", SystemFonts.StatusFont.SizeInPoints, FontStyle.Regular);
         }
 
         private static void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e) =>

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTable365.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTable365.cs
@@ -623,8 +623,8 @@ namespace Krypton.Toolkit
             _statusFont?.Dispose();
 
             // Create new font using system information
-            _menuToolFont = new Font("Segoe UI", SystemFonts.MenuFont.SizeInPoints, FontStyle.Regular);
-            _statusFont = new Font("Segoe UI", SystemFonts.StatusFont.SizeInPoints, FontStyle.Regular);
+            _menuToolFont = new Font(@"Segoe UI", SystemFonts.MenuFont.SizeInPoints, FontStyle.Regular);
+            _statusFont = new Font(@"Segoe UI", SystemFonts.StatusFont.SizeInPoints, FontStyle.Regular);
         }
 
         private static void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e) =>

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTableOffice365.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTableOffice365.cs
@@ -627,8 +627,8 @@ namespace Krypton.Toolkit
             _statusFont?.Dispose();
 
             // Create new font using system information
-            _menuToolFont = new Font("Segoe UI", SystemFonts.MenuFont.SizeInPoints, FontStyle.Regular);
-            _statusFont = new Font("Segoe UI", SystemFonts.StatusFont.SizeInPoints, FontStyle.Regular);
+            _menuToolFont = new Font(@"Segoe UI", SystemFonts.MenuFont.SizeInPoints, FontStyle.Regular);
+            _statusFont = new Font(@"Segoe UI", SystemFonts.StatusFont.SizeInPoints, FontStyle.Regular);
         }
 
         private static void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e) =>

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTableSparkle.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTableSparkle.cs
@@ -616,8 +616,8 @@ namespace Krypton.Toolkit
             _statusFont?.Dispose();
 
             // Create new font using system information
-            _menuToolFont = new Font("Segoe UI", SystemFonts.MenuFont.SizeInPoints, FontStyle.Regular);
-            _statusFont = new Font("Segoe UI", SystemFonts.StatusFont.SizeInPoints, FontStyle.Regular);
+            _menuToolFont = new Font(@"Segoe UI", SystemFonts.MenuFont.SizeInPoints, FontStyle.Regular);
+            _statusFont = new Font(@"Segoe UI", SystemFonts.StatusFont.SizeInPoints, FontStyle.Regular);
         }
 
         private static void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e) =>

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/LinkLabelBehaviorInherit.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/LinkLabelBehaviorInherit.cs
@@ -392,8 +392,7 @@ namespace Krypton.Toolkit
                         underline = true;
                         break;
                     case KryptonLinkBehavior.HoverUnderline:
-                        underline = (state == PaletteState.Tracking) ||
-                                     (state == PaletteState.Pressed);
+                        underline = state is PaletteState.Tracking or PaletteState.Pressed;
                         break;
                     case KryptonLinkBehavior.NeverUnderline:
                         // Nothing to do

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteBorderEdgeRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteBorderEdgeRedirect.cs
@@ -138,7 +138,7 @@ namespace Krypton.Toolkit
             _borderWidth = -1;
 
             // Create the helper object that passes background
-            // requests from the base clas and converts them into
+            // requests from the base class and converts them into
             // border requests on ourself.
             _translate = new BackToBorder(this);
             SetInherit(_translate);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteHeaderButtonRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteHeaderButtonRedirect.cs
@@ -134,15 +134,7 @@ namespace Krypton.Toolkit
         public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
         {
             // Is this the metric we provide?
-            if ((metric == PaletteMetricInt.HeaderButtonEdgeInsetPrimary) ||
-                (metric == PaletteMetricInt.HeaderButtonEdgeInsetSecondary) ||
-                (metric == PaletteMetricInt.HeaderButtonEdgeInsetDockInactive) ||
-                (metric == PaletteMetricInt.HeaderButtonEdgeInsetDockActive) ||
-                (metric == PaletteMetricInt.HeaderButtonEdgeInsetForm) ||
-                (metric == PaletteMetricInt.HeaderButtonEdgeInsetInputControl) ||
-                (metric == PaletteMetricInt.HeaderButtonEdgeInsetCustom1) 
-                ||(metric == PaletteMetricInt.HeaderButtonEdgeInsetCustom2)
-                || (metric == PaletteMetricInt.HeaderButtonEdgeInsetCustom3)
+            if (metric is PaletteMetricInt.HeaderButtonEdgeInsetPrimary or PaletteMetricInt.HeaderButtonEdgeInsetSecondary or PaletteMetricInt.HeaderButtonEdgeInsetDockInactive or PaletteMetricInt.HeaderButtonEdgeInsetDockActive or PaletteMetricInt.HeaderButtonEdgeInsetForm or PaletteMetricInt.HeaderButtonEdgeInsetInputControl or PaletteMetricInt.HeaderButtonEdgeInsetCustom1 or PaletteMetricInt.HeaderButtonEdgeInsetCustom2 or PaletteMetricInt.HeaderButtonEdgeInsetCustom3
                 )
             {
                 // If the user has defined an actual value to use
@@ -175,15 +167,7 @@ namespace Krypton.Toolkit
         public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
         {
             // Is this the metric we provide?
-            if ((metric == PaletteMetricPadding.HeaderButtonPaddingPrimary) ||
-                (metric == PaletteMetricPadding.HeaderButtonPaddingSecondary) ||
-                (metric == PaletteMetricPadding.HeaderButtonPaddingDockInactive) ||
-                (metric == PaletteMetricPadding.HeaderButtonPaddingDockActive) ||
-                (metric == PaletteMetricPadding.HeaderButtonPaddingForm) ||
-                (metric == PaletteMetricPadding.HeaderButtonPaddingInputControl) ||
-                (metric == PaletteMetricPadding.HeaderButtonPaddingCustom1) 
-                ||(metric == PaletteMetricPadding.HeaderButtonPaddingCustom2)
-                || (metric == PaletteMetricPadding.HeaderButtonPaddingCustom3)
+            if (metric is PaletteMetricPadding.HeaderButtonPaddingPrimary or PaletteMetricPadding.HeaderButtonPaddingSecondary or PaletteMetricPadding.HeaderButtonPaddingDockInactive or PaletteMetricPadding.HeaderButtonPaddingDockActive or PaletteMetricPadding.HeaderButtonPaddingForm or PaletteMetricPadding.HeaderButtonPaddingInputControl or PaletteMetricPadding.HeaderButtonPaddingCustom1 or PaletteMetricPadding.HeaderButtonPaddingCustom2 or PaletteMetricPadding.HeaderButtonPaddingCustom3
                 )
             {
                 // If the user has defined an actual value to use

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteHeaderPaddingRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteHeaderPaddingRedirect.cs
@@ -100,10 +100,7 @@ namespace Krypton.Toolkit
         public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
         {
             // Is this the metric we provide?
-            if ((metric == PaletteMetricPadding.HeaderGroupPaddingPrimary) ||
-                (metric == PaletteMetricPadding.HeaderGroupPaddingSecondary) ||
-                (metric == PaletteMetricPadding.HeaderGroupPaddingDockInactive) ||
-                (metric == PaletteMetricPadding.HeaderGroupPaddingDockActive))
+            if (metric is PaletteMetricPadding.HeaderGroupPaddingPrimary or PaletteMetricPadding.HeaderGroupPaddingSecondary or PaletteMetricPadding.HeaderGroupPaddingDockInactive or PaletteMetricPadding.HeaderGroupPaddingDockActive)
             {
                 // If the user has defined an actual value to use
                 if (!HeaderPadding.Equals(CommonHelper.InheritPadding))

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteHeaderRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteHeaderRedirect.cs
@@ -150,15 +150,7 @@ namespace Krypton.Toolkit
         public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
         {
             // Is this the metric we provide?
-            if ((metric == PaletteMetricInt.HeaderButtonEdgeInsetPrimary) ||
-                (metric == PaletteMetricInt.HeaderButtonEdgeInsetSecondary) ||
-                (metric == PaletteMetricInt.HeaderButtonEdgeInsetDockInactive) ||
-                (metric == PaletteMetricInt.HeaderButtonEdgeInsetDockActive) ||
-                (metric == PaletteMetricInt.HeaderButtonEdgeInsetForm) ||
-                (metric == PaletteMetricInt.HeaderButtonEdgeInsetInputControl) ||
-                (metric == PaletteMetricInt.HeaderButtonEdgeInsetCustom1) 
-                || (metric == PaletteMetricInt.HeaderButtonEdgeInsetCustom2)
-                || (metric == PaletteMetricInt.HeaderButtonEdgeInsetCustom3)
+            if (metric is PaletteMetricInt.HeaderButtonEdgeInsetPrimary or PaletteMetricInt.HeaderButtonEdgeInsetSecondary or PaletteMetricInt.HeaderButtonEdgeInsetDockInactive or PaletteMetricInt.HeaderButtonEdgeInsetDockActive or PaletteMetricInt.HeaderButtonEdgeInsetForm or PaletteMetricInt.HeaderButtonEdgeInsetInputControl or PaletteMetricInt.HeaderButtonEdgeInsetCustom1 or PaletteMetricInt.HeaderButtonEdgeInsetCustom2 or PaletteMetricInt.HeaderButtonEdgeInsetCustom3
                 )
             {
                 // If the user has defined an actual value to use
@@ -191,15 +183,7 @@ namespace Krypton.Toolkit
         public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
         {
             // Is this the metric we provide?
-            if ((metric == PaletteMetricPadding.HeaderButtonPaddingPrimary) ||
-                (metric == PaletteMetricPadding.HeaderButtonPaddingSecondary) ||
-                (metric == PaletteMetricPadding.HeaderButtonPaddingDockInactive) ||
-                (metric == PaletteMetricPadding.HeaderButtonPaddingDockActive) ||
-                (metric == PaletteMetricPadding.HeaderButtonPaddingForm) ||
-                (metric == PaletteMetricPadding.HeaderButtonPaddingInputControl) ||
-                (metric == PaletteMetricPadding.HeaderButtonPaddingCustom1) 
-                || (metric == PaletteMetricPadding.HeaderButtonPaddingCustom2)
-                || (metric == PaletteMetricPadding.HeaderButtonPaddingCustom3)
+            if (metric is PaletteMetricPadding.HeaderButtonPaddingPrimary or PaletteMetricPadding.HeaderButtonPaddingSecondary or PaletteMetricPadding.HeaderButtonPaddingDockInactive or PaletteMetricPadding.HeaderButtonPaddingDockActive or PaletteMetricPadding.HeaderButtonPaddingForm or PaletteMetricPadding.HeaderButtonPaddingInputControl or PaletteMetricPadding.HeaderButtonPaddingCustom1 or PaletteMetricPadding.HeaderButtonPaddingCustom2 or PaletteMetricPadding.HeaderButtonPaddingCustom3
                 )
             {
                 // If the user has defined an actual value to use

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteSeparatorPadding.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteSeparatorPadding.cs
@@ -145,12 +145,7 @@ namespace Krypton.Toolkit
         public Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
         {
             // Is this the metric we provide?
-            if ((metric == PaletteMetricPadding.SeparatorPaddingLowProfile) ||
-                (metric == PaletteMetricPadding.SeparatorPaddingHighProfile) ||
-                (metric == PaletteMetricPadding.SeparatorPaddingHighInternalProfile) 
-                || (metric == PaletteMetricPadding.SeparatorPaddingCustom1)
-                || (metric == PaletteMetricPadding.SeparatorPaddingCustom2)
-                || (metric == PaletteMetricPadding.SeparatorPaddingCustom3)
+            if (metric is PaletteMetricPadding.SeparatorPaddingLowProfile or PaletteMetricPadding.SeparatorPaddingHighProfile or PaletteMetricPadding.SeparatorPaddingHighInternalProfile or PaletteMetricPadding.SeparatorPaddingCustom1 or PaletteMetricPadding.SeparatorPaddingCustom2 or PaletteMetricPadding.SeparatorPaddingCustom3
                 )
             {
                 // If the user has defined an actual value to use

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteSeparatorPaddingRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteSeparatorPaddingRedirect.cs
@@ -120,12 +120,7 @@ namespace Krypton.Toolkit
         public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
         {
             // Is this the metric we provide?
-            if ((metric == PaletteMetricPadding.SeparatorPaddingLowProfile) ||
-                (metric == PaletteMetricPadding.SeparatorPaddingHighProfile) ||
-                (metric == PaletteMetricPadding.SeparatorPaddingHighInternalProfile) 
-                || (metric == PaletteMetricPadding.SeparatorPaddingCustom1)
-                || (metric == PaletteMetricPadding.SeparatorPaddingCustom2)
-                || (metric == PaletteMetricPadding.SeparatorPaddingCustom3)
+            if (metric is PaletteMetricPadding.SeparatorPaddingLowProfile or PaletteMetricPadding.SeparatorPaddingHighProfile or PaletteMetricPadding.SeparatorPaddingHighInternalProfile or PaletteMetricPadding.SeparatorPaddingCustom1 or PaletteMetricPadding.SeparatorPaddingCustom2 or PaletteMetricPadding.SeparatorPaddingCustom3
                 )
             {
                 // If the user has defined an actual value to use

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonOffice2007Renderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonOffice2007Renderer.cs
@@ -415,9 +415,7 @@ namespace Krypton.Toolkit
         /// <param name="e">A ToolStripItemTextRenderEventArgs that contains the event data.</param>
         protected override void OnRenderItemText(ToolStripItemTextRenderEventArgs e)
         {
-            if ((e.ToolStrip is ToolStrip) ||
-                (e.ToolStrip is ContextMenuStrip) ||
-                (e.ToolStrip is ToolStripDropDownMenu))
+            if ((e.ToolStrip is ToolStrip or ContextMenuStrip or ToolStripDropDownMenu))
             {
                 e.TextColor = KCT.ToolStripText;
                 if (!e.Item.Enabled)
@@ -462,8 +460,7 @@ namespace Krypton.Toolkit
         protected override void OnRenderItemImage(ToolStripItemImageRenderEventArgs e)
         {
             // We only override the image drawing for context menus
-            if ((e.ToolStrip is ContextMenuStrip) ||
-                (e.ToolStrip is ToolStripDropDownMenu))
+            if ((e.ToolStrip is ContextMenuStrip or ToolStripDropDownMenu))
             {
                 if (e.Image != null)
                 {
@@ -497,9 +494,7 @@ namespace Krypton.Toolkit
         /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
         protected override void OnRenderMenuItemBackground(ToolStripItemRenderEventArgs e)
         {
-            if ((e.ToolStrip is MenuStrip) ||
-                (e.ToolStrip is ContextMenuStrip) ||
-                (e.ToolStrip is ToolStripDropDownMenu))
+            if ((e.ToolStrip is MenuStrip or ContextMenuStrip or ToolStripDropDownMenu))
             {
                 if (e.Item.Pressed && (e.ToolStrip is MenuStrip))
                 {
@@ -784,8 +779,7 @@ namespace Krypton.Toolkit
         /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
         protected override void OnRenderImageMargin(ToolStripRenderEventArgs e)
         {
-            if ((e.ToolStrip is ContextMenuStrip) ||
-                (e.ToolStrip is ToolStripDropDownMenu))
+            if ((e.ToolStrip is ContextMenuStrip or ToolStripDropDownMenu))
             {
                 // Start with the total margin area
                 Rectangle marginRect = e.AffectedBounds;
@@ -1436,8 +1430,7 @@ namespace Krypton.Toolkit
             int x, y;
 
             // Find the correct starting position, which depends on direction
-            if ((direction == ArrowDirection.Left) ||
-                (direction == ArrowDirection.Right))
+            if (direction is ArrowDirection.Left or ArrowDirection.Right)
             {
                 x = rect.Right - ((rect.Width - 4) / 2);
                 y = rect.Y + (rect.Height / 2);

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonOffice2010Renderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonOffice2010Renderer.cs
@@ -533,9 +533,7 @@ namespace Krypton.Toolkit
         /// <param name="e">A ToolStripItemTextRenderEventArgs that contains the event data.</param>
         protected override void OnRenderItemText(ToolStripItemTextRenderEventArgs e)
         {
-            if ((e.ToolStrip is ToolStrip) ||
-                (e.ToolStrip is ContextMenuStrip) ||
-                (e.ToolStrip is ToolStripDropDownMenu))
+            if ((e.ToolStrip is ToolStrip or ContextMenuStrip or ToolStripDropDownMenu))
             {
                 if (!e.Item.Enabled)
                 {
@@ -608,8 +606,7 @@ namespace Krypton.Toolkit
         protected override void OnRenderItemImage(ToolStripItemImageRenderEventArgs e)
         {
             // We only override the image drawing for context menus
-            if ((e.ToolStrip is ContextMenuStrip) ||
-                (e.ToolStrip is ToolStripDropDownMenu))
+            if ((e.ToolStrip is ContextMenuStrip or ToolStripDropDownMenu))
             {
                 if (e.Image != null)
                 {
@@ -643,9 +640,7 @@ namespace Krypton.Toolkit
         /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
         protected override void OnRenderMenuItemBackground(ToolStripItemRenderEventArgs e)
         {
-            if ((e.ToolStrip is MenuStrip) ||
-                (e.ToolStrip is ContextMenuStrip) ||
-                (e.ToolStrip is ToolStripDropDownMenu))
+            if ((e.ToolStrip is MenuStrip or ContextMenuStrip or ToolStripDropDownMenu))
             {
                 if (e.Item.Pressed && (e.ToolStrip is MenuStrip))
                 {
@@ -708,8 +703,7 @@ namespace Krypton.Toolkit
         /// <param name="e">An ToolStripSeparatorRenderEventArgs containing the event data.</param>
         protected override void OnRenderSeparator(ToolStripSeparatorRenderEventArgs e)
         {
-            if ((e.ToolStrip is ContextMenuStrip) ||
-                (e.ToolStrip is ToolStripDropDownMenu))
+            if ((e.ToolStrip is ContextMenuStrip or ToolStripDropDownMenu))
             {
                 DrawContextMenuSeparator(e.Graphics, e.Vertical, e.Item.Bounds, SEPARATOR_INSET,
                                          e.ToolStrip.RightToLeft == RightToLeft.Yes);
@@ -1004,8 +998,7 @@ namespace Krypton.Toolkit
         /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
         protected override void OnRenderImageMargin(ToolStripRenderEventArgs e)
         {
-            if ((e.ToolStrip is ContextMenuStrip) ||
-                (e.ToolStrip is ToolStripDropDownMenu))
+            if ((e.ToolStrip is ContextMenuStrip or ToolStripDropDownMenu))
             {
                 // Start with the total margin area
                 Rectangle marginRect = e.AffectedBounds;
@@ -1531,8 +1524,7 @@ namespace Krypton.Toolkit
             int x, y;
 
             // Find the correct starting position, which depends on direction
-            if ((direction == ArrowDirection.Left) ||
-                (direction == ArrowDirection.Right))
+            if (direction is ArrowDirection.Left or ArrowDirection.Right)
             {
                 x = rect.Right - ((rect.Width - 4) / 2);
                 y = rect.Y + (rect.Height / 2);

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonOffice2013Renderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonOffice2013Renderer.cs
@@ -532,9 +532,7 @@ namespace Krypton.Toolkit
         /// <param name="e">A ToolStripItemTextRenderEventArgs that contains the event data.</param>
         protected override void OnRenderItemText(ToolStripItemTextRenderEventArgs e)
         {
-            if ((e.ToolStrip is ToolStrip) ||
-                (e.ToolStrip is ContextMenuStrip) ||
-                (e.ToolStrip is ToolStripDropDownMenu))
+            if ((e.ToolStrip is ToolStrip or ContextMenuStrip or ToolStripDropDownMenu))
             {
                 if (!e.Item.Enabled)
                 {
@@ -606,8 +604,7 @@ namespace Krypton.Toolkit
         protected override void OnRenderItemImage(ToolStripItemImageRenderEventArgs e)
         {
             // We only override the image drawing for context menus
-            if ((e.ToolStrip is ContextMenuStrip) ||
-                (e.ToolStrip is ToolStripDropDownMenu))
+            if ((e.ToolStrip is ContextMenuStrip or ToolStripDropDownMenu))
             {
                 if (e.Image != null)
                 {
@@ -641,9 +638,7 @@ namespace Krypton.Toolkit
         /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
         protected override void OnRenderMenuItemBackground(ToolStripItemRenderEventArgs e)
         {
-            if ((e.ToolStrip is MenuStrip) ||
-                (e.ToolStrip is ContextMenuStrip) ||
-                (e.ToolStrip is ToolStripDropDownMenu))
+            if ((e.ToolStrip is MenuStrip or ContextMenuStrip or ToolStripDropDownMenu))
             {
                 if (e.Item.Pressed && (e.ToolStrip is MenuStrip))
                 {
@@ -706,8 +701,7 @@ namespace Krypton.Toolkit
         /// <param name="e">An ToolStripSeparatorRenderEventArgs containing the event data.</param>
         protected override void OnRenderSeparator(ToolStripSeparatorRenderEventArgs e)
         {
-            if ((e.ToolStrip is ContextMenuStrip) ||
-                (e.ToolStrip is ToolStripDropDownMenu))
+            if ((e.ToolStrip is ContextMenuStrip or ToolStripDropDownMenu))
             {
                 DrawContextMenuSeparator(e.Graphics, e.Vertical, e.Item.Bounds, _separatorInset,
                                          e.ToolStrip.RightToLeft == RightToLeft.Yes);
@@ -820,8 +814,7 @@ namespace Krypton.Toolkit
         /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
         protected override void OnRenderToolStripBackground(ToolStripRenderEventArgs e)
         {
-            if ((e.ToolStrip is ContextMenuStrip) ||
-                (e.ToolStrip is ToolStripDropDownMenu))
+            if ((e.ToolStrip is ContextMenuStrip or ToolStripDropDownMenu))
             {
                 // Make sure the font is current
                 if (e.ToolStrip.Font != KCT.MenuStripFont)
@@ -938,8 +931,7 @@ namespace Krypton.Toolkit
         /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
         protected override void OnRenderToolStripBorder(ToolStripRenderEventArgs e)
         {
-            if ((e.ToolStrip is ContextMenuStrip) ||
-                (e.ToolStrip is ToolStripDropDownMenu))
+            if ((e.ToolStrip is ContextMenuStrip or ToolStripDropDownMenu))
             {
                 // If there is a connected area to be drawn
                 if (!e.ConnectedArea.IsEmpty)
@@ -993,8 +985,7 @@ namespace Krypton.Toolkit
         /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
         protected override void OnRenderImageMargin(ToolStripRenderEventArgs e)
         {
-            if ((e.ToolStrip is ContextMenuStrip) ||
-                (e.ToolStrip is ToolStripDropDownMenu))
+            if ((e.ToolStrip is ContextMenuStrip or ToolStripDropDownMenu))
             {
                 // Start with the total margin area
                 Rectangle marginRect = e.AffectedBounds;
@@ -1518,8 +1509,7 @@ namespace Krypton.Toolkit
             int x, y;
 
             // Find the correct starting position, which depends on direction
-            if ((direction == ArrowDirection.Left) ||
-                (direction == ArrowDirection.Right))
+            if (direction is ArrowDirection.Left or ArrowDirection.Right)
             {
                 x = rect.Right - (rect.Width - 4) / 2;
                 y = rect.Y + rect.Height / 2;

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonOffice365Renderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonOffice365Renderer.cs
@@ -531,9 +531,7 @@ namespace Krypton.Toolkit
         /// <param name="e">A ToolStripItemTextRenderEventArgs that contains the event data.</param>
         protected override void OnRenderItemText(ToolStripItemTextRenderEventArgs e)
         {
-            if ((e.ToolStrip is ToolStrip) ||
-                (e.ToolStrip is ContextMenuStrip) ||
-                (e.ToolStrip is ToolStripDropDownMenu))
+            if ((e.ToolStrip is ToolStrip or ContextMenuStrip or ToolStripDropDownMenu))
             {
                 if (!e.Item.Enabled)
                 {
@@ -605,8 +603,7 @@ namespace Krypton.Toolkit
         protected override void OnRenderItemImage(ToolStripItemImageRenderEventArgs e)
         {
             // We only override the image drawing for context menus
-            if ((e.ToolStrip is ContextMenuStrip) ||
-                (e.ToolStrip is ToolStripDropDownMenu))
+            if ((e.ToolStrip is ContextMenuStrip or ToolStripDropDownMenu))
             {
                 if (e.Image != null)
                 {
@@ -640,9 +637,7 @@ namespace Krypton.Toolkit
         /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
         protected override void OnRenderMenuItemBackground(ToolStripItemRenderEventArgs e)
         {
-            if ((e.ToolStrip is MenuStrip) ||
-                (e.ToolStrip is ContextMenuStrip) ||
-                (e.ToolStrip is ToolStripDropDownMenu))
+            if ((e.ToolStrip is MenuStrip or ContextMenuStrip or ToolStripDropDownMenu))
             {
                 if (e.Item.Pressed && (e.ToolStrip is MenuStrip))
                 {
@@ -705,8 +700,7 @@ namespace Krypton.Toolkit
         /// <param name="e">An ToolStripSeparatorRenderEventArgs containing the event data.</param>
         protected override void OnRenderSeparator(ToolStripSeparatorRenderEventArgs e)
         {
-            if ((e.ToolStrip is ContextMenuStrip) ||
-                (e.ToolStrip is ToolStripDropDownMenu))
+            if ((e.ToolStrip is ContextMenuStrip or ToolStripDropDownMenu))
             {
                 DrawContextMenuSeparator(e.Graphics, e.Vertical, e.Item.Bounds, _separatorInset,
                                          e.ToolStrip.RightToLeft == RightToLeft.Yes);
@@ -819,8 +813,7 @@ namespace Krypton.Toolkit
         /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
         protected override void OnRenderToolStripBackground(ToolStripRenderEventArgs e)
         {
-            if ((e.ToolStrip is ContextMenuStrip) ||
-                (e.ToolStrip is ToolStripDropDownMenu))
+            if ((e.ToolStrip is ContextMenuStrip or ToolStripDropDownMenu))
             {
                 // Make sure the font is current
                 if (e.ToolStrip.Font != KCT.MenuStripFont)
@@ -937,8 +930,7 @@ namespace Krypton.Toolkit
         /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
         protected override void OnRenderToolStripBorder(ToolStripRenderEventArgs e)
         {
-            if ((e.ToolStrip is ContextMenuStrip) ||
-                (e.ToolStrip is ToolStripDropDownMenu))
+            if ((e.ToolStrip is ContextMenuStrip or ToolStripDropDownMenu))
             {
                 // If there is a connected area to be drawn
                 if (!e.ConnectedArea.IsEmpty)
@@ -992,8 +984,7 @@ namespace Krypton.Toolkit
         /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
         protected override void OnRenderImageMargin(ToolStripRenderEventArgs e)
         {
-            if ((e.ToolStrip is ContextMenuStrip) ||
-                (e.ToolStrip is ToolStripDropDownMenu))
+            if ((e.ToolStrip is ContextMenuStrip or ToolStripDropDownMenu))
             {
                 // Start with the total margin area
                 Rectangle marginRect = e.AffectedBounds;
@@ -1517,8 +1508,7 @@ namespace Krypton.Toolkit
             int x, y;
 
             // Find the correct starting position, which depends on direction
-            if ((direction == ArrowDirection.Left) ||
-                (direction == ArrowDirection.Right))
+            if (direction is ArrowDirection.Left or ArrowDirection.Right)
             {
                 x = rect.Right - (rect.Width - 4) / 2;
                 y = rect.Y + rect.Height / 2;

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonSparkleRenderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonSparkleRenderer.cs
@@ -145,12 +145,9 @@ namespace Krypton.Toolkit
                 if (e.Item.Enabled)
                 {
                     // If the arrow is on a context menu
-                    if ((e.Item.Owner is ContextMenuStrip) ||
-                        (e.Item.Owner is ToolStripDropDownMenu) ||
-                        (e.Item.OwnerItem is ToolStripOverflowButton))
+                    if ((e.Item.Owner is ContextMenuStrip or ToolStripDropDownMenu) || (e.Item.OwnerItem is ToolStripOverflowButton))
                     {
-                        if ((e.Item.Owner is ContextMenuStrip) || (e.Item.Owner is ToolStripDropDownMenu) ||
-                            ((e.Item.OwnerItem is ToolStripOverflowButton) && ((e.Item is ToolStripSplitButton) || (e.Item is ToolStripDropDownButton)) && (!e.Item.Selected || e.Item.Pressed)))
+                        if ((e.Item.Owner is ContextMenuStrip or ToolStripDropDownMenu) || ((e.Item.OwnerItem is ToolStripOverflowButton) && (e.Item is ToolStripSplitButton or ToolStripDropDownButton) && (!e.Item.Selected || e.Item.Pressed)))
                         {
                             color1 = KCT.MenuItemText;
                         }
@@ -163,10 +160,9 @@ namespace Krypton.Toolkit
                     }
                     else
                     {
-                        if ((e.Item.Owner is ToolStrip) ||
-                            (e.Item.Owner is StatusStrip))
+                        if ((e.Item.Owner is ToolStrip or StatusStrip))
                         {
-                            if (((e.Item is ToolStripSplitButton) || (e.Item is ToolStripDropDownButton)) && e.Item.Pressed)
+                            if ((e.Item is ToolStripSplitButton or ToolStripDropDownButton) && e.Item.Pressed)
                             {
                                 color1 = KCT.MenuItemText;
                             }
@@ -336,9 +332,7 @@ namespace Krypton.Toolkit
         /// <param name="e">A ToolStripItemTextRenderEventArgs that contains the event data.</param>
         protected override void OnRenderItemText(ToolStripItemTextRenderEventArgs e)
         {
-            if ((e.ToolStrip is ToolStrip) ||
-                (e.ToolStrip is ContextMenuStrip) ||
-                (e.ToolStrip is ToolStripDropDownMenu))
+            if ((e.ToolStrip is ToolStrip or ContextMenuStrip or ToolStripDropDownMenu))
             {
                 if (!e.Item.Enabled)
                 {
@@ -363,11 +357,11 @@ namespace Krypton.Toolkit
                             break;
                         default:
                             {
-                                if (((e.ToolStrip is ToolStripDropDownMenu) || (e.ToolStrip is ToolStripOverflow)) && !e.Item.Selected)
+                                if ((e.ToolStrip is ToolStripDropDownMenu or ToolStripOverflow) && !e.Item.Selected)
                                 {
                                     e.TextColor = KCT.MenuItemText;
                                 }
-                                else if ((e.ToolStrip is ToolStrip) && ((e.Item is ToolStripSplitButton) || (e.Item is ToolStripDropDownButton)) &&
+                                else if ((e.ToolStrip is ToolStrip) && (e.Item is ToolStripSplitButton or ToolStripDropDownButton) &&
                                          e.Item.Pressed)
                                 {
                                     e.TextColor = KCT.MenuItemText;
@@ -407,8 +401,7 @@ namespace Krypton.Toolkit
         protected override void OnRenderItemImage(ToolStripItemImageRenderEventArgs e)
         {
             // We only override the image drawing for context menus
-            if ((e.ToolStrip is ContextMenuStrip) ||
-                (e.ToolStrip is ToolStripDropDownMenu))
+            if ((e.ToolStrip is ContextMenuStrip or ToolStripDropDownMenu))
             {
                 if (e.Image != null)
                 {
@@ -442,9 +435,7 @@ namespace Krypton.Toolkit
         /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
         protected override void OnRenderMenuItemBackground(ToolStripItemRenderEventArgs e)
         {
-            if ((e.ToolStrip is MenuStrip) ||
-                (e.ToolStrip is ContextMenuStrip) ||
-                (e.ToolStrip is ToolStripDropDownMenu))
+            if ((e.ToolStrip is MenuStrip or ContextMenuStrip or ToolStripDropDownMenu))
             {
                 if (e.Item.Pressed && (e.ToolStrip is MenuStrip))
                 {
@@ -733,8 +724,7 @@ namespace Krypton.Toolkit
         /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
         protected override void OnRenderImageMargin(ToolStripRenderEventArgs e)
         {
-            if ((e.ToolStrip is ContextMenuStrip) ||
-                (e.ToolStrip is ToolStripDropDownMenu))
+            if ((e.ToolStrip is ContextMenuStrip or ToolStripDropDownMenu))
             {
                 // Start with the total margin area
                 Rectangle marginRect = e.AffectedBounds;
@@ -793,8 +783,7 @@ namespace Krypton.Toolkit
         /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
         protected override void OnRenderToolStripBorder(ToolStripRenderEventArgs e)
         {
-            if ((e.ToolStrip is ContextMenuStrip) ||
-                (e.ToolStrip is ToolStripDropDownMenu))
+            if ((e.ToolStrip is ContextMenuStrip or ToolStripDropDownMenu))
             {
                 // If there is a connected area to be drawn
                 if (!e.ConnectedArea.IsEmpty)
@@ -1369,8 +1358,7 @@ namespace Krypton.Toolkit
             int x, y;
 
             // Find the correct starting position, which depends on direction
-            if ((direction == ArrowDirection.Left) ||
-                (direction == ArrowDirection.Right))
+            if (direction is ArrowDirection.Left or ArrowDirection.Right)
             {
                 x = rect.Right - ((rect.Width - 4) / 2);
                 y = rect.Y + (rect.Height / 2);

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderGlassHelpers.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderGlassHelpers.cs
@@ -1749,8 +1749,7 @@ namespace Krypton.Toolkit
         }
 
         private static bool VerticalOrientation(VisualOrientation orientation) =>
-            (orientation == VisualOrientation.Top) ||
-            (orientation == VisualOrientation.Bottom);
+            orientation is VisualOrientation.Top or VisualOrientation.Bottom;
 
         private static float AngleFromOrientation(VisualOrientation orientation)
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
@@ -754,8 +754,7 @@ namespace Krypton.Toolkit
                             GraphicsPath borderPath1 = null;
 
                             // We only need the second border path if the two borders used are opposite each other
-                            if ((borders == PaletteDrawBorders.TopBottom) ||
-                                (borders == PaletteDrawBorders.LeftRight))
+                            if (borders is PaletteDrawBorders.TopBottom or PaletteDrawBorders.LeftRight)
                             {
                                 borderPath1 = CreateBorderBackPath(true, true, rect, borders, borderWidth,
                                                                    palette.GetBorderRounding(state),
@@ -1077,8 +1076,7 @@ namespace Krypton.Toolkit
                 var spacingGap = palette.GetContentAdjacentGap(state);
 
                 // Is the content intended for a vertical drawing orientation?
-                var vertical = (orientation == VisualOrientation.Left) ||
-                               (orientation == VisualOrientation.Right);
+                var vertical = orientation is VisualOrientation.Left or VisualOrientation.Right;
 
                 // Drawing vertical means we can ignore right to left, otherwise get value from control
                 RightToLeft rtl = vertical ? RightToLeft.No : context.Control.RightToLeft;
@@ -1097,8 +1095,7 @@ namespace Krypton.Toolkit
 
                 // For the form level buttons we have to calculate the correct padding based on caption area
                 PaletteContentStyle contentStyle = palette.GetContentStyle();
-                if ((contentStyle == PaletteContentStyle.ButtonForm) ||
-                    (contentStyle == PaletteContentStyle.ButtonFormClose))
+                if (contentStyle is PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose)
                 {
                     borderPadding = ContentPaddingForButtonForm(borderPadding, context, allocatedHeight);
                 }
@@ -1171,8 +1168,7 @@ namespace Krypton.Toolkit
             Padding borderPadding = palette.GetContentPadding(state);
 
             // Is the content intended for a vertical drawing orientation?
-            var vertical = (orientation == VisualOrientation.Left) ||
-                           (orientation == VisualOrientation.Right);
+            var vertical = orientation is VisualOrientation.Left or VisualOrientation.Right;
 
             // If we need to apply in a vertical orientation
             if (vertical)
@@ -1821,9 +1817,7 @@ namespace Krypton.Toolkit
                     break;
                 case TabBorderStyle.OneNote:
                     // Is the current tab selected?
-                    var selected = (state == PaletteState.CheckedNormal) ||
-                                   (state == PaletteState.CheckedPressed) ||
-                                   (state == PaletteState.CheckedTracking);
+                    var selected = state is PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking;
 
                     // Find the correct edge padding values to use
                     var lp = selected ? SPACING_TAB_ONE_NOTE_LPS : SPACING_TAB_ONE_NOTE_LPI;
@@ -2558,8 +2552,7 @@ namespace Krypton.Toolkit
             }
 
             // Alter size for different orientations
-            if ((orientation == VisualOrientation.Left) ||
-                (orientation == VisualOrientation.Right))
+            if (orientation is VisualOrientation.Left or VisualOrientation.Right)
             {
                 // Switch dimensions to reflect rotation of 90 or 270 degrees
                 imageSize = new Size(imageSize.Height, imageSize.Width);
@@ -4488,7 +4481,7 @@ namespace Krypton.Toolkit
                         rect = AdjustOutsizeTab(state, rect, orientation);
                     }
 
-                    if (rtl && ((orientation == VisualOrientation.Top) || (orientation == VisualOrientation.Bottom)))
+                    if (rtl && orientation is VisualOrientation.Top or VisualOrientation.Bottom)
                     {
                         AddSlantFarPath(borderPath, orientation, rect, forBorder);
                     }
@@ -4505,7 +4498,7 @@ namespace Krypton.Toolkit
                         rect = AdjustOutsizeTab(state, rect, orientation);
                     }
 
-                    if (rtl && ((orientation == VisualOrientation.Top) || (orientation == VisualOrientation.Bottom)))
+                    if (rtl && orientation is VisualOrientation.Top or VisualOrientation.Bottom)
                     {
                         AddSlantNearPath(borderPath, orientation, rect, forBorder);
                     }
@@ -4526,9 +4519,7 @@ namespace Krypton.Toolkit
                     break;
                 case TabBorderStyle.OneNote:
                     // Is the current tab selected?
-                    var selected = (state == PaletteState.CheckedNormal) ||
-                                   (state == PaletteState.CheckedPressed) ||
-                                   (state == PaletteState.CheckedTracking);
+                    var selected = state is PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking;
 
                     // The right padding depends on the selected state
                     var rp = selected ? SPACING_TAB_ONE_NOTE_RPS : SPACING_TAB_ONE_NOTE_RPI;
@@ -4539,7 +4530,7 @@ namespace Krypton.Toolkit
                         rect = AdjustOneNoteTab(rect, orientation);
                     }
 
-                    if (rtl && ((orientation == VisualOrientation.Top) || (orientation == VisualOrientation.Bottom)))
+                    if (rtl && orientation is VisualOrientation.Top or VisualOrientation.Bottom)
                     {
                         AddOneNoteReversePath(borderPath, orientation, rect, forBorder, rp);
                     }
@@ -5823,9 +5814,9 @@ namespace Krypton.Toolkit
                 if (paletteContent.GetContentShortTextMultiLine(state) == InheritBool.False)
                 {
                     // Replace any carriage returns and newlines with just spaces
-                    shortText = shortText.Replace("\r\n", " ");
-                    shortText = shortText.Replace("\n", " ");
-                    shortText = shortText.Replace("\r", " ");
+                    shortText = shortText.Replace("\r\n", @" ");
+                    shortText = shortText.Replace("\n", @" ");
+                    shortText = shortText.Replace("\r", @" ");
                 }
 
                 // Convert from alignment enums to integers
@@ -5908,9 +5899,9 @@ namespace Krypton.Toolkit
                 if (paletteContent.GetContentLongTextMultiLine(state) == InheritBool.False)
                 {
                     // Replace any carriage returns and newlines with just spaces
-                    longText = longText.Replace("\r\n", " ");
-                    longText = longText.Replace("\n", " ");
-                    longText = longText.Replace("\r", " ");
+                    longText = longText.Replace("\r\n", @" ");
+                    longText = longText.Replace("\n", @" ");
+                    longText = longText.Replace("\r", @" ");
                 }
 
                 // Convert from alignment enums to integers
@@ -10472,7 +10463,7 @@ namespace Krypton.Toolkit
             var lightTransparency = 50;
             var mediumTransparency = 50;
 
-            if ((state == PaletteState.Pressed) || (state == PaletteState.Tracking))
+            if (state is PaletteState.Pressed or PaletteState.Tracking)
             {
                 lightTransparency = 200;
                 mediumTransparency = 200;

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/ThemeManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/ThemeManager.cs
@@ -373,7 +373,7 @@ namespace Krypton.Toolkit
                 // TODO: Add silent option
                 if (silent)
                 {
-                    if (themeFile != string.Empty || themeFile != "")
+                    if (themeFile is not ("" and ""))
                     {
                         palette.Import(themeFile, silent);
                     }

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/Win10Glass/ThemeService.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/Win10Glass/ThemeService.cs
@@ -29,14 +29,14 @@ namespace Krypton.Toolkit
         //{
         //    dictionary["WindowBackground"] = new SolidColorBrush(GetWindowBackgroundColor());
 
-        //    SetBrush(dictionary, "WindowForeground", "ImmersiveApplicationTextDarkTheme");
-        //    ReplaceBrush(dictionary, "CottonSwabSliderThumb", "ImmersiveSystemAccent");
+        //    SetBrush(dictionary, "WindowForeground", @"ImmersiveApplicationTextDarkTheme");
+        //    ReplaceBrush(dictionary, "CottonSwabSliderThumb", @"ImmersiveSystemAccent");
         //    ReplaceBrush(dictionary, "CottonSwabSliderTrackBackground", SystemParameters.HighContrast ? "ImmersiveSystemAccentLight1" : "ImmersiveControlDarkSliderTrackBackgroundRest");
         //    SetBrushWithOpacity(dictionary, "CottonSwabSliderTrackBackgroundHover", SystemParameters.HighContrast ? "ImmersiveSystemAccentLight1" : "ImmersiveDarkBaseMediumHigh", SystemParameters.HighContrast ? 1.0 : 0.25);
-        //    SetBrush(dictionary, "CottonSwabSliderTrackBackgroundPressed", "ImmersiveControlDarkSliderTrackBackgroundRest");
-        //    ReplaceBrush(dictionary, "CottonSwabSliderTrackFill", "ImmersiveSystemAccentLight1");
-        //    SetBrush(dictionary, "CottonSwabSliderThumbHover", "ImmersiveControlDarkSliderThumbHover");
-        //    SetBrush(dictionary, "CottonSwabSliderThumbPressed", "ImmersiveControlDarkSliderThumbHover");
+        //    SetBrush(dictionary, "CottonSwabSliderTrackBackgroundPressed", @"ImmersiveControlDarkSliderTrackBackgroundRest");
+        //    ReplaceBrush(dictionary, "CottonSwabSliderTrackFill", @"ImmersiveSystemAccentLight1");
+        //    SetBrush(dictionary, "CottonSwabSliderThumbHover", @"ImmersiveControlDarkSliderThumbHover");
+        //    SetBrush(dictionary, "CottonSwabSliderThumbPressed", @"ImmersiveControlDarkSliderThumbHover");
         //}
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/BlueArrowResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/BlueArrowResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute(@"System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class BlueArrowResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(@"Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal BlueArrowResources() {
         }
         
@@ -39,7 +39,7 @@ namespace Krypton.Toolkit.Resources {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Krypton.Toolkit.Resources.BlueArrowResources", typeof(BlueArrowResources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager(@"Krypton.Toolkit.Resources.BlueArrowResources", typeof(BlueArrowResources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -65,7 +65,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap arrow_down_blue {
             get {
-                object obj = ResourceManager.GetObject("arrow_down_blue", resourceCulture);
+                object obj = ResourceManager.GetObject(@"arrow_down_blue", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -75,7 +75,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap arrow_up_blue {
             get {
-                object obj = ResourceManager.GetObject("arrow_up_blue", resourceCulture);
+                object obj = ResourceManager.GetObject(@"arrow_up_blue", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/CheckBoxStripResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/CheckBoxStripResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute(@"System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class CheckBoxStripResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(@"Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal CheckBoxStripResources() {
         }
         
@@ -39,7 +39,7 @@ namespace Krypton.Toolkit.Resources {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Krypton.Toolkit.Resources.CheckBoxStripResources", typeof(CheckBoxStripResources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager(@"Krypton.Toolkit.Resources.CheckBoxStripResources", typeof(CheckBoxStripResources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -65,7 +65,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap CheckBoxStrip2007Black {
             get {
-                object obj = ResourceManager.GetObject("CheckBoxStrip2007Black", resourceCulture);
+                object obj = ResourceManager.GetObject(@"CheckBoxStrip2007Black", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -75,7 +75,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap CheckBoxStrip2007Blue {
             get {
-                object obj = ResourceManager.GetObject("CheckBoxStrip2007Blue", resourceCulture);
+                object obj = ResourceManager.GetObject(@"CheckBoxStrip2007Blue", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -85,7 +85,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap CheckBoxStrip2007Silver {
             get {
-                object obj = ResourceManager.GetObject("CheckBoxStrip2007Silver", resourceCulture);
+                object obj = ResourceManager.GetObject(@"CheckBoxStrip2007Silver", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -95,7 +95,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap CheckBoxStrip2010Black {
             get {
-                object obj = ResourceManager.GetObject("CheckBoxStrip2010Black", resourceCulture);
+                object obj = ResourceManager.GetObject(@"CheckBoxStrip2010Black", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -105,7 +105,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap CheckBoxStrip2010Blue {
             get {
-                object obj = ResourceManager.GetObject("CheckBoxStrip2010Blue", resourceCulture);
+                object obj = ResourceManager.GetObject(@"CheckBoxStrip2010Blue", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -115,7 +115,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap CheckBoxStrip2010Silver {
             get {
-                object obj = ResourceManager.GetObject("CheckBoxStrip2010Silver", resourceCulture);
+                object obj = ResourceManager.GetObject(@"CheckBoxStrip2010Silver", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -125,7 +125,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap CheckBoxStripSparkle {
             get {
-                object obj = ResourceManager.GetObject("CheckBoxStripSparkle", resourceCulture);
+                object obj = ResourceManager.GetObject(@"CheckBoxStripSparkle", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -135,7 +135,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap CheckBoxStripSparkleOrange {
             get {
-                object obj = ResourceManager.GetObject("CheckBoxStripSparkleOrange", resourceCulture);
+                object obj = ResourceManager.GetObject(@"CheckBoxStripSparkleOrange", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -145,7 +145,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap CheckBoxStripSparklePurple {
             get {
-                object obj = ResourceManager.GetObject("CheckBoxStripSparklePurple", resourceCulture);
+                object obj = ResourceManager.GetObject(@"CheckBoxStripSparklePurple", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/ColourScaleImageResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/ColourScaleImageResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute(@"System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class ColourScaleImageResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(@"Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal ColourScaleImageResources() {
         }
         
@@ -39,7 +39,7 @@ namespace Krypton.Toolkit.Resources {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Krypton.Toolkit.Resources.ColourScaleImageResources", typeof(ColourScaleImageResources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager(@"Krypton.Toolkit.Resources.ColourScaleImageResources", typeof(ColourScaleImageResources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -65,7 +65,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap Colour2scale_generic_16 {
             get {
-                object obj = ResourceManager.GetObject("Colour2scale_generic_16", resourceCulture);
+                object obj = ResourceManager.GetObject(@"Colour2scale_generic_16", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -75,7 +75,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap Colour3scale_generic_16 {
             get {
-                object obj = ResourceManager.GetObject("Colour3scale_generic_16", resourceCulture);
+                object obj = ResourceManager.GetObject(@"Colour3scale_generic_16", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -85,7 +85,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap ThreeColours_blue_white_red_32 {
             get {
-                object obj = ResourceManager.GetObject("ThreeColours_blue_white_red_32", resourceCulture);
+                object obj = ResourceManager.GetObject(@"ThreeColours_blue_white_red_32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -95,7 +95,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap ThreeColours_green_white_red_32 {
             get {
-                object obj = ResourceManager.GetObject("ThreeColours_green_white_red_32", resourceCulture);
+                object obj = ResourceManager.GetObject(@"ThreeColours_green_white_red_32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -105,7 +105,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap ThreeColours_green_yellow_red_32 {
             get {
-                object obj = ResourceManager.GetObject("ThreeColours_green_yellow_red_32", resourceCulture);
+                object obj = ResourceManager.GetObject(@"ThreeColours_green_yellow_red_32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -115,7 +115,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap ThreeColours_red_white_blue_32 {
             get {
-                object obj = ResourceManager.GetObject("ThreeColours_red_white_blue_32", resourceCulture);
+                object obj = ResourceManager.GetObject(@"ThreeColours_red_white_blue_32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -125,7 +125,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap ThreeColours_red_white_green_32 {
             get {
-                object obj = ResourceManager.GetObject("ThreeColours_red_white_green_32", resourceCulture);
+                object obj = ResourceManager.GetObject(@"ThreeColours_red_white_green_32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -135,7 +135,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap ThreeColours_red_yellow_green_32 {
             get {
-                object obj = ResourceManager.GetObject("ThreeColours_red_yellow_green_32", resourceCulture);
+                object obj = ResourceManager.GetObject(@"ThreeColours_red_yellow_green_32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -145,7 +145,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap TwoColours_blue_white_32 {
             get {
-                object obj = ResourceManager.GetObject("TwoColours_blue_white_32", resourceCulture);
+                object obj = ResourceManager.GetObject(@"TwoColours_blue_white_32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -155,7 +155,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap TwoColours_green_white_32 {
             get {
-                object obj = ResourceManager.GetObject("TwoColours_green_white_32", resourceCulture);
+                object obj = ResourceManager.GetObject(@"TwoColours_green_white_32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -165,7 +165,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap TwoColours_pink_white_32 {
             get {
-                object obj = ResourceManager.GetObject("TwoColours_pink_white_32", resourceCulture);
+                object obj = ResourceManager.GetObject(@"TwoColours_pink_white_32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -175,7 +175,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap TwoColours_red_white_32 {
             get {
-                object obj = ResourceManager.GetObject("TwoColours_red_white_32", resourceCulture);
+                object obj = ResourceManager.GetObject(@"TwoColours_red_white_32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -185,7 +185,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap TwoColours_violet_white_32 {
             get {
-                object obj = ResourceManager.GetObject("TwoColours_violet_white_32", resourceCulture);
+                object obj = ResourceManager.GetObject(@"TwoColours_violet_white_32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -195,7 +195,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap TwoColours_white_blue_32 {
             get {
-                object obj = ResourceManager.GetObject("TwoColours_white_blue_32", resourceCulture);
+                object obj = ResourceManager.GetObject(@"TwoColours_white_blue_32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -205,7 +205,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap TwoColours_white_green_32 {
             get {
-                object obj = ResourceManager.GetObject("TwoColours_white_green_32", resourceCulture);
+                object obj = ResourceManager.GetObject(@"TwoColours_white_green_32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -215,7 +215,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap TwoColours_white_pink_32 {
             get {
-                object obj = ResourceManager.GetObject("TwoColours_white_pink_32", resourceCulture);
+                object obj = ResourceManager.GetObject(@"TwoColours_white_pink_32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -225,7 +225,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap TwoColours_white_red_32 {
             get {
-                object obj = ResourceManager.GetObject("TwoColours_white_red_32", resourceCulture);
+                object obj = ResourceManager.GetObject(@"TwoColours_white_red_32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -235,7 +235,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap TwoColours_white_violet_32 {
             get {
-                object obj = ResourceManager.GetObject("TwoColours_white_violet_32", resourceCulture);
+                object obj = ResourceManager.GetObject(@"TwoColours_white_violet_32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -245,7 +245,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap TwoColours_white_yellow_32 {
             get {
-                object obj = ResourceManager.GetObject("TwoColours_white_yellow_32", resourceCulture);
+                object obj = ResourceManager.GetObject(@"TwoColours_white_yellow_32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -255,7 +255,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap TwoColours_yellow_white_32 {
             get {
-                object obj = ResourceManager.GetObject("TwoColours_yellow_white_32", resourceCulture);
+                object obj = ResourceManager.GetObject(@"TwoColours_yellow_white_32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/CommonDialogIcons.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/CommonDialogIcons.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute(@"System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class CommonDialogIcons {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(@"Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal CommonDialogIcons() {
         }
         
@@ -39,7 +39,7 @@ namespace Krypton.Toolkit.Resources {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Krypton.Toolkit.Resources.CommonDialogIcons", typeof(CommonDialogIcons).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager(@"Krypton.Toolkit.Resources.CommonDialogIcons", typeof(CommonDialogIcons).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -65,7 +65,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Icon color {
             get {
-                object obj = ResourceManager.GetObject("color", resourceCulture);
+                object obj = ResourceManager.GetObject(@"color", resourceCulture);
                 return ((System.Drawing.Icon)(obj));
             }
         }
@@ -75,7 +75,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Icon Colour_V10 {
             get {
-                object obj = ResourceManager.GetObject("Colour_V10", resourceCulture);
+                object obj = ResourceManager.GetObject(@"Colour_V10", resourceCulture);
                 return ((System.Drawing.Icon)(obj));
             }
         }
@@ -85,7 +85,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Icon font {
             get {
-                object obj = ResourceManager.GetObject("font", resourceCulture);
+                object obj = ResourceManager.GetObject(@"font", resourceCulture);
                 return ((System.Drawing.Icon)(obj));
             }
         }
@@ -95,7 +95,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Icon printer {
             get {
-                object obj = ResourceManager.GetObject("printer", resourceCulture);
+                object obj = ResourceManager.GetObject(@"printer", resourceCulture);
                 return ((System.Drawing.Icon)(obj));
             }
         }
@@ -105,7 +105,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Icon Printer_V10 {
             get {
-                object obj = ResourceManager.GetObject("Printer_V10", resourceCulture);
+                object obj = ResourceManager.GetObject(@"Printer_V10", resourceCulture);
                 return ((System.Drawing.Icon)(obj));
             }
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/CursorResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/CursorResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute(@"System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class CursorResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(@"Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal CursorResources() {
         }
         
@@ -39,7 +39,7 @@ namespace Krypton.Toolkit.Resources {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Krypton.Toolkit.Resources.CursorResources", typeof(CursorResources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager(@"Krypton.Toolkit.Resources.CursorResources", typeof(CursorResources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -65,7 +65,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static byte[] SplitHorizontal {
             get {
-                object obj = ResourceManager.GetObject("SplitHorizontal", resourceCulture);
+                object obj = ResourceManager.GetObject(@"SplitHorizontal", resourceCulture);
                 return ((byte[])(obj));
             }
         }
@@ -75,7 +75,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static byte[] SplitVertical {
             get {
-                object obj = ResourceManager.GetObject("SplitVertical", resourceCulture);
+                object obj = ResourceManager.GetObject(@"SplitVertical", resourceCulture);
                 return ((byte[])(obj));
             }
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/DataBarImageResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/DataBarImageResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute(@"System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class DataBarImageResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(@"Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal DataBarImageResources() {
         }
         
@@ -39,7 +39,7 @@ namespace Krypton.Toolkit.Resources {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Krypton.Toolkit.Resources.DataBarImageResources", typeof(DataBarImageResources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager(@"Krypton.Toolkit.Resources.DataBarImageResources", typeof(DataBarImageResources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -65,7 +65,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap databar_generic_16 {
             get {
-                object obj = ResourceManager.GetObject("databar_generic_16", resourceCulture);
+                object obj = ResourceManager.GetObject(@"databar_generic_16", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -75,7 +75,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap Databar_gradient_blue_32 {
             get {
-                object obj = ResourceManager.GetObject("Databar_gradient_blue_32", resourceCulture);
+                object obj = ResourceManager.GetObject(@"Databar_gradient_blue_32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -85,7 +85,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap Databar_gradient_green_32 {
             get {
-                object obj = ResourceManager.GetObject("Databar_gradient_green_32", resourceCulture);
+                object obj = ResourceManager.GetObject(@"Databar_gradient_green_32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -95,7 +95,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap Databar_gradient_pink_32 {
             get {
-                object obj = ResourceManager.GetObject("Databar_gradient_pink_32", resourceCulture);
+                object obj = ResourceManager.GetObject(@"Databar_gradient_pink_32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -105,7 +105,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap Databar_gradient_red_32 {
             get {
-                object obj = ResourceManager.GetObject("Databar_gradient_red_32", resourceCulture);
+                object obj = ResourceManager.GetObject(@"Databar_gradient_red_32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -115,7 +115,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap Databar_gradient_rose_32 {
             get {
-                object obj = ResourceManager.GetObject("Databar_gradient_rose_32", resourceCulture);
+                object obj = ResourceManager.GetObject(@"Databar_gradient_rose_32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -125,7 +125,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap Databar_gradient_violet_32 {
             get {
-                object obj = ResourceManager.GetObject("Databar_gradient_violet_32", resourceCulture);
+                object obj = ResourceManager.GetObject(@"Databar_gradient_violet_32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -135,7 +135,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap Databar_gradient_yellow_32 {
             get {
-                object obj = ResourceManager.GetObject("Databar_gradient_yellow_32", resourceCulture);
+                object obj = ResourceManager.GetObject(@"Databar_gradient_yellow_32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -145,7 +145,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap Databar_gradient2_blue_32 {
             get {
-                object obj = ResourceManager.GetObject("Databar_gradient2_blue_32", resourceCulture);
+                object obj = ResourceManager.GetObject(@"Databar_gradient2_blue_32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -155,7 +155,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap Databar_solid_blue_32 {
             get {
-                object obj = ResourceManager.GetObject("Databar_solid_blue_32", resourceCulture);
+                object obj = ResourceManager.GetObject(@"Databar_solid_blue_32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -165,7 +165,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap Databar_solid_green_32 {
             get {
-                object obj = ResourceManager.GetObject("Databar_solid_green_32", resourceCulture);
+                object obj = ResourceManager.GetObject(@"Databar_solid_green_32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -175,7 +175,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap Databar_solid_pink_32 {
             get {
-                object obj = ResourceManager.GetObject("Databar_solid_pink_32", resourceCulture);
+                object obj = ResourceManager.GetObject(@"Databar_solid_pink_32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -185,7 +185,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap Databar_solid_red_32 {
             get {
-                object obj = ResourceManager.GetObject("Databar_solid_red_32", resourceCulture);
+                object obj = ResourceManager.GetObject(@"Databar_solid_red_32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -195,7 +195,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap Databar_solid_rose_32 {
             get {
-                object obj = ResourceManager.GetObject("Databar_solid_rose_32", resourceCulture);
+                object obj = ResourceManager.GetObject(@"Databar_solid_rose_32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -205,7 +205,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap Databar_solid_violet_32 {
             get {
-                object obj = ResourceManager.GetObject("Databar_solid_violet_32", resourceCulture);
+                object obj = ResourceManager.GetObject(@"Databar_solid_violet_32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -215,7 +215,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap Databar_solid_yellow_32 {
             get {
-                object obj = ResourceManager.GetObject("Databar_solid_yellow_32", resourceCulture);
+                object obj = ResourceManager.GetObject(@"Databar_solid_yellow_32", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/DropDownArrowImageResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/DropDownArrowImageResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute(@"System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class DropDownArrowImageResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(@"Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal DropDownArrowImageResources() {
         }
         
@@ -39,7 +39,7 @@ namespace Krypton.Toolkit.Resources {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Krypton.Toolkit.Resources.DropDownArrowImageResources", typeof(DropDownArrowImageResources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager(@"Krypton.Toolkit.Resources.DropDownArrowImageResources", typeof(DropDownArrowImageResources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -65,7 +65,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap DisabledDropDownButton {
             get {
-                object obj = ResourceManager.GetObject("DisabledDropDownButton", resourceCulture);
+                object obj = ResourceManager.GetObject(@"DisabledDropDownButton", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -75,7 +75,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap DisabledDropDownButton2 {
             get {
-                object obj = ResourceManager.GetObject("DisabledDropDownButton2", resourceCulture);
+                object obj = ResourceManager.GetObject(@"DisabledDropDownButton2", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -85,7 +85,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap DisabledDropUpButton {
             get {
-                object obj = ResourceManager.GetObject("DisabledDropUpButton", resourceCulture);
+                object obj = ResourceManager.GetObject(@"DisabledDropUpButton", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -95,7 +95,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap DisabledGalleryDropButton {
             get {
-                object obj = ResourceManager.GetObject("DisabledGalleryDropButton", resourceCulture);
+                object obj = ResourceManager.GetObject(@"DisabledGalleryDropButton", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/DropDownArrowResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/DropDownArrowResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute(@"System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class DropDownArrowResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(@"Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal DropDownArrowResources() {
         }
         
@@ -39,7 +39,7 @@ namespace Krypton.Toolkit.Resources {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Krypton.Toolkit.Resources.DropDownArrowResources", typeof(DropDownArrowResources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager(@"Krypton.Toolkit.Resources.DropDownArrowResources", typeof(DropDownArrowResources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -65,7 +65,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap DisabledDropDownButton {
             get {
-                object obj = ResourceManager.GetObject("DisabledDropDownButton", resourceCulture);
+                object obj = ResourceManager.GetObject(@"DisabledDropDownButton", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -75,7 +75,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap DisabledDropDownButton2 {
             get {
-                object obj = ResourceManager.GetObject("DisabledDropDownButton2", resourceCulture);
+                object obj = ResourceManager.GetObject(@"DisabledDropDownButton2", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -85,7 +85,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap DisabledDropUpButton {
             get {
-                object obj = ResourceManager.GetObject("DisabledDropUpButton", resourceCulture);
+                object obj = ResourceManager.GetObject(@"DisabledDropUpButton", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -95,7 +95,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap DisabledGalleryDropButton {
             get {
-                object obj = ResourceManager.GetObject("DisabledGalleryDropButton", resourceCulture);
+                object obj = ResourceManager.GetObject(@"DisabledGalleryDropButton", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/ElementsImageResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/ElementsImageResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute(@"System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class ElementsImageResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(@"Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal ElementsImageResources() {
         }
         
@@ -39,7 +39,7 @@ namespace Krypton.Toolkit.Resources {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Krypton.Toolkit.Resources.ElementsImageResources", typeof(ElementsImageResources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager(@"Krypton.Toolkit.Resources.ElementsImageResources", typeof(ElementsImageResources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -65,7 +65,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap element {
             get {
-                object obj = ResourceManager.GetObject("element", resourceCulture);
+                object obj = ResourceManager.GetObject(@"element", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -75,7 +75,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap element_delete {
             get {
-                object obj = ResourceManager.GetObject("element_delete", resourceCulture);
+                object obj = ResourceManager.GetObject(@"element_delete", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -85,7 +85,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap element_minus_16 {
             get {
-                object obj = ResourceManager.GetObject("element_minus_16", resourceCulture);
+                object obj = ResourceManager.GetObject(@"element_minus_16", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -95,7 +95,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap element_plus_16 {
             get {
-                object obj = ResourceManager.GetObject("element_plus_16", resourceCulture);
+                object obj = ResourceManager.GetObject(@"element_plus_16", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -105,7 +105,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap element_selection_delete {
             get {
-                object obj = ResourceManager.GetObject("element_selection_delete", resourceCulture);
+                object obj = ResourceManager.GetObject(@"element_selection_delete", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -115,7 +115,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap elements_minus_16 {
             get {
-                object obj = ResourceManager.GetObject("elements_minus_16", resourceCulture);
+                object obj = ResourceManager.GetObject(@"elements_minus_16", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -125,7 +125,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap elements_plus_16 {
             get {
-                object obj = ResourceManager.GetObject("elements_plus_16", resourceCulture);
+                object obj = ResourceManager.GetObject(@"elements_plus_16", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/GalleryImageResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/GalleryImageResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute(@"System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class GalleryImageResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(@"Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal GalleryImageResources() {
         }
         
@@ -39,7 +39,7 @@ namespace Krypton.Toolkit.Resources {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Krypton.Toolkit.Resources.GalleryImageResources", typeof(GalleryImageResources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager(@"Krypton.Toolkit.Resources.GalleryImageResources", typeof(GalleryImageResources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -65,7 +65,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap DisabledDropDownButton {
             get {
-                object obj = ResourceManager.GetObject("DisabledDropDownButton", resourceCulture);
+                object obj = ResourceManager.GetObject(@"DisabledDropDownButton", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -75,7 +75,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap DisabledDropDownButton2 {
             get {
-                object obj = ResourceManager.GetObject("DisabledDropDownButton2", resourceCulture);
+                object obj = ResourceManager.GetObject(@"DisabledDropDownButton2", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -85,7 +85,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap DisabledDropUpButton {
             get {
-                object obj = ResourceManager.GetObject("DisabledDropUpButton", resourceCulture);
+                object obj = ResourceManager.GetObject(@"DisabledDropUpButton", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -95,7 +95,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap DisabledGalleryDropButton {
             get {
-                object obj = ResourceManager.GetObject("DisabledGalleryDropButton", resourceCulture);
+                object obj = ResourceManager.GetObject(@"DisabledGalleryDropButton", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -105,7 +105,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap Gallery2010 {
             get {
-                object obj = ResourceManager.GetObject("Gallery2010", resourceCulture);
+                object obj = ResourceManager.GetObject(@"Gallery2010", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -115,7 +115,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap GalleryBlue {
             get {
-                object obj = ResourceManager.GetObject("GalleryBlue", resourceCulture);
+                object obj = ResourceManager.GetObject(@"GalleryBlue", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -125,7 +125,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap GallerySilverBlack {
             get {
-                object obj = ResourceManager.GetObject("GallerySilverBlack", resourceCulture);
+                object obj = ResourceManager.GetObject(@"GallerySilverBlack", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/GenericImageResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/GenericImageResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute(@"System.Resources.Tools.StronglyTypedResourceBuilder", @"17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class GenericImageResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(@"Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal GenericImageResources() {
         }
         
@@ -39,7 +39,7 @@ namespace Krypton.Toolkit.Resources {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Krypton.Toolkit.Resources.GenericImageResources", typeof(GenericImageResources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager(@"Krypton.Toolkit.Resources.GenericImageResources", typeof(GenericImageResources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -65,7 +65,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap add {
             get {
-                object obj = ResourceManager.GetObject("add", resourceCulture);
+                object obj = ResourceManager.GetObject(@"add", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -75,7 +75,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap BlackButtonCollapse {
             get {
-                object obj = ResourceManager.GetObject("BlackButtonCollapse", resourceCulture);
+                object obj = ResourceManager.GetObject(@"BlackButtonCollapse", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -85,7 +85,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap BlackButtonExpand {
             get {
-                object obj = ResourceManager.GetObject("BlackButtonExpand", resourceCulture);
+                object obj = ResourceManager.GetObject(@"BlackButtonExpand", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -95,7 +95,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap BlackContextMenuSub {
             get {
-                object obj = ResourceManager.GetObject("BlackContextMenuSub", resourceCulture);
+                object obj = ResourceManager.GetObject(@"BlackContextMenuSub", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -105,7 +105,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap BlackDropDownButton {
             get {
-                object obj = ResourceManager.GetObject("BlackDropDownButton", resourceCulture);
+                object obj = ResourceManager.GetObject(@"BlackDropDownButton", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -115,7 +115,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap BlueContextMenuSub {
             get {
-                object obj = ResourceManager.GetObject("BlueContextMenuSub", resourceCulture);
+                object obj = ResourceManager.GetObject(@"BlueContextMenuSub", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -125,7 +125,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap BlueDropDownButton {
             get {
-                object obj = ResourceManager.GetObject("BlueDropDownButton", resourceCulture);
+                object obj = ResourceManager.GetObject(@"BlueDropDownButton", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -135,7 +135,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap ButtonColorImageSmall {
             get {
-                object obj = ResourceManager.GetObject("ButtonColorImageSmall", resourceCulture);
+                object obj = ResourceManager.GetObject(@"ButtonColorImageSmall", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -145,7 +145,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap ButtonNoColor {
             get {
-                object obj = ResourceManager.GetObject("ButtonNoColor", resourceCulture);
+                object obj = ResourceManager.GetObject(@"ButtonNoColor", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -155,7 +155,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap CollapseIcon {
             get {
-                object obj = ResourceManager.GetObject("CollapseIcon", resourceCulture);
+                object obj = ResourceManager.GetObject(@"CollapseIcon", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -165,7 +165,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap CollapseIcon2010 {
             get {
-                object obj = ResourceManager.GetObject("CollapseIcon2010", resourceCulture);
+                object obj = ResourceManager.GetObject(@"CollapseIcon2010", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -175,7 +175,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap delete2 {
             get {
-                object obj = ResourceManager.GetObject("delete2", resourceCulture);
+                object obj = ResourceManager.GetObject(@"delete2", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -185,7 +185,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap Empty16x16 {
             get {
-                object obj = ResourceManager.GetObject("Empty16x16", resourceCulture);
+                object obj = ResourceManager.GetObject(@"Empty16x16", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -195,7 +195,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap eraser {
             get {
-                object obj = ResourceManager.GetObject("eraser", resourceCulture);
+                object obj = ResourceManager.GetObject(@"eraser", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -205,7 +205,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap ExpandIcon {
             get {
-                object obj = ResourceManager.GetObject("ExpandIcon", resourceCulture);
+                object obj = ResourceManager.GetObject(@"ExpandIcon", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -215,7 +215,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap ExpandIcon2010 {
             get {
-                object obj = ResourceManager.GetObject("ExpandIcon2010", resourceCulture);
+                object obj = ResourceManager.GetObject(@"ExpandIcon2010", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -225,7 +225,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap fit_to_size {
             get {
-                object obj = ResourceManager.GetObject("fit_to_size", resourceCulture);
+                object obj = ResourceManager.GetObject(@"fit_to_size", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -235,7 +235,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap GenericWhiteCloseButton {
             get {
-                object obj = ResourceManager.GetObject("GenericWhiteCloseButton", resourceCulture);
+                object obj = ResourceManager.GetObject(@"GenericWhiteCloseButton", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -245,7 +245,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap GenericWhiteMaximize {
             get {
-                object obj = ResourceManager.GetObject("GenericWhiteMaximize", resourceCulture);
+                object obj = ResourceManager.GetObject(@"GenericWhiteMaximize", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -255,7 +255,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap GenericWhiteMinNormal {
             get {
-                object obj = ResourceManager.GetObject("GenericWhiteMinNormal", resourceCulture);
+                object obj = ResourceManager.GetObject(@"GenericWhiteMinNormal", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -265,7 +265,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap GenericWhiteRestore {
             get {
-                object obj = ResourceManager.GetObject("GenericWhiteRestore", resourceCulture);
+                object obj = ResourceManager.GetObject(@"GenericWhiteRestore", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -275,7 +275,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap GenericWhiteRestoreNormal {
             get {
-                object obj = ResourceManager.GetObject("GenericWhiteRestoreNormal", resourceCulture);
+                object obj = ResourceManager.GetObject(@"GenericWhiteRestoreNormal", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -285,7 +285,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap GridErrorIcon {
             get {
-                object obj = ResourceManager.GetObject("GridErrorIcon", resourceCulture);
+                object obj = ResourceManager.GetObject(@"GridErrorIcon", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -295,7 +295,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap HourGlass {
             get {
-                object obj = ResourceManager.GetObject("HourGlass", resourceCulture);
+                object obj = ResourceManager.GetObject(@"HourGlass", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -305,7 +305,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap KryptonLogoGeneric {
             get {
-                object obj = ResourceManager.GetObject("KryptonLogoGeneric", resourceCulture);
+                object obj = ResourceManager.GetObject(@"KryptonLogoGeneric", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -315,7 +315,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap MoveFirst {
             get {
-                object obj = ResourceManager.GetObject("MoveFirst", resourceCulture);
+                object obj = ResourceManager.GetObject(@"MoveFirst", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -325,7 +325,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap MoveLast {
             get {
-                object obj = ResourceManager.GetObject("MoveLast", resourceCulture);
+                object obj = ResourceManager.GetObject(@"MoveLast", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -335,7 +335,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap MoveNext {
             get {
-                object obj = ResourceManager.GetObject("MoveNext", resourceCulture);
+                object obj = ResourceManager.GetObject(@"MoveNext", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -345,7 +345,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap MovePrevious {
             get {
-                object obj = ResourceManager.GetObject("MovePrevious", resourceCulture);
+                object obj = ResourceManager.GetObject(@"MovePrevious", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -355,7 +355,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap navigate_minus {
             get {
-                object obj = ResourceManager.GetObject("navigate_minus", resourceCulture);
+                object obj = ResourceManager.GetObject(@"navigate_minus", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -365,7 +365,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap navigate_plus {
             get {
-                object obj = ResourceManager.GetObject("navigate_plus", resourceCulture);
+                object obj = ResourceManager.GetObject(@"navigate_plus", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -375,7 +375,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap paint_bucket_green {
             get {
-                object obj = ResourceManager.GetObject("paint_bucket_green", resourceCulture);
+                object obj = ResourceManager.GetObject(@"paint_bucket_green", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -385,7 +385,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap PropertyGridVersion1 {
             get {
-                object obj = ResourceManager.GetObject("PropertyGridVersion1", resourceCulture);
+                object obj = ResourceManager.GetObject(@"PropertyGridVersion1", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -395,7 +395,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap PropertyGridVersion2 {
             get {
-                object obj = ResourceManager.GetObject("PropertyGridVersion2", resourceCulture);
+                object obj = ResourceManager.GetObject(@"PropertyGridVersion2", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -405,7 +405,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap SelectParentControl {
             get {
-                object obj = ResourceManager.GetObject("SelectParentControl", resourceCulture);
+                object obj = ResourceManager.GetObject(@"SelectParentControl", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -415,7 +415,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap SelectParentControlFlipped {
             get {
-                object obj = ResourceManager.GetObject("SelectParentControlFlipped", resourceCulture);
+                object obj = ResourceManager.GetObject(@"SelectParentControlFlipped", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -425,7 +425,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap SilverContextMenuSub {
             get {
-                object obj = ResourceManager.GetObject("SilverContextMenuSub", resourceCulture);
+                object obj = ResourceManager.GetObject(@"SilverContextMenuSub", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -435,7 +435,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap SilverDropDownButton {
             get {
-                object obj = ResourceManager.GetObject("SilverDropDownButton", resourceCulture);
+                object obj = ResourceManager.GetObject(@"SilverDropDownButton", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -445,7 +445,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap table_conditional_16 {
             get {
-                object obj = ResourceManager.GetObject("table_conditional_16", resourceCulture);
+                object obj = ResourceManager.GetObject(@"table_conditional_16", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -455,7 +455,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap table2_selection_column {
             get {
-                object obj = ResourceManager.GetObject("table2_selection_column", resourceCulture);
+                object obj = ResourceManager.GetObject(@"table2_selection_column", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -465,7 +465,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap WebBrowser {
             get {
-                object obj = ResourceManager.GetObject("WebBrowser", resourceCulture);
+                object obj = ResourceManager.GetObject(@"WebBrowser", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/GenericOffice2007ImageResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/GenericOffice2007ImageResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute(@"System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class GenericOffice2007ImageResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(@"Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal GenericOffice2007ImageResources() {
         }
         
@@ -39,7 +39,7 @@ namespace Krypton.Toolkit.Resources {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Krypton.Toolkit.Resources.GenericOffice2007ImageResources", typeof(GenericOffice2007ImageResources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager(@"Krypton.Toolkit.Resources.GenericOffice2007ImageResources", typeof(GenericOffice2007ImageResources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -65,7 +65,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap Office2007Checked {
             get {
-                object obj = ResourceManager.GetObject("Office2007Checked", resourceCulture);
+                object obj = ResourceManager.GetObject(@"Office2007Checked", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -75,7 +75,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap Office2007Indeterminate {
             get {
-                object obj = ResourceManager.GetObject("Office2007Indeterminate", resourceCulture);
+                object obj = ResourceManager.GetObject(@"Office2007Indeterminate", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/GenericProfessionalImageResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/GenericProfessionalImageResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute(@"System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class GenericProfessionalImageResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(@"Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal GenericProfessionalImageResources() {
         }
         
@@ -39,7 +39,7 @@ namespace Krypton.Toolkit.Resources {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Krypton.Toolkit.Resources.GenericProfessionalImageResources", typeof(GenericProfessionalImageResources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager(@"Krypton.Toolkit.Resources.GenericProfessionalImageResources", typeof(GenericProfessionalImageResources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -65,7 +65,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap ProfessionalArrowDownButton {
             get {
-                object obj = ResourceManager.GetObject("ProfessionalArrowDownButton", resourceCulture);
+                object obj = ResourceManager.GetObject(@"ProfessionalArrowDownButton", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -75,7 +75,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap ProfessionalArrowLeftButton {
             get {
-                object obj = ResourceManager.GetObject("ProfessionalArrowLeftButton", resourceCulture);
+                object obj = ResourceManager.GetObject(@"ProfessionalArrowLeftButton", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -85,7 +85,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap ProfessionalArrowRightButton {
             get {
-                object obj = ResourceManager.GetObject("ProfessionalArrowRightButton", resourceCulture);
+                object obj = ResourceManager.GetObject(@"ProfessionalArrowRightButton", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -95,7 +95,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap ProfessionalArrowUpButton {
             get {
-                object obj = ResourceManager.GetObject("ProfessionalArrowUpButton", resourceCulture);
+                object obj = ResourceManager.GetObject(@"ProfessionalArrowUpButton", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -105,7 +105,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap ProfessionalCloseButton {
             get {
-                object obj = ResourceManager.GetObject("ProfessionalCloseButton", resourceCulture);
+                object obj = ResourceManager.GetObject(@"ProfessionalCloseButton", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -115,7 +115,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap ProfessionalContextButton {
             get {
-                object obj = ResourceManager.GetObject("ProfessionalContextButton", resourceCulture);
+                object obj = ResourceManager.GetObject(@"ProfessionalContextButton", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -125,7 +125,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap ProfessionalDropDownButton {
             get {
-                object obj = ResourceManager.GetObject("ProfessionalDropDownButton", resourceCulture);
+                object obj = ResourceManager.GetObject(@"ProfessionalDropDownButton", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -135,7 +135,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap ProfessionalMaximize {
             get {
-                object obj = ResourceManager.GetObject("ProfessionalMaximize", resourceCulture);
+                object obj = ResourceManager.GetObject(@"ProfessionalMaximize", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -145,7 +145,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap ProfessionalNextButton {
             get {
-                object obj = ResourceManager.GetObject("ProfessionalNextButton", resourceCulture);
+                object obj = ResourceManager.GetObject(@"ProfessionalNextButton", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -155,7 +155,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap ProfessionalPreviousButton {
             get {
-                object obj = ResourceManager.GetObject("ProfessionalPreviousButton", resourceCulture);
+                object obj = ResourceManager.GetObject(@"ProfessionalPreviousButton", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -165,7 +165,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap ProfessionalRestore {
             get {
-                object obj = ResourceManager.GetObject("ProfessionalRestore", resourceCulture);
+                object obj = ResourceManager.GetObject(@"ProfessionalRestore", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -175,7 +175,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap SystemChecked {
             get {
-                object obj = ResourceManager.GetObject("SystemChecked", resourceCulture);
+                object obj = ResourceManager.GetObject(@"SystemChecked", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -185,7 +185,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap SystemContextMenuSub {
             get {
-                object obj = ResourceManager.GetObject("SystemContextMenuSub", resourceCulture);
+                object obj = ResourceManager.GetObject(@"SystemContextMenuSub", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -195,7 +195,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap SystemIndeterminate {
             get {
-                object obj = ResourceManager.GetObject("SystemIndeterminate", resourceCulture);
+                object obj = ResourceManager.GetObject(@"SystemIndeterminate", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/GenericSparkleImageResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/GenericSparkleImageResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute(@"System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class GenericSparkleImageResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(@"Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal GenericSparkleImageResources() {
         }
         
@@ -39,7 +39,7 @@ namespace Krypton.Toolkit.Resources {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Krypton.Toolkit.Resources.GenericSparkleImageResources", typeof(GenericSparkleImageResources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager(@"Krypton.Toolkit.Resources.GenericSparkleImageResources", typeof(GenericSparkleImageResources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -65,7 +65,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap SparkleChecked {
             get {
-                object obj = ResourceManager.GetObject("SparkleChecked", resourceCulture);
+                object obj = ResourceManager.GetObject(@"SparkleChecked", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -75,7 +75,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap SparkleContextMenuSub {
             get {
-                object obj = ResourceManager.GetObject("SparkleContextMenuSub", resourceCulture);
+                object obj = ResourceManager.GetObject(@"SparkleContextMenuSub", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -85,7 +85,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap SparkleDropDownButton {
             get {
-                object obj = ResourceManager.GetObject("SparkleDropDownButton", resourceCulture);
+                object obj = ResourceManager.GetObject(@"SparkleDropDownButton", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -95,7 +95,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap SparkleDropDownOutlineButton {
             get {
-                object obj = ResourceManager.GetObject("SparkleDropDownOutlineButton", resourceCulture);
+                object obj = ResourceManager.GetObject(@"SparkleDropDownOutlineButton", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -105,7 +105,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap SparkleDropUpButton {
             get {
-                object obj = ResourceManager.GetObject("SparkleDropUpButton", resourceCulture);
+                object obj = ResourceManager.GetObject(@"SparkleDropUpButton", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -115,7 +115,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap SparkleGalleryDropButton {
             get {
-                object obj = ResourceManager.GetObject("SparkleGalleryDropButton", resourceCulture);
+                object obj = ResourceManager.GetObject(@"SparkleGalleryDropButton", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -125,7 +125,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap SparkleGrayChecked {
             get {
-                object obj = ResourceManager.GetObject("SparkleGrayChecked", resourceCulture);
+                object obj = ResourceManager.GetObject(@"SparkleGrayChecked", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/GridImageResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/GridImageResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute(@"System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class GridImageResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(@"Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal GridImageResources() {
         }
         
@@ -39,7 +39,7 @@ namespace Krypton.Toolkit.Resources {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Krypton.Toolkit.Resources.GridImageResources", typeof(GridImageResources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager(@"Krypton.Toolkit.Resources.GridImageResources", typeof(GridImageResources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -65,7 +65,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap GridRowIndicators {
             get {
-                object obj = ResourceManager.GetObject("GridRowIndicators", resourceCulture);
+                object obj = ResourceManager.GetObject(@"GridRowIndicators", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -75,7 +75,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap GridSortOrder {
             get {
-                object obj = ResourceManager.GetObject("GridSortOrder", resourceCulture);
+                object obj = ResourceManager.GetObject(@"GridSortOrder", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/HelpIconResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/HelpIconResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute(@"System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class HelpIconResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute(@"Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal HelpIconResources() {
         }
         
@@ -39,7 +39,7 @@ namespace Krypton.Toolkit.Resources {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Krypton.Toolkit.Resources.HelpIconResources", typeof(HelpIconResources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager(@"Krypton.Toolkit.Resources.HelpIconResources", typeof(HelpIconResources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -65,7 +65,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap GenericOffice2010HelpIcon {
             get {
-                object obj = ResourceManager.GetObject("GenericOffice2010HelpIcon", resourceCulture);
+                object obj = ResourceManager.GetObject(@"GenericOffice2010HelpIcon", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -75,7 +75,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap GenericOffice2010HelpIconBlack {
             get {
-                object obj = ResourceManager.GetObject("GenericOffice2010HelpIconBlack", resourceCulture);
+                object obj = ResourceManager.GetObject(@"GenericOffice2010HelpIconBlack", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -85,7 +85,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap GenericOffice2010HelpIconBlue {
             get {
-                object obj = ResourceManager.GetObject("GenericOffice2010HelpIconBlue", resourceCulture);
+                object obj = ResourceManager.GetObject(@"GenericOffice2010HelpIconBlue", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -95,7 +95,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap GenericOffice2010HelpIconDisabled {
             get {
-                object obj = ResourceManager.GetObject("GenericOffice2010HelpIconDisabled", resourceCulture);
+                object obj = ResourceManager.GetObject(@"GenericOffice2010HelpIconDisabled", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -105,7 +105,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap GenericOffice2010HelpIconHover {
             get {
-                object obj = ResourceManager.GetObject("GenericOffice2010HelpIconHover", resourceCulture);
+                object obj = ResourceManager.GetObject(@"GenericOffice2010HelpIconHover", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -115,7 +115,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap GenericOffice2010HelpIconSilver {
             get {
-                object obj = ResourceManager.GetObject("GenericOffice2010HelpIconSilver", resourceCulture);
+                object obj = ResourceManager.GetObject(@"GenericOffice2010HelpIconSilver", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -125,7 +125,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap GenericOffice2010HelpIconWhite {
             get {
-                object obj = ResourceManager.GetObject("GenericOffice2010HelpIconWhite", resourceCulture);
+                object obj = ResourceManager.GetObject(@"GenericOffice2010HelpIconWhite", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -135,7 +135,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap GenericOffice365HelpIcon {
             get {
-                object obj = ResourceManager.GetObject("GenericOffice365HelpIcon", resourceCulture);
+                object obj = ResourceManager.GetObject(@"GenericOffice365HelpIcon", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -145,7 +145,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap GenericOffice365HelpIconBlack {
             get {
-                object obj = ResourceManager.GetObject("GenericOffice365HelpIconBlack", resourceCulture);
+                object obj = ResourceManager.GetObject(@"GenericOffice365HelpIconBlack", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -155,7 +155,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap GenericOffice365HelpIconBlue {
             get {
-                object obj = ResourceManager.GetObject("GenericOffice365HelpIconBlue", resourceCulture);
+                object obj = ResourceManager.GetObject(@"GenericOffice365HelpIconBlue", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -165,7 +165,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap GenericOffice365HelpIconDisabled {
             get {
-                object obj = ResourceManager.GetObject("GenericOffice365HelpIconDisabled", resourceCulture);
+                object obj = ResourceManager.GetObject(@"GenericOffice365HelpIconDisabled", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -175,7 +175,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap GenericOffice365HelpIconHover {
             get {
-                object obj = ResourceManager.GetObject("GenericOffice365HelpIconHover", resourceCulture);
+                object obj = ResourceManager.GetObject(@"GenericOffice365HelpIconHover", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -185,7 +185,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap GenericOffice365HelpIconSilver {
             get {
-                object obj = ResourceManager.GetObject("GenericOffice365HelpIconSilver", resourceCulture);
+                object obj = ResourceManager.GetObject(@"GenericOffice365HelpIconSilver", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -195,7 +195,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap GenericOffice365HelpIconWhite {
             get {
-                object obj = ResourceManager.GetObject("GenericOffice365HelpIconWhite", resourceCulture);
+                object obj = ResourceManager.GetObject(@"GenericOffice365HelpIconWhite", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -205,7 +205,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap GenericPre2010HelpIcon {
             get {
-                object obj = ResourceManager.GetObject("GenericPre2010HelpIcon", resourceCulture);
+                object obj = ResourceManager.GetObject(@"GenericPre2010HelpIcon", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -215,7 +215,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap GenericPre2010HelpIconBlack {
             get {
-                object obj = ResourceManager.GetObject("GenericPre2010HelpIconBlack", resourceCulture);
+                object obj = ResourceManager.GetObject(@"GenericPre2010HelpIconBlack", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -225,7 +225,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap GenericPre2010HelpIconBlue {
             get {
-                object obj = ResourceManager.GetObject("GenericPre2010HelpIconBlue", resourceCulture);
+                object obj = ResourceManager.GetObject(@"GenericPre2010HelpIconBlue", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -235,7 +235,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap GenericPre2010HelpIconDisabled {
             get {
-                object obj = ResourceManager.GetObject("GenericPre2010HelpIconDisabled", resourceCulture);
+                object obj = ResourceManager.GetObject(@"GenericPre2010HelpIconDisabled", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -245,7 +245,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap GenericPre2010HelpIconHover {
             get {
-                object obj = ResourceManager.GetObject("GenericPre2010HelpIconHover", resourceCulture);
+                object obj = ResourceManager.GetObject(@"GenericPre2010HelpIconHover", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -255,7 +255,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap GenericPre2010HelpIconSilver {
             get {
-                object obj = ResourceManager.GetObject("GenericPre2010HelpIconSilver", resourceCulture);
+                object obj = ResourceManager.GetObject(@"GenericPre2010HelpIconSilver", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }
@@ -265,7 +265,7 @@ namespace Krypton.Toolkit.Resources {
         /// </summary>
         internal static System.Drawing.Bitmap GenericPre2010HelpIconWhite {
             get {
-                object obj = ResourceManager.GetObject("GenericPre2010HelpIconWhite", resourceCulture);
+                object obj = ResourceManager.GetObject(@"GenericPre2010HelpIconWhite", resourceCulture);
                 return ((System.Drawing.Bitmap)(obj));
             }
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/KryptonGenericResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/KryptonGenericResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class KryptonGenericResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal KryptonGenericResources() {
         }
         

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/MDIImageResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/MDIImageResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class MDIImageResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal MDIImageResources() {
         }
         

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/MessageBoxResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/MessageBoxResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", @"17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class MessageBoxResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal MessageBoxResources() {
         }
         

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/Office2007BlackRadioButtonResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/Office2007BlackRadioButtonResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Office2007BlackRadioButtonResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal Office2007BlackRadioButtonResources() {
         }
         

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/Office2007BlueRadioButtonResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/Office2007BlueRadioButtonResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Office2007BlueRadioButtonResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal Office2007BlueRadioButtonResources() {
         }
         

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/Office2007ControlBoxResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/Office2007ControlBoxResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", @"17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Office2007ControlBoxResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal Office2007ControlBoxResources() {
         }
         

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/Office2007SilverRadioButtonResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/Office2007SilverRadioButtonResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Office2007SilverRadioButtonResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal Office2007SilverRadioButtonResources() {
         }
         

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/Office2010Arrows.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/Office2010Arrows.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Office2010Arrows {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal Office2010Arrows() {
         }
         

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/Office2010BlueRadioButtonResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/Office2010BlueRadioButtonResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Office2010BlueRadioButtonResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal Office2010BlueRadioButtonResources() {
         }
         

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/Office2010ControlBoxResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/Office2010ControlBoxResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", @"17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Office2010ControlBoxResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal Office2010ControlBoxResources() {
         }
         

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/Office2010SilverRadioButtonResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/Office2010SilverRadioButtonResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Office2010SilverRadioButtonResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal Office2010SilverRadioButtonResources() {
         }
         

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/ProfessionalButtonSpecResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/ProfessionalButtonSpecResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class ProfessionalButtonSpecResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal ProfessionalButtonSpecResources() {
         }
         

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/ProfessionalControlBoxResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/ProfessionalControlBoxResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class ProfessionalControlBoxResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal ProfessionalControlBoxResources() {
         }
         

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/ProfessionalPendantImageResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/ProfessionalPendantImageResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class ProfessionalPendantImageResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal ProfessionalPendantImageResources() {
         }
         

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/ProfessionalPinImageResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/ProfessionalPinImageResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class ProfessionalPinImageResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal ProfessionalPinImageResources() {
         }
         

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/RibbonArrowImageResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/RibbonArrowImageResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class RibbonArrowImageResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal RibbonArrowImageResources() {
         }
         

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/SortArrowImageResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/SortArrowImageResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class SortArrowImageResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal SortArrowImageResources() {
         }
         

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/SparkleBlueRadioButtonResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/SparkleBlueRadioButtonResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class SparkleBlueRadioButtonResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal SparkleBlueRadioButtonResources() {
         }
         

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/SparkleControlBoxResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/SparkleControlBoxResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class SparkleControlBoxResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal SparkleControlBoxResources() {
         }
         

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/SparkleGeneralRadioButtonResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/SparkleGeneralRadioButtonResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class SparkleGeneralRadioButtonResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal SparkleGeneralRadioButtonResources() {
         }
         

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/SparkleOrangeRadioButtonResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/SparkleOrangeRadioButtonResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class SparkleOrangeRadioButtonResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal SparkleOrangeRadioButtonResources() {
         }
         

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/SparklePurpleRadioButtonResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/SparklePurpleRadioButtonResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class SparklePurpleRadioButtonResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal SparklePurpleRadioButtonResources() {
         }
         

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/StarImageResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/StarImageResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class StarImageResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal StarImageResources() {
         }
         

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/TreeItemImageResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/TreeItemImageResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class TreeItemImageResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal TreeItemImageResources() {
         }
         

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/VisualStudioImageResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/VisualStudioImageResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class VisualStudioImageResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal VisualStudioImageResources() {
         }
         

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/VisualTaskDialogImageResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/VisualTaskDialogImageResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class VisualTaskDialogImageResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal VisualTaskDialogImageResources() {
         }
         

--- a/Source/Krypton Components/Krypton.Toolkit/Resources/WhiteImageResources.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Resources/WhiteImageResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", @"16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class WhiteImageResources {
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit.Resources {
         
         private static global::System.Globalization.CultureInfo resourceCulture;
         
-        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", @"CA1811:AvoidUncalledPrivateCode")]
         internal WhiteImageResources() {
         }
         

--- a/Source/Krypton Components/Krypton.Toolkit/Utilities/Portable.System.ValueTuple.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Utilities/Portable.System.ValueTuple.cs
@@ -75,7 +75,7 @@ namespace System
             /// treat the first type argument as a tuple with element names and the
             /// second as a tuple without element names. In which case, the
             /// appropriate attribute specification should use a
-            /// <c>transformNames</c> value of <c>{ "name1", "name2", null, null,
+            /// <c>transformNames</c> value of <c>{ "name1", @"name2", null, null,
             /// null }</c>.
             /// </remarks>
             public TupleElementNamesAttribute(string[] transformNames) => _transformNames = transformNames ?? throw new ArgumentNullException(nameof(transformNames));

--- a/Source/Krypton Components/Krypton.Toolkit/Values/BlurValues.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/BlurValues.cs
@@ -17,7 +17,7 @@ namespace Krypton.Toolkit
     /// 
     /// </summary>
     [ToolboxItem(false)]
-    [DesignerCategory("code")]
+    [DesignerCategory(@"code")]
     public class BlurValues : Storage
     {
         #region statics
@@ -63,7 +63,7 @@ namespace Krypton.Toolkit
 
         /// <summary>
         /// </summary>
-        [Description("Blur this when not Active")]
+        [Description(@"Blur this when not Active")]
         [DefaultValue(false)]
         public bool EnableBlur
         {
@@ -90,7 +90,7 @@ namespace Krypton.Toolkit
 
         /// <summary>
         /// </summary>
-        [Description("Gausian pixel radius used to blur each pixel")]
+        [Description(@"Gausian pixel radius used to blur each pixel")]
         [DefaultValue(_radiusDefault)]
         public byte Radius
         {
@@ -116,7 +116,7 @@ namespace Krypton.Toolkit
 
         /// <summary>
         /// </summary>
-        [Description("Opacity Percentage to be applied to the blur over source form. Tuning this allows for background updates to show through.")]
+        [Description(@"Opacity Percentage to be applied to the blur over source form. Tuning this allows for background updates to show through.")]
         [DefaultValue(_opacityDefault)]
         public double Opacity
         {
@@ -144,7 +144,7 @@ namespace Krypton.Toolkit
 
         /// <summary>
         /// </summary>
-        [Description("Blur this when not Focused")]
+        [Description(@"Blur this when not Focused")]
         [DefaultValue(false)]
         public bool BlurWhenFocusLost
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Values/ButtonImageStates.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/ButtonImageStates.cs
@@ -43,8 +43,8 @@ namespace Krypton.Toolkit
         /// </summary>
         [KryptonPersist(false)]
         [Localizable(true)]
-        [Category("Visuals")]
-        [Description("Button image for normal state.")]
+        [Category(@"Visuals")]
+        [Description(@"Button image for normal state.")]
         [RefreshProperties(RefreshProperties.All)]
         [DefaultValue(null)]
         public Image ImageNormal
@@ -78,8 +78,8 @@ namespace Krypton.Toolkit
         /// </summary>
         [KryptonPersist(false)]
         [Localizable(true)]
-        [Category("Visuals")]
-        [Description("Button image for disabled state.")]
+        [Category(@"Visuals")]
+        [Description(@"Button image for disabled state.")]
         [RefreshProperties(RefreshProperties.All)]
         [DefaultValue(null)]
         public Image ImageDisabled
@@ -113,8 +113,8 @@ namespace Krypton.Toolkit
         /// </summary>
         [KryptonPersist(false)]
         [Localizable(true)]
-        [Category("Visuals")]
-        [Description("Button image for pressed state.")]
+        [Category(@"Visuals")]
+        [Description(@"Button image for pressed state.")]
         [RefreshProperties(RefreshProperties.All)]
         [DefaultValue(null)]
         public Image ImagePressed
@@ -148,8 +148,8 @@ namespace Krypton.Toolkit
         /// </summary>
         [KryptonPersist(false)]
         [Localizable(true)]
-        [Category("Visuals")]
-        [Description("Button image for tracking state.")]
+        [Category(@"Visuals")]
+        [Description(@"Button image for tracking state.")]
         [RefreshProperties(RefreshProperties.All)]
         [DefaultValue(null)]
         public Image ImageTracking

--- a/Source/Krypton Components/Krypton.Toolkit/Values/ButtonValues.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/ButtonValues.cs
@@ -77,8 +77,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the button image.
         /// </summary>
         [Localizable(true)]
-        [Category("Visuals")]
-        [Description("Button image.")]
+        [Category(@"Visuals")]
+        [Description(@"Button image.")]
         [RefreshProperties(RefreshProperties.All)]
         public Image Image
         {
@@ -110,8 +110,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the label image transparent color.
         /// </summary>
         [Localizable(true)]
-        [Category("Visuals")]
-        [Description("Label image transparent color.")]
+        [Category(@"Visuals")]
+        [Description(@"Label image transparent color.")]
         [RefreshProperties(RefreshProperties.All)]
         [KryptonDefaultColor()]
         public Color ImageTransparentColor
@@ -151,8 +151,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the state specific images for the button.
         /// </summary>
-        [Category("Visuals")]
-        [Description("State specific images for the button.")]
+        [Category(@"Visuals")]
+        [Description(@"State specific images for the button.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public ButtonImageStates ImageStates { get; }
 
@@ -165,10 +165,10 @@ namespace Krypton.Toolkit
         /// Gets and sets the button text.
         /// </summary>
         [Localizable(true)]
-        [Category("Visuals")]
-        [Description("Button text.")]
+        [Category(@"Visuals")]
+        [Description(@"Button text.")]
         [RefreshProperties(RefreshProperties.All)]
-        [Editor("System.ComponentModel.Design.MultilineStringEditor", typeof(UITypeEditor))]
+        [Editor(@"System.ComponentModel.Design.MultilineStringEditor", typeof(UITypeEditor))]
         public string Text
         {
             get => _text;
@@ -200,11 +200,11 @@ namespace Krypton.Toolkit
         /// Gets and sets the button extra text.
         /// </summary>
         [Localizable(true)]
-        [Category("Visuals")]
-        [Description("Button extra text.")]
+        [Category(@"Visuals")]
+        [Description(@"Button extra text.")]
         [RefreshProperties(RefreshProperties.All)]
-        [Editor("System.ComponentModel.Design.MultilineStringEditor", typeof(UITypeEditor))]
-        [DefaultValue("")]
+        [Editor(@"System.ComponentModel.Design.MultilineStringEditor", typeof(UITypeEditor))]
+        [DefaultValue(@"")]
         public string ExtraText
         {
             get => _extraText;

--- a/Source/Krypton Components/Krypton.Toolkit/Values/CaptionValues.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/CaptionValues.cs
@@ -58,7 +58,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the header description text.
         /// </summary>
-        [DefaultValue("")]
+        [DefaultValue(@"")]
         public override string Description
         {
             get => base.Description;

--- a/Source/Krypton Components/Krypton.Toolkit/Values/CheckBoxImages.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/CheckBoxImages.cs
@@ -95,8 +95,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the common image that other check box images inherit from.
         /// </summary>
         [KryptonPersist(false)]
-        [Category("Visuals")]
-        [Description("Common image that other check box images inherit from.")]
+        [Category(@"Visuals")]
+        [Description(@"Common image that other check box images inherit from.")]
         [DefaultValue(null)]
         [RefreshProperties(RefreshProperties.All)]
         public Image Common
@@ -127,8 +127,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the image for use when the check box is not checked and disabled.
         /// </summary>
         [KryptonPersist(false)]
-        [Category("Visuals")]
-        [Description("Image for use when the check box is not checked and disabled.")]
+        [Category(@"Visuals")]
+        [Description(@"Image for use when the check box is not checked and disabled.")]
         [DefaultValue(null)]
         [RefreshProperties(RefreshProperties.All)]
         public Image UncheckedDisabled
@@ -159,8 +159,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the image for use when the check box is unchecked.
         /// </summary>
         [KryptonPersist(false)]
-        [Category("Visuals")]
-        [Description("Image for use when the check box is unchecked.")]
+        [Category(@"Visuals")]
+        [Description(@"Image for use when the check box is unchecked.")]
         [DefaultValue(null)]
         [RefreshProperties(RefreshProperties.All)]
         public Image UncheckedNormal
@@ -191,8 +191,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the image for use when the check box is unchecked and hot tracking.
         /// </summary>
         [KryptonPersist(false)]
-        [Category("Visuals")]
-        [Description("Image for use when the check box is unchecked and hot tracking.")]
+        [Category(@"Visuals")]
+        [Description(@"Image for use when the check box is unchecked and hot tracking.")]
         [DefaultValue(null)]
         [RefreshProperties(RefreshProperties.All)]
         public Image UncheckedTracking
@@ -223,8 +223,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the image for use when the check box is unchecked and pressed.
         /// </summary>
         [KryptonPersist(false)]
-        [Category("Visuals")]
-        [Description("Image for use when the check box is unchecked and pressed.")]
+        [Category(@"Visuals")]
+        [Description(@"Image for use when the check box is unchecked and pressed.")]
         [DefaultValue(null)]
         [RefreshProperties(RefreshProperties.All)]
         public Image UncheckedPressed
@@ -255,8 +255,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the image for use when the check box is checked but disabled.
         /// </summary>
         [KryptonPersist(false)]
-        [Category("Visuals")]
-        [Description("Image for use when the check box is checked but disabled.")]
+        [Category(@"Visuals")]
+        [Description(@"Image for use when the check box is checked but disabled.")]
         [DefaultValue(null)]
         [RefreshProperties(RefreshProperties.All)]
         public Image CheckedDisabled
@@ -287,8 +287,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the image for use when the check box is checked.
         /// </summary>
         [KryptonPersist(false)]
-        [Category("Visuals")]
-        [Description("Image for use when the check box is checked.")]
+        [Category(@"Visuals")]
+        [Description(@"Image for use when the check box is checked.")]
         [DefaultValue(null)]
         [RefreshProperties(RefreshProperties.All)]
         public Image CheckedNormal
@@ -319,8 +319,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the image for use when the check box is checked and hot tracking.
         /// </summary>
         [KryptonPersist(false)]
-        [Category("Visuals")]
-        [Description("Image for use when the check box is checked and hot tracking.")]
+        [Category(@"Visuals")]
+        [Description(@"Image for use when the check box is checked and hot tracking.")]
         [DefaultValue(null)]
         [RefreshProperties(RefreshProperties.All)]
         public Image CheckedTracking
@@ -351,8 +351,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the image for use when the check box is checked and pressed.
         /// </summary>
         [KryptonPersist(false)]
-        [Category("Visuals")]
-        [Description("Image for use when the check box is checked and pressed.")]
+        [Category(@"Visuals")]
+        [Description(@"Image for use when the check box is checked and pressed.")]
         [DefaultValue(null)]
         [RefreshProperties(RefreshProperties.All)]
         public Image CheckedPressed
@@ -383,8 +383,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the image for use when the check box is indeterminate but disabled.
         /// </summary>
         [KryptonPersist(false)]
-        [Category("Visuals")]
-        [Description("Image for use when the check box is indeterminate but disabled.")]
+        [Category(@"Visuals")]
+        [Description(@"Image for use when the check box is indeterminate but disabled.")]
         [DefaultValue(null)]
         [RefreshProperties(RefreshProperties.All)]
         public Image IndeterminateDisabled
@@ -415,8 +415,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the image for use when the check box is indeterminate.
         /// </summary>
         [KryptonPersist(false)]
-        [Category("Visuals")]
-        [Description("Image for use when the check box is indeterminate.")]
+        [Category(@"Visuals")]
+        [Description(@"Image for use when the check box is indeterminate.")]
         [DefaultValue(null)]
         [RefreshProperties(RefreshProperties.All)]
         public Image IndeterminateNormal
@@ -447,8 +447,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the image for use when the check box is indeterminate and hot tracking.
         /// </summary>
         [KryptonPersist(false)]
-        [Category("Visuals")]
-        [Description("Image for use when the check box is indeterminate and hot tracking.")]
+        [Category(@"Visuals")]
+        [Description(@"Image for use when the check box is indeterminate and hot tracking.")]
         [DefaultValue(null)]
         [RefreshProperties(RefreshProperties.All)]
         public Image IndeterminateTracking
@@ -479,8 +479,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the image for use when the check box is indeterminate and pressed.
         /// </summary>
         [KryptonPersist(false)]
-        [Category("Visuals")]
-        [Description("Image for use when the check box is indeterminate and pressed.")]
+        [Category(@"Visuals")]
+        [Description(@"Image for use when the check box is indeterminate and pressed.")]
         [DefaultValue(null)]
         [RefreshProperties(RefreshProperties.All)]
         public Image IndeterminatePressed

--- a/Source/Krypton Components/Krypton.Toolkit/Values/CheckButtonImageStates.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/CheckButtonImageStates.cs
@@ -42,8 +42,8 @@ namespace Krypton.Toolkit
         /// </summary>
         [KryptonPersist(false)]
         [Localizable(true)]
-        [Category("Visuals")]
-        [Description("Button image for checked normal state.")]
+        [Category(@"Visuals")]
+        [Description(@"Button image for checked normal state.")]
         [RefreshProperties(RefreshProperties.All)]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Browsable(true)]
@@ -79,8 +79,8 @@ namespace Krypton.Toolkit
         /// </summary>
         [KryptonPersist(false)]
         [Localizable(true)]
-        [Category("Visuals")]
-        [Description("Button image for checked pressed state.")]
+        [Category(@"Visuals")]
+        [Description(@"Button image for checked pressed state.")]
         [RefreshProperties(RefreshProperties.All)]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Browsable(true)]
@@ -116,8 +116,8 @@ namespace Krypton.Toolkit
         /// </summary>
         [KryptonPersist(false)]
         [Localizable(true)]
-        [Category("Visuals")]
-        [Description("Button image for checked tracking state.")]
+        [Category(@"Visuals")]
+        [Description(@"Button image for checked tracking state.")]
         [RefreshProperties(RefreshProperties.All)]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Browsable(true)]

--- a/Source/Krypton Components/Krypton.Toolkit/Values/ColorButtonValues.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/ColorButtonValues.cs
@@ -88,8 +88,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the button image.
         /// </summary>
         [Localizable(true)]
-        [Category("Visuals")]
-        [Description("Button image.")]
+        [Category(@"Visuals")]
+        [Description(@"Button image.")]
         [RefreshProperties(RefreshProperties.All)]
         public Image Image
         {
@@ -121,8 +121,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the label image transparent color.
         /// </summary>
         [Localizable(true)]
-        [Category("Visuals")]
-        [Description("Label image transparent color.")]
+        [Category(@"Visuals")]
+        [Description(@"Label image transparent color.")]
         [RefreshProperties(RefreshProperties.All)]
         [KryptonDefaultColor()]
         public Color ImageTransparentColor
@@ -162,8 +162,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the state specific images for the button.
         /// </summary>
-        [Category("Visuals")]
-        [Description("State specific images for the button.")]
+        [Category(@"Visuals")]
+        [Description(@"State specific images for the button.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public ButtonImageStates ImageStates { get; }
 
@@ -176,10 +176,10 @@ namespace Krypton.Toolkit
         /// Gets and sets the button text.
         /// </summary>
         [Localizable(true)]
-        [Category("Visuals")]
-        [Description("Button text.")]
+        [Category(@"Visuals")]
+        [Description(@"Button text.")]
         [RefreshProperties(RefreshProperties.All)]
-        [Editor("System.ComponentModel.Design.MultilineStringEditor", typeof(UITypeEditor))]
+        [Editor(@"System.ComponentModel.Design.MultilineStringEditor", typeof(UITypeEditor))]
         public string Text
         {
             get => _text;
@@ -211,11 +211,11 @@ namespace Krypton.Toolkit
         /// Gets and sets the button extra text.
         /// </summary>
         [Localizable(true)]
-        [Category("Visuals")]
-        [Description("Button extra text.")]
+        [Category(@"Visuals")]
+        [Description(@"Button extra text.")]
         [RefreshProperties(RefreshProperties.All)]
-        [Editor("System.ComponentModel.Design.MultilineStringEditor", typeof(UITypeEditor))]
-        [DefaultValue("")]
+        [Editor(@"System.ComponentModel.Design.MultilineStringEditor", typeof(UITypeEditor))]
+        [DefaultValue(@"")]
         public string ExtraText
         {
             get => _extraText;
@@ -292,8 +292,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the selected color drawing rectangle.
         /// </summary>
         [Bindable(true)]
-        [Category("Appearance")]
-        [Description("Rounded color drawing rectangle.")]
+        [Category(@"Appearance")]
+        [Description(@"Rounded color drawing rectangle.")]
         public int RoundedCorners
         {
             get => _roundedCorners;

--- a/Source/Krypton Components/Krypton.Toolkit/Values/ContextMenuImages.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/ContextMenuImages.cs
@@ -57,8 +57,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the image for a checked context menu item.
         /// </summary>
         [KryptonPersist(false)]
-        [Category("Visuals")]
-        [Description("Image for a checked context menu item.")]
+        [Category(@"Visuals")]
+        [Description(@"Image for a checked context menu item.")]
         [DefaultValue(null)]
         [RefreshProperties(RefreshProperties.All)]
         public Image Checked
@@ -89,8 +89,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the image for an indeterminate context menu item.
         /// </summary>
         [KryptonPersist(false)]
-        [Category("Visuals")]
-        [Description("Image for an indeterminate context menu item.")]
+        [Category(@"Visuals")]
+        [Description(@"Image for an indeterminate context menu item.")]
         [DefaultValue(null)]
         [RefreshProperties(RefreshProperties.All)]
         public Image Indeterminate
@@ -121,8 +121,8 @@ namespace Krypton.Toolkit
         /// Gets and sets an image indicating a sub-menu on a context menu item.
         /// </summary>
         [KryptonPersist(false)]
-        [Category("Visuals")]
-        [Description("Image indicating a sub-menu on a context menu item.")]
+        [Category(@"Visuals")]
+        [Description(@"Image indicating a sub-menu on a context menu item.")]
         [DefaultValue(null)]
         [RefreshProperties(RefreshProperties.All)]
         public Image SubMenu

--- a/Source/Krypton Components/Krypton.Toolkit/Values/DropDownButtonImages.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/DropDownButtonImages.cs
@@ -71,8 +71,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the common image that other drop down button images inherit from.
         /// </summary>
         [KryptonPersist(false)]
-        [Category("Visuals")]
-        [Description("Common image that other drop down button images inherit from.")]
+        [Category(@"Visuals")]
+        [Description(@"Common image that other drop down button images inherit from.")]
         [DefaultValue(null)]
         [RefreshProperties(RefreshProperties.All)]
         public Image Common
@@ -103,8 +103,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the image for use when the drop down button is disabled.
         /// </summary>
         [KryptonPersist(false)]
-        [Category("Visuals")]
-        [Description("Image for use when the drop down button is disabled.")]
+        [Category(@"Visuals")]
+        [Description(@"Image for use when the drop down button is disabled.")]
         [DefaultValue(null)]
         [RefreshProperties(RefreshProperties.All)]
         public Image Disabled
@@ -135,8 +135,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the image for use when the drop down button is normal.
         /// </summary>
         [KryptonPersist(false)]
-        [Category("Visuals")]
-        [Description("Image for use when the drop down button is normal.")]
+        [Category(@"Visuals")]
+        [Description(@"Image for use when the drop down button is normal.")]
         [DefaultValue(null)]
         [RefreshProperties(RefreshProperties.All)]
         public Image Normal
@@ -167,8 +167,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the image for use when the drop down button is tracking.
         /// </summary>
         [KryptonPersist(false)]
-        [Category("Visuals")]
-        [Description("Image for use when the drop down button is tracking.")]
+        [Category(@"Visuals")]
+        [Description(@"Image for use when the drop down button is tracking.")]
         [DefaultValue(null)]
         [RefreshProperties(RefreshProperties.All)]
         public Image Tracking
@@ -199,8 +199,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the image for use when the drop down button is pressed.
         /// </summary>
         [KryptonPersist(false)]
-        [Category("Visuals")]
-        [Description("Image for use when the drop down button is pressed.")]
+        [Category(@"Visuals")]
+        [Description(@"Image for use when the drop down button is pressed.")]
         [DefaultValue(null)]
         [RefreshProperties(RefreshProperties.All)]
         public Image Pressed

--- a/Source/Krypton Components/Krypton.Toolkit/Values/FixedContentValue.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/FixedContentValue.cs
@@ -54,10 +54,10 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the short text.
         /// </summary>
-        [Category("Appearance")]
-        [Description("Main text.")]
+        [Category(@"Appearance")]
+        [Description(@"Main text.")]
         [Localizable(true)]
-        [DefaultValue("")]
+        [DefaultValue(@"")]
         public string ShortText { get; set; }
 
         private bool ShouldSerializeShortText() => !string.IsNullOrEmpty(ShortText);
@@ -68,10 +68,10 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the long text.
         /// </summary>
-        [Category("Appearance")]
-        [Description("Supplementary text.")]
+        [Category(@"Appearance")]
+        [Description(@"Supplementary text.")]
         [Localizable(true)]
-        [DefaultValue("")]
+        [DefaultValue(@"")]
         public string LongText { get; set; }
 
         private bool ShouldSerializeLongText() => !string.IsNullOrEmpty(LongText);
@@ -82,8 +82,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the image.
         /// </summary>
-        [Category("Appearance")]
-        [Description("Image associated with item.")]
+        [Category(@"Appearance")]
+        [Description(@"Image associated with item.")]
         [Localizable(true)]
         public Image Image { get; set; }
 
@@ -95,8 +95,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the image transparent color.
         /// </summary>
-        [Category("Appearance")]
-        [Description("Color to treat as transparent in the Image.")]
+        [Category(@"Appearance")]
+        [Description(@"Color to treat as transparent in the Image.")]
         [Localizable(true)]
         public Color ImageTransparentColor { get; set; }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Values/GalleryButtonImages.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/GalleryButtonImages.cs
@@ -63,8 +63,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the common image that other gallery button images inherit from.
         /// </summary>
         [KryptonPersist(false)]
-        [Category("Visuals")]
-        [Description("Common image that other gallery button images inherit from.")]
+        [Category(@"Visuals")]
+        [Description(@"Common image that other gallery button images inherit from.")]
         [DefaultValue(null)]
         [RefreshProperties(RefreshProperties.All)]
         public Image Common
@@ -95,8 +95,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the image for use when the gallery button is disabled.
         /// </summary>
         [KryptonPersist(false)]
-        [Category("Visuals")]
-        [Description("Image for use when the gallery button is disabled.")]
+        [Category(@"Visuals")]
+        [Description(@"Image for use when the gallery button is disabled.")]
         [DefaultValue(null)]
         [RefreshProperties(RefreshProperties.All)]
         public Image Disabled
@@ -127,8 +127,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the image for use when the gallery button is normal.
         /// </summary>
         [KryptonPersist(false)]
-        [Category("Visuals")]
-        [Description("Image for use when the gallery button is normal.")]
+        [Category(@"Visuals")]
+        [Description(@"Image for use when the gallery button is normal.")]
         [DefaultValue(null)]
         [RefreshProperties(RefreshProperties.All)]
         public Image Normal
@@ -159,8 +159,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the image for use when the gallery button is hot tracking.
         /// </summary>
         [KryptonPersist(false)]
-        [Category("Visuals")]
-        [Description("Image for use when the gallery button is hot tracking.")]
+        [Category(@"Visuals")]
+        [Description(@"Image for use when the gallery button is hot tracking.")]
         [DefaultValue(null)]
         [RefreshProperties(RefreshProperties.All)]
         public Image Tracking
@@ -191,8 +191,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the image for use when the gallery button is pressed.
         /// </summary>
         [KryptonPersist(false)]
-        [Category("Visuals")]
-        [Description("Image for use when the gallery button is pressed.")]
+        [Category(@"Visuals")]
+        [Description(@"Image for use when the gallery button is pressed.")]
         [DefaultValue(null)]
         [RefreshProperties(RefreshProperties.All)]
         public Image Pressed

--- a/Source/Krypton Components/Krypton.Toolkit/Values/GalleryImages.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/GalleryImages.cs
@@ -55,8 +55,8 @@ namespace Krypton.Toolkit
         /// Gallery up button images.
         /// </summary>
         [KryptonPersist(true)]
-        [Category("Visuals")]
-        [Description("Gallery up button images.")]
+        [Category(@"Visuals")]
+        [Description(@"Gallery up button images.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public GalleryButtonImages Up { get; }
 
@@ -67,8 +67,8 @@ namespace Krypton.Toolkit
         /// Gallery down button images.
         /// </summary>
         [KryptonPersist(true)]
-        [Category("Visuals")]
-        [Description("Gallery down button images.")]
+        [Category(@"Visuals")]
+        [Description(@"Gallery down button images.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public GalleryButtonImages Down { get; }
 
@@ -79,8 +79,8 @@ namespace Krypton.Toolkit
         /// Gallery drop down button images.
         /// </summary>
         [KryptonPersist(true)]
-        [Category("Visuals")]
-        [Description("Gallery drop down button images.")]
+        [Category(@"Visuals")]
+        [Description(@"Gallery drop down button images.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public GalleryButtonImages DropDown { get; }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Values/HeaderGroupValuesPrimary.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/HeaderGroupValuesPrimary.cs
@@ -52,7 +52,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the header text.
         /// </summary>
-        [DefaultValue("Heading")]
+        [DefaultValue(@"Heading")]
         public override string Heading
         {
             get => base.Heading;

--- a/Source/Krypton Components/Krypton.Toolkit/Values/HeaderGroupValuesSecondary.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/HeaderGroupValuesSecondary.cs
@@ -58,7 +58,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the heading text.
         /// </summary>
-        [DefaultValue("Description")]
+        [DefaultValue(@"Description")]
         public override string Heading
         {
             get => base.Heading;

--- a/Source/Krypton Components/Krypton.Toolkit/Values/HeaderValuesBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/HeaderValuesBase.cs
@@ -92,8 +92,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the heading image.
         /// </summary>
         [Localizable(true)]
-        [Category("Visuals")]
-        [Description("Heading image.")]
+        [Category(@"Visuals")]
+        [Description(@"Heading image.")]
         [RefreshProperties(RefreshProperties.All)]
         public Image Image
         {
@@ -133,8 +133,8 @@ namespace Krypton.Toolkit
         /// Gets and sets the heading image transparent color.
         /// </summary>
         [Localizable(true)]
-        [Category("Visuals")]
-        [Description("Heading image transparent color.")]
+        [Category(@"Visuals")]
+        [Description(@"Heading image transparent color.")]
         [RefreshProperties(RefreshProperties.All)]
         [KryptonDefaultColor()]
         public Color ImageTransparentColor
@@ -175,10 +175,10 @@ namespace Krypton.Toolkit
         /// Gets and sets the heading text.
         /// </summary>
         [Localizable(true)]
-        [Category("Visuals")]
-        [Description("Heading text.")]
+        [Category(@"Visuals")]
+        [Description(@"Heading text.")]
         [RefreshProperties(RefreshProperties.All)]
-        [Editor("System.ComponentModel.Design.MultilineStringEditor", typeof(UITypeEditor))]
+        [Editor(@"System.ComponentModel.Design.MultilineStringEditor", typeof(UITypeEditor))]
         public virtual string Heading
         {
             get => _heading;
@@ -216,10 +216,10 @@ namespace Krypton.Toolkit
         /// Gets and sets the header description text.
         /// </summary>
         [Localizable(true)]
-        [Category("Visuals")]
-        [Description("Header description text.")]
+        [Category(@"Visuals")]
+        [Description(@"Header description text.")]
         [RefreshProperties(RefreshProperties.All)]
-        [Editor("System.ComponentModel.Design.MultilineStringEditor", typeof(UITypeEditor))]
+        [Editor(@"System.ComponentModel.Design.MultilineStringEditor", typeof(UITypeEditor))]
         public virtual string Description
         {
             get => _description;

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawDateTimeButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawDateTimeButton.cs
@@ -197,8 +197,7 @@ namespace Krypton.Toolkit
             else
             {
                 // If the button is in a normal state (not being tracked or pressed)
-                if ((ElementState == PaletteState.Normal) ||
-                    (ElementState == PaletteState.CheckedNormal))
+                if (ElementState is PaletteState.Normal or PaletteState.CheckedNormal)
                 {
                     // If the control is active then use the checked normal appearance, otherwise not active and so use the normal appearance
                     if (_dateTimePicker.IsActive || (_dateTimePicker.IsFixedActive && (_dateTimePicker.InputControlStyle == InputControlStyle.Standalone)))

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawTrackBar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawTrackBar.cs
@@ -298,7 +298,7 @@ namespace Krypton.Toolkit
                 {
                     if ((value < Minimum) || (value > Maximum))
                     {
-                        throw new ArgumentOutOfRangeException("Value", "Provided value is out of the Minimum to Maximum range of values.");
+                        throw new ArgumentOutOfRangeException(@"Value", @"Provided value is out of the Minimum to Maximum range of values.");
                     }
 
                     _value = value;
@@ -319,7 +319,7 @@ namespace Krypton.Toolkit
             {
                 if (value < 0)
                 {
-                    throw new ArgumentOutOfRangeException("SmallChange", "SmallChange cannot be less than zero.");
+                    throw new ArgumentOutOfRangeException(@"SmallChange", @"SmallChange cannot be less than zero.");
                 }
 
                 _smallChange = value;
@@ -337,7 +337,7 @@ namespace Krypton.Toolkit
             {
                 if (value < 0)
                 {
-                    throw new ArgumentOutOfRangeException("LargeChange", "LargeChange cannot be less than zero.");
+                    throw new ArgumentOutOfRangeException(@"LargeChange", @"LargeChange cannot be less than zero.");
                 }
 
                 _largeChange = value;
@@ -385,7 +385,7 @@ namespace Krypton.Toolkit
         /// <param name="state">Palette state to fix.</param>
         public virtual void SetFixedState(PaletteState state)
         {
-            if ((state == PaletteState.Normal) || (state == PaletteState.Disabled))
+            if (state is PaletteState.Normal or PaletteState.Disabled)
             {
                 _ticksTop.FixedState = state;
                 _ticksBottom.FixedState = state;

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawTrackTP.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawTrackTP.cs
@@ -92,7 +92,7 @@ namespace Krypton.Toolkit
         /// <param name="state">Palette state to fix.</param>
         public virtual void SetFixedState(PaletteState state)
         {
-            if ((state == PaletteState.Normal) || (state == PaletteState.Disabled))
+            if (state is PaletteState.Normal or PaletteState.Disabled)
             {
                 _drawTrack.FixedState = state;
             }

--- a/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutViewport.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutViewport.cs
@@ -640,8 +640,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private bool Horizontal => (Orientation == VisualOrientation.Top) ||
-                                    (Orientation == VisualOrientation.Bottom);
+        private bool Horizontal => Orientation is VisualOrientation.Top or VisualOrientation.Bottom;
 
         private RelativePositionAlign AlignmentRTL
         {
@@ -765,8 +764,7 @@ namespace Krypton.Toolkit
             Point offset = _offset;
 
             // Are we scrolling in the horizontal?
-            if ((Orientation == VisualOrientation.Top) ||
-                (Orientation == VisualOrientation.Bottom))
+            if (Orientation is VisualOrientation.Top or VisualOrientation.Bottom)
             {
                 // Find the distance to move horizontally
                 var change = Math.Max((int)(ClientSize.Width * _scrollPercentage), _scrollMinimum);
@@ -866,8 +864,7 @@ namespace Krypton.Toolkit
 
             // Move the required rectangle more than exactly into view in order to make it
             // easier for users to see extra pages before and after it for easy selection
-            if ((Orientation == VisualOrientation.Top) ||
-                (Orientation == VisualOrientation.Bottom))
+            if (Orientation is VisualOrientation.Top or VisualOrientation.Bottom)
             {
                 rect.X -= overs;
                 rect.Width += overs * 2;


### PR DESCRIPTION
….cs files

- Set "Magic strings" not to be localised
- Allow Resharper to perform logic `or` pattern
Fixes #525

Note: This needs to go into the current canary as well I think.. Or specify that the workaround needs to be documented on it's page.

Look for these files for the actual changes:
![image](https://user-images.githubusercontent.com/2418812/145769648-1b65e17a-3c03-4b8d-b64c-ffa9d566fea5.png)

And warnings have gone up..
![image](https://user-images.githubusercontent.com/2418812/145769887-71075c6d-b66f-4201-b6ab-f3ecb2b924a3.png)

