### PR TITLE
- Massive clean-up of Compiler Warnings and messages

### DIFF
--- a/Source/.editorconfig
+++ b/Source/.editorconfig
@@ -13,17 +13,35 @@ dotnet_sort_system_directives_first = true
 dotnet_separate_import_directive_groups = true
 dotnet_code_quality.enable_platform_analyzer_on_pre_net5_target=true
 
+# 	Indexing can be simplified	Krypton.Toolkit 2022 (net5.0-windows), Krypton.Toolkit 2022 (net6.0-windows), Krypton.Toolkit 2022 (netcoreapp3.1)	
+dotnet_diagnostic.IDE0056.severity = silent
 
-# CS1591: Missing XML comment for publicly visible type or member
-dotnet_diagnostic.CS1591.severity = suggestion
+# 	Substring can be simplified	Krypton.Workspace 2022 (net5.0-windows), Krypton.Workspace 2022 (net6.0-windows), Krypton.Workspace 2022 (netcoreapp3.1)
+dotnet_diagnostic.IDE0057.severity = silent
+
+# 	Naming rule violation: These words must begin with upper case characters: textBoxResponse_KeyDown
+dotnet_diagnostic.IDE1006.severity = silent
+
+#	Remove unnecessary suppression
+dotnet_diagnostic.IDE0079.severity = silent
 
 #warning CA1416: This call site is reachable on all platforms. 'KryptonRibbonGroupButton.Checked' is only supported on: 'Windows' 7.0 and later.
 dotnet_diagnostic.CA1416.severity = None
 
-#Warning	CS8618	Non-nullable field '_panelMessage' must contain a non-null value when exiting constructor. Consider declaring the field as nullable.	Krypton.Toolkit 2019	Z:\GitHub\Krypton-Suite\Standard-Toolkit\Source\Krypton Components\Krypton.Toolkit\Controls Toolkit\KryptonInputBox.cs	46	Active
+# UpdateShadowLayer calls ReleaseDC but does not use the HRESULT or error code that the method returns. This could lead to unexpected behavior in error conditions or low-resource situations. Use the result in a conditional statement, assign the result to a variable, or pass it as an argument to another method.	
+dotnet_diagnostic.CA1806.severity = silent	
+
+# 	Member 'ShouldSerializeValue' does not access instance data and can be marked as static	
+dotnet_diagnostic.CA1822.severity = None
+
+#Warning	CS8618	Non-nullable field '_panelMessage' must contain a non-null value when exiting constructor. Consider declaring the field as nullable.	
 dotnet_diagnostic.CS8618.severity = None
 
 # CS8073:  The result of the expression is always 'true' or 'null'
 dotnet_diagnostic.CS8073.severity = None
 
 dotnet_diagnostic.CS0649.severity = None
+
+# CS1591: Missing XML comment for publicly visible type or member
+dotnet_diagnostic.CS1591.severity = suggestion
+

--- a/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonAutoHiddenGroup.cs
+++ b/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonAutoHiddenGroup.cs
@@ -80,7 +80,7 @@ namespace Krypton.Docking
         /// </summary>
         public void StoreAllPages()
         {
-            List<string> uniqueNames = new List<string>();
+            var uniqueNames = new List<string>();
 
             // Create a list of pages that have not yet store placeholders
             foreach(KryptonPage page in Pages)
@@ -100,7 +100,7 @@ namespace Krypton.Docking
         /// <param name="uniqueNames">Array of page names.</param>
         public void StorePages(string[] uniqueNames)
         {
-            foreach (string uniqueName in uniqueNames)
+            foreach (var uniqueName in uniqueNames)
             {
                 // If a matching page exists and it is not a store placeholder already
                 KryptonPage page = Pages[uniqueName];

--- a/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonAutoHiddenPanel.cs
+++ b/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonAutoHiddenPanel.cs
@@ -60,8 +60,8 @@ namespace Krypton.Docking
         /// </summary>
         public override Size GetPreferredSize(Size proposedSize)
         {
-            int width = 0;
-            int height = 0;
+            var width = 0;
+            var height = 0;
             foreach (KryptonAutoHiddenGroup group in Controls)
             {
                 // Only interested in the group if it has some visible pages

--- a/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonAutoHiddenSlidePanel.cs
+++ b/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonAutoHiddenSlidePanel.cs
@@ -59,10 +59,10 @@ namespace Krypton.Docking
         public event EventHandler<SplitterMoveRectMenuArgs> SplitterMoveRect;
 
         /// <summary>
-        /// Occurs when the separator move finishes and a move has occured.
+        /// Occurs when the separator move finishes and a move has occurred.
         /// </summary>
         [Category("Behavior")]
-        [Description("Occurs when the separator move finishes and a move has occured.")]
+        [Description("Occurs when the separator move finishes and a move has occurred.")]
         public event SplitterEventHandler SplitterMoved;
 
         /// <summary>
@@ -487,16 +487,14 @@ namespace Krypton.Docking
             //    We have an associated auto hidden group control that is not disposed  AND
             //    We are not disposed
             if ((parentForm != null)
-                 && ((parentForm == Form.ActiveForm)
-                      || ((parentMdi != null)
-                           && (parentMdi.ActiveMdiChild == parentForm)
-                      )
-                 )
-                 && parentForm.ContainsFocus
-                 && (_state != DockingAutoHiddenShowState.Hidden)
-                 && (_group != null)
-                 && !_group.IsDisposed
-                 && !IsDisposed
+                && ((parentForm == Form.ActiveForm)
+                    || ((parentMdi != null)
+                        && (parentMdi.ActiveMdiChild == parentForm)
+                    )
+                )
+                && parentForm.ContainsFocus
+                && (_state != DockingAutoHiddenShowState.Hidden)
+                && _group is { IsDisposed: false } && !IsDisposed
                  )
             {
                 switch (msg.Msg)
@@ -717,7 +715,7 @@ namespace Krypton.Docking
         private void ResetChildIndex()
         {
             // Find the child index of our matching panel
-            int panelIndex = _control.Controls.IndexOf(_panel);
+            var panelIndex = _control.Controls.IndexOf(_panel);
 
             // Position ourself just before the matching panel
             _control.Controls.SetChildIndex(this, panelIndex);
@@ -759,7 +757,7 @@ namespace Krypton.Docking
                     break;
                 case DockingAutoHiddenShowState.SlidingOut:
                     {
-                        bool finished = true;
+                        var finished = true;
                         Size newSlideSize = Size;
                         Point newSlideLocation = Location;
                         Point newInnerLocation = _inner.Location;
@@ -805,7 +803,7 @@ namespace Krypton.Docking
                     break;
                 case DockingAutoHiddenShowState.SlidingIn:
                     {
-                        bool finished = true;
+                        var finished = true;
                         Size newSlideSize = Size;
                         Point newSlideLocation = Location;
                         Point newInnerLocation = _inner.Location;

--- a/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonDockspace.cs
+++ b/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonDockspace.cs
@@ -25,15 +25,15 @@ namespace Krypton.Docking
         /// Initialize a new instance of the KryptonDockspace class.
         /// </summary>
         public KryptonDockspace()
-            : base("Docked") =>
+            : base(@"Docked") =>
             // Define a sensible default minimum size
-            MinimumSize = new Size(22, 22);
+            base.MinimumSize = new Size(50, 50);
 
         /// <summary>
         /// Gets a string representation of the class.
         /// </summary>
         /// <returns></returns>
-        public override string ToString() => "KryptonDockspace " + Dock.ToString();
+        public override string ToString() => $@"KryptonDockspace {Dock}";
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonFloatingWindow.cs
+++ b/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonFloatingWindow.cs
@@ -99,7 +99,7 @@ namespace Krypton.Docking
                 case PI.WM_.NCLBUTTONDOWN:
                     {
                         // Perform a hit test to determine which area the mouse press is over at the moment
-                        uint result = PI.SendMessage(Handle, PI.WM_.NCHITTEST, IntPtr.Zero, m.LParam);
+                        var result = PI.SendMessage(Handle, PI.WM_.NCHITTEST, IntPtr.Zero, m.LParam);
 
                         // Only want to override the behaviour of moving the window via the caption bar
                         if (result == PI.HT.CAPTION)
@@ -185,7 +185,7 @@ namespace Krypton.Docking
             e.Cancel = true;
 
             // Generate event so handlers to perform appropriate processing
-            string[] uniqueNames = VisibleCloseableUniqueNames();
+            var uniqueNames = VisibleCloseableUniqueNames();
             if (uniqueNames.Length > 0)
             {
                 OnWindowCloseClicked(new UniqueNamesEventArgs(uniqueNames));
@@ -246,6 +246,7 @@ namespace Krypton.Docking
         private void OnFloatspaceCellAdding(object sender, WorkspaceCellEventArgs e)
         {
             e.Cell.TabVisibleCountChanged += OnTabVisibleCountChanged;
+            e.Cell.MinimumSize = new Size(400, 400);
         }
 
         private void OnFloatspaceCellRemoved(object sender, WorkspaceCellEventArgs e)
@@ -287,7 +288,7 @@ namespace Krypton.Docking
 
         private string[] VisibleCloseableUniqueNames()
         {
-            List<string> uniqueNames = new List<string>();
+            var uniqueNames = new List<string>();
             KryptonWorkspaceCell cell = FloatspaceControl.FirstVisibleCell();
             while (cell != null)
             {

--- a/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonSpace.cs
+++ b/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonSpace.cs
@@ -478,7 +478,7 @@ namespace Krypton.Docking
             // If the cell already have pages then raise inserting events for those pages
             if (cell.Pages.Count > 0)
             {
-                for (int i = cell.Pages.Count - 1; i >= 0; i--)
+                for (var i = cell.Pages.Count - 1; i >= 0; i--)
                 {
                     OnCellPageInserting(new KryptonPageEventArgs(cell.Pages[i], i));
                 }
@@ -680,12 +680,12 @@ namespace Krypton.Docking
         {
             if (ApplyDockingVisibility)
             {
-                bool visibleChanged = false;
+                var visibleChanged = false;
                 KryptonWorkspaceCell cell = FirstCell();
                 while (cell != null)
                 {
                     // Cell if only visible if it has at least 1 visible page
-                    bool newVisible = (cell.Pages.VisibleCount > 0);
+                    var newVisible = (cell.Pages.VisibleCount > 0);
                     visibleChanged |= (cell.Visible != newVisible);
                     cell.Visible = newVisible;
 
@@ -787,7 +787,7 @@ namespace Krypton.Docking
             // Should we apply docking specific change of focus when the primary header is clicked?
             if (ApplyDockingAppearance)
             {
-                List<string> uniqueNames = new List<string>();
+                var uniqueNames = new List<string>();
 
                 // Create list of visible pages that are not placeholders
                 KryptonWorkspaceCell cell = (KryptonWorkspaceCell)sender;

--- a/Source/Krypton Components/Krypton.Docking/Dragging/DockingDragManager.cs
+++ b/Source/Krypton Components/Krypton.Docking/Dragging/DockingDragManager.cs
@@ -147,7 +147,7 @@ namespace Krypton.Docking
         public override bool DragEnd(Point screenPt)
         {
             RemoveFilter();
-            bool ret = base.DragEnd(screenPt);
+            var ret = base.DragEnd(screenPt);
             _manager?.RaiseDoDragDropEnd(EventArgs.Empty);
             return ret;
         }
@@ -221,7 +221,7 @@ namespace Krypton.Docking
                 case PI.WM_.KEYDOWN:
                     {
                         // Extract the keys being pressed
-                        Keys keys = ((Keys)((int)m.WParam.ToInt64()));
+                        Keys keys = (Keys)(int)m.WParam.ToInt64();
 
                         // Pressing escape ends dragging
                         if (keys == Keys.Escape)
@@ -233,19 +233,15 @@ namespace Krypton.Docking
                         return true;
                     }
                 case PI.WM_.SYSKEYDOWN:
+                    // Pressing ALT+TAB ends dragging because user is moving to another app
+                    if (PI.IsKeyDown(Keys.Tab) 
+                        && ((Control.ModifierKeys & Keys.Alt) == Keys.Alt)
+                        )
                     {
-                        // Extract the keys being pressed
-                        Keys keys = ((Keys)((int)m.WParam.ToInt64()));
-
-                        // Pressing ALT+TAB ends dragging because user is moving to another app
-                        if (PI.IsKeyDown(Keys.Tab) && ((Control.ModifierKeys & Keys.Alt) == Keys.Alt))
-                        {
-                            DragQuit();
-                            Dispose();
-                        }
-
-                        break;
+                        DragQuit();
+                        Dispose();
                     }
+                    break;
                 case PI.WM_.MOUSEMOVE:
                     if (_monitorMouse)
                     {

--- a/Source/Krypton Components/Krypton.Docking/Dragging/DockingDragTargetProvider.cs
+++ b/Source/Krypton Components/Krypton.Docking/Dragging/DockingDragTargetProvider.cs
@@ -19,7 +19,7 @@ namespace Krypton.Docking
     {
         #region Instance Fields
         private readonly KryptonDockingManager _manager;
-        private KryptonPageCollection _pages;
+        private readonly KryptonPageCollection _pages;
         private readonly KryptonFloatingWindow _floatingWindow;
         #endregion
 

--- a/Source/Krypton Components/Krypton.Docking/Dragging/DragTargetControlEdge.cs
+++ b/Source/Krypton Components/Krypton.Docking/Dragging/DragTargetControlEdge.cs
@@ -63,7 +63,7 @@ namespace Krypton.Docking
                     break;
                 default:
                     Debug.Assert(false);
-                    throw new ArgumentOutOfRangeException("Hint must be an edge value.");
+                    throw new ArgumentOutOfRangeException(nameof(hint), @"Hint must be an edge value.");
             }
         }
 
@@ -133,8 +133,8 @@ namespace Krypton.Docking
             if (manager != null)
             {
                 // Create a list of pages that are allowed to be transferred into the dockspace
-                List<KryptonPage> transferPages = new List<KryptonPage>();
-                List<string> transferUniqueNames = new List<string>();
+                var transferPages = new List<KryptonPage>();
+                var transferUniqueNames = new List<string>();
                 foreach (KryptonPage page in data.Pages)
                 {
                     if (page.AreFlagsSet(KryptonPageFlags.DockingAllowDocked))

--- a/Source/Krypton Components/Krypton.Docking/Elements Base/DockingElement.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Base/DockingElement.cs
@@ -89,12 +89,12 @@ namespace Krypton.Docking
             // Path names cannot be zero length
             if (path.Length == 0)
             {
-                throw new ArgumentException("path");
+                throw new ArgumentException(@"Needs Comma separated list of names to resolve.", nameof(path));
             }
 
             // Extract the first name in the path
-            int comma = path.IndexOf(',');
-            string firstName = (comma == -1 ? path : path.Substring(0, comma));
+            var comma = path.IndexOf(',');
+            var firstName = (comma == -1 ? path : path.Substring(0, comma));
 
             // If the first name matches ourself...
             if (firstName == Name)
@@ -107,7 +107,7 @@ namespace Krypton.Docking
                 else
                 {
                     // Extract the remainder of the path
-                    string remainder = path.Substring(comma, path.Length - comma);
+                    var remainder = path.Substring(comma, path.Length - comma);
 
                     // Give each child a chance to resolve the remainder of the path
                     foreach (IDockingElement child in this)
@@ -138,7 +138,7 @@ namespace Krypton.Docking
                 // We do not allow the same name to occur twice in a collection (so check new parent collection)
                 if (value?[Name] != null)
                 {
-                    throw new ArgumentNullException(@"Parent provided already has our Name in its collection.");
+                    throw new ArgumentNullException(nameof(Parent), @"Parent provided already has our Name in its collection.");
                 }
 
                 _parent = value;
@@ -154,7 +154,7 @@ namespace Krypton.Docking
         {
             // Propagate the action request to all the child elements
             // (use reverse order so if element removes itself we still have a valid loop)
-            for (int i = Count - 1; i >= 0; i--)
+            for (var i = Count - 1; i >= 0; i--)
             {
                 this[i].PropogateAction(action, uniqueNames);
             }
@@ -169,7 +169,7 @@ namespace Krypton.Docking
         {
             // Propagate the action request to all the child elements
             // (use reverse order so if element removes itself we still have a valid loop)
-            for (int i = Count - 1; i >= 0; i--)
+            for (var i = Count - 1; i >= 0; i--)
             {
                 this[i].PropogateAction(action, pages);
             }
@@ -184,7 +184,7 @@ namespace Krypton.Docking
         {
             // Propagate the action request to all the child elements
             // (use reverse order so if element removes itself we still have a valid loop)
-            for (int i = Count - 1; i >= 0; i--)
+            for (var i = Count - 1; i >= 0; i--)
             {
                 this[i].PropogateAction(action, value);
             }
@@ -199,10 +199,10 @@ namespace Krypton.Docking
         public virtual bool? PropogateBoolState(DockingPropogateBoolState state, string uniqueName)
         {
             // Search all child docking elements
-            for (int i = 0; i < Count; i++)
+            for (var i = 0; i < Count; i++)
             {
                 // If the child knows the exact answer then return it now
-                bool? ret = this[i].PropogateBoolState(state, uniqueName);
+                var ret = this[i].PropogateBoolState(state, uniqueName);
                 if (ret.HasValue)
                 {
                     return ret;
@@ -220,7 +220,7 @@ namespace Krypton.Docking
         public virtual void PropogateIntState(DockingPropogateIntState state, ref int value)
         {
             // Propagate the request to all the child elements
-            for (int i = Count - 1; i >= 0; i--)
+            for (var i = Count - 1; i >= 0; i--)
             {
                 this[i].PropogateIntState(state, ref value);
             }
@@ -235,7 +235,7 @@ namespace Krypton.Docking
         public virtual KryptonPage PropogatePageState(DockingPropogatePageState state, string uniqueName)
         {
             // Search all child docking elements
-            for (int i = 0; i < Count; i++)
+            for (var i = 0; i < Count; i++)
             {
                 // If the child knows the answer then return it now
                 KryptonPage page = this[i].PropogatePageState(state, uniqueName);
@@ -257,7 +257,7 @@ namespace Krypton.Docking
         {
             // Propagate the action request to all the child elements
             // (use reverse order so if element removes itself we still have a valid loop)
-            for (int i = Count - 1; i >= 0; i--)
+            for (var i = Count - 1; i >= 0; i--)
             {
                 this[i].PropogatePageList(state, pages);
             }
@@ -272,7 +272,7 @@ namespace Krypton.Docking
         {
             // Propagate the action request to all the child elements
             // (use reverse order so if element removes itself we still have a valid loop)
-            for (int i = Count - 1; i >= 0; i--)
+            for (var i = Count - 1; i >= 0; i--)
             {
                 this[i].PropogateCellList(state, cells);
             }
@@ -306,7 +306,7 @@ namespace Krypton.Docking
             DockingLocation location = DockingLocation.None;
 
             // Search all child docking elements
-            for (int i = 0; i < Count; i++)
+            for (var i = 0; i < Count; i++)
             {
                 location = this[i].FindPageLocation(uniqueName);
                 if (location != DockingLocation.None)
@@ -329,7 +329,7 @@ namespace Krypton.Docking
             IDockingElement dockingElement = null;
 
             // Search all child docking elements
-            for (int i = 0; i < Count; i++)
+            for (var i = 0; i < Count; i++)
             {
                 dockingElement = this[i].FindPageElement(uniqueName);
                 if (dockingElement != null)
@@ -353,7 +353,7 @@ namespace Krypton.Docking
             IDockingElement dockingElement = null;
 
             // Search all child docking elements
-            for (int i = 0; i < Count; i++)
+            for (var i = 0; i < Count; i++)
             {
                 dockingElement = this[i].FindStorePageElement(location, uniqueName);
                 if (dockingElement != null)
@@ -376,7 +376,7 @@ namespace Krypton.Docking
             KryptonDockingFloating floatingElement = null;
 
             // Search all child docking elements
-            for (int i = 0; i < Count; i++)
+            for (var i = 0; i < Count; i++)
             {
                 floatingElement = this[i].FindDockingFloating(uniqueName);
                 if (floatingElement != null)
@@ -399,7 +399,7 @@ namespace Krypton.Docking
             KryptonDockingEdgeDocked edgeDockedElement = null;
 
             // Search all child docking elements
-            for (int i = 0; i < Count; i++)
+            for (var i = 0; i < Count; i++)
             {
                 edgeDockedElement = this[i].FindDockingEdgeDocked(uniqueName);
                 if (edgeDockedElement != null)
@@ -422,7 +422,7 @@ namespace Krypton.Docking
             KryptonDockingEdgeAutoHidden edgeAutoHiddenElement = null;
 
             // Search all child docking elements
-            for (int i = 0; i < Count; i++)
+            for (var i = 0; i < Count; i++)
             {
                 edgeAutoHiddenElement = this[i].FindDockingEdgeAutoHidden(uniqueName);
                 if (edgeAutoHiddenElement != null)
@@ -445,7 +445,7 @@ namespace Krypton.Docking
             KryptonDockingWorkspace workspaceElement = null;
 
             // Search all child docking elements
-            for (int i = 0; i < Count; i++)
+            for (var i = 0; i < Count; i++)
             {
                 workspaceElement = this[i].FindDockingWorkspace(uniqueName);
                 if (workspaceElement != null)
@@ -468,7 +468,7 @@ namespace Krypton.Docking
             KryptonDockingNavigator navigatorElement = null;
 
             // Search all child docking elements
-            for (int i = 0; i < Count; i++)
+            for (var i = 0; i < Count; i++)
             {
                 navigatorElement = this[i].FindDockingNavigator(uniqueName);
                 if (navigatorElement != null)
@@ -515,8 +515,8 @@ namespace Krypton.Docking
             }
 
             // Grab the element attributes
-            string elementName = xmlReader.GetAttribute(@"N");
-            string elementCount = xmlReader.GetAttribute(@"C");
+            var elementName = xmlReader.GetAttribute(@"N");
+            var elementCount = xmlReader.GetAttribute(@"C");
 
             // Check the name matches up
             if (elementName != Name)
@@ -528,10 +528,10 @@ namespace Krypton.Docking
             LoadDockingElement(xmlReader, pages);
 
             // If there are children then move over them
-            int count = int.Parse(elementCount);
+            var count = int.Parse(elementCount);
             if (count > 0)
             {
-                for (int i = 0; i < count; i++)
+                for (var i = 0; i < count; i++)
                 {
                     // Read to the next element
                     if (!xmlReader.Read())
@@ -708,7 +708,7 @@ namespace Krypton.Docking
             }
             else
             {
-                string nodeName = xmlReader.Name;
+                var nodeName = xmlReader.Name;
 
                 do
                 {

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingAutoHiddenGroup.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingAutoHiddenGroup.cs
@@ -130,7 +130,7 @@ namespace Krypton.Docking
                 case DockingPropogateAction.ShowPages:
                 case DockingPropogateAction.HidePages:
                     {
-                        bool newVisible = (action == DockingPropogateAction.ShowPages);
+                        var newVisible = (action == DockingPropogateAction.ShowPages);
                         // Update visible state of pages that are not placeholders
                         foreach (KryptonPage page in uniqueNames
                             .Select(uniqueName => AutoHiddenGroupControl.Pages[uniqueName])
@@ -169,7 +169,7 @@ namespace Krypton.Docking
                     break;
                 case DockingPropogateAction.RemoveAllPages:
                 case DockingPropogateAction.RemoveAndDisposeAllPages:
-                    for (int i = AutoHiddenGroupControl.Pages.Count - 1; i >= 0; i--)
+                    for (var i = AutoHiddenGroupControl.Pages.Count - 1; i >= 0; i--)
                     {
                         // Only remove the actual page and not placeholders
                         KryptonPage page = AutoHiddenGroupControl.Pages[i];
@@ -192,7 +192,7 @@ namespace Krypton.Docking
                     break;
                 case DockingPropogateAction.ClearAutoHiddenStoredPages:
                 case DockingPropogateAction.ClearStoredPages:
-                    foreach (string uniqueName in uniqueNames)
+                    foreach (var uniqueName in uniqueNames)
                     {
                         // Only remove a matching placeholder page
                         KryptonPage page = AutoHiddenGroupControl.Pages[uniqueName];
@@ -203,7 +203,7 @@ namespace Krypton.Docking
                     }
                     break;
                 case DockingPropogateAction.ClearAllStoredPages:
-                    for (int i = AutoHiddenGroupControl.Pages.Count - 1; i >= 0; i--)
+                    for (var i = AutoHiddenGroupControl.Pages.Count - 1; i >= 0; i--)
                     {
                         // Only remove a placeholder paged
                         KryptonPage page = AutoHiddenGroupControl.Pages[i];
@@ -316,7 +316,7 @@ namespace Krypton.Docking
             {
                 case DockingPropogatePageList.All:
                 case DockingPropogatePageList.AutoHidden:
-                    for (int i = AutoHiddenGroupControl.Pages.Count - 1; i >= 0; i--)
+                    for (var i = AutoHiddenGroupControl.Pages.Count - 1; i >= 0; i--)
                     {
                         // Only add real pages and not just placeholders
                         KryptonPage page = AutoHiddenGroupControl.Pages[i];
@@ -393,7 +393,7 @@ namespace Krypton.Docking
         /// <returns>Array of page references.</returns>
         public KryptonPage[] VisiblePages()
         {
-            List<KryptonPage> pages = new List<KryptonPage>();
+            var pages = new List<KryptonPage>();
 
             // Only interested in visible pages that are not placeholders
             foreach (KryptonPage page in AutoHiddenGroupControl.Pages)
@@ -418,8 +418,8 @@ namespace Krypton.Docking
 
             // Output docking manager element
             xmlWriter.WriteStartElement(XmlElementName);
-            xmlWriter.WriteAttributeString("N", Name);
-            xmlWriter.WriteAttributeString("C", AutoHiddenGroupControl.Pages.Count.ToString());
+            xmlWriter.WriteAttributeString(@"N", Name);
+            xmlWriter.WriteAttributeString(@"C", AutoHiddenGroupControl.Pages.Count.ToString());
 
             // Output an element per page
             foreach (KryptonPage page in AutoHiddenGroupControl.Pages)
@@ -428,9 +428,9 @@ namespace Krypton.Docking
                 if (page.AreFlagsSet(KryptonPageFlags.AllowConfigSave))
                 {
                     xmlWriter.WriteStartElement("KP");
-                    xmlWriter.WriteAttributeString("UN", page.UniqueName);
-                    xmlWriter.WriteAttributeString("V", CommonHelper.BoolToString(page.LastVisibleSet));
-                    xmlWriter.WriteAttributeString("S", CommonHelper.BoolToString(page is KryptonStorePage));
+                    xmlWriter.WriteAttributeString(@"UN", page.UniqueName);
+                    xmlWriter.WriteAttributeString(@"V", CommonHelper.BoolToString(page.LastVisibleSet));
+                    xmlWriter.WriteAttributeString(@"S", CommonHelper.BoolToString(page is KryptonStorePage));
 
                     // Give event handlers a chance to save custom data with the page
                     xmlWriter.WriteStartElement("CPD");
@@ -507,7 +507,7 @@ namespace Krypton.Docking
         /// <summary>
         /// Gets the xml element name to use when saving.
         /// </summary>
-        protected override string XmlElementName => "DAHG";
+        protected override string XmlElementName => @"DAHG";
 
         /// <summary>
         /// Perform docking element specific actions for loading a child xml.
@@ -528,9 +528,9 @@ namespace Krypton.Docking
             }
 
             // Get the unique name of the page
-            string uniqueName = xmlReader.GetAttribute("UN");
-            string boolStore = xmlReader.GetAttribute("S");
-            string boolVisible = xmlReader.GetAttribute("V");
+            var uniqueName = xmlReader.GetAttribute(@"UN");
+            var boolStore = xmlReader.GetAttribute(@"S");
+            var boolVisible = xmlReader.GetAttribute(@"V");
 
             KryptonPage page;
 
@@ -583,7 +583,7 @@ namespace Krypton.Docking
                 throw new ArgumentException("Expected 'CPD' element was not found");
             }
 
-            bool finished = xmlReader.IsEmptyElement;
+            var finished = xmlReader.IsEmptyElement;
 
             // Generate event so custom data can be loaded and/or the page to be added can be modified
             DockPageLoadingEventArgs pageLoading = new(manager, xmlReader, page);
@@ -618,7 +618,7 @@ namespace Krypton.Docking
         private void AppendPagesToControl(KryptonPage[] pages)
         {
             // Make a list of all the 'store' pages being added
-            List<string> uniqueNames = new List<string>();
+            var uniqueNames = new List<string>();
             foreach (KryptonPage page in pages)
             {
                 if (page is KryptonStorePage)
@@ -634,7 +634,7 @@ namespace Krypton.Docking
             }
 
             // Non-store pages need to be wrapped in a proxy appropriate for the auto hidden control
-            for (int i = 0; i < pages.Length; i++)
+            for (var i = 0; i < pages.Length; i++)
             {
                 if (pages[i] is not KryptonStorePage)
                 {

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingControl.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingControl.cs
@@ -186,7 +186,7 @@ namespace Krypton.Docking
                                                   DragTargetList targets)
         {
             // Create a list of pages that are allowed to be transferred into a dockspace
-            List<KryptonPage> transferPages = new List<KryptonPage>();
+            var transferPages = new List<KryptonPage>();
             foreach (KryptonPage page in dragData.Pages)
             {
                 if (page.AreFlagsSet(KryptonPageFlags.DockingAllowDocked))
@@ -200,8 +200,8 @@ namespace Krypton.Docking
             {
                 // Generate targets for the four control edges
                 Rectangle screenRect = Control.RectangleToScreen(Control.ClientRectangle);
-                Rectangle[] rectsDraw = SubdivideRectangle(screenRect, 3, int.MaxValue);
-                Rectangle[] rectsHot = SubdivideRectangle(screenRect, 10, 20);
+                var rectsDraw = SubdivideRectangle(screenRect, 3, int.MaxValue);
+                var rectsHot = SubdivideRectangle(screenRect, 10, 20);
 
                 // Must insert at start of target list as they are higher priority than cell targets
                 targets.Add(new DragTargetControlEdge(screenRect, rectsHot[0], rectsDraw[0], DragTargetHint.EdgeLeft | DragTargetHint.ExcludeCluster, this, KryptonPageFlags.DockingAllowDocked, true));
@@ -243,8 +243,8 @@ namespace Krypton.Docking
                     if ((innerRect.Width > 0) && (innerRect.Height > 0))
                     {
                         Rectangle innerScreenRect = Control.RectangleToScreen(innerRect);
-                        Rectangle[] innerRectsDraw = SubdivideRectangle(innerScreenRect, 3, int.MaxValue);
-                        Rectangle[] innerRectsHot = SubdivideRectangle(innerScreenRect, 10, 20);
+                        var innerRectsDraw = SubdivideRectangle(innerScreenRect, 3, int.MaxValue);
+                        var innerRectsHot = SubdivideRectangle(innerScreenRect, 10, 20);
                         targets.Add(new DragTargetControlEdge(innerScreenRect, innerRectsHot[0], innerRectsDraw[0], DragTargetHint.EdgeLeft, this, KryptonPageFlags.DockingAllowDocked, false));
                         targets.Add(new DragTargetControlEdge(innerScreenRect, innerRectsHot[1], innerRectsDraw[1], DragTargetHint.EdgeRight, this, KryptonPageFlags.DockingAllowDocked, false));
                         targets.Add(new DragTargetControlEdge(innerScreenRect, innerRectsHot[2], innerRectsDraw[2], DragTargetHint.EdgeTop, this, KryptonPageFlags.DockingAllowDocked, false));
@@ -258,8 +258,8 @@ namespace Krypton.Docking
                     Rectangle innerScreenRect = dockingNavigator.DockableNavigatorControl.RectangleToScreen(dockingNavigator.DockableNavigatorControl.ClientRectangle);
                     if ((innerScreenRect.Width > 0) && (innerScreenRect.Height > 0))
                     {
-                        Rectangle[] innerRectsDraw = SubdivideRectangle(innerScreenRect, 3, int.MaxValue);
-                        Rectangle[] innerRectsHot = SubdivideRectangle(innerScreenRect, 10, 20);
+                        var innerRectsDraw = SubdivideRectangle(innerScreenRect, 3, int.MaxValue);
+                        var innerRectsHot = SubdivideRectangle(innerScreenRect, 10, 20);
                         targets.Add(new DragTargetControlEdge(innerScreenRect, innerRectsHot[0], innerRectsDraw[0], DragTargetHint.EdgeLeft, this, KryptonPageFlags.DockingAllowDocked, false));
                         targets.Add(new DragTargetControlEdge(innerScreenRect, innerRectsHot[1], innerRectsDraw[1], DragTargetHint.EdgeRight, this, KryptonPageFlags.DockingAllowDocked, false));
                         targets.Add(new DragTargetControlEdge(innerScreenRect, innerRectsHot[2], innerRectsDraw[2], DragTargetHint.EdgeTop, this, KryptonPageFlags.DockingAllowDocked, false));
@@ -277,7 +277,7 @@ namespace Krypton.Docking
         /// <summary>
         /// Gets the xml element name to use when saving.
         /// </summary>
-        protected override string XmlElementName => "DC";
+        protected override string XmlElementName => @"DC";
 
         /// <summary>
         /// Loads docking configuration information using a provider xml reader.
@@ -290,7 +290,7 @@ namespace Krypton.Docking
             base.LoadElementFromXml(xmlReader, pages);
 
             // Find the largest ordering value for all dockspace controls
-            int largestOrder = -1;
+            var largestOrder = -1;
             PropogateIntState(DockingPropogateIntState.DockspaceOrder, ref largestOrder);
 
             if (largestOrder > 0)
@@ -299,7 +299,7 @@ namespace Krypton.Docking
                 largestOrder = Math.Min(largestOrder, 30);
 
                 // Request each dockspace in ordering sequence reposition itself
-                for (int i = 0; i <= largestOrder; i++)
+                for (var i = 0; i <= largestOrder; i++)
                 {
                     PropogateAction(DockingPropogateAction.RepositionDockspace, i);
                 }
@@ -327,10 +327,10 @@ namespace Krypton.Docking
             Control.Controls.Add(_obscure);
 
             // Create docking elements for managing each of the four control edges
-            Add(new KryptonDockingEdge("Top", control, DockingEdge.Top));
-            Add(new KryptonDockingEdge("Bottom", control, DockingEdge.Bottom));
-            Add(new KryptonDockingEdge("Left", control, DockingEdge.Left));
-            Add(new KryptonDockingEdge("Right", control, DockingEdge.Right));
+            Add(new KryptonDockingEdge(@"Top", control, DockingEdge.Top));
+            Add(new KryptonDockingEdge(@"Bottom", control, DockingEdge.Bottom));
+            Add(new KryptonDockingEdge(@"Left", control, DockingEdge.Left));
+            Add(new KryptonDockingEdge(@"Right", control, DockingEdge.Right));
         }
 
         private void OnControlDisposed(object sender, EventArgs e)
@@ -376,7 +376,7 @@ namespace Krypton.Docking
         {
             // Create a list of all the dockspace controls in our orientation and a matching array 
             // of lengths that will be used in the final phase of updating the control sizes
-            List<KryptonDockspace> controls = new List<KryptonDockspace>();
+            var controls = new List<KryptonDockspace>();
             foreach (Control c in Control.Controls)
             {
                 if ((c is KryptonDockspace dockspace) && c.Visible)
@@ -408,11 +408,11 @@ namespace Krypton.Docking
             while ((remove > 0) && (controls.Count > 0))
             {
                 // How much space to remove from each control
-                int delta = Math.Max(1, remove / controls.Count);
+                var delta = Math.Max(1, remove / controls.Count);
 
                 // Try and remove delta from each control
                 int dockDelta;
-                for (int i = controls.Count - 1; i >= 0; i--)
+                for (var i = controls.Count - 1; i >= 0; i--)
                 {
                     KryptonDockspace dockspace = controls[i];
 
@@ -450,11 +450,11 @@ namespace Krypton.Docking
             }
         }
 
-        private Rectangle[] SubdivideRectangle(Rectangle area,
+        private static Rectangle[] SubdivideRectangle(Rectangle area,
                                                int divisor,
                                                int maxLength)
         {
-            int length = Math.Min(area.Width / divisor, Math.Min(area.Height / divisor, maxLength));
+            var length = Math.Min(area.Width / divisor, Math.Min(area.Height / divisor, maxLength));
 
             // Find the left, right, top, bottom, center rectangles
             return new Rectangle[]{ new(area.X, area.Y, length, area.Height),

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingDockspace.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingDockspace.cs
@@ -37,6 +37,7 @@ namespace Krypton.Docking
         #endregion
 
         #region Identity
+
         /// <summary>
         /// Initialize a new instance of the KryptonDockingDockspace class.
         /// </summary>
@@ -44,7 +45,7 @@ namespace Krypton.Docking
         /// <param name="edge">Docking edge this dockspace is against.</param>
         /// <param name="size">Initial size of the dockspace.</param>
         public KryptonDockingDockspace(string name, DockingEdge edge, Size size)
-            : base(name, "Docked")
+            : base(name, @"Docked")
         {
             // Create a new dockspace that will be a host for docking pages
             SpaceControl = new KryptonDockspace();
@@ -102,8 +103,8 @@ namespace Krypton.Docking
                         if (parent != null)
                         {
                             // Process all sibling controls starting from end to front of collection
-                            int indexInsert = -1;
-                            for (int i = parent.Controls.Count - 1; i >= 0; i--)
+                            var indexInsert = -1;
+                            for (var i = parent.Controls.Count - 1; i >= 0; i--)
                             {
                                 Control c = parent.Controls[i];
 
@@ -130,7 +131,7 @@ namespace Krypton.Docking
                             if (indexInsert >= 0)
                             {
                                 // Our separator should be one before is in the controls collection
-                                int ourIndex = parent.Controls.IndexOf(DockspaceControl);
+                                var ourIndex = parent.Controls.IndexOf(DockspaceControl);
                                 if (ourIndex > 0)
                                 {
                                     Control separator = parent.Controls[ourIndex - 1];
@@ -354,8 +355,8 @@ namespace Krypton.Docking
             {
                 // Count the number of KryptonDockspace that occur after ourself in the collection by scanning
                 // backwards from end of collection to the front.
-                int numDockspace = 0;
-                for (int i = parent.Controls.Count - 1; i >= 0; i--)
+                var numDockspace = 0;
+                for (var i = parent.Controls.Count - 1; i >= 0; i--)
                 {
                     Control child = parent.Controls[i];
                     if (child == DockspaceControl)
@@ -485,7 +486,7 @@ namespace Krypton.Docking
         private void OnDockspaceBeforePageDrag(object sender, PageDragCancelEventArgs e)
         {
             // Validate the list of names to those that are still present in the dockspace
-            List<KryptonPage> pages = new List<KryptonPage>();
+            var pages = new List<KryptonPage>();
             foreach (KryptonPage page in e.Pages)
             {
                 if (page is not KryptonStorePage && (DockspaceControl.CellForPage(page) != null))

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingEdge.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingEdge.cs
@@ -38,8 +38,8 @@ namespace Krypton.Docking
             Edge = edge;
 
             // Auto create elements for handling standard docked content and auto hidden content
-            InternalAdd(new KryptonDockingEdgeAutoHidden("AutoHidden", control, edge));
-            InternalAdd(new KryptonDockingEdgeDocked("Docked", control, edge));
+            InternalAdd(new KryptonDockingEdgeAutoHidden(@"AutoHidden", control, edge));
+            InternalAdd(new KryptonDockingEdgeDocked(@"Docked", control, edge));
         }
         #endregion
 
@@ -60,7 +60,7 @@ namespace Krypton.Docking
         /// <summary>
         /// Gets the xml element name to use when saving.
         /// </summary>
-        protected override string XmlElementName => "DE";
+        protected override string XmlElementName => @"DE";
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingEdgeAutoHidden.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingEdgeAutoHidden.cs
@@ -128,7 +128,7 @@ namespace Krypton.Docking
                 case DockingPropogateAction.RemoveAndDisposePages:
                 case DockingPropogateAction.StorePages:
                     // Ask the sliding panel to remove its display if an incoming name matches
-                    foreach (string uniqueName in uniqueNames)
+                    foreach (var uniqueName in uniqueNames)
                     {
                         _slidePanel.HideUniqueName(uniqueName);
                     }
@@ -206,7 +206,7 @@ namespace Krypton.Docking
         public void SlidePageOut(string uniqueName, bool select)
         {
             // Search each of our AutoHiddenGroup entries
-            for (int i = 0; i < Count; i++)
+            for (var i = 0; i < Count; i++)
             {
                 if (this[i] is KryptonDockingAutoHiddenGroup ahg)
                 {
@@ -228,7 +228,7 @@ namespace Krypton.Docking
         /// <summary>
         /// Gets the xml element name to use when saving.
         /// </summary>
-        protected override string XmlElementName => "DEAH";
+        protected override string XmlElementName => @"DEAH";
 
         /// <summary>
         /// Perform docking element specific actions for loading a child xml.
@@ -247,7 +247,7 @@ namespace Krypton.Docking
             else
             {
                 // Create a new auto hidden group and then reload it
-                KryptonDockingAutoHiddenGroup autoHiddenGroup = AppendAutoHiddenGroup(xmlReader.GetAttribute("N"));
+                KryptonDockingAutoHiddenGroup autoHiddenGroup = AppendAutoHiddenGroup(xmlReader.GetAttribute(@"N"));
                 autoHiddenGroup.LoadElementFromXml(xmlReader, pages);
             }
         }
@@ -474,12 +474,12 @@ namespace Krypton.Docking
 
             // How much can we reduce the width/height of the dockspace to reach the minimum
             Size dockspaceMinimum = _slidePanel.DockspaceControl.MinimumSize;
-            int reduceWidth = Math.Max(_slidePanel.DockspaceControl.Width - dockspaceMinimum.Width, 0);
-            int reduceHeight = Math.Max(_slidePanel.DockspaceControl.Height - dockspaceMinimum.Height, 0);
+            var reduceWidth = Math.Max(_slidePanel.DockspaceControl.Width - dockspaceMinimum.Width, 0);
+            var reduceHeight = Math.Max(_slidePanel.DockspaceControl.Height - dockspaceMinimum.Height, 0);
 
             // How much can we expand the width/height of the dockspace to reach the inner minimum
-            int expandWidth = Math.Max(innerSize.Width - _slidePanel.Width, 0);
-            int expandHeight = Math.Max(innerSize.Height - _slidePanel.Height, 0);
+            var expandWidth = Math.Max(innerSize.Width - _slidePanel.Width, 0);
+            var expandHeight = Math.Max(innerSize.Height - _slidePanel.Height, 0);
 
             // Create movement rectangle based on the initial rectangle and the allowed range
             Rectangle retRect = Rectangle.Empty;

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingEdgeDocked.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingEdgeDocked.cs
@@ -126,7 +126,7 @@ namespace Krypton.Docking
         /// <summary>
         /// Gets the xml element name to use when saving.
         /// </summary>
-        protected override string XmlElementName => "DED";
+        protected override string XmlElementName => @"DED";
 
         /// <summary>
         /// Perform docking element specific actions for loading a child xml.
@@ -145,7 +145,7 @@ namespace Krypton.Docking
             else
             {
                 Size dockspaceSize = _defaultDockspaceSize;
-                string elementSize = xmlReader.GetAttribute("S");
+                var elementSize = xmlReader.GetAttribute(@"S");
 
                 // Cache the loading size
                 if (!string.IsNullOrEmpty(elementSize))
@@ -154,7 +154,7 @@ namespace Krypton.Docking
                 }
 
                 // Create a new dockspace and then reload it
-                KryptonDockingDockspace dockspace = AppendDockspace(xmlReader.GetAttribute("N"), dockspaceSize);
+                KryptonDockingDockspace dockspace = AppendDockspace(xmlReader.GetAttribute(@"N"), dockspaceSize);
                 dockspace.LoadElementFromXml(xmlReader, pages);
             }
         }
@@ -352,8 +352,8 @@ namespace Krypton.Docking
 
             // How much can we reduce the width/height of the dockspace to reach the minimum
             Size dockspaceMinimum = dockspaceElement.DockspaceControl.MinimumSize;
-            int reduceWidth = Math.Max(dockspaceElement.DockspaceControl.Width - dockspaceMinimum.Width, 0);
-            int reduceHeight = Math.Max(dockspaceElement.DockspaceControl.Height - dockspaceMinimum.Height, 0);
+            var reduceWidth = Math.Max(dockspaceElement.DockspaceControl.Width - dockspaceMinimum.Width, 0);
+            var reduceHeight = Math.Max(dockspaceElement.DockspaceControl.Height - dockspaceMinimum.Height, 0);
 
             // Get the minimum size requested for the inner area of the control
             Size innerMinimum = Size.Empty;
@@ -363,8 +363,8 @@ namespace Krypton.Docking
             }
 
             // How much can we expand the width/height of the dockspace to reach the inner minimum
-            int expandWidth = Math.Max(innerRect.Width - innerMinimum.Width, 0);
-            int expandHeight = Math.Max(innerRect.Height - innerMinimum.Height, 0);
+            var expandWidth = Math.Max(innerRect.Width - innerMinimum.Width, 0);
+            var expandHeight = Math.Max(innerRect.Height - innerMinimum.Height, 0);
 
             // Limit check we are not growing bigger than the maximum allowed
             Size dockspaceMaximum = dockspaceElement.DockspaceControl.MaximumSize;
@@ -406,8 +406,8 @@ namespace Krypton.Docking
         private void InsertAtInnerMost(Control c)
         {
             // Find control that we should always insert ourself before
-            int insertIndex = Control.Controls.Count;
-            for (int i = 0; i < Control.Controls.Count; i++)
+            var insertIndex = Control.Controls.Count;
+            for (var i = 0; i < Control.Controls.Count; i++)
             {
                 Control test = Control.Controls[i];
                 if ((test is KryptonDockspaceSeparator) || (test is KryptonDockspace) ||
@@ -426,8 +426,8 @@ namespace Krypton.Docking
         private void InsertAtOuterMost(Control c)
         {
             // Find control that we should always insert ourself after
-            int insertIndex = Control.Controls.Count;
-            for (int i = 0; i < Control.Controls.Count; i++)
+            var insertIndex = Control.Controls.Count;
+            for (var i = 0; i < Control.Controls.Count; i++)
             {
                 Control test = Control.Controls[i];
                 if (test is KryptonDockspace)
@@ -450,8 +450,8 @@ namespace Krypton.Docking
         private void InsertAfter(Control c, Control after)
         {
             // Find control that we should always insert ourself after
-            int insertIndex = Control.Controls.Count;
-            for (int i = 0; i < Control.Controls.Count; i++)
+            var insertIndex = Control.Controls.Count;
+            for (var i = 0; i < Control.Controls.Count; i++)
             {
                 if (Control.Controls[i] == after)
                 {

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingFloating.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingFloating.cs
@@ -32,7 +32,7 @@ namespace Krypton.Docking
         /// <param name="ownerForm">Reference to form that will own all the floating windows.</param>
         public KryptonDockingFloating(string name, Form ownerForm)
             : base(name) =>
-            OwnerForm = ownerForm ?? throw new ArgumentNullException("owner");
+            OwnerForm = ownerForm ?? throw new ArgumentNullException(nameof(ownerForm));
 
         #endregion
 
@@ -77,7 +77,7 @@ namespace Krypton.Docking
                 // Only interested in floating window elements
                 if (child is KryptonDockingFloatingWindow floatingWindow)
                 {
-                    bool? ret = floatingWindow.PropogateBoolState(DockingPropogateBoolState.ContainsStorePage, uniqueName);
+                    var ret = floatingWindow.PropogateBoolState(DockingPropogateBoolState.ContainsStorePage, uniqueName);
                     if (ret.HasValue && ret.Value)
                     {
                         return floatingWindow;
@@ -88,6 +88,9 @@ namespace Krypton.Docking
             return null;
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
         public bool UseMinimiseBox { get; set; }
         #endregion
 
@@ -95,7 +98,7 @@ namespace Krypton.Docking
         /// <summary>
         /// Gets the xml element name to use when saving.
         /// </summary>
-        protected override string XmlElementName => "DF";
+        protected override string XmlElementName => @"DF";
 
         /// <summary>
         /// Perform docking element specific actions for loading a child xml.
@@ -114,7 +117,7 @@ namespace Krypton.Docking
             else
             {
                 // Create a new floating window and then reload it
-                KryptonDockingFloatingWindow floatingWindow = AddFloatingWindow(xmlReader.GetAttribute("N"));
+                KryptonDockingFloatingWindow floatingWindow = AddFloatingWindow(xmlReader.GetAttribute(@"N"));
                 floatingWindow.LoadElementFromXml(xmlReader, pages);
             }
         }

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingFloatingWindow.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingFloatingWindow.cs
@@ -179,10 +179,10 @@ namespace Krypton.Docking
         {
             // Output floating window docking element
             xmlWriter.WriteStartElement(XmlElementName);
-            xmlWriter.WriteAttributeString("N", Name);
-            xmlWriter.WriteAttributeString("C", Count.ToString());
-            xmlWriter.WriteAttributeString("L", CommonHelper.PointToString(FloatingWindow.Location));
-            xmlWriter.WriteAttributeString("S", CommonHelper.SizeToString(FloatingWindow.ClientSize));
+            xmlWriter.WriteAttributeString(@"N", Name);
+            xmlWriter.WriteAttributeString(@"C", Count.ToString());
+            xmlWriter.WriteAttributeString(@"L", CommonHelper.PointToString(FloatingWindow.Location));
+            xmlWriter.WriteAttributeString(@"S", CommonHelper.SizeToString(FloatingWindow.ClientSize));
 
             // Output an element per child
             foreach (IDockingElement child in this)
@@ -199,7 +199,7 @@ namespace Krypton.Docking
         /// <summary>
         /// Gets the xml element name to use when saving.
         /// </summary>
-        protected override string XmlElementName => "DFW";
+        protected override string XmlElementName => @"DFW";
 
         /// <summary>
         /// Perform docking element specific actions based on the loading xml.
@@ -209,12 +209,12 @@ namespace Krypton.Docking
         protected override void LoadDockingElement(XmlReader xmlReader, KryptonPageCollection pages)
         {
             // Grab the requested size and location
-            Point location = CommonHelper.StringToPoint(xmlReader.GetAttribute("L"));
-            Size clientSize = CommonHelper.StringToSize(xmlReader.GetAttribute("S"));
+            Point location = CommonHelper.StringToPoint(xmlReader.GetAttribute(@"L"));
+            Size clientSize = CommonHelper.StringToSize(xmlReader.GetAttribute(@"S"));
 
             // Find the size of the floating window borders
-            int hBorders = FloatingWindow.Width - FloatingWindow.ClientSize.Width;
-            int vBorders = FloatingWindow.Height - FloatingWindow.ClientSize.Height;
+            var hBorders = FloatingWindow.Width - FloatingWindow.ClientSize.Width;
+            var vBorders = FloatingWindow.Height - FloatingWindow.ClientSize.Height;
 
             // Find the monitor that has the window
             Rectangle workingArea = Screen.GetWorkingArea(new Rectangle(location, clientSize));

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingFloatspace.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingFloatspace.cs
@@ -236,7 +236,7 @@ namespace Krypton.Docking
         /// <summary>
         /// Gets the xml element name to use when saving.
         /// </summary>
-        protected override string XmlElementName => "DF";
+        protected override string XmlElementName => @"DF";
 
         /// <summary>
         /// Loads docking configuration information using a provider xml reader.
@@ -289,7 +289,7 @@ namespace Krypton.Docking
         private void OnFloatspaceBeforePageDrag(object sender, PageDragCancelEventArgs e)
         {
             // Validate the list of names to those that are still present in the floatspace
-            List<KryptonPage> pages = new List<KryptonPage>();
+            var pages = new List<KryptonPage>();
             foreach (KryptonPage page in e.Pages)
             {
                 if (page is not KryptonStorePage && (FloatspaceControl.CellForPage(page) != null))

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingManager.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingManager.cs
@@ -345,7 +345,7 @@ namespace Krypton.Docking
         /// </summary>
         /// <param name="c">Reference to control instance.</param>
         /// <returns>KryptonDockingControl instance created.</returns>
-        public KryptonDockingControl ManageControl(Control c) => ManageControl("Control", c);
+        public KryptonDockingControl ManageControl(Control c) => ManageControl(@"Control", c);
 
         /// <summary>
         /// Manage auto hidden/docked capabilities for provided control.
@@ -353,7 +353,7 @@ namespace Krypton.Docking
         /// <param name="c">Reference to control instance.</param>
         /// <param name="navigator">Reference to docking navigator that is inside the control.</param>
         /// <returns>KryptonDockingControl instance created.</returns>
-        public KryptonDockingControl ManageControl(Control c, KryptonDockingNavigator navigator) => ManageControl("Control", c, navigator);
+        public KryptonDockingControl ManageControl(Control c, KryptonDockingNavigator navigator) => ManageControl(@"Control", c, navigator);
 
         /// <summary>
         /// Manage auto hidden/docked capabilities for provided control.
@@ -361,7 +361,7 @@ namespace Krypton.Docking
         /// <param name="c">Reference to control instance.</param>
         /// <param name="workspace">Reference to docking workspace that is inside the control.</param>
         /// <returns>KryptonDockingControl instance created.</returns>
-        public KryptonDockingControl ManageControl(Control c, KryptonDockingWorkspace workspace) => ManageControl("Control", c, workspace);
+        public KryptonDockingControl ManageControl(Control c, KryptonDockingWorkspace workspace) => ManageControl(@"Control", c, workspace);
 
         /// <summary>
         /// Manage auto hidden/docked capabilities for provided control.
@@ -409,7 +409,7 @@ namespace Krypton.Docking
         /// </summary>
         /// <param name="f">Reference to form.</param>
         /// <returns>KryptonDockingFloating instance created.</returns>
-        public KryptonDockingFloating ManageFloating(Form f) => ManageFloating("Floating", f);
+        public KryptonDockingFloating ManageFloating(Form f) => ManageFloating(@"Floating", f);
 
         /// <summary>
         /// Manage floating windows capability for provided form.
@@ -504,7 +504,7 @@ namespace Krypton.Docking
             // Path names cannot be zero length
             if (path.Length == 0)
             {
-                throw new ArgumentException(nameof(path));
+                throw new ArgumentException(@"Needs Comma separated list of names to resolve.", nameof(path));
             }
 
             // Give each child a chance to resolve the entire path
@@ -564,8 +564,8 @@ namespace Krypton.Docking
 
             if (pages.Length > 0)
             {
-                string[] uniqueNames = new string[pages.Length];
-                for (int i = 0; i < uniqueNames.Length; i++)
+                var uniqueNames = new string[pages.Length];
+                for (var i = 0; i < uniqueNames.Length; i++)
                 {
                     // Cannot show a null page reference
                     if (pages[i] == null)
@@ -595,7 +595,7 @@ namespace Krypton.Docking
             if (uniqueNames.Length > 0)
             {
                 // Cannot show a null or zero length unique name
-                foreach (string uniqueName in uniqueNames)
+                foreach (var uniqueName in uniqueNames)
                 {
                     if (uniqueName == null)
                     {
@@ -670,8 +670,8 @@ namespace Krypton.Docking
             if (pages.Length > 0)
             {
                 // Cannot hide a null page reference
-                string[] uniqueNames = new string[pages.Length];
-                for (int i = 0; i < uniqueNames.Length; i++)
+                var uniqueNames = new string[pages.Length];
+                for (var i = 0; i < uniqueNames.Length; i++)
                 {
                     // Cannot show a null page reference
                     if (pages[i] == null)
@@ -701,7 +701,7 @@ namespace Krypton.Docking
             if (uniqueNames.Length > 0)
             {
                 // Cannot hide a null or zero length unique name
-                foreach (string uniqueName in uniqueNames)
+                foreach (var uniqueName in uniqueNames)
                 {
                     if (uniqueName == null)
                     {
@@ -764,7 +764,7 @@ namespace Krypton.Docking
             }
 
             // Search docking hierarchy for the requested information
-            bool? contained = PropogateBoolState(DockingPropogateBoolState.IsPageShowing, uniqueName);
+            var contained = PropogateBoolState(DockingPropogateBoolState.IsPageShowing, uniqueName);
 
             // Page contained and showing only if we get a definite True returned
             return (contained.HasValue && contained.Value);
@@ -824,8 +824,8 @@ namespace Krypton.Docking
             if (pages.Length > 0)
             {
                 // Cannot remove a null page reference
-                string[] uniqueNames = new string[pages.Length];
-                for (int i = 0; i < uniqueNames.Length; i++)
+                var uniqueNames = new string[pages.Length];
+                for (var i = 0; i < uniqueNames.Length; i++)
                 {
                     // Cannot show a null page reference
                     if (pages[i] == null)
@@ -856,7 +856,7 @@ namespace Krypton.Docking
             if (uniqueNames.Length > 0)
             {
                 // Cannot remove a null or zero length unique name
-                foreach (string uniqueName in uniqueNames)
+                foreach (var uniqueName in uniqueNames)
                 {
                     if (uniqueName == null)
                     {
@@ -922,7 +922,7 @@ namespace Krypton.Docking
             }
 
             // Search docking hierarchy for the requested information
-            bool? contained = PropogateBoolState(DockingPropogateBoolState.ContainsPage, uniqueName);
+            var contained = PropogateBoolState(DockingPropogateBoolState.ContainsPage, uniqueName);
 
             // Page contained only if we get a definite True returned
             return (contained.HasValue && contained.Value);
@@ -1002,8 +1002,8 @@ namespace Krypton.Docking
             if (pages.Length > 0)
             {
                 // Cannot replace a null page reference
-                string[] uniqueNames = new string[pages.Length];
-                for (int i = 0; i < uniqueNames.Length; i++)
+                var uniqueNames = new string[pages.Length];
+                for (var i = 0; i < uniqueNames.Length; i++)
                 {
                     // Cannot show a null page reference
                     if (pages[i] == null)
@@ -1033,7 +1033,7 @@ namespace Krypton.Docking
             if (uniqueNames.Length > 0)
             {
                 // Cannot replace a null or zero length unique name
-                foreach (string uniqueName in uniqueNames)
+                foreach (var uniqueName in uniqueNames)
                 {
                     if (uniqueName == null)
                     {
@@ -1074,8 +1074,8 @@ namespace Krypton.Docking
 
             if (pages.Length > 0)
             {
-                string[] uniqueNames = new string[pages.Length];
-                for (int i = 0; i < uniqueNames.Length; i++)
+                var uniqueNames = new string[pages.Length];
+                for (var i = 0; i < uniqueNames.Length; i++)
                 {
                     // Cannot show a null page reference
                     if (pages[i] == null)
@@ -1109,7 +1109,7 @@ namespace Krypton.Docking
             }
 
             // Cannot clear a null or zero length unique name
-            foreach (string uniqueName in uniqueNames)
+            foreach (var uniqueName in uniqueNames)
             {
                 if (uniqueName == null)
                 {
@@ -1434,7 +1434,7 @@ namespace Krypton.Docking
             }
 
             // Cannot action a null or zero length unique name
-            foreach (string uniqueName in uniqueNames)
+            foreach (var uniqueName in uniqueNames)
             {
                 if (uniqueName == null)
                 {
@@ -1448,7 +1448,7 @@ namespace Krypton.Docking
             }
 
             using DockingMultiUpdate update = new(this);
-            foreach (string uniqueName in uniqueNames)
+            foreach (var uniqueName in uniqueNames)
             {
                 // Raise event that allows the action to be defined by handlers
                 CloseRequestEventArgs e = new(uniqueName, DefaultCloseRequest);
@@ -1521,7 +1521,7 @@ namespace Krypton.Docking
                         {
                             // Find the target index of the restore page
                             KryptonAutoHiddenGroup control = restoreElement.AutoHiddenGroupControl;
-                            int pageIndex = control.Pages.IndexOf(control.Pages[uniqueName]);
+                            var pageIndex = control.Pages.IndexOf(control.Pages[uniqueName]);
 
                             // Insert the page at the same index as the restore page
                             control.Pages.Insert(pageIndex, new KryptonAutoHiddenProxyPage(page));
@@ -1585,7 +1585,7 @@ namespace Krypton.Docking
                         {
                             // Find the target cell and the index of the restore page
                             KryptonWorkspaceCell cell = restoreElement.CellForPage(uniqueName);
-                            int pageIndex = cell.Pages.IndexOf(cell.Pages[uniqueName]);
+                            var pageIndex = cell.Pages.IndexOf(cell.Pages[uniqueName]);
 
                             // Insert the page at the same index as the restore page
                             restoreElement.CellInsert(cell, pageIndex, new KryptonPage[] { page });
@@ -1655,7 +1655,7 @@ namespace Krypton.Docking
                         {
                             // Find the target cell and the index of the restore page
                             KryptonWorkspaceCell cell = restoreElement.CellForPage(uniqueName);
-                            int pageIndex = cell.Pages.IndexOf(cell.Pages[uniqueName]);
+                            var pageIndex = cell.Pages.IndexOf(cell.Pages[uniqueName]);
 
                             // Insert the page at the same index as the restore page
                             restoreElement.FloatspaceElement.CellInsert(cell, pageIndex, new KryptonPage[] { page });
@@ -1724,7 +1724,7 @@ namespace Krypton.Docking
                         if (cell != null)
                         {
                             // Insert the page at the same index as the restore page
-                            int pageIndex = cell.Pages.IndexOf(cell.Pages[uniqueName]);
+                            var pageIndex = cell.Pages.IndexOf(cell.Pages[uniqueName]);
                             workspaceElement.CellInsert(cell, pageIndex, new KryptonPage[] { page });
                             workspaceElement.SelectPage(uniqueName);
                             workspaceElement.DockableWorkspaceControl.Select();
@@ -1789,7 +1789,7 @@ namespace Krypton.Docking
                         KryptonPage insertPage = navigatorControl.Pages[uniqueName];
                         if (insertPage != null)
                         {
-                            int pageIndex = navigatorControl.Pages.IndexOf(insertPage);
+                            var pageIndex = navigatorControl.Pages.IndexOf(insertPage);
 
                             if (pageIndex >= 0)
                             {
@@ -1831,7 +1831,7 @@ namespace Krypton.Docking
             }
 
             // By default there is nothing to display
-            bool retDisplay = false;
+            var retDisplay = false;
 
             // If the page is not located in the hierarchy then there are no options we can provide
             DockingLocation location = FindPageLocation(page);
@@ -1961,19 +1961,19 @@ namespace Krypton.Docking
                 if (dockspace != null)
                 {
                     // Does the dockspace currently have the focus?
-                    bool hadFocus = dockspace.DockspaceControl.ContainsFocus;
+                    var hadFocus = dockspace.DockspaceControl.ContainsFocus;
 
                     // Find the sibling auto hidden edge so we can add a new auto hidden group to it later on
                     KryptonDockingEdgeAutoHidden edgeAutoHidden = dockspace.EdgeAutoHiddenElement;
                     if (edgeAutoHidden != null)
                     {
                         // Grab the set of visible pages in the same cell as the target unique name
-                        KryptonPage[] visiblePages = dockspace.CellVisiblePages(uniqueName);
+                        var visiblePages = dockspace.CellVisiblePages(uniqueName);
                         if (visiblePages.Length > 0)
                         {
                             // Use events to determine which pages in the cell should be switched
-                            List<string> switchUniqueNames = new List<string>();
-                            List<KryptonPage> switchPages = new List<KryptonPage>();
+                            var switchUniqueNames = new List<string>();
+                            var switchPages = new List<KryptonPage>();
                             foreach (KryptonPage page in visiblePages)
                             {
                                 CancelUniqueNameEventArgs args = new(page.UniqueName, !page.AreFlagsSet(KryptonPageFlags.DockingAllowAutoHidden));
@@ -1991,7 +1991,7 @@ namespace Krypton.Docking
                             {
                                 using DockingMultiUpdate update = new(this);
                                 // Convert the pages to placeholders so they can be returned to the same location
-                                string[] uniqueNames = switchUniqueNames.ToArray();
+                                var uniqueNames = switchUniqueNames.ToArray();
                                 dockspace.PropogateAction(DockingPropogateAction.StorePages, uniqueNames);
 
                                 // Create a new auto hidden group and add the switch pages into it
@@ -2003,7 +2003,7 @@ namespace Krypton.Docking
                                 {
                                     // ...and focus has not moved to another part of the form...
                                     Form topForm = dockspace.DockspaceControl.FindForm();
-                                    if ((topForm != null) && !topForm.ContainsFocus)
+                                    if (topForm is { ContainsFocus: false })
                                     {
                                         // ...then shift focus to the auto hidden group placeholder, to ensure the form still has the 
                                         // focus and so hovering the mouse over the auto hidden tabs will correctly get them to slide out
@@ -2045,7 +2045,7 @@ namespace Krypton.Docking
             }
 
             // Cannot action a null or zero length unique name
-            foreach (string uniqueName in uniqueNames)
+            foreach (var uniqueName in uniqueNames)
             {
                 if (uniqueName == null)
                 {
@@ -2059,10 +2059,10 @@ namespace Krypton.Docking
             }
 
             // Use events to determine which pages should be switched
-            List<string> switchUniqueNames = new List<string>();
-            List<KryptonPage> switchPages = new List<KryptonPage>();
+            var switchUniqueNames = new List<string>();
+            var switchPages = new List<KryptonPage>();
             string selectedPage = null;
-            foreach (string uniqueName in uniqueNames)
+            foreach (var uniqueName in uniqueNames)
             {
                 // Does the provided unique name exist and is in the required 'docked' state
                 if (FindPageLocation(uniqueName) == DockingLocation.Docked)
@@ -2107,7 +2107,7 @@ namespace Krypton.Docking
                     // Convert the pages to placeholders so they can be returned to the same location
                     PropogateAction(DockingPropogateAction.StorePages, switchUniqueNames.ToArray());
 
-                    foreach (string switchUniqueName in switchUniqueNames)
+                    foreach (var switchUniqueName in switchUniqueNames)
                     {
                         // Is there a floating window with a restore page for this unique name?
                         KryptonDockingFloatingWindow restoreElement = floating.FloatingWindowForStorePage(switchUniqueName);
@@ -2115,7 +2115,7 @@ namespace Krypton.Docking
                         {
                             // Find the target cell and the index of the restore page
                             KryptonWorkspaceCell cell = restoreElement.CellForPage(switchUniqueName);
-                            int pageIndex = cell.Pages.IndexOf(cell.Pages[switchUniqueName]);
+                            var pageIndex = cell.Pages.IndexOf(cell.Pages[switchUniqueName]);
 
                             // Insert the set of pages at the same index as the restore page
                             restoreElement.FloatspaceElement.CellInsert(cell, pageIndex, switchPages.ToArray());
@@ -2168,7 +2168,7 @@ namespace Krypton.Docking
             }
 
             // Cannot action a null or zero length unique name
-            foreach (string uniqueName in uniqueNames)
+            foreach (var uniqueName in uniqueNames)
             {
                 if (uniqueName == null)
                 {
@@ -2182,10 +2182,10 @@ namespace Krypton.Docking
             }
 
             // Use events to determine which pages should be switched
-            List<string> switchUniqueNames = new List<string>();
-            List<KryptonPage> switchPages = new List<KryptonPage>();
+            var switchUniqueNames = new List<string>();
+            var switchPages = new List<KryptonPage>();
             string selectedPage = null;
-            foreach (string uniqueName in uniqueNames)
+            foreach (var uniqueName in uniqueNames)
             {
                 // Does the provided unique name exist and is in the required 'floating' state
                 if (FindPageLocation(uniqueName) == DockingLocation.Floating)
@@ -2228,17 +2228,17 @@ namespace Krypton.Docking
 
                 // Try and restore each page, but make a note of those that failed to be restore
                 //List<string> defaultUniqueNames = new List<string>();
-                List<KryptonPage> defaultPages = new List<KryptonPage>();
+                var defaultPages = new List<KryptonPage>();
                 KryptonPage defaultSelectedPage = null;
-                for (int i = 0; i < switchUniqueNames.Count; i++)
+                for (var i = 0; i < switchUniqueNames.Count; i++)
                 {
                     // Find any dockspace that contains a restore page for this named page
-                    string switchUniqueName = switchUniqueNames[i];
+                    var switchUniqueName = switchUniqueNames[i];
                     if (DockingManager.FindStorePageElement(DockingLocation.Docked, switchUniqueName) is KryptonDockingDockspace restoreElement)
                     {
                         // Find the target cell and the index of the restore page
                         KryptonWorkspaceCell cell = restoreElement.CellForPage(switchUniqueName);
-                        int pageIndex = cell.Pages.IndexOf(cell.Pages[switchUniqueName]);
+                        var pageIndex = cell.Pages.IndexOf(cell.Pages[switchUniqueName]);
 
                         // Insert the set of pages at the same index as the restore page
                         restoreElement.CellInsert(cell, pageIndex, switchPages[i]);
@@ -2306,7 +2306,7 @@ namespace Krypton.Docking
             }
 
             // Cannot action a null or zero length unique name
-            foreach (string uniqueName in uniqueNames)
+            foreach (var uniqueName in uniqueNames)
             {
                 if (uniqueName == null)
                 {
@@ -2320,10 +2320,10 @@ namespace Krypton.Docking
             }
 
             // Use events to determine which pages should be switched
-            List<string> switchUniqueNames = new List<string>();
-            List<KryptonPage> switchPages = new List<KryptonPage>();
+            var switchUniqueNames = new List<string>();
+            var switchPages = new List<KryptonPage>();
             string selectedPage = null;
-            foreach (string uniqueName in uniqueNames)
+            foreach (var uniqueName in uniqueNames)
             {
                 // Does the provided unique name exist and is in the required 'floating' state
                 if (FindPageLocation(uniqueName) == DockingLocation.Floating)
@@ -2415,12 +2415,12 @@ namespace Krypton.Docking
                 if (edgeDocked != null)
                 {
                     // Grab the set of visible pages in the auto hidden group
-                    KryptonPage[] visiblePages = autoHiddenGroup.VisiblePages();
+                    var visiblePages = autoHiddenGroup.VisiblePages();
                     if (visiblePages.Length > 0)
                     {
                         // Use events to determine which pages in the cell should be switched
-                        List<string> switchUniqueNames = new List<string>();
-                        List<KryptonPage> switchPages = new List<KryptonPage>();
+                        var switchUniqueNames = new List<string>();
+                        var switchPages = new List<KryptonPage>();
                         foreach (KryptonPage page in visiblePages)
                         {
                             CancelUniqueNameEventArgs args = new(page.UniqueName, !page.AreFlagsSet(KryptonPageFlags.DockingAllowDocked));
@@ -2438,16 +2438,16 @@ namespace Krypton.Docking
                         {
                             using DockingMultiUpdate update = new(this);
                             // Remove the pages from the auto hidden group
-                            string[] uniqueNames = switchUniqueNames.ToArray();
+                            var uniqueNames = switchUniqueNames.ToArray();
                             PropogateAction(DockingPropogateAction.RemovePages, uniqueNames);
 
                             // Attempt to restore each page back to original location on the same edge
-                            List<KryptonPage> defaultPages = new List<KryptonPage>();
+                            var defaultPages = new List<KryptonPage>();
                             KryptonPage defaultSelectedPage = null;
-                            for (int i = 0; i < switchPages.Count; i++)
+                            for (var i = 0; i < switchPages.Count; i++)
                             {
                                 // If we find a store page then we can simply restore straight back to that position
-                                bool? canRestore = edgeDocked.PropogateBoolState(DockingPropogateBoolState.ContainsStorePage, uniqueNames[i]);
+                                var canRestore = edgeDocked.PropogateBoolState(DockingPropogateBoolState.ContainsStorePage, uniqueNames[i]);
                                 if (canRestore.HasValue && canRestore.Value)
                                 {
                                     // Restore page back into a dockspace
@@ -2525,7 +2525,7 @@ namespace Krypton.Docking
             // Array must contain some values
             if (pages.Length == 0)
             {
-                throw new ArgumentException("pages cannot be zero length");
+                throw new ArgumentException(@"pages cannot be zero length");
             }
 
             // Cannot action a null page reference
@@ -2535,36 +2535,35 @@ namespace Krypton.Docking
             }
 
             // Resolve the given path to the expected docking control element
-            if (ResolvePath(path) is not KryptonDockingControl control)
+            if (ResolvePath(path) is not KryptonDockingControl dockControl)
             {
-                throw new ArgumentException("Path does not resolve to a KryptonDockingControl");
+                throw new ArgumentException(@"Path does not resolve to a KryptonDockingControl");
             }
 
             // Find the requested target edge
-            if (control[edge.ToString()] is not KryptonDockingEdge edgeElement)
+            if (dockControl[edge.ToString()] is not KryptonDockingEdge edgeElement)
             {
-                throw new ArgumentException("KryptonDockingControl does not have the requested edge.");
+                throw new ArgumentException(@"KryptonDockingControl does not have the requested edge.");
             }
 
             // Find the docked edge
-            if (edgeElement["Docked"] is not KryptonDockingEdgeDocked edgeDocked)
+            if (edgeElement[@"Docked"] is not KryptonDockingEdgeDocked edgeDocked)
             {
-                throw new ArgumentException("KryptonDockingControl edge does not have a docked element.");
+                throw new ArgumentException(@"KryptonDockingControl edge does not have a docked element.");
             }
 
-            KryptonDockingDockspace dockspace;
             using DockingMultiUpdate update = new(this);
             // Create a new dockspace and add the provided array of pages
-            dockspace = edgeDocked.AppendDockspace();
+            var dockspace = edgeDocked.AppendDockspace();
             dockspace.Append(pages);
 
             // If we have extra pages then we need to add a stack of tabbed cells
-            if ((stackPages != null) && (stackPages.Length > 0))
+            if (stackPages is { Length: > 0 })
             {
                 // For each array of pages...
-                foreach (KryptonPage[] pageArray in stackPages)
+                foreach (var pageArray in stackPages)
                 {
-                    if ((pageArray != null) && (pageArray.Length > 0))
+                    if (pageArray is { Length: > 0 })
                     {
                         // We need a new cell with all the pages from the array
                         KryptonWorkspaceCell cell = new();
@@ -2648,12 +2647,12 @@ namespace Krypton.Docking
             autoHiddenGroup.Append(pages);
 
             // If we have extra pages then we need to add extra auto hidden groups
-            if ((extraPages != null) && (extraPages.Length > 0))
+            if (extraPages is { Length: > 0 })
             {
                 // For each array of pages...
-                foreach (KryptonPage[] pageArray in extraPages)
+                foreach (var pageArray in extraPages)
                 {
-                    if ((pageArray != null) && (pageArray.Length > 0))
+                    if (pageArray is { Length: > 0 })
                     {
                         // Create a new auto hidden group and add the provided array of pages
                         KryptonDockingAutoHiddenGroup extraAutoHiddenGroup = edgeAutoHidden.AppendAutoHiddenGroup();
@@ -2891,12 +2890,12 @@ namespace Krypton.Docking
             dockspace.Append(pages);
 
             // If we have extra pages then we need to add a stack of tabbed cells
-            if ((stackPages != null) && (stackPages.Length > 0))
+            if (stackPages is { Length: > 0 })
             {
                 // For each array of pages...
-                foreach (KryptonPage[] pageArray in stackPages)
+                foreach (var pageArray in stackPages)
                 {
-                    if ((pageArray != null) && (pageArray.Length > 0))
+                    if (pageArray is { Length: > 0 })
                     {
                         // We need a new cell with all the pages from the array
                         KryptonWorkspaceCell cell = new();
@@ -2982,12 +2981,12 @@ namespace Krypton.Docking
             autoHiddenGroup.Append(pages);
 
             // If we have extra pages then we need to add extra auto hidden groups
-            if ((extraPages != null) && (extraPages.Length > 0))
+            if (extraPages is { Length: > 0 })
             {
                 // For each array of pages...
-                foreach (KryptonPage[] pageArray in extraPages)
+                foreach (var pageArray in extraPages)
                 {
-                    if ((pageArray != null) && (pageArray.Length > 0))
+                    if (pageArray is { Length: > 0 })
                     {
                         // Create a new auto hidden group and add the provided array of pages
                         KryptonDockingAutoHiddenGroup extraAutoHiddenGroup = edgeAutoHidden.AppendAutoHiddenGroup();
@@ -3026,7 +3025,7 @@ namespace Krypton.Docking
                 FloatingWindowOffset = elementOffset
             };
 
-            bool atLeastOneFloating = false;
+            var atLeastOneFloating = false;
             KryptonPage firstFloatingPage = null;
             foreach (KryptonPage page in pages)
             {
@@ -3079,8 +3078,8 @@ namespace Krypton.Docking
                             floatingWindow.PropogateAction(DockingPropogateAction.RestorePages, firstFloatingPages);
 
                             // Make a list of all pages that should be appended to the floating window
-                            List<string> appendUniqueNames = new List<string>();
-                            List<KryptonPage> appendPages = new List<KryptonPage>();
+                            var appendUniqueNames = new List<string>();
+                            var appendPages = new List<KryptonPage>();
                             foreach (KryptonPage page in pages)
                             {
                                 if (page is not KryptonStorePage && (page != firstFloatingPage) && page.AreFlagsSet(KryptonPageFlags.DockingAllowFloating))
@@ -3115,8 +3114,8 @@ namespace Krypton.Docking
                         dragManager.FloatingWindow = floatingWindow.FloatingWindow;
 
                         // Make a list of all pages that should be appended to the floating window
-                        List<string> appendUniqueNames = new List<string>();
-                        List<KryptonPage> appendPages = new List<KryptonPage>();
+                        var appendUniqueNames = new List<string>();
+                        var appendPages = new List<KryptonPage>();
                         foreach (KryptonPage page in pages)
                         {
                             if (page is not KryptonStorePage && page.AreFlagsSet(KryptonPageFlags.DockingAllowFloating))
@@ -3390,10 +3389,10 @@ namespace Krypton.Docking
                 }
 
                 // Load the format version number
-                string version = xmlReader.GetAttribute(@"V");
+                var version = xmlReader.GetAttribute(@"V");
 
                 // Convert format version from string to double
-                int formatVersion = (int)Convert.ToDouble(version);
+                var formatVersion = (int)Convert.ToDouble(version);
 
                 // We can only load 1 upward version formats
                 if (formatVersion < 1)
@@ -3422,7 +3421,7 @@ namespace Krypton.Docking
                         throw new ArgumentException(@"Expected 'DGD' element was not found.");
                     }
 
-                    bool finished = xmlReader.IsEmptyElement;
+                    var finished = xmlReader.IsEmptyElement;
 
                     // Give handlers chance to reload custom saved data
                     OnGlobalLoading(new DockGlobalLoadingEventArgs(this, xmlReader));
@@ -4254,7 +4253,7 @@ namespace Krypton.Docking
             return element;
         }
 
-        private void RemoveControlStorePages(DockingElement element, string[] uniqueNames, bool autoHidden, bool docked)
+        private static void RemoveControlStorePages(DockingElement element, string[] uniqueNames, bool autoHidden, bool docked)
         {
             // Find the control element from the provided starting point
             if (element is not KryptonDockingControl control)
@@ -4302,7 +4301,7 @@ namespace Krypton.Docking
         private void OnDropDownWorkspaceClicked(object sender, EventArgs e)
         {
             KryptonContextMenuItem workspaceItem = (KryptonContextMenuItem)sender;
-            string uniqueName = (string)workspaceItem.Tag;
+            var uniqueName = (string)workspaceItem.Tag;
 
             // Action depends on the current location
             switch (FindPageLocation(uniqueName))
@@ -4323,7 +4322,7 @@ namespace Krypton.Docking
         private void OnDropDownNavigatorClicked(object sender, EventArgs e)
         {
             KryptonContextMenuItem workspaceItem = (KryptonContextMenuItem)sender;
-            string uniqueName = (string)workspaceItem.Tag;
+            var uniqueName = (string)workspaceItem.Tag;
 
             // Action depends on the current location
             switch (FindPageLocation(uniqueName))
@@ -4344,7 +4343,7 @@ namespace Krypton.Docking
         private void OnDropDownAutoHiddenClicked(object sender, EventArgs e)
         {
             KryptonContextMenuItem autoHiddenItem = (KryptonContextMenuItem)sender;
-            string uniqueName = (string)autoHiddenItem.Tag;
+            var uniqueName = (string)autoHiddenItem.Tag;
 
             // Action depends on the current location
             switch (FindPageLocation(uniqueName))
@@ -4365,7 +4364,7 @@ namespace Krypton.Docking
         private void OnDropDownDockedClicked(object sender, EventArgs e)
         {
             KryptonContextMenuItem dockedItem = (KryptonContextMenuItem)sender;
-            string uniqueName = (string)dockedItem.Tag;
+            var uniqueName = (string)dockedItem.Tag;
 
             // Action depends on the current location
             switch (FindPageLocation(uniqueName))
@@ -4387,7 +4386,7 @@ namespace Krypton.Docking
         {
             // Get the unique name of the page that needs to be converted to floating
             KryptonContextMenuItem floatingItem = (KryptonContextMenuItem)sender;
-            string uniqueName = (string)floatingItem.Tag;
+            var uniqueName = (string)floatingItem.Tag;
 
             // Action depends on the current location
             switch (FindPageLocation(uniqueName))
@@ -4411,11 +4410,11 @@ namespace Krypton.Docking
             CloseRequest(new string[] { (string)closeItem.Tag });
         }
 
-        private KryptonPage[] ArrayFromCollection(KryptonPageCollection pages)
+        private static KryptonPage[] ArrayFromCollection(KryptonPageCollection pages)
         {
             // Convert collection to array
-            KryptonPage[] array = new KryptonPage[pages.Count];
-            for (int i = 0; i < array.Length; i++)
+            var array = new KryptonPage[pages.Count];
+            for (var i = 0; i < array.Length; i++)
             {
                 array[i] = pages[i];
             }

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingNavigator.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingNavigator.cs
@@ -153,8 +153,8 @@ namespace Krypton.Docking
 
             if (pages.Length > 0)
             {
-                string[] uniqueNames = new string[pages.Length];
-                for (int i = 0; i < uniqueNames.Length; i++)
+                var uniqueNames = new string[pages.Length];
+                for (var i = 0; i < uniqueNames.Length; i++)
                 {
                     // Cannot show a null page reference
                     if (pages[i] == null)
@@ -184,7 +184,7 @@ namespace Krypton.Docking
             if (uniqueNames.Length > 0)
             {
                 // Cannot show a null or zero length unique name
-                foreach (string uniqueName in uniqueNames)
+                foreach (var uniqueName in uniqueNames)
                 {
                     if (uniqueName == null)
                     {
@@ -259,8 +259,8 @@ namespace Krypton.Docking
             if (pages.Length > 0)
             {
                 // Cannot hide a null page reference
-                string[] uniqueNames = new string[pages.Length];
-                for (int i = 0; i < uniqueNames.Length; i++)
+                var uniqueNames = new string[pages.Length];
+                for (var i = 0; i < uniqueNames.Length; i++)
                 {
                     // Cannot show a null page reference
                     if (pages[i] == null)
@@ -290,7 +290,7 @@ namespace Krypton.Docking
             if (uniqueNames.Length > 0)
             {
                 // Cannot hide a null or zero length unique name
-                foreach (string uniqueName in uniqueNames)
+                foreach (var uniqueName in uniqueNames)
                 {
                     if (uniqueName == null)
                     {
@@ -355,8 +355,8 @@ namespace Krypton.Docking
             if (pages.Length > 0)
             {
                 // Cannot remove a null page reference
-                string[] uniqueNames = new string[pages.Length];
-                for (int i = 0; i < uniqueNames.Length; i++)
+                var uniqueNames = new string[pages.Length];
+                for (var i = 0; i < uniqueNames.Length; i++)
                 {
                     // Cannot show a null page reference
                     if (pages[i] == null)
@@ -387,7 +387,7 @@ namespace Krypton.Docking
             if (uniqueNames.Length > 0)
             {
                 // Cannot remove a null or zero length unique name
-                foreach (string uniqueName in uniqueNames)
+                foreach (var uniqueName in uniqueNames)
                 {
                     if (uniqueName == null)
                     {
@@ -438,7 +438,7 @@ namespace Krypton.Docking
                     // Ignore some global actions
                     return;
                 case DockingPropogateAction.StorePages:
-                    foreach (string uniqueName in uniqueNames)
+                    foreach (var uniqueName in uniqueNames)
                     {
                         // Swap pages that are not placeholders to become placeholders
                         KryptonPage page = pageCollection[uniqueName];
@@ -453,7 +453,7 @@ namespace Krypton.Docking
                     break;
                 case DockingPropogateAction.StoreAllPages:
                     // Process each page inside the cell
-                    for (int i = pageCollection.Count - 1; i >= 0; i--)
+                    for (var i = pageCollection.Count - 1; i >= 0; i--)
                     {
                         // Swap pages that are not placeholders to become placeholders
                         KryptonPage page = pageCollection[i];
@@ -469,7 +469,7 @@ namespace Krypton.Docking
                     break;
                 case DockingPropogateAction.ClearFillerStoredPages:
                 case DockingPropogateAction.ClearStoredPages:
-                    foreach (string uniqueName in uniqueNames)
+                    foreach (var uniqueName in uniqueNames)
                     {
                         // Only remove a matching unique name if it is a placeholder page
                         KryptonPage removePage = pageCollection[uniqueName];
@@ -482,7 +482,7 @@ namespace Krypton.Docking
                 case DockingPropogateAction.ClearAllStoredPages:
                     {
                         // Process each page inside the cell
-                        for (int i = pageCollection.Count - 1; i >= 0; i--)
+                        for (var i = pageCollection.Count - 1; i >= 0; i--)
                         {
                             // Remove all placeholders
                             KryptonPage page = pageCollection[i];
@@ -593,7 +593,7 @@ namespace Krypton.Docking
                         if ((state == DockingPropogatePageList.All) || (state == DockingPropogatePageList.Filler))
                         {
                             // Process each page inside the navigator
-                            for (int i = DockableNavigatorControl.Pages.Count - 1; i >= 0; i--)
+                            for (var i = DockableNavigatorControl.Pages.Count - 1; i >= 0; i--)
                             {
                                 // Only add real pages and not placeholders
                                 KryptonPage page = DockableNavigatorControl.Pages[i];
@@ -775,8 +775,8 @@ namespace Krypton.Docking
             }
 
             // Grab the element attributes
-            string elementName = xmlReader.GetAttribute(@"N");
-            string elementCount = xmlReader.GetAttribute(@"C");
+            var elementName = xmlReader.GetAttribute(@"N");
+            var elementCount = xmlReader.GetAttribute(@"C");
 
             // Check the name matches up
             if (elementName != Name)
@@ -788,11 +788,11 @@ namespace Krypton.Docking
             DockableNavigatorControl.Pages.Clear();
 
             // If there are children then load them
-            int count = int.Parse(elementCount);
+            var count = int.Parse(elementCount);
             if (count > 0)
             {
                 KryptonDockingManager manager = DockingManager;
-                for (int i = 0; i < count; i++)
+                for (var i = 0; i < count; i++)
                 {
                     // Read past this element
                     if (!xmlReader.Read())
@@ -807,9 +807,9 @@ namespace Krypton.Docking
                     }
 
                     // Get the unique name of the page
-                    string uniqueName = XmlHelper.XmlAttributeToText(xmlReader, @"UN");
-                    bool boolStore = CommonHelper.StringToBool(XmlHelper.XmlAttributeToText(xmlReader, @"S"));
-                    bool boolVisible = CommonHelper.StringToBool(XmlHelper.XmlAttributeToText(xmlReader, @"V", @"True"));
+                    var uniqueName = XmlHelper.XmlAttributeToText(xmlReader, @"UN");
+                    var boolStore = CommonHelper.StringToBool(XmlHelper.XmlAttributeToText(xmlReader, @"S"));
+                    var boolVisible = CommonHelper.StringToBool(XmlHelper.XmlAttributeToText(xmlReader, @"V", @"True"));
 
                     // If the entry is for just a placeholder...
                     KryptonPage page;
@@ -858,7 +858,7 @@ namespace Krypton.Docking
                         throw new ArgumentException(@"Expected 'CPD' element was not found");
                     }
 
-                    bool finished = xmlReader.IsEmptyElement;
+                    var finished = xmlReader.IsEmptyElement;
 
                     // Generate event so custom data can be loaded and/or the page to be added can be modified
                     DockPageLoadingEventArgs pageLoading = new(manager, xmlReader, page);
@@ -934,7 +934,7 @@ namespace Krypton.Docking
         private void OnDockableNavigatorBeforePageDrag(object sender, PageDragCancelEventArgs e)
         {
             // Validate the list of names to those that are still present in the navigator
-            List<KryptonPage> pages = new List<KryptonPage>();
+            var pages = new List<KryptonPage>();
             foreach (KryptonPage page in e.Pages)
             {
                 if (page is not KryptonStorePage && DockableNavigatorControl.Pages.Contains(page))

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingSpace.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingSpace.cs
@@ -251,7 +251,7 @@ namespace Krypton.Docking
                 case DockingPropogateAction.ShowPages:
                 case DockingPropogateAction.HidePages:
                     {
-                        bool newVisible = (action == DockingPropogateAction.ShowPages);
+                        var newVisible = (action == DockingPropogateAction.ShowPages);
                         // Update visible state of pages that are not placeholders
                         foreach (KryptonPage page in uniqueNames
                             .Select(uniqueName => SpaceControl.PageForUniqueName(uniqueName))
@@ -269,7 +269,7 @@ namespace Krypton.Docking
                     break;
                 case DockingPropogateAction.RemovePages:
                 case DockingPropogateAction.RemoveAndDisposePages:
-                    foreach (string uniqueName in uniqueNames)
+                    foreach (var uniqueName in uniqueNames)
                     {
                         // If the named page exists and is not placeholder then remove it
                         KryptonPage removePage = SpaceControl.PageForUniqueName(uniqueName);
@@ -298,7 +298,7 @@ namespace Krypton.Docking
                         while (cell != null)
                         {
                             // Process each page inside the cell
-                            for (int i = cell.Pages.Count - 1; i >= 0; i--)
+                            for (var i = cell.Pages.Count - 1; i >= 0; i--)
                             {
                                 // Only remove the actual page and not placeholders
                                 KryptonPage page = cell.Pages[i];
@@ -321,7 +321,7 @@ namespace Krypton.Docking
                     }
                     break;
                 case DockingPropogateAction.StorePages:
-                    foreach (string uniqueName in uniqueNames)
+                    foreach (var uniqueName in uniqueNames)
                     {
                         // Swap pages that are not placeholders to become placeholders
                         KryptonPage page = SpaceControl.PageForUniqueName(uniqueName);
@@ -342,7 +342,7 @@ namespace Krypton.Docking
                         while (cell != null)
                         {
                             // Process each page inside the cell
-                            for (int i = cell.Pages.Count - 1; i >= 0; i--)
+                            for (var i = cell.Pages.Count - 1; i >= 0; i--)
                             {
                                 // Swap pages that are not placeholders to become placeholders
                                 KryptonPage page = cell.Pages[i];
@@ -366,7 +366,7 @@ namespace Krypton.Docking
                     // Only process an attempt to clear all pages or those related to this docking location
                     if ((action == DockingPropogateAction.ClearStoredPages) || (action == ClearStoreAction))
                     {
-                        foreach (string uniqueName in uniqueNames)
+                        foreach (var uniqueName in uniqueNames)
                         {
                             // Only remove a matching unique name if it is a placeholder page
                             KryptonPage removePage = SpaceControl.PageForUniqueName(uniqueName);
@@ -390,7 +390,7 @@ namespace Krypton.Docking
                         while (cell != null)
                         {
                             // Process each page inside the cell
-                            for (int i = cell.Pages.Count - 1; i >= 0; i--)
+                            for (var i = cell.Pages.Count - 1; i >= 0; i--)
                             {
                                 // Remove all placeholders
                                 KryptonPage page = cell.Pages[i];
@@ -541,7 +541,7 @@ namespace Krypton.Docking
                             while (cell != null)
                             {
                                 // Process each page inside the cell
-                                for (int i = cell.Pages.Count - 1; i >= 0; i--)
+                                for (var i = cell.Pages.Count - 1; i >= 0; i--)
                                 {
                                     // Only add real pages and not placeholders
                                     KryptonPage page = cell.Pages[i];
@@ -610,7 +610,7 @@ namespace Krypton.Docking
         /// <returns>Array of page references.</returns>
         public KryptonPage[] CellVisiblePages(string uniqueName)
         {
-            List<KryptonPage> pages = new List<KryptonPage>();
+            var pages = new List<KryptonPage>();
 
             // Grab the cell that contains the provided unique name
             KryptonWorkspaceCell cell = SpaceControl.CellForUniqueName(uniqueName);
@@ -704,9 +704,9 @@ namespace Krypton.Docking
             }
 
             // Grab the element attributes
-            string elementName = xmlReader.GetAttribute("N");
-            string elementOrder = xmlReader.GetAttribute("O");
-            string elementSize = xmlReader.GetAttribute("S");
+            var elementName = xmlReader.GetAttribute(@"N");
+            var elementOrder = xmlReader.GetAttribute(@"O");
+            var elementSize = xmlReader.GetAttribute(@"S");
 
             // Check the name matches up
             if (elementName != Name)
@@ -885,8 +885,40 @@ namespace Krypton.Docking
             RaiseRemoved();
         }
 
+        private Size GetMinSize(Control.ControlCollection controls)
+        {
+            var minWidth = int.MinValue;
+            var minHeight = int.MinValue;
+            foreach (var kryptonPage in controls.OfType<Control>())
+            {
+                var childMinSize = GetMinSize(kryptonPage.Controls);
+                if (minWidth < childMinSize.Width)
+                {
+                    minWidth = childMinSize.Width;
+                }
+                if (minHeight < childMinSize.Height)
+                {
+                    minHeight = childMinSize.Height;
+                }
+                if (minWidth < kryptonPage.MinimumSize.Width)
+                {
+                    minWidth = kryptonPage.MinimumSize.Width;
+                }
+                if (minHeight < kryptonPage.MinimumSize.Height)
+                {
+                    minHeight = kryptonPage.MinimumSize.Height;
+                }
+            }
+
+            return new Size(minWidth, minHeight);
+        }
+
         private void OnSpaceCellAdding(object sender, WorkspaceCellEventArgs e)
         {
+            var childMinSize = GetMinSize(e.Cell.Controls);
+            SpaceControl.MinimumSize = new Size(Math.Max(SpaceControl.MinimumSize.Width, childMinSize.Width),
+                Math.Max(SpaceControl.MinimumSize.Height,childMinSize.Height));
+
             RaiseCellAdding(e.Cell);
 
             // Need to generate the removed event to match this adding event

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingWorkspace.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingWorkspace.cs
@@ -120,8 +120,8 @@ namespace Krypton.Docking
 
             if (pages.Length > 0)
             {
-                string[] uniqueNames = new string[pages.Length];
-                for (int i = 0; i < uniqueNames.Length; i++)
+                var uniqueNames = new string[pages.Length];
+                for (var i = 0; i < uniqueNames.Length; i++)
                 {
                     // Cannot show a null page reference
                     if (pages[i] == null)
@@ -151,7 +151,7 @@ namespace Krypton.Docking
             if (uniqueNames.Length > 0)
             {
                 // Cannot show a null or zero length unique name
-                foreach (string uniqueName in uniqueNames)
+                foreach (var uniqueName in uniqueNames)
                 {
                     if (uniqueName == null)
                     {
@@ -226,8 +226,8 @@ namespace Krypton.Docking
             if (pages.Length > 0)
             {
                 // Cannot hide a null page reference
-                string[] uniqueNames = new string[pages.Length];
-                for (int i = 0; i < uniqueNames.Length; i++)
+                var uniqueNames = new string[pages.Length];
+                for (var i = 0; i < uniqueNames.Length; i++)
                 {
                     // Cannot show a null page reference
                     if (pages[i] == null)
@@ -257,7 +257,7 @@ namespace Krypton.Docking
             if (uniqueNames.Length > 0)
             {
                 // Cannot hide a null or zero length unique name
-                foreach (string uniqueName in uniqueNames)
+                foreach (var uniqueName in uniqueNames)
                 {
                     if (uniqueName == null)
                     {
@@ -322,8 +322,8 @@ namespace Krypton.Docking
             if (pages.Length > 0)
             {
                 // Cannot remove a null page reference
-                string[] uniqueNames = new string[pages.Length];
-                for (int i = 0; i < uniqueNames.Length; i++)
+                var uniqueNames = new string[pages.Length];
+                for (var i = 0; i < uniqueNames.Length; i++)
                 {
                     // Cannot show a null page reference
                     if (pages[i] == null)
@@ -354,7 +354,7 @@ namespace Krypton.Docking
             if (uniqueNames.Length > 0)
             {
                 // Cannot remove a null or zero length unique name
-                foreach (string uniqueName in uniqueNames)
+                foreach (var uniqueName in uniqueNames)
                 {
                     if (uniqueName == null)
                     {
@@ -578,7 +578,7 @@ namespace Krypton.Docking
         private void OnDockableWorkspaceBeforePageDrag(object sender, PageDragCancelEventArgs e)
         {
             // Validate the list of names to those that are still present in the dockspace
-            List<KryptonPage> pages = new List<KryptonPage>();
+            var pages = new List<KryptonPage>();
             foreach (KryptonPage page in e.Pages)
             {
                 if (page is not KryptonStorePage && (DockableWorkspaceControl.CellForPage(page) != null))

--- a/Source/Krypton Components/Krypton.Docking/General/Definitions.cs
+++ b/Source/Krypton Components/Krypton.Docking/General/Definitions.cs
@@ -206,18 +206,18 @@ namespace Krypton.Docking
     public interface IFloatingMessages
     {
         /// <summary>
-        /// The WM_KEYDOWN message has occured.
+        /// The WM_KEYDOWN message has occurred.
         /// </summary>
         /// <returns>True to eat message; otherwise false.</returns>
         bool OnKEYDOWN(ref Message m);
 
         /// <summary>
-        /// The WM_MOUSEMOVE message has occured.
+        /// The WM_MOUSEMOVE message has occurred.
         /// </summary>
         void OnMOUSEMOVE();
 
         /// <summary>
-        /// The WM_LBUTTONUP message has occured.
+        /// The WM_LBUTTONUP message has occurred.
         /// </summary>
         void OnLBUTTONUP();
     }

--- a/Source/Krypton Components/Krypton.Docking/General/DockingMultiUpdate.cs
+++ b/Source/Krypton Components/Krypton.Docking/General/DockingMultiUpdate.cs
@@ -41,6 +41,7 @@ namespace Krypton.Docking
         {
             // Inform docking elements that a multi-part update has ended
             _dockingElement.PropogateAction(DockingPropogateAction.EndUpdate, (string[])null);
+            GC.SuppressFinalize(this);
         }
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Docking/Palette/DockingManagerStrings.cs
+++ b/Source/Krypton Components/Krypton.Docking/Palette/DockingManagerStrings.cs
@@ -54,7 +54,6 @@ namespace Krypton.Docking
         /// </summary>
         /// <param name="docking">Reference to owning docking manager.</param>
         public DockingManagerStrings(KryptonDockingManager docking)
-            : base()
         {
             // Default values
             _textAutoHide = DEFAULT_TEXT_AUTO_HIDE;

--- a/Source/Krypton Components/Krypton.Docking/ViewDraw/ViewDrawAutoHiddenTab.cs
+++ b/Source/Krypton Components/Krypton.Docking/ViewDraw/ViewDrawAutoHiddenTab.cs
@@ -20,7 +20,7 @@ namespace Krypton.Docking
     {
         #region Instance Fields
 
-        private VisualOrientation _orientation;
+        private readonly VisualOrientation _orientation;
         #endregion
 
         #region Identity

--- a/Source/Krypton Components/Krypton.Navigator/Controller/DragViewController.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Controller/DragViewController.cs
@@ -23,7 +23,6 @@ namespace Krypton.Navigator
     {
         #region Instance Fields
 
-        private bool _mouseOver;
         private bool _dragging;
         private bool _draggingAttempt;
         private DateTime _lastClick;
@@ -107,7 +106,6 @@ namespace Krypton.Navigator
         /// <param name="c">Reference to the source control instance.</param>
         public virtual void MouseEnter(Control c)
         {
-            _mouseOver = true;
         }
 
         /// <summary>
@@ -214,7 +212,6 @@ namespace Krypton.Navigator
             if (!Target.ContainsRecurse(next))
             {
                 // Mouse is no longer over the target
-                _mouseOver = false;
 
                 // Not tracking the mouse means a null value
                 MousePoint = CommonHelper.NullPoint; 
@@ -303,7 +300,7 @@ namespace Krypton.Navigator
                     }
 
                     // Recalculate if the mouse is over the button area
-                    _mouseOver = Target.ClientRectangle.Contains(c.PointToClient(Control.MousePosition));
+                    Target.ClientRectangle.Contains(c.PointToClient(Control.MousePosition));
                 }
             }
             
@@ -351,7 +348,7 @@ namespace Krypton.Navigator
                 }
 
                 // Recalculate if the mouse is over the button area
-                _mouseOver = Target.ClientRectangle.Contains(c.PointToClient(Control.MousePosition));
+                Target.ClientRectangle.Contains(c.PointToClient(Control.MousePosition));
             }
         }
         #endregion

--- a/Source/Krypton Components/Krypton.Navigator/Controller/OutlookMiniController.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Controller/OutlookMiniController.cs
@@ -358,10 +358,10 @@ namespace Krypton.Navigator
         protected void UpdateTargetState(Point pt)
         {
             // By default the button is in the normal state
-            PaletteState newState = PaletteState.Normal;
+            PaletteState newState;
 
             // When disabled the button itself is shown as normal, the 
-            // content is expected to draw itself as disbled though
+            // content is expected to draw itself as disabled though
             if (!_target.Enabled)
             {
                 newState = PaletteState.Normal;

--- a/Source/Krypton Components/Krypton.Navigator/Controls Navigator/KryptonNavigator.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Controls Navigator/KryptonNavigator.cs
@@ -546,7 +546,7 @@ namespace Krypton.Navigator
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public NavigatorButton Button { get; private set; }
 
-        private bool ShouldSerializeButtons() => !Button.IsDefault;
+        private bool ShouldSerializeButton() => !Button.IsDefault;
 
         /// <summary>
         /// Gets access to the group specific settings.
@@ -556,7 +556,7 @@ namespace Krypton.Navigator
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public NavigatorGroup Group { get; private set; }
 
-        private bool ShouldSerializeGroups() => !Group.IsDefault;
+        private bool ShouldSerializeGroup() => !Group.IsDefault;
 
         /// <summary>
         /// Gets access to the header specific settings.
@@ -566,7 +566,7 @@ namespace Krypton.Navigator
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public NavigatorHeader Header { get; private set; }
 
-        private bool ShouldSerializeHeaders() => !Header.IsDefault;
+        private bool ShouldSerializeHeader() => !Header.IsDefault;
 
         /// <summary>
         /// Gets access to the panels specific settings.
@@ -576,7 +576,7 @@ namespace Krypton.Navigator
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public NavigatorPanel Panel { get; private set; }
 
-        private bool ShouldSerializePanels() => !Panel.IsDefault;
+        private bool ShouldSerializePanel() => !Panel.IsDefault;
 
         /// <summary>
         /// Gets access to the popup page specific settings.
@@ -2093,15 +2093,7 @@ namespace Krypton.Navigator
                 }
 
                 // Create a list of the pages being dragged
-                if (page != null)
-                {
-                    _dragPages = new KryptonPage[] { page };
-                }
-                else
-                {
-                    // Providing 'null' means we want all the pages
-                    _dragPages = (from KryptonPage p in Pages select p).ToArray();
-                }
+                _dragPages = page != null ? new [] { page } : (from KryptonPage p in Pages select p).ToArray();
 
                 // Do any of the dragging pages have a flag set saying they can be dragged?
                 var allowPageDrag = _dragPages.Any(p => p.AreFlagsSet(KryptonPageFlags.AllowPageDrag));
@@ -2498,7 +2490,7 @@ namespace Krypton.Navigator
                 // If the page is the currently selected one...
                 if (SelectedPage == page)
                 {
-                    // And a change in a palette setting has occured...
+                    // And a change in a palette setting has occurred...
                     if (e.PropertyName == @"Palette")
                     {
                         // ...then need to repaint and layout to effect change

--- a/Source/Krypton Components/Krypton.Navigator/Controls Navigator/KryptonNavigatorControlCollection.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Controls Navigator/KryptonNavigatorControlCollection.cs
@@ -19,7 +19,7 @@ namespace Krypton.Navigator
     public class KryptonNavigatorControlCollection : KryptonControlCollection
     {
         #region Instance Fields
-        private KryptonNavigator _owner;
+        private readonly KryptonNavigator _owner;
         #endregion
 
         #region Identity

--- a/Source/Krypton Components/Krypton.Navigator/Dragging/DragFeedbackDocking.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Dragging/DragFeedbackDocking.cs
@@ -279,7 +279,7 @@ _hintToTarget.ContainsKey(DragTargetHint.Transfer))
             // Update the solid feedback rectangle with area of the specific target
             if (_solid != null)
             {
-                _solid.SolidRect = (matchTarget != null) ? matchTarget.DrawRect : Rectangle.Empty;
+                _solid.SolidRect = matchTarget?.DrawRect ?? Rectangle.Empty;
             }
 
             return matchTarget;

--- a/Source/Krypton Components/Krypton.Navigator/Dragging/DragFeedbackSolid.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Dragging/DragFeedbackSolid.cs
@@ -85,7 +85,7 @@ namespace Krypton.Navigator
 
             if (_solid != null)
             {
-                _solid.SolidRect = (target != null) ? target.DrawRect : Rectangle.Empty;
+                _solid.SolidRect = target?.DrawRect ?? Rectangle.Empty;
             }
 
             return target;

--- a/Source/Krypton Components/Krypton.Navigator/Page/KryptonPage.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Page/KryptonPage.cs
@@ -75,7 +75,9 @@ namespace Krypton.Navigator
         /// </summary>
         [Category("Page")]
         [Description("Occurs when an appearance specific page property has changed.")]
+#pragma warning disable CA1070 // Do not declare event fields as virtual
         public virtual event PropertyChangedEventHandler AppearancePropertyChanged;
+#pragma warning restore CA1070 // Do not declare event fields as virtual
 
         /// <summary>
         /// Occurs when the flags have changed.

--- a/Source/Krypton Components/Krypton.Navigator/Palette/NavigatorOutlookFull.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Palette/NavigatorOutlookFull.cs
@@ -19,7 +19,7 @@ namespace Krypton.Navigator
     public class NavigatorOutlookFull : Storage
     {
         #region Instance Fields
-        private KryptonNavigator _navigator;
+        private readonly KryptonNavigator _navigator;
         private MapKryptonPageText _overflowMapText;
         private MapKryptonPageText _overflowMapExtraText;
         private MapKryptonPageImage _overflowMapImage;

--- a/Source/Krypton Components/Krypton.Navigator/Palette/NavigatorPopupPages.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Palette/NavigatorPopupPages.cs
@@ -28,7 +28,7 @@ namespace Krypton.Navigator
         #endregion
 
         #region Instance Fields
-        private KryptonNavigator _navigator;
+        private readonly KryptonNavigator _navigator;
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Navigator/Palette/NavigatorToolTips.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Palette/NavigatorToolTips.cs
@@ -19,7 +19,7 @@ namespace Krypton.Navigator
 	public class NavigatorToolTips : Storage
 	{
 		#region Instance Fields
-		private KryptonNavigator _navigator;
+		private readonly KryptonNavigator _navigator;
 		private MapKryptonPageImage _mapImage;
 		#endregion
 

--- a/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderBase.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderBase.cs
@@ -125,7 +125,7 @@ namespace Krypton.Navigator
         }
 
         /// <summary>
-        /// Change has occured to the collection of pages.
+        /// Change has occurred to the collection of pages.
         /// </summary>
         public virtual void PageCollectionChanged()
         {
@@ -187,7 +187,7 @@ namespace Krypton.Navigator
         }
 
         /// <summary>
-        /// Gets the screen coorindates for showing a context action menu.
+        /// Gets the screen coordinates for showing a context action menu.
         /// </summary>
         /// <returns>Point in screen coordinates.</returns>
         public virtual Point GetContextShowPoint()
@@ -664,7 +664,7 @@ namespace Krypton.Navigator
             [DebuggerStepThrough]
             get =>
                 // Only create the delegate when it is first needed
-                _needPaintDelegate ?? (_needPaintDelegate = OnNeedPaint);
+                _needPaintDelegate ??= OnNeedPaint;
         }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderHeaderBarCheckButtonHeaderGroup.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderHeaderBarCheckButtonHeaderGroup.cs
@@ -207,7 +207,7 @@ namespace Krypton.Navigator
         }
 
         /// <summary>
-        /// Change has occured to the collection of pages.
+        /// Change has occurred to the collection of pages.
         /// </summary>
         public override void PageCollectionChanged()
         {
@@ -269,7 +269,7 @@ namespace Krypton.Navigator
         }
 
         /// <summary>
-        /// Gets the screen coorindates for showing a context action menu.
+        /// Gets the screen coordinates for showing a context action menu.
         /// </summary>
         /// <returns>Point in screen coordinates.</returns>
         public override Point GetContextShowPoint() =>

--- a/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderHeaderBarTabGroup.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderHeaderBarTabGroup.cs
@@ -70,7 +70,7 @@ namespace Krypton.Navigator
         }
 
         /// <summary>
-        /// Change has occured to the collection of pages.
+        /// Change has occurred to the collection of pages.
         /// </summary>
         public override void PageCollectionChanged()
         {
@@ -111,7 +111,7 @@ namespace Krypton.Navigator
         }
 
         /// <summary>
-        /// Gets the screen coorindates for showing a context action menu.
+        /// Gets the screen coordinates for showing a context action menu.
         /// </summary>
         /// <returns>Point in screen coordinates.</returns>
         public override Point GetContextShowPoint()

--- a/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderHeaderGroup.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderHeaderGroup.cs
@@ -108,7 +108,7 @@ namespace Krypton.Navigator
         }
 
         /// <summary>
-        /// Change has occured to the collection of pages.
+        /// Change has occurred to the collection of pages.
         /// </summary>
         public override void PageCollectionChanged()
         {
@@ -201,7 +201,7 @@ namespace Krypton.Navigator
         }
 
         /// <summary>
-        /// Gets the screen coorindates for showing a context action menu.
+        /// Gets the screen coordinates for showing a context action menu.
         /// </summary>
         /// <returns>Point in screen coordinates.</returns>
         public override Point GetContextShowPoint() =>
@@ -303,7 +303,10 @@ namespace Krypton.Navigator
 
                             if (!ce.Cancel)
                             {
-                                var changed = !shift ? SelectNextPage(Navigator.SelectedPage, true, true) : SelectPreviousPage(Navigator.SelectedPage, true, true);
+                                if (!shift)
+                                    SelectNextPage(Navigator.SelectedPage, true, true);
+                                else
+                                    SelectPreviousPage(Navigator.SelectedPage, true, true);
                             }
                         }
                         return true;

--- a/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderItemBase.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderItemBase.cs
@@ -136,7 +136,7 @@ namespace Krypton.Navigator
         }
 
         /// <summary>
-        /// Change has occured to the collection of pages.
+        /// Change has occurred to the collection of pages.
         /// </summary>
         public override void PageCollectionChanged()
         {
@@ -330,7 +330,7 @@ namespace Krypton.Navigator
         }
 
         /// <summary>
-        /// Gets the screen coorindates for showing a context action menu.
+        /// Gets the screen coordinates for showing a context action menu.
         /// </summary>
         /// <returns>Point in screen coordinates.</returns>
         public override Point GetContextShowPoint()
@@ -598,7 +598,10 @@ namespace Krypton.Navigator
 
                             if (!ce.Cancel)
                             {
-                                var changed = !shift ? SelectNextPage(Navigator.SelectedPage, true, true) : SelectPreviousPage(Navigator.SelectedPage, true, true);
+                                if (!shift)
+                                    SelectNextPage(Navigator.SelectedPage, true, true);
+                                else
+                                    SelectPreviousPage(Navigator.SelectedPage, true, true);
                             }
                         }
                         return true;

--- a/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderOutlookBase.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderOutlookBase.cs
@@ -393,7 +393,7 @@ namespace Krypton.Navigator
         }
 
         /// <summary>
-        /// Change has occured to the collection of pages.
+        /// Change has occurred to the collection of pages.
         /// </summary>
         public override void PageCollectionChanged()
         {
@@ -716,7 +716,10 @@ namespace Krypton.Navigator
 
                             if (!ce.Cancel)
                             {
-                                var changed = !shift ? SelectNextPage(Navigator.SelectedPage, true, true) : SelectPreviousPage(Navigator.SelectedPage, true, true);
+                                if (!shift)
+                                    SelectNextPage(Navigator.SelectedPage, true, true);
+                                else
+                                    SelectPreviousPage(Navigator.SelectedPage, true, true);
                             }
                         }
                         return true;
@@ -939,7 +942,7 @@ namespace Krypton.Navigator
         }
 
         /// <summary>
-        /// Gets the screen coorindates for showing a context action menu.
+        /// Gets the screen coordinates for showing a context action menu.
         /// </summary>
         /// <returns>Point in screen coordinates.</returns>
         public override Point GetContextShowPoint() =>
@@ -2376,9 +2379,7 @@ namespace Krypton.Navigator
 
         private void RecreateView()
         {
-            VisualOrientation checkButtonOrient = ResolveStackButtonOrientation();
             Orientation stackOrient = Navigator.Outlook.Orientation;
-            Orientation buttonEdgeOrient = (stackOrient == Orientation.Vertical ? Orientation.Horizontal : Orientation.Vertical);
             ViewDockStyle dockFar = (stackOrient == Orientation.Vertical ? ViewDockStyle.Bottom : ViewDockStyle.Right);
 
             // Remove all existing layout items

--- a/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderOutlookMini.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderOutlookMini.cs
@@ -68,10 +68,6 @@ namespace Krypton.Navigator
         /// <returns>True if the key eaten; otherwise false.</returns>
         public override bool ProcessDialogKey(Keys keyData)
         {
-            // Find out which modifier keys are being pressed
-            var shift = ((keyData & Keys.Shift) == Keys.Shift);
-            var control = ((keyData & Keys.Control) == Keys.Control);
-
             // Extract just the key and not modifier keys
             Keys keyCode = (keyData & Keys.KeyCode);
 

--- a/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderStackCheckButtonBase.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderStackCheckButtonBase.cs
@@ -389,7 +389,10 @@ namespace Krypton.Navigator
 
                             if (!ce.Cancel)
                             {
-                                var changed = !shift ? SelectNextPage(Navigator.SelectedPage, true, true) : SelectPreviousPage(Navigator.SelectedPage, true, true);
+                                if (!shift)
+                                    SelectNextPage(Navigator.SelectedPage, true, true);
+                                else
+                                    SelectPreviousPage(Navigator.SelectedPage, true, true);
                             }
                         }
                         return true;

--- a/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderStackCheckButtonHeaderGroup.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderStackCheckButtonHeaderGroup.cs
@@ -51,7 +51,7 @@ namespace Krypton.Navigator
         }
 
         /// <summary>
-        /// Change has occured to the collection of pages.
+        /// Change has occurred to the collection of pages.
         /// </summary>
         public override void PageCollectionChanged()
         {
@@ -113,7 +113,7 @@ namespace Krypton.Navigator
         }
 
         /// <summary>
-        /// Gets the screen coorindates for showing a context action menu.
+        /// Gets the screen coordinates for showing a context action menu.
         /// </summary>
         /// <returns>Point in screen coordinates.</returns>
         public override Point GetContextShowPoint() =>

--- a/Source/Krypton Components/Krypton.Navigator/View Builder/ViewletHeaderGroup.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Builder/ViewletHeaderGroup.cs
@@ -158,7 +158,7 @@ namespace Krypton.Navigator
         }
 
         /// <summary>
-        /// Gets the screen coorindates for showing a context action menu.
+        /// Gets the screen coordinates for showing a context action menu.
         /// </summary>
         /// <returns>Point in screen coordinates.</returns>
         public Point GetContextShowPoint()

--- a/Source/Krypton Components/Krypton.Navigator/View Draw/ViewDrawNavRibbonTab.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Draw/ViewDrawNavRibbonTab.cs
@@ -309,7 +309,7 @@ namespace Krypton.Navigator
             CheckPaletteState(context);
             
             // Cache the ribbon shape
-            _lastRibbonShape = (Navigator.Palette == null ? PaletteRibbonShape.Office2007 : Navigator.Palette.GetRibbonShape());
+            _lastRibbonShape = Navigator.Palette?.GetRibbonShape() ?? PaletteRibbonShape.Office2007;
             
             // We take on all the provided size
             ClientRectangle = context.DisplayRectangle;

--- a/Source/Krypton Components/Krypton.Navigator/View Layout/ViewLayoutBar.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Layout/ViewLayoutBar.cs
@@ -832,7 +832,6 @@ namespace Krypton.Navigator
             ClientRectangle = context.DisplayRectangle;
 
             // Start laying out children from the top left
-            Point pt = ClientLocation;
 
             // Nothing to calculate if there are no children
             if (Count > 0)

--- a/Source/Krypton Components/Krypton.Navigator/View Layout/ViewLayoutInsetOverlap.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Layout/ViewLayoutInsetOverlap.cs
@@ -143,7 +143,7 @@ namespace Krypton.Navigator
             }
 
             // Convert childRectF to a 'int' Rectangle
-            Rectangle childRect = new Rectangle((int)childRectF.X, (int)childRectF.Y, (int)childRectF.Width, (int)childRectF.Height);
+            var childRect = new Rectangle((int)childRectF.X, (int)childRectF.Y, (int)childRectF.Width, (int)childRectF.Height);
 
             // Inform each child to layout inside the reduced rectangle
             foreach (ViewBase child in this)

--- a/Source/Krypton Components/Krypton.Navigator/View Layout/ViewLayoutOutlookFull.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Layout/ViewLayoutOutlookFull.cs
@@ -175,7 +175,7 @@ namespace Krypton.Navigator
 
             } while (relayout);
 
-            // Now all layouts have occured we can actually move child controls
+            // Now all layouts have occurred we can actually move child controls
             context.ViewManager.DoNotLayoutControls = false;
 
             // Perform actual layout of child controls

--- a/Source/Krypton Components/Krypton.Ribbon/Controller/CollapsedGroupController.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controller/CollapsedGroupController.cs
@@ -295,12 +295,9 @@ namespace Krypton.Ribbon
                 case Keys.Space:
                 case Keys.Enter:
                     OnClick(new MouseEventArgs(MouseButtons.Left, 1, 0, 0, 0));
-
                     // Get access to the popup for the group
-                    if (VisualPopupManager.Singleton.CurrentPopup is VisualPopupGroup)
+                    if (VisualPopupManager.Singleton.CurrentPopup is VisualPopupGroup popupGroup)
                     {
-                        // Cast to correct type
-                        VisualPopupGroup popupGroup = (VisualPopupGroup)VisualPopupManager.Singleton.CurrentPopup;
                         popupGroup.SetFirstFocusItem();
                     }
                     break;
@@ -338,10 +335,8 @@ namespace Krypton.Ribbon
                     OnClick(new MouseEventArgs(MouseButtons.Left, 1, 0, 0, 0));
 
                     // Get access to the popup for the group
-                    if (VisualPopupManager.Singleton.CurrentPopup is VisualPopupGroup)
+                    if (VisualPopupManager.Singleton.CurrentPopup is VisualPopupGroup popup)
                     {
-                        // Cast to correct type
-                        VisualPopupGroup popup = (VisualPopupGroup)VisualPopupManager.Singleton.CurrentPopup;
                         popup.SetFirstFocusItem();
                     }
                     break;
@@ -365,10 +360,8 @@ namespace Krypton.Ribbon
                     OnClick(new MouseEventArgs(MouseButtons.Left, 1, 0, 0, 0));
 
                     // Get access to the popup for the group
-                    if (VisualPopupManager.Singleton.CurrentPopup is VisualPopupGroup)
+                    if (VisualPopupManager.Singleton.CurrentPopup is VisualPopupGroup popupGroup)
                     {
-                        // Cast to correct type
-                        VisualPopupGroup popupGroup = (VisualPopupGroup)VisualPopupManager.Singleton.CurrentPopup;
                         popupGroup.SetFirstFocusItem();
                     }
                     break;

--- a/Source/Krypton Components/Krypton.Ribbon/Controller/GalleryItemController.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controller/GalleryItemController.cs
@@ -402,7 +402,7 @@ namespace Krypton.Ribbon
         protected virtual void UpdateTargetState(Point pt)
         {
             // By default the button is in the normal state
-            PaletteState newState = PaletteState.Normal;
+            PaletteState newState;
 
             // If the button is disabled then show as disabled
             if (!_target.Enabled)

--- a/Source/Krypton Components/Krypton.Ribbon/Controller/GroupButtonController.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controller/GroupButtonController.cs
@@ -530,10 +530,10 @@ namespace Krypton.Ribbon
         protected void UpdateTargetState(Point pt)
         {
             // By default the button is in the normal state
-            PaletteState newState = PaletteState.Normal;
+            PaletteState newState;
 
             // When disabled the button itself is shown as normal, the 
-            // content is expected to draw itself as disbled though
+            // content is expected to draw itself as disabled though
             if (!_target.Enabled)
             {
                 newState = PaletteState.Normal;

--- a/Source/Krypton Components/Krypton.Ribbon/Controller/LeftUpButtonController.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controller/LeftUpButtonController.cs
@@ -268,7 +268,7 @@ namespace Krypton.Ribbon
         protected virtual void UpdateTargetState(Point pt)
         {
             // By default the button is in the normal state
-            PaletteState newState = PaletteState.Normal;
+            PaletteState newState;
 
             // If the button is disabled then show as disabled
             if (!Target.Enabled)

--- a/Source/Krypton Components/Krypton.Ribbon/Controller/NullController.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controller/NullController.cs
@@ -36,7 +36,7 @@ namespace Krypton.Ribbon
         /// <summary>
         /// Gets access to the single instance of the controller.
         /// </summary>
-        public static NullController Singleton => _singleton ?? (_singleton = new NullController());
+        public static NullController Singleton => _singleton ??= new NullController();
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Ribbon/Controller/QATExtraButtonController.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controller/QATExtraButtonController.cs
@@ -142,12 +142,10 @@ namespace Krypton.Ribbon
             OnClick(new MouseEventArgs(MouseButtons.Left, 1, 0, 0, 0));
 
             // We should have a visual popup for showing the qat overflow group
-            if (VisualPopupManager.Singleton.IsTracking &&
-                (VisualPopupManager.Singleton.CurrentPopup is VisualPopupQATOverflow))
+            if (VisualPopupManager.Singleton.IsTracking 
+                && (VisualPopupManager.Singleton.CurrentPopup is VisualPopupQATOverflow popupOverflow)
+                )
             {
-                // Cast to correct type
-                VisualPopupQATOverflow popupOverflow = (VisualPopupQATOverflow)VisualPopupManager.Singleton.CurrentPopup;
-
                 // Grab the list of key tips from the popup group
                 Ribbon.KeyTipMode = KeyTipMode.PopupQATOverflow;
                 KeyTipInfoList keyTipList = new();
@@ -211,11 +209,10 @@ namespace Krypton.Ribbon
                     OnClick(new MouseEventArgs(MouseButtons.Left, 1, 0, 0, 0));
 
                     // Get access to the popup for the group
-                    if (!VisualPopupManager.Singleton.IsShowingCMS &&
-                        VisualPopupManager.Singleton.CurrentPopup is VisualPopupQATOverflow)
+                    if (!VisualPopupManager.Singleton.IsShowingCMS
+                        && (VisualPopupManager.Singleton.CurrentPopup is VisualPopupQATOverflow popupOverflow)
+                        )
                     {
-                        // Cast to correct type
-                        VisualPopupQATOverflow popupOverflow = (VisualPopupQATOverflow)VisualPopupManager.Singleton.CurrentPopup;
                         popupOverflow.SetFirstFocusItem();
                     }
                     break;
@@ -259,11 +256,10 @@ namespace Krypton.Ribbon
                     OnClick(new MouseEventArgs(MouseButtons.Left, 1, 0, 0, 0));
 
                     // Get access to the popup for the group
-                    if (!VisualPopupManager.Singleton.IsShowingCMS &&
-                        VisualPopupManager.Singleton.CurrentPopup is VisualPopupQATOverflow)
+                    if (!VisualPopupManager.Singleton.IsShowingCMS 
+                        && (VisualPopupManager.Singleton.CurrentPopup is VisualPopupQATOverflow popupOverflow)
+                        )
                     {
-                        // Cast to correct type
-                        VisualPopupQATOverflow popupOverflow = (VisualPopupQATOverflow)VisualPopupManager.Singleton.CurrentPopup;
                         popupOverflow.SetFirstFocusItem();
                     }
                     break;

--- a/Source/Krypton Components/Krypton.Ribbon/Controller/RepeatButtonController.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controller/RepeatButtonController.cs
@@ -256,7 +256,7 @@ namespace Krypton.Ribbon
         protected void UpdateTargetState(Point pt)
         {
             // By default the button is in the normal state
-            PaletteState newState = PaletteState.Normal;
+            PaletteState newState;
 
             // If the button is disabled then show as disabled
             if (!_target.Enabled)

--- a/Source/Krypton Components/Krypton.Ribbon/Controller/RibbonTabController.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controller/RibbonTabController.cs
@@ -339,10 +339,8 @@ namespace Krypton.Ribbon
                         _ribbon.SelectedTab = _target.RibbonTab;
 
                         // Get access to the popup for the group
-                        if (VisualPopupManager.Singleton.CurrentPopup is VisualPopupMinimized)
+                        if (VisualPopupManager.Singleton.CurrentPopup is VisualPopupMinimized popupMinimized)
                         {
-                            // Cast to correct type
-                            VisualPopupMinimized popupMinimized = (VisualPopupMinimized)VisualPopupManager.Singleton.CurrentPopup;
                             popupMinimized.SetFirstFocusItem();
                         }
                     }

--- a/Source/Krypton Components/Krypton.Ribbon/Controller/RibbonTabsController.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controller/RibbonTabsController.cs
@@ -20,7 +20,7 @@ namespace Krypton.Ribbon
                                           IMouseController
     {
         #region Instance Fields
-        private KryptonRibbon _ribbon;
+        private readonly KryptonRibbon _ribbon;
         private bool _rightButtonDown;
         #endregion
 

--- a/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonRibbon.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonRibbon.cs
@@ -1487,7 +1487,7 @@ namespace Krypton.Ribbon
             // Check if a shortcut is triggered on the application button context menu
             if (RibbonAppButton.AppButtonMenuItems.ProcessShortcut(keyData))
             {
-                ActionOccured();
+                Actionoccurred();
                 return true;
             }
 
@@ -2444,7 +2444,7 @@ namespace Krypton.Ribbon
             }
         }
 
-        internal void ActionOccured()
+        internal void Actionoccurred()
         {
             // If showing the popup in minimized mode, then remove it gracefully
             if (_minimizedPopup != null)

--- a/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonRibbonGroup.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonRibbonGroup.cs
@@ -490,7 +490,7 @@ namespace Krypton.Ribbon
         {
             // Perform processing that is common to any action that would dismiss
             // any popup controls such as the showing minimized group popup
-            Ribbon?.ActionOccured();
+            Ribbon?.Actionoccurred();
 
             DialogBoxLauncherClick?.Invoke(this, e);
         }

--- a/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonRibbonQATButton.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonRibbonQATButton.cs
@@ -101,7 +101,7 @@ namespace Krypton.Ribbon
                         // quick access toolbar. So we reject anything bigger than 16x16.
                         if ((value.Width > 16) || (value.Height > 16))
                         {
-                            throw new ArgumentOutOfRangeException("Image must be 16x16 or smaller.");
+                            throw new ArgumentOutOfRangeException(nameof(Image), @"Image must be 16x16 or smaller.");
                         }
                     }
 
@@ -491,7 +491,7 @@ namespace Krypton.Ribbon
         {
             // Perform processing that is common to any action that would dismiss
             // any popup controls such as the showing minimized group popup
-            Ribbon?.ActionOccured();
+            Ribbon?.Actionoccurred();
 
             Click?.Invoke(this, e);
 

--- a/Source/Krypton Components/Krypton.Ribbon/Controls Visuals/VisualPopupAppMenu.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controls Visuals/VisualPopupAppMenu.cs
@@ -29,7 +29,7 @@ namespace Krypton.Ribbon
         private ViewLayoutDocker _viewButtonSpecDocker;
         private ButtonSpecManagerLayout _buttonManager;
         private readonly Rectangle _rectAppButtonBottomHalf;
-        private Rectangle _rectAppButtonTopHalf;
+        private readonly Rectangle _rectAppButtonTopHalf;
         #endregion
 
         #region Identity

--- a/Source/Krypton Components/Krypton.Ribbon/General/Definitions.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/General/Definitions.cs
@@ -159,6 +159,9 @@ namespace Krypton.Ribbon
         /// <returns>ViewBase derived instance.</returns>
         ViewBase CreateView(KryptonRibbon ribbon, NeedPaintHandler needPaint);
 
+        /// <summary>
+        /// Return base objects tooltip
+        /// </summary>
         ToolTipValues ToolTipValues 
         { 
             // Return base objects tooltip

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupItem.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupItem.cs
@@ -213,7 +213,7 @@ namespace Krypton.Ribbon
         [Browsable(false)]
         public BindingContext BindingContext
         {
-            get => bindingContext ?? (bindingContext = new BindingContext());
+            get => bindingContext ??= new BindingContext();
             set => bindingContext = value;
         }
 
@@ -225,7 +225,7 @@ namespace Krypton.Ribbon
         [Description(@"ControlBindings")]
         [RefreshProperties(RefreshProperties.All)]
         [ParenthesizePropertyName(true)]
-        public ControlBindingsCollection DataBindings => dataBindings ?? (dataBindings = new ControlBindingsCollection(this));
+        public ControlBindingsCollection DataBindings => dataBindings ??= new ControlBindingsCollection(this);
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupLines.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupLines.cs
@@ -392,7 +392,7 @@ namespace Krypton.Ribbon
                     }
 
                     // Update all contained elements to reflect the same sizing
-                    GroupItemSize itemSize = LinesToItemSize(_itemSizeMin);
+                    _ = LinesToItemSize(_itemSizeMin);
                     foreach (IRibbonGroupItem item in Items)
                     {
                         item.ItemSizeMinimum = value;

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupThemeSelector.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupThemeSelector.cs
@@ -1,8 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿#region BSD License
+/*
+ * 
+ * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
+ *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
+ * 
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2022. All rights reserved. 
+ *  
+ */
+#endregion
+
 
 namespace Krypton.Ribbon
 {
@@ -20,7 +27,7 @@ namespace Krypton.Ribbon
     {
         #region Instance Fields
 
-        private string[] _themeArray = new string[]
+        private readonly string[] _themeArray = new string[]
         {
             "Professional - System",
 
@@ -113,7 +120,7 @@ namespace Krypton.Ribbon
 
         public KryptonRibbonGroupThemeSelector()
         {
-            foreach (string theme in _themeArray)
+            foreach (var theme in _themeArray)
             {
                 Items.Add(theme);
             }

--- a/Source/Krypton Components/Krypton.Ribbon/Palette/PaletteRibbonContextBack.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Palette/PaletteRibbonContextBack.cs
@@ -68,7 +68,7 @@ namespace Krypton.Ribbon
             // If empty then try and recover the context specific color
             if (retColor == Color.Empty)
             {
-                retColor = CheckForContextColor(state);
+                retColor = CheckForContextColor();
             }
 
             return retColor;
@@ -88,7 +88,7 @@ namespace Krypton.Ribbon
             // If empty then try and recover the context specific color
             if (retColor == Color.Empty)
             {
-                retColor = CheckForContextColor(state);
+                retColor = CheckForContextColor();
             }
 
             return retColor;
@@ -108,7 +108,7 @@ namespace Krypton.Ribbon
             // If empty then try and recover the context specific color
             if (retColor == Color.Empty)
             {
-                retColor = CheckForContextColor(state);
+                retColor = CheckForContextColor();
             }
             else
             {
@@ -117,7 +117,7 @@ namespace Krypton.Ribbon
                     (state == PaletteState.ContextPressed))
                 {
                     // For context drawing we merge the incoming color and the context color
-                    Color contextColor = CheckForContextColor(state);
+                    Color contextColor = CheckForContextColor();
                     return CommonHelper.MergeColors(retColor, 0.5f, contextColor, 0.5f);
                 }
             }
@@ -139,7 +139,7 @@ namespace Krypton.Ribbon
             // If empty then try and recover the context specific color
             if (retColor == Color.Empty)
             {
-                retColor = CheckForContextColor(state);
+                retColor = CheckForContextColor();
             }
 
             return retColor;
@@ -159,7 +159,7 @@ namespace Krypton.Ribbon
             // If empty then try and recover the context specific color
             if (retColor == Color.Empty)
             {
-                retColor = CheckForContextColor(state);
+                retColor = CheckForContextColor();
             }
 
             return retColor;
@@ -167,7 +167,7 @@ namespace Krypton.Ribbon
         #endregion
 
         #region Implementation
-        private Color CheckForContextColor(PaletteState state)
+        private Color CheckForContextColor()
         {
             // We need an associated ribbon tab
             // Does the ribbon tab have a context setting?

--- a/Source/Krypton Components/Krypton.Ribbon/Palette/QATButtonToContent.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Palette/QATButtonToContent.cs
@@ -16,7 +16,7 @@ namespace Krypton.Ribbon
     internal class QATButtonToContent : IPaletteContent
     {
         #region Instance Fields
-        private IQuickAccessToolbarButton _qatButton;
+        private readonly IQuickAccessToolbarButton _qatButton;
         #endregion
 
         #region Identity

--- a/Source/Krypton Components/Krypton.Ribbon/Palette/RibbonThemeManager.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Palette/RibbonThemeManager.cs
@@ -142,109 +142,71 @@ namespace Krypton.Ribbon
         /// <exception cref="ArgumentNullException"></exception>
         private static void ApplyTheme(string themeName, KryptonManager manager)
         {
-            if (themeName == "Custom")
+            switch (themeName)
             {
-                ApplyTheme(PaletteModeManager.Custom, manager);
-            }
-
-            if (themeName == "Professional - System")
-            {
-                ApplyTheme(PaletteModeManager.ProfessionalSystem, manager);
-            }
-
-            if (themeName == "Professional - Office 2003")
-            {
-                ApplyTheme(PaletteModeManager.ProfessionalOffice2003, manager);
-            }
-
-            if (themeName == "Office 2007 - Blue")
-            {
-                ApplyTheme(PaletteModeManager.Office2007Blue, manager);
-            }
-
-            if (themeName == "Office 2007 - Silver")
-            {
-                ApplyTheme(PaletteModeManager.Office2007Silver, manager);
-            }
-
-            if (themeName == "Office 2007 - White")
-            {
-                ApplyTheme(PaletteModeManager.Office2007White, manager);
-            }
-
-            if (themeName == "Office 2007 - Black")
-            {
-                ApplyTheme(PaletteModeManager.Office2007Black, manager);
-            }
-
-            if (themeName == "Office 2010 - Blue")
-            {
-                ApplyTheme(PaletteModeManager.Office2010Blue, manager);
-            }
-
-            if (themeName == "Office 2010 - Silver")
-            {
-                ApplyTheme(PaletteModeManager.Office2010Silver, manager);
-            }
-
-            if (themeName == "Office 2010 - White")
-            {
-                ApplyTheme(PaletteModeManager.Office2010White, manager);
-            }
-
-            if (themeName == "Office 2010 - Black")
-            {
-                ApplyTheme(PaletteModeManager.Office2010Black, manager);
-            }
-
-            /*if (themeName == "Office 2013")
+                case "Custom":
+                    ApplyTheme(PaletteModeManager.Custom, manager);
+                    break;
+                case "Professional - System":
+                    ApplyTheme(PaletteModeManager.ProfessionalSystem, manager);
+                    break;
+                case "Professional - Office 2003":
+                    ApplyTheme(PaletteModeManager.ProfessionalOffice2003, manager);
+                    break;
+                case "Office 2007 - Blue":
+                    ApplyTheme(PaletteModeManager.Office2007Blue, manager);
+                    break;
+                case "Office 2007 - Silver":
+                    ApplyTheme(PaletteModeManager.Office2007Silver, manager);
+                    break;
+                case "Office 2007 - White":
+                    ApplyTheme(PaletteModeManager.Office2007White, manager);
+                    break;
+                case "Office 2007 - Black":
+                    ApplyTheme(PaletteModeManager.Office2007Black, manager);
+                    break;
+                case "Office 2010 - Blue":
+                    ApplyTheme(PaletteModeManager.Office2010Blue, manager);
+                    break;
+                case "Office 2010 - Silver":
+                    ApplyTheme(PaletteModeManager.Office2010Silver, manager);
+                    break;
+                case "Office 2010 - White":
+                    ApplyTheme(PaletteModeManager.Office2010White, manager);
+                    break;
+                case "Office 2010 - Black":
+                    ApplyTheme(PaletteModeManager.Office2010Black, manager);
+                    break;
+                /*if (themeName == "Office 2013")
             {
                 ApplyTheme(PaletteModeManager.Office2013, manager);
             }*/
-
-            if (themeName == "Office 2013 - White")
-            {
-                ApplyTheme(PaletteModeManager.Office2013White, manager);
-            }
-
-            if (themeName == "Sparkle - Blue")
-            {
-                ApplyTheme(PaletteModeManager.SparkleBlue, manager);
-            }
-
-            if (themeName == "Sparkle - Orange")
-            {
-                ApplyTheme(PaletteModeManager.SparkleOrange, manager);
-            }
-
-            if (themeName == "Sparkle - Purple")
-            {
-                ApplyTheme(PaletteModeManager.SparklePurple, manager);
-            }
-
-            if (themeName == "Office 365 - Black")
-            {
-                ApplyTheme(PaletteModeManager.Office365Black, manager);
-            }
-
-            if (themeName == "Office 365 - Blue")
-            {
-                ApplyTheme(PaletteModeManager.Office365Blue, manager);
-            }
-
-            if (themeName == "Office 365 - Silver")
-            {
-                ApplyTheme(PaletteModeManager.Office365Silver, manager);
-            }
-
-            if (themeName == "Office 365 - White")
-            {
-                ApplyTheme(PaletteModeManager.Office365White, manager);
-            }
-
-            if (string.IsNullOrEmpty(themeName))
-            {
-                throw new ArgumentNullException();
+                case "Office 2013 - White":
+                    ApplyTheme(PaletteModeManager.Office2013White, manager);
+                    break;
+                case "Sparkle - Blue":
+                    ApplyTheme(PaletteModeManager.SparkleBlue, manager);
+                    break;
+                case "Sparkle - Orange":
+                    ApplyTheme(PaletteModeManager.SparkleOrange, manager);
+                    break;
+                case "Sparkle - Purple":
+                    ApplyTheme(PaletteModeManager.SparklePurple, manager);
+                    break;
+                case "Office 365 - Black":
+                    ApplyTheme(PaletteModeManager.Office365Black, manager);
+                    break;
+                case "Office 365 - Blue":
+                    ApplyTheme(PaletteModeManager.Office365Blue, manager);
+                    break;
+                case "Office 365 - Silver":
+                    ApplyTheme(PaletteModeManager.Office365Silver, manager);
+                    break;
+                case "Office 365 - White":
+                    ApplyTheme(PaletteModeManager.Office365White, manager);
+                    break;
+                default:
+                    throw new ArgumentNullException(nameof(themeName));
             }
         }
 

--- a/Source/Krypton Components/Krypton.Ribbon/Ribbon/KryptonRibbonGroupComboBoxDesigner.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Ribbon/KryptonRibbonGroupComboBoxDesigner.cs
@@ -150,7 +150,7 @@ namespace Krypton.Ribbon
             base.PreFilterProperties(properties);
 
             // Setup the array of properties we override
-            var attributes = new Attribute[0];
+            var attributes = Array.Empty<Attribute>();
             string[] strArray = { "Visible", "Enabled" };
 
             // Adjust our list of properties

--- a/Source/Krypton Components/Krypton.Ribbon/Ribbon/KryptonRibbonGroupDateTimePickerDesigner.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Ribbon/KryptonRibbonGroupDateTimePickerDesigner.cs
@@ -150,7 +150,7 @@ namespace Krypton.Ribbon
             base.PreFilterProperties(properties);
 
             // Setup the array of properties we override
-            var attributes = new Attribute[0];
+            var attributes = Array.Empty<Attribute>();
             string[] strArray = { "Visible", "Enabled" };
 
             // Adjust our list of properties

--- a/Source/Krypton Components/Krypton.Ribbon/Ribbon/KryptonRibbonGroupGalleryDesigner.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Ribbon/KryptonRibbonGroupGalleryDesigner.cs
@@ -159,7 +159,7 @@ namespace Krypton.Ribbon
             base.PreFilterProperties(properties);
 
             // Setup the array of properties we override
-            var attributes = new Attribute[0];
+            var attributes = Array.Empty<Attribute>();
             string[] strArray = { "Visible", "Enabled" };
 
             // Adjust our list of properties

--- a/Source/Krypton Components/Krypton.Ribbon/Ribbon/KryptonRibbonGroupNumericUpDownDesigner.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Ribbon/KryptonRibbonGroupNumericUpDownDesigner.cs
@@ -150,14 +150,13 @@ namespace Krypton.Ribbon
             base.PreFilterProperties(properties);
 
             // Setup the array of properties we override
-            var attributes = new Attribute[0];
+            var attributes = Array.Empty<Attribute>();
             string[] strArray = { "Visible", "Enabled" };
 
             // Adjust our list of properties
             for (var i = 0; i < strArray.Length; i++)
             {
-                PropertyDescriptor descrip = (PropertyDescriptor)properties[strArray[i]];
-                if (descrip != null)
+                if (properties[strArray[i]] is PropertyDescriptor descrip)
                 {
                     properties[strArray[i]] = TypeDescriptor.CreateProperty(typeof(KryptonRibbonGroupNumericUpDownDesigner), descrip, attributes);
                 }

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonAppButton.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonAppButton.cs
@@ -86,7 +86,7 @@ namespace Krypton.Ribbon
         /// </summary>
         public override bool Visible
         {
-            get => base.Visible && ((Parent == null) ? true : Parent.Visible);
+            get => base.Visible && (Parent?.Visible ?? true);
             set => base.Visible = value;
         }
         #endregion

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonAppMenu.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonAppMenu.cs
@@ -20,7 +20,7 @@ namespace Krypton.Ribbon
     {
         #region Instance Fields
         private readonly ViewBase _fixedElement;
-        private Rectangle _fixedScreenRect;
+        private readonly Rectangle _fixedScreenRect;
         #endregion
 
         #region Identity

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonCaptionArea.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonCaptionArea.cs
@@ -686,12 +686,12 @@ namespace Krypton.Ribbon
         #endregion
 
         #region Instance Fields
-        private KryptonRibbon _ribbon;
-        private NeedPaintHandler _needPaintDelegate;
-        private NeedPaintHandler _needIntegratedDelegate;
-        private PaletteCaptionRedirect _redirect;
+        private readonly KryptonRibbon _ribbon;
+        private readonly NeedPaintHandler _needPaintDelegate;
+        private readonly NeedPaintHandler _needIntegratedDelegate;
+        private readonly PaletteCaptionRedirect _redirect;
         private PaletteDoubleRedirect _redirectCaption;
-        private ViewDrawRibbonComposition _compositionArea;
+        private readonly ViewDrawRibbonComposition _compositionArea;
         private ViewLayoutRibbonAppButton _captionAppButton;
         private ViewLayoutRibbonAppButton _otherAppButton;
         private ViewLayoutSeparator _spaceInsteadOfAppButton;

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonComposition.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonComposition.cs
@@ -29,7 +29,7 @@ namespace Krypton.Ribbon
         private readonly KryptonRibbon _ribbon;
         private VisualForm _ownerForm;
         private readonly NeedPaintHandler _needPaint;
-        private Blend _compBlend;
+        private readonly Blend _compBlend;
         #endregion
 
         #region Identity
@@ -144,7 +144,7 @@ namespace Krypton.Ribbon
         /// Discover the preferred size of the element.
         /// </summary>
         /// <param name="context">Layout context.</param>
-        public override Size GetPreferredSize(ViewLayoutContext context) => new Size(0, CONSTANT_COMPOSITION_HEIGHT);
+        public override Size GetPreferredSize(ViewLayoutContext context) => new (0, CONSTANT_COMPOSITION_HEIGHT);
 
         /// <summary>
         /// Perform a layout of the elements.

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonDesignBase.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonDesignBase.cs
@@ -21,7 +21,7 @@ namespace Krypton.Ribbon
     {
         #region Instance Fields
 
-        private NeedPaintHandler _needPaint;
+        private readonly NeedPaintHandler _needPaint;
         private readonly DesignTextToContent _contentProvider;
         #endregion
 

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGalleryButton.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGalleryButton.cs
@@ -29,7 +29,7 @@ namespace Krypton.Ribbon
         private readonly PaletteRelativeAlign _alignment;
         private IDisposable _mementoBack;
         private IDisposable _mementoContent;
-        private NeedPaintHandler _needPaint;
+        private readonly NeedPaintHandler _needPaint;
         #endregion
 
         #region Events

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupButtonBackBorder.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupButtonBackBorder.cs
@@ -730,7 +730,7 @@ namespace Krypton.Ribbon
             // Remove any popups that result from an action occuring
             if ((_ribbon != null) && fireAction)
             {
-                _ribbon.ActionOccured();
+                _ribbon.Actionoccurred();
             }
 
             // Remove the fixed pressed appearance

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupCheckBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupCheckBox.cs
@@ -473,7 +473,7 @@ namespace Krypton.Ribbon
         private void ActionFinishedLarge(object sender, EventArgs e)
         {
             // Remove any popups that result from an action occuring
-            _ribbon?.ActionOccured();
+            _ribbon?.Actionoccurred();
 
             // Remove the fixed pressed appearance
             _viewLargeController.RemoveFixed();
@@ -482,7 +482,7 @@ namespace Krypton.Ribbon
         private void ActionFinishedMediumSmall(object sender, EventArgs e)
         {
             // Remove any popups that result from an action occuring
-            _ribbon?.ActionOccured();
+            _ribbon?.Actionoccurred();
 
             // Remove the fixed pressed appearance
             _viewMediumSmallController.RemoveFixed();

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupCheckBoxImage.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupCheckBoxImage.cs
@@ -24,7 +24,7 @@ namespace Krypton.Ribbon
         #endregion
 
         #region Instance Fields
-        private KryptonRibbonGroupCheckBox _ribbonCheckBox;
+        private readonly KryptonRibbonGroupCheckBox _ribbonCheckBox;
         private readonly ViewDrawCheckBox _drawCheckBox;
         private readonly bool _large;
         #endregion

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupRadioButton.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupRadioButton.cs
@@ -463,7 +463,7 @@ namespace Krypton.Ribbon
         private void ActionFinishedLarge(object sender, EventArgs e)
         {
             // Remove any popups that result from an action occuring
-            _ribbon?.ActionOccured();
+            _ribbon?.Actionoccurred();
 
             // Remove the fixed pressed appearance
             _viewLargeController.RemoveFixed();
@@ -472,7 +472,7 @@ namespace Krypton.Ribbon
         private void ActionFinishedMediumSmall(object sender, EventArgs e)
         {
             // Remove any popups that result from an action occuring
-            _ribbon?.ActionOccured();
+            _ribbon?.Actionoccurred();
 
             // Remove the fixed pressed appearance
             _viewMediumSmallController.RemoveFixed();

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupRadioButtonImage.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupRadioButtonImage.cs
@@ -24,7 +24,7 @@ namespace Krypton.Ribbon
         #endregion
 
         #region Instance Fields
-        private KryptonRibbonGroupRadioButton _ribbonRadioButton;
+        private readonly KryptonRibbonGroupRadioButton _ribbonRadioButton;
         private readonly ViewDrawRadioButton _drawRadioButton;
         private readonly bool _large;
         #endregion

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupTitle.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupTitle.cs
@@ -110,7 +110,7 @@ namespace Krypton.Ribbon
         /// Discover the preferred size of the element.
         /// </summary>
         /// <param name="context">Layout context.</param>
-        public override Size GetPreferredSize(ViewLayoutContext context) => new Size(0, Height);
+        public override Size GetPreferredSize(ViewLayoutContext context) => new (0, Height);
 
         /// <summary>
         /// Perform a layout of the elements.

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonQATBorder.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonQATBorder.cs
@@ -33,7 +33,7 @@ namespace Krypton.Ribbon
 
         #region Instance Fields
         private readonly KryptonRibbon _ribbon;
-        private NeedPaintHandler _needPaintDelegate;
+        private readonly NeedPaintHandler _needPaintDelegate;
         private IDisposable _memento;
         private readonly bool _minibar;
 
@@ -227,7 +227,7 @@ namespace Krypton.Ribbon
             }
 
             // Decide if we need to draw onto a composition area
-            var composition = (OwnerForm != null) ? OwnerForm.ApplyComposition && OwnerForm.ApplyCustomChrome : false;
+            var composition = (OwnerForm != null) && OwnerForm.ApplyComposition && OwnerForm.ApplyCustomChrome;
 
             // Perform actual drawing
             _memento = context.Renderer.RenderRibbon.DrawRibbonBack(_ribbon.RibbonShape, context, drawRect, state, palette, VisualOrientation.Top, composition, _memento);

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonQATButton.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonQATButton.cs
@@ -174,7 +174,6 @@ namespace Krypton.Ribbon
 
             IPaletteBack paletteBack = _ribbon.StateCommon.RibbonQATButton.PaletteBack;
             IPaletteBorder paletteBorder = _ribbon.StateCommon.RibbonQATButton.PaletteBorder;
-            IPaletteRibbonGeneral paletteGeneral = _ribbon.StateCommon.RibbonGeneral;
 
             // Do we need to draw the background?
             if (paletteBack.GetBackDraw(State) == InheritBool.True)

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonQATOverflow.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonQATOverflow.cs
@@ -26,7 +26,7 @@ namespace Krypton.Ribbon
 
         #region Instance Fields
         private readonly KryptonRibbon _ribbon;
-        private NeedPaintHandler _needPaintDelegate;
+        private readonly NeedPaintHandler _needPaintDelegate;
         private IDisposable _memento;
         #endregion
 

--- a/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonAppTab.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonAppTab.cs
@@ -19,7 +19,7 @@ namespace Krypton.Ribbon
     internal class ViewLayoutRibbonAppTab : ViewLayoutDocker
     {
         #region Instance Fields
-        private KryptonRibbon _ribbon;
+        private readonly KryptonRibbon _ribbon;
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonGroupContent.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonGroupContent.cs
@@ -361,11 +361,10 @@ namespace Krypton.Ribbon
             var maxEntries = 0;
             for (var i = 0; i < Count; i++)
             {
-                if (this[i].Visible && (this[i] is IRibbonViewGroupContainerView))
+                if (this[i].Visible 
+                    && (this[i] is IRibbonViewGroupContainerView container)
+                    )
                 {
-                    // Cast child view to correct interface
-                    IRibbonViewGroupContainerView container = (IRibbonViewGroupContainerView)this[i];
-
                     // Find list of possible sizes for this container
                     var widths = container.GetPossibleSizes(context);
 
@@ -534,9 +533,10 @@ namespace Krypton.Ribbon
                 // Look for visible child containers
                 for (var i = 0; i < Count; i++)
                 {
-                    if (this[i].Visible && (this[i] is IRibbonViewGroupContainerView))
+                    if (this[i].Visible 
+                        && (this[i] is IRibbonViewGroupContainerView container)
+                        )
                     {
-                        IRibbonViewGroupContainerView container = (IRibbonViewGroupContainerView)this[i];
                         container.ResetSolutionSize();
                     }
                 }
@@ -551,13 +551,12 @@ namespace Krypton.Ribbon
                 // Look for visible child containers
                 for (int i = 0, j = 0; i < Count; i++)
                 {
-                    if (this[i].Visible && (this[i] is IRibbonViewGroupContainerView))
+                    if (this[i].Visible 
+                        && (this[i] is IRibbonViewGroupContainerView container)
+                        )
                     {
                         // Get the width returned for this container
                         _containerWidths[j] = size[j].Width;
-
-                        // Cast child view to correct interface
-                        IRibbonViewGroupContainerView container = (IRibbonViewGroupContainerView)this[i];
 
                         // Push the solution size into the actual container
                         container.SetSolutionSize(size[j++]);

--- a/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonQATContents.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonQATContents.cs
@@ -143,12 +143,11 @@ namespace Krypton.Ribbon
             foreach (ViewBase child in this)
             {
                 // If visible and we have another key tip available on stack
-                if (child.Visible && (keyTipsPool.Count > 0) &&
-                    (child is ViewDrawRibbonQATButton))
+                if (child.Visible 
+                    && (keyTipsPool.Count > 0) 
+                    && (child is ViewDrawRibbonQATButton viewQAT)
+                    )
                 {
-                    // Cast to correct type
-                    ViewDrawRibbonQATButton viewQAT = (ViewDrawRibbonQATButton)child;
-
                     // Get the screen location of the view tab
                     Rectangle viewRect = ParentControl.RectangleToScreen(viewQAT.ClientRectangle);
 

--- a/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonScrollPort.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonScrollPort.cs
@@ -600,11 +600,10 @@ namespace Krypton.Ribbon
             context.DisplayRectangle = ClientRectangle;
 
             // If we are the scroller for the tab headers
-            if (_ribbon.InKeyboardMode && (_viewFiller is ViewLayoutRibbonTabs))
+            if (_ribbon.InKeyboardMode 
+                && (_viewFiller is ViewLayoutRibbonTabs layoutTabs)
+                )
             {
-                // Cast to correct type
-                ViewLayoutRibbonTabs layoutTabs = (ViewLayoutRibbonTabs)_viewFiller;
-
                 // If we have a selected tab, then ensure it is visible
                 if (_ribbon.SelectedTab != null)
                 {

--- a/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonScroller.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonScroller.cs
@@ -103,7 +103,7 @@ namespace Krypton.Ribbon
         /// <param name="context">Layout context.</param>
         public override Size GetPreferredSize(ViewLayoutContext context) =>
             // Always return the same minimum size
-            new Size(SCROLLER_LENGTH + GAP_LENGTH, SCROLLER_LENGTH + GAP_LENGTH);
+            new (SCROLLER_LENGTH + GAP_LENGTH, SCROLLER_LENGTH + GAP_LENGTH);
 
         /// <summary>
         /// Perform a layout of the elements.

--- a/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonSeparator.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonSeparator.cs
@@ -86,7 +86,7 @@ namespace Krypton.Ribbon
         /// <param name="context">Layout context.</param>
         public override Size GetPreferredSize(ViewLayoutContext context) =>
             // Always return the same minimum size
-            new Size(_width, _height);
+            new (_width, _height);
 
         /// <summary>
         /// Perform a layout of the elements.

--- a/Source/Krypton Components/Krypton.Toolkit/AccurateText/AccurateTextMemento.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/AccurateText/AccurateTextMemento.cs
@@ -100,12 +100,12 @@ namespace Krypton.Toolkit
         /// <remarks>
         /// Only create the single instance when first requested
         /// </remarks>
-        internal static AccurateTextMemento Empty => _empty ?? (_empty = new AccurateTextMemento(string.Empty,
-                                                         null,
-                                                         Size.Empty,
-                                                         StringFormat.GenericDefault,
-                                                         TextRenderingHint.SystemDefault,
-                                                         false));
+        internal static AccurateTextMemento Empty => _empty ??= new AccurateTextMemento(string.Empty,
+            null,
+            Size.Empty,
+            StringFormat.GenericDefault,
+            TextRenderingHint.SystemDefault,
+            false);
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecCalendar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecCalendar.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit
     public class ButtonSpecCalendar : ButtonSpec
     {
         #region Instance Fields
-        private ViewDrawMonth _month;
+
         private readonly RelativeEdgeAlign _edge;
 
         #endregion
@@ -35,10 +35,7 @@ namespace Krypton.Toolkit
                                   PaletteButtonSpecStyle fixedStyle,
                                   RelativeEdgeAlign edge)
         {
-            Debug.Assert(month != null);
-
             // Remember back reference to owning navigator.
-            _month = month;
             _edge = edge;
             Enabled = true;
             Visible = true;

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecManagerBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecManagerBase.cs
@@ -675,7 +675,7 @@ namespace Krypton.Toolkit
                                                               IPaletteMetric viewPaletteMetric,
                                                               PaletteMetricPadding viewMetricPadding,
                                                               ButtonSpec buttonSpec) =>
-            new ButtonSpecView(redirector,
+            new (redirector,
                 viewPaletteMetric,
                 viewMetricPadding,
                 this,

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecView.cs
@@ -157,14 +157,14 @@ namespace Krypton.Toolkit
             var prevVisible = ViewCenter.Visible;
             ViewCenter.Visible = ButtonSpec.GetVisible(_redirector);
 
-            // Return if a change has occured
+            // Return if a change has occurred
             return prevVisible != ViewCenter.Visible;
         }
 
         /// <summary>
         /// Update view button to reflect new button enabled setting.
         /// </summary>
-        /// <returns>True is a change in state has occured.</returns>
+        /// <returns>True is a change in state has occurred.</returns>
         public bool UpdateEnabled()
         {
             var changed = false;
@@ -214,7 +214,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Update view button to reflect new button checked setting.
         /// </summary>
-        /// <returns>True is a change in state has occured.</returns>
+        /// <returns>True is a change in state has occurred.</returns>
         public bool UpdateChecked()
         {
             // Remember the initial state

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuItem.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuItem.cs
@@ -645,7 +645,7 @@ namespace Krypton.Toolkit
             if (CheckOnClick)
             {
                 // Grab current state from command or ourself
-                CheckState state = KryptonCommand == null ? CheckState : KryptonCommand.CheckState;
+                CheckState state = KryptonCommand?.CheckState ?? CheckState;
 
                 // Find new state
                 switch (state)

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuMonthCalendar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuMonthCalendar.cs
@@ -1204,22 +1204,22 @@ namespace Krypton.Toolkit
         {
             if (start.Ticks > _maxDate.Ticks)
             {
-                throw new ArgumentOutOfRangeException(@"Start date provided is greater than the maximum date.");
+                throw new ArgumentOutOfRangeException(nameof(start), @"Start date provided is greater than the maximum date.");
             }
 
             if (start.Ticks < _minDate.Ticks)
             {
-                throw new ArgumentOutOfRangeException(@"Start date provided is less than the minimum date.");
+                throw new ArgumentOutOfRangeException(nameof(start), @"Start date provided is less than the minimum date.");
             }
 
             if (end.Ticks > _maxDate.Ticks)
             {
-                throw new ArgumentOutOfRangeException(@"End date provided is greater than the maximum date.");
+                throw new ArgumentOutOfRangeException(nameof(end), @"End date provided is greater than the maximum date.");
             }
 
             if (end.Ticks < _minDate.Ticks)
             {
-                throw new ArgumentOutOfRangeException(@"End date provided is less than the minimum date.");
+                throw new ArgumentOutOfRangeException(nameof(end), @"End date provided is less than the minimum date.");
             }
 
             if (start > end)

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/CheckBoxController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/CheckBoxController.cs
@@ -87,7 +87,7 @@ namespace Krypton.Toolkit
                     // Only pressed if mouse still over the view element
                     var pressed = _top.ClientRectangle.Contains(pt);
 
-                    // Only update and paint if we a change has occured
+                    // Only update and paint if we a change has occurred
                     if (_target.Pressed != pressed)
                     {
                         _target.Pressed = pressed;

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/LinkLabelController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/LinkLabelController.cs
@@ -482,7 +482,7 @@ namespace Krypton.Toolkit
         /// <param name="e">A MouseEventArgs containing the event data.</param>
         protected virtual void OnClick(MouseEventArgs e)
         {
-            // Find how long since the last click occured
+            // Find how long since the last click occurred
             TimeSpan clickInterval =  DateTime.Now - _clickTime;
 
             // If less than the double click interval then ignore

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/MenuItemController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/MenuItemController.cs
@@ -122,7 +122,11 @@ namespace Krypton.Toolkit
             // If the item is enabled and the mouse is over the sub menu area, then return false
             // because we do not want pressed it to cause the context menu to become current. This
             // cause the showing sub menu to be dismissed.
-            _menuItem.ItemEnabled ? !_menuItem.PointInSubMenu(pt) : true;
+            !
+            // If the item is enabled and the mouse is over the sub menu area, then return false
+            // because we do not want pressed it to cause the context menu to become current. This
+            // cause the showing sub menu to be dismissed.
+            _menuItem.ItemEnabled || !_menuItem.PointInSubMenu(pt);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/MonthCalendarController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/MonthCalendarController.cs
@@ -175,14 +175,12 @@ namespace Krypton.Toolkit
                             }
 
                             // Switch around so the begin is before the end
-                            DateTime temp = selectEnd;
-                            selectEnd = selectStart;
-                            selectStart = temp;
+                            (selectEnd, selectStart) = (selectStart, selectEnd);
 
                             _months.FocusDay = selectStart;
                         }
 
-                        // Use the new seletion range
+                        // Use the new selection range
                         _months.Calendar.SetSelectionRange(selectStart, selectEnd);
                         _needPaint(_months, new NeedLayoutEventArgs(false));
                     }

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/RadioButtonController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/RadioButtonController.cs
@@ -84,7 +84,7 @@ namespace Krypton.Toolkit
                     // Only pressed if mouse still over the view element
                     var pressed = _top.ClientRectangle.Contains(pt);
 
-                    // Only update and paint if we a change has occured
+                    // Only update and paint if we a change has occurred
                     if (_target.Pressed != pressed)
                     {
                         _target.Pressed = pressed;

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/SeparatorController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/SeparatorController.cs
@@ -67,7 +67,7 @@ namespace Krypton.Toolkit
     #endregion
 
     /// <summary>
-    ///Process mouse events for a separator style element.
+    /// Process mouse events for a separator style element.
     /// </summary>
     public class SeparatorController : ButtonController,
                                        IDisposable
@@ -84,6 +84,9 @@ namespace Krypton.Toolkit
             #endregion
 
             #region Indentity
+            /// <summary>
+            /// Process mouse events for a separator style element.
+            /// </summary>
             public SeparatorIndicator()
             {
                 FormBorderStyle = FormBorderStyle.None;
@@ -278,7 +281,7 @@ namespace Krypton.Toolkit
             // Let base class process the mouse down
             var ret = base.MouseDown(c, pt, button);
 
-            // If a change in capturing state has occured
+            // If a change in capturing state has occurred
             if (ret != _moving)
             {
                 // If we are now capturing input

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonBreadCrumbItem.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonBreadCrumbItem.cs
@@ -46,7 +46,7 @@ namespace Krypton.Toolkit
             /// <summary>
             /// Gets the item with the provided unique name.
             /// </summary>
-            /// <param name=(@"Name")>Name of the ribbon tab instance.</param>
+            /// <param name="name">Name of the ribbon tab instance.</param>
             /// <returns>Item at specified index.</returns>
             public override KryptonBreadCrumbItem this[string name]
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonButton.cs
@@ -572,10 +572,10 @@ namespace Krypton.Toolkit
 
             if (_useAsUACElevationButton)
             {
-                Bitmap rawUACShield = SystemIcons.Shield.ToBitmap();
+                var rawUACShield = SystemIcons.Shield.ToBitmap();
 
                 // Resize rawUACShield down to 16 x 16 to make it fit
-                Bitmap resizedUACShield = new Bitmap(rawUACShield, new Size(16, 16));
+                var resizedUACShield = new Bitmap(rawUACShield, new Size(16, 16));
 
                 if (Values.Image == null)
                 {
@@ -678,7 +678,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <returns>Set of button values.</returns>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        protected virtual ButtonValues CreateButtonValues(NeedPaintHandler needPaint) => new ButtonValues(needPaint);
+        protected virtual ButtonValues CreateButtonValues(NeedPaintHandler needPaint) => new (needPaint);
 
         /// <summary>
         /// Raises the KryptonCommandChanged event.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckedListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckedListBox.cs
@@ -520,7 +520,7 @@ namespace Krypton.Toolkit
             /// Creates a new instance of the item collection.
             /// </summary>
             /// <returns>A ListBox.ObjectCollection that represents the new item collection.</returns>
-            protected override ObjectCollection CreateItemCollection() => new ObjectCollection(this);
+            protected override ObjectCollection CreateItemCollection() => new (this);
 
             /// <summary>
             /// Raises the KeyPress event.
@@ -1867,7 +1867,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool IsActive => _fixedActive != null ? _fixedActive.Value : DesignMode || AlwaysActive || ContainsFocus || _mouseOver || _listBox.MouseOver;
+        public bool IsActive => _fixedActive ?? DesignMode || AlwaysActive || ContainsFocus || _mouseOver || _listBox.MouseOver;
 
         /// <summary>
         /// Sets input focus to the control.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -1999,14 +1999,12 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool IsActive =>
-            _fixedActive != null
-                ? _fixedActive.Value
-                : DesignMode
-                  || AlwaysActive
-                  || ContainsFocus
-                  || _mouseOver
-                  || _comboBox.MouseOver
-                  || _subclassEdit is { MouseOver: true };
+            _fixedActive ?? DesignMode
+            || AlwaysActive
+            || ContainsFocus
+            || _mouseOver
+            || _comboBox.MouseOver
+            || _subclassEdit is { MouseOver: true };
 
         /// <summary>
         /// Gets access to the ToolTipManager used for displaying tool tips.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCommand.cs
@@ -400,7 +400,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the item with the provided name.
         /// </summary>
-        /// <param name=(@"Name")>Name to find.</param>
+        /// <param name="name">Name to find.</param>
         /// <returns>Item with matching name.</returns>
         public override KryptonCommand this[string name]
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonContextMenu.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonContextMenu.cs
@@ -439,7 +439,7 @@ namespace Krypton.Toolkit
                                                               KryptonContextMenuCollection items,
                                                               bool enabled,
                                                               bool keyboardActivated) =>
-            new VisualContextMenu(kcm, palette, paletteMode, redirector, redirectorImages, items, enabled, keyboardActivated);
+            new (kcm, palette, paletteMode, redirector, redirectorImages, items, enabled, keyboardActivated);
 
         /// <summary>
         /// Raises the Opening event.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -522,7 +522,7 @@ namespace Krypton.Toolkit
                         _paletteMode = PaletteMode.Custom;
                     }
 
-                    // If real change has occured
+                    // If real change has occurred
                     if (old != _localPalette)
                     {
                         // Raise the change event

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewButtonColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewButtonColumn.cs
@@ -153,9 +153,7 @@ namespace Krypton.Toolkit
         public bool UseColumnTextForButtonValue
         {
             get =>
-                CellTemplate == null
-                    ? throw new InvalidOperationException(@"KryptonDataGridViewButtonColumn cell template required")
-                    : ((KryptonDataGridViewButtonCell)CellTemplate).UseColumnTextForButtonValue;
+                ((KryptonDataGridViewButtonCell)CellTemplate)?.UseColumnTextForButtonValue ?? throw new InvalidOperationException(@"KryptonDataGridViewButtonColumn cell template required");
 
             set
             {
@@ -188,9 +186,7 @@ namespace Krypton.Toolkit
         public ButtonStyle ButtonStyle
         {
             get =>
-                CellTemplate == null
-                    ? throw new InvalidOperationException(@"KryptonDataGridViewButtonColumn cell template required")
-                    : ((KryptonDataGridViewButtonCell)CellTemplate).ButtonStyle;
+                ((KryptonDataGridViewButtonCell)CellTemplate)?.ButtonStyle ?? throw new InvalidOperationException(@"KryptonDataGridViewButtonColumn cell template required");
 
             set
             {
@@ -224,14 +220,13 @@ namespace Krypton.Toolkit
             }
 
             DataGridViewCellStyle defaultCellStyle = DefaultCellStyle;
-            return defaultCellStyle.BackColor.IsEmpty && defaultCellStyle.ForeColor.IsEmpty &&
-                  defaultCellStyle.SelectionBackColor.IsEmpty && defaultCellStyle.SelectionForeColor.IsEmpty &&
-                 (defaultCellStyle.Font == null) && defaultCellStyle.IsNullValueDefault &&
-                  defaultCellStyle.IsDataSourceNullValueDefault && string.IsNullOrEmpty(defaultCellStyle.Format) &&
-                defaultCellStyle.FormatProvider.Equals(CultureInfo.CurrentCulture) && (defaultCellStyle.Alignment == DataGridViewContentAlignment.MiddleCenter) &&
-                 (defaultCellStyle.WrapMode == DataGridViewTriState.NotSet) && (defaultCellStyle.Tag == null)
-                ? !defaultCellStyle.Padding.Equals(Padding.Empty)
-                : true;
+            return !defaultCellStyle.BackColor.IsEmpty || !defaultCellStyle.ForeColor.IsEmpty ||
+!defaultCellStyle.SelectionBackColor.IsEmpty || !defaultCellStyle.SelectionForeColor.IsEmpty ||
+                 defaultCellStyle.Font != null || !defaultCellStyle.IsNullValueDefault ||
+!defaultCellStyle.IsDataSourceNullValueDefault || !string.IsNullOrEmpty(defaultCellStyle.Format) ||
+!defaultCellStyle.FormatProvider.Equals(CultureInfo.CurrentCulture) || defaultCellStyle.Alignment != DataGridViewContentAlignment.MiddleCenter ||
+                 defaultCellStyle.WrapMode != DataGridViewTriState.NotSet || defaultCellStyle.Tag != null
+|| !defaultCellStyle.Padding.Equals(Padding.Empty);
         }
 
         private void ColumnCommonChange(int columnIndex)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewCheckBoxColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewCheckBoxColumn.cs
@@ -205,9 +205,7 @@ namespace Krypton.Toolkit
         public bool ThreeState
         {
             get =>
-                CheckBoxCellTemplate == null
-                    ? throw new InvalidOperationException(@"KryptonDataGridViewCheckBoxColumn cell template required")
-                    : CheckBoxCellTemplate.ThreeState;
+                CheckBoxCellTemplate?.ThreeState ?? throw new InvalidOperationException(@"KryptonDataGridViewCheckBoxColumn cell template required");
             set
             {
                 if (ThreeState != value)
@@ -248,7 +246,7 @@ namespace Krypton.Toolkit
         #region Private
         private KryptonDataGridViewCheckBoxCell CheckBoxCellTemplate => (KryptonDataGridViewCheckBoxCell)CellTemplate;
 
-        private bool ShouldSerializeDefaultCellStyle()
+        private bool ShouldSerializeCellTemplate()
         {
             KryptonDataGridViewCheckBoxCell cellTemplate = CheckBoxCellTemplate;
             if (cellTemplate != null)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxCell.cs
@@ -495,9 +495,8 @@ namespace Krypton.Toolkit
         }
 
         private bool OwnsEditingComboBox(int rowIndex) =>
-            (rowIndex == -1) || (DataGridView == null)
-                ? false
-                : (DataGridView.EditingControl is KryptonDataGridViewComboBoxEditingControl control)
+            rowIndex != -1 && DataGridView != null
+&& (DataGridView.EditingControl is KryptonDataGridViewComboBoxEditingControl control)
                   && (rowIndex == ((IDataGridViewEditingControl)control).EditingControlRowIndex);
 
         private static bool PartPainted(DataGridViewPaintParts paintParts, DataGridViewPaintParts paintPart) => (paintParts & paintPart) != 0;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxColumn.cs
@@ -131,7 +131,7 @@ namespace Krypton.Toolkit
         [Localizable(true)]
         public List<object> Items { get; }
 
-        private bool ShouldSerializeItems => true;
+        private bool ShouldSerializeItems() => Items.Any();
 
         /// <summary>
         /// Gets and sets the appearance and functionality of the KryptonComboBox.
@@ -143,9 +143,7 @@ namespace Krypton.Toolkit
         public ComboBoxStyle DropDownStyle
         {
             get =>
-                ComboBoxCellTemplate == null
-                    ? throw new InvalidOperationException(@"Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : ComboBoxCellTemplate.DropDownStyle;
+                ComboBoxCellTemplate?.DropDownStyle ?? throw new InvalidOperationException(@"Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
 
             set
             {
@@ -187,9 +185,7 @@ namespace Krypton.Toolkit
         public int MaxDropDownItems
         {
             get =>
-                ComboBoxCellTemplate == null
-                    ? throw new InvalidOperationException(@"Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : ComboBoxCellTemplate.MaxDropDownItems;
+                ComboBoxCellTemplate?.MaxDropDownItems ?? throw new InvalidOperationException(@"Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
 
             set
             {
@@ -232,9 +228,7 @@ namespace Krypton.Toolkit
         public int DropDownHeight
         {
             get =>
-                ComboBoxCellTemplate == null
-                    ? throw new InvalidOperationException(@"Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : ComboBoxCellTemplate.DropDownHeight;
+                ComboBoxCellTemplate?.DropDownHeight ?? throw new InvalidOperationException(@"Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
 
             set
             {
@@ -276,9 +270,7 @@ namespace Krypton.Toolkit
         public int DropDownWidth
         {
             get =>
-                ComboBoxCellTemplate == null
-                    ? throw new InvalidOperationException(@"Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : ComboBoxCellTemplate.DropDownWidth;
+                ComboBoxCellTemplate?.DropDownWidth ?? throw new InvalidOperationException(@"Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
 
             set
             {
@@ -321,7 +313,7 @@ namespace Krypton.Toolkit
         [Browsable(true)]
         public AutoCompleteStringCollection AutoCompleteCustomSource { get; }
 
-        private bool ShouldSerializeAutoCompleteCustomSource => true;
+        private bool ShouldSerializeAutoCompleteCustomSource() => AutoCompleteCustomSource.Count>0;
 
         /// <summary>
         /// Gets or sets the text completion behavior of the combobox.
@@ -333,9 +325,7 @@ namespace Krypton.Toolkit
         public AutoCompleteMode AutoCompleteMode
         {
             get =>
-                ComboBoxCellTemplate == null
-                    ? throw new InvalidOperationException(@"Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : ComboBoxCellTemplate.AutoCompleteMode;
+                ComboBoxCellTemplate?.AutoCompleteMode ?? throw new InvalidOperationException(@"Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
 
             set
             {
@@ -377,9 +367,7 @@ namespace Krypton.Toolkit
         public AutoCompleteSource AutoCompleteSource
         {
             get =>
-                ComboBoxCellTemplate == null
-                    ? throw new InvalidOperationException(@"Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : ComboBoxCellTemplate.AutoCompleteSource;
+                ComboBoxCellTemplate?.AutoCompleteSource ?? throw new InvalidOperationException(@"Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
 
             set
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDateTimePickerCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDateTimePickerCell.cs
@@ -775,9 +775,8 @@ namespace Krypton.Toolkit
         }
 
         private bool OwnsEditingDateTimePicker(int rowIndex) =>
-            (rowIndex == -1) || (DataGridView == null)
-                ? false
-                : (DataGridView.EditingControl is KryptonDataGridViewDateTimePickerEditingControl control)
+            rowIndex != -1 && DataGridView != null
+&& (DataGridView.EditingControl is KryptonDataGridViewDateTimePickerEditingControl control)
                   && (rowIndex == ((IDataGridViewEditingControl)control).EditingControlRowIndex);
 
         private static bool PartPainted(DataGridViewPaintParts paintParts, DataGridViewPaintParts paintPart) => (paintParts & paintPart) != 0;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDateTimePickerColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDateTimePickerColumn.cs
@@ -123,9 +123,7 @@ namespace Krypton.Toolkit
         public bool ShowCheckBox
         {
             get =>
-                DateTimePickerCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : DateTimePickerCellTemplate.ShowCheckBox;
+                DateTimePickerCellTemplate?.ShowCheckBox ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (DateTimePickerCellTemplate == null)
@@ -165,9 +163,7 @@ namespace Krypton.Toolkit
         public bool ShowUpDown
         {
             get =>
-                DateTimePickerCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : DateTimePickerCellTemplate.ShowUpDown;
+                DateTimePickerCellTemplate?.ShowUpDown ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (DateTimePickerCellTemplate == null)
@@ -208,9 +204,7 @@ namespace Krypton.Toolkit
         public DateTimePickerFormat Format
         {
             get =>
-                DateTimePickerCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : DateTimePickerCellTemplate.Format;
+                DateTimePickerCellTemplate?.Format ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (DateTimePickerCellTemplate == null)
@@ -250,9 +244,7 @@ namespace Krypton.Toolkit
         public bool AutoShift
         {
             get =>
-                DateTimePickerCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : DateTimePickerCellTemplate.AutoShift;
+                DateTimePickerCellTemplate?.AutoShift ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (DateTimePickerCellTemplate == null)
@@ -292,9 +284,7 @@ namespace Krypton.Toolkit
         public bool Checked
         {
             get =>
-                DateTimePickerCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : DateTimePickerCellTemplate.Checked;
+                DateTimePickerCellTemplate?.Checked ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (DateTimePickerCellTemplate == null)
@@ -417,9 +407,7 @@ namespace Krypton.Toolkit
         public DateTime MaxDate
         {
             get =>
-                DateTimePickerCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : DateTimePickerCellTemplate.MaxDate;
+                DateTimePickerCellTemplate?.MaxDate ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (DateTimePickerCellTemplate == null)
@@ -467,9 +455,7 @@ namespace Krypton.Toolkit
         public DateTime MinDate
         {
             get =>
-                DateTimePickerCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : DateTimePickerCellTemplate.MinDate;
+                DateTimePickerCellTemplate?.MinDate ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (DateTimePickerCellTemplate == null)
@@ -518,9 +504,7 @@ namespace Krypton.Toolkit
         public Size CalendarDimensions
         {
             get =>
-                DateTimePickerCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : DateTimePickerCellTemplate.CalendarDimensions;
+                DateTimePickerCellTemplate?.CalendarDimensions ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (DateTimePickerCellTemplate == null)
@@ -607,9 +591,7 @@ namespace Krypton.Toolkit
         public Day CalendarFirstDayOfWeek
         {
             get =>
-                DateTimePickerCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : DateTimePickerCellTemplate.CalendarFirstDayOfWeek;
+                DateTimePickerCellTemplate?.CalendarFirstDayOfWeek ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (DateTimePickerCellTemplate == null)
@@ -649,9 +631,7 @@ namespace Krypton.Toolkit
         public bool CalendarShowToday
         {
             get =>
-                DateTimePickerCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : DateTimePickerCellTemplate.CalendarShowToday;
+                DateTimePickerCellTemplate?.CalendarShowToday ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (DateTimePickerCellTemplate == null)
@@ -691,9 +671,7 @@ namespace Krypton.Toolkit
         public bool CalendarCloseOnTodayClick
         {
             get =>
-                DateTimePickerCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : DateTimePickerCellTemplate.CalendarCloseOnTodayClick;
+                DateTimePickerCellTemplate?.CalendarCloseOnTodayClick ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (DateTimePickerCellTemplate == null)
@@ -733,9 +711,7 @@ namespace Krypton.Toolkit
         public bool CalendarShowTodayCircle
         {
             get =>
-                DateTimePickerCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : DateTimePickerCellTemplate.CalendarShowTodayCircle;
+                DateTimePickerCellTemplate?.CalendarShowTodayCircle ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (DateTimePickerCellTemplate == null)
@@ -775,9 +751,7 @@ namespace Krypton.Toolkit
         public bool CalendarShowWeekNumbers
         {
             get =>
-                DateTimePickerCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : DateTimePickerCellTemplate.CalendarShowWeekNumbers;
+                DateTimePickerCellTemplate?.CalendarShowWeekNumbers ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (DateTimePickerCellTemplate == null)
@@ -816,9 +790,7 @@ namespace Krypton.Toolkit
         public DateTime CalendarTodayDate
         {
             get =>
-                DateTimePickerCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : DateTimePickerCellTemplate.CalendarTodayDate;
+                DateTimePickerCellTemplate?.CalendarTodayDate ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (DateTimePickerCellTemplate == null)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownCell.cs
@@ -260,9 +260,8 @@ namespace Krypton.Toolkit
         }
 
         private bool OwnsEditingDomainUpDown(int rowIndex) =>
-            (rowIndex == -1) || (DataGridView == null)
-                ? false
-                : (DataGridView.EditingControl is KryptonDataGridViewDomainUpDownEditingControl control)
+            rowIndex != -1 && DataGridView != null
+&& (DataGridView.EditingControl is KryptonDataGridViewDomainUpDownEditingControl control)
                   && (rowIndex == ((IDataGridViewEditingControl)control).EditingControlRowIndex);
 
         private static bool PartPainted(DataGridViewPaintParts paintParts, DataGridViewPaintParts paintPart) => (paintParts & paintPart) != 0;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewLinkColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewLinkColumn.cs
@@ -173,9 +173,7 @@ namespace Krypton.Toolkit
         public LinkBehavior LinkBehavior
         {
             get =>
-                CellTemplate == null
-                    ? throw new InvalidOperationException("KryptonDataGridViewLinkCell cell template required")
-                    : ((KryptonDataGridViewLinkCell)CellTemplate).LinkBehavior;
+                ((KryptonDataGridViewLinkCell)CellTemplate)?.LinkBehavior ?? throw new InvalidOperationException("KryptonDataGridViewLinkCell cell template required");
             set
             {
                 if (!LinkBehavior.Equals(value))
@@ -208,9 +206,7 @@ namespace Krypton.Toolkit
         public bool TrackVisitedState
         {
             get =>
-                CellTemplate == null
-                    ? throw new InvalidOperationException("KryptonDataGridViewLinkCell cell template required")
-                    : ((KryptonDataGridViewLinkCell)CellTemplate).TrackVisitedState;
+                ((KryptonDataGridViewLinkCell)CellTemplate)?.TrackVisitedState ?? throw new InvalidOperationException("KryptonDataGridViewLinkCell cell template required");
             set
             {
                 if (TrackVisitedState != value)
@@ -241,9 +237,7 @@ namespace Krypton.Toolkit
         public bool UseColumnTextForLinkValue
         {
             get =>
-                CellTemplate == null
-                    ? throw new InvalidOperationException("KryptonDataGridViewLinkCell cell template required")
-                    : ((KryptonDataGridViewLinkCell)CellTemplate).UseColumnTextForLinkValue;
+                ((KryptonDataGridViewLinkCell)CellTemplate)?.UseColumnTextForLinkValue ?? throw new InvalidOperationException("KryptonDataGridViewLinkCell cell template required");
 
             set
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewMaskedTextBoxCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewMaskedTextBoxCell.cs
@@ -619,9 +619,8 @@ namespace Krypton.Toolkit
         }
 
         private bool OwnsEditingMaskedTextBox(int rowIndex) =>
-            (rowIndex == -1) || (DataGridView == null)
-                ? false
-                : (DataGridView.EditingControl is KryptonDataGridViewMaskedTextBoxEditingControl control)
+            rowIndex != -1 && DataGridView != null
+&& (DataGridView.EditingControl is KryptonDataGridViewMaskedTextBoxEditingControl control)
                   && (rowIndex == ((IDataGridViewEditingControl)control).EditingControlRowIndex);
 
         private static bool PartPainted(DataGridViewPaintParts paintParts, DataGridViewPaintParts paintPart) => (paintParts & paintPart) != 0;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewMaskedTextBoxColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewMaskedTextBoxColumn.cs
@@ -110,9 +110,7 @@ namespace Krypton.Toolkit
         public char PromptChar
         {
             get =>
-                MaskedTextBoxCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : MaskedTextBoxCellTemplate.PromptChar;
+                MaskedTextBoxCellTemplate?.PromptChar ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (MaskedTextBoxCellTemplate == null)
@@ -152,9 +150,7 @@ namespace Krypton.Toolkit
         public bool AllowPromptAsInput
         {
             get =>
-                MaskedTextBoxCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : MaskedTextBoxCellTemplate.AllowPromptAsInput;
+                MaskedTextBoxCellTemplate?.AllowPromptAsInput ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (MaskedTextBoxCellTemplate == null)
@@ -194,9 +190,7 @@ namespace Krypton.Toolkit
         public bool AsciiOnly
         {
             get =>
-                MaskedTextBoxCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : MaskedTextBoxCellTemplate.AsciiOnly;
+                MaskedTextBoxCellTemplate?.AsciiOnly ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (MaskedTextBoxCellTemplate == null)
@@ -236,9 +230,7 @@ namespace Krypton.Toolkit
         public bool BeepOnError
         {
             get =>
-                MaskedTextBoxCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : MaskedTextBoxCellTemplate.BeepOnError;
+                MaskedTextBoxCellTemplate?.BeepOnError ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (MaskedTextBoxCellTemplate == null)
@@ -278,9 +270,7 @@ namespace Krypton.Toolkit
         public MaskFormat CutCopyMaskFormat
         {
             get =>
-                MaskedTextBoxCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : MaskedTextBoxCellTemplate.CutCopyMaskFormat;
+                MaskedTextBoxCellTemplate?.CutCopyMaskFormat ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (MaskedTextBoxCellTemplate == null)
@@ -320,9 +310,7 @@ namespace Krypton.Toolkit
         public bool HidePromptOnLeave
         {
             get =>
-                MaskedTextBoxCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : MaskedTextBoxCellTemplate.HidePromptOnLeave;
+                MaskedTextBoxCellTemplate?.HidePromptOnLeave ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (MaskedTextBoxCellTemplate == null)
@@ -362,9 +350,7 @@ namespace Krypton.Toolkit
         public bool HideSelection
         {
             get =>
-                MaskedTextBoxCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : MaskedTextBoxCellTemplate.HideSelection;
+                MaskedTextBoxCellTemplate?.HideSelection ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (MaskedTextBoxCellTemplate == null)
@@ -404,9 +390,7 @@ namespace Krypton.Toolkit
         public InsertKeyMode InsertKeyMode
         {
             get =>
-                MaskedTextBoxCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : MaskedTextBoxCellTemplate.InsertKeyMode;
+                MaskedTextBoxCellTemplate?.InsertKeyMode ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (MaskedTextBoxCellTemplate == null)
@@ -488,9 +472,7 @@ namespace Krypton.Toolkit
         public char PasswordChar
         {
             get =>
-                MaskedTextBoxCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : MaskedTextBoxCellTemplate.PasswordChar;
+                MaskedTextBoxCellTemplate?.PasswordChar ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (MaskedTextBoxCellTemplate == null)
@@ -530,9 +512,7 @@ namespace Krypton.Toolkit
         public bool RejectInputOnFirstFailure
         {
             get =>
-                MaskedTextBoxCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : MaskedTextBoxCellTemplate.RejectInputOnFirstFailure;
+                MaskedTextBoxCellTemplate?.RejectInputOnFirstFailure ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (MaskedTextBoxCellTemplate == null)
@@ -572,9 +552,7 @@ namespace Krypton.Toolkit
         public bool ResetOnPrompt
         {
             get =>
-                MaskedTextBoxCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : MaskedTextBoxCellTemplate.ResetOnPrompt;
+                MaskedTextBoxCellTemplate?.ResetOnPrompt ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (MaskedTextBoxCellTemplate == null)
@@ -614,9 +592,7 @@ namespace Krypton.Toolkit
         public bool ResetOnSpace
         {
             get =>
-                MaskedTextBoxCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : MaskedTextBoxCellTemplate.ResetOnSpace;
+                MaskedTextBoxCellTemplate?.ResetOnSpace ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (MaskedTextBoxCellTemplate == null)
@@ -656,9 +632,7 @@ namespace Krypton.Toolkit
         public bool SkipLiterals
         {
             get =>
-                MaskedTextBoxCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : MaskedTextBoxCellTemplate.SkipLiterals;
+                MaskedTextBoxCellTemplate?.SkipLiterals ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (MaskedTextBoxCellTemplate == null)
@@ -698,9 +672,7 @@ namespace Krypton.Toolkit
         public MaskFormat TextMaskFormat
         {
             get =>
-                MaskedTextBoxCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : MaskedTextBoxCellTemplate.TextMaskFormat;
+                MaskedTextBoxCellTemplate?.TextMaskFormat ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (MaskedTextBoxCellTemplate == null)
@@ -740,9 +712,7 @@ namespace Krypton.Toolkit
         public bool UseSystemPasswordChar
         {
             get =>
-                MaskedTextBoxCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : MaskedTextBoxCellTemplate.UseSystemPasswordChar;
+                MaskedTextBoxCellTemplate?.UseSystemPasswordChar ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (MaskedTextBoxCellTemplate == null)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewNumericUpDownCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewNumericUpDownCell.cs
@@ -131,7 +131,7 @@ namespace Krypton.Toolkit
             {
                 if (value is < 0 or > 99)
                 {
-                    throw new ArgumentOutOfRangeException(@"The DecimalPlaces property cannot be smaller than 0 or larger than 99.");
+                    throw new ArgumentOutOfRangeException(nameof(DecimalPlaces), @"The DecimalPlaces property cannot be smaller than 0 or larger than 99.");
                 }
 
                 if (_decimalPlaces != value)
@@ -170,7 +170,7 @@ namespace Krypton.Toolkit
             {
                 if (value < (decimal)0.0)
                 {
-                    throw new ArgumentOutOfRangeException(@"The Increment property cannot be smaller than 0.");
+                    throw new ArgumentOutOfRangeException(nameof(Increment), @"The Increment property cannot be smaller than 0.");
                 }
 
                 SetIncrement(RowIndex, value);
@@ -518,9 +518,8 @@ namespace Krypton.Toolkit
         }
 
         private bool OwnsEditingNumericUpDown(int rowIndex) =>
-            (rowIndex == -1) || (DataGridView == null)
-                ? false
-                : (DataGridView.EditingControl is KryptonDataGridViewNumericUpDownEditingControl control)
+            rowIndex != -1 && DataGridView != null
+&& (DataGridView.EditingControl is KryptonDataGridViewNumericUpDownEditingControl control)
                   && (rowIndex == ((IDataGridViewEditingControl)control).EditingControlRowIndex);
 
         private static bool PartPainted(DataGridViewPaintParts paintParts, DataGridViewPaintParts paintPart) => (paintParts & paintPart) != 0;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewNumericUpDownColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewNumericUpDownColumn.cs
@@ -110,9 +110,7 @@ namespace Krypton.Toolkit
         public bool AllowDecimals
         {
             get =>
-                NumericUpDownCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : NumericUpDownCellTemplate.AllowDecimals;
+                NumericUpDownCellTemplate?.AllowDecimals ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (NumericUpDownCellTemplate == null)
@@ -153,9 +151,7 @@ namespace Krypton.Toolkit
         public bool TrailingZeroes
         {
             get =>
-                NumericUpDownCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : NumericUpDownCellTemplate.TrailingZeroes;
+                NumericUpDownCellTemplate?.TrailingZeroes ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (NumericUpDownCellTemplate == null)
@@ -195,9 +191,7 @@ namespace Krypton.Toolkit
         public int DecimalPlaces
         {
             get =>
-                NumericUpDownCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : NumericUpDownCellTemplate.DecimalPlaces;
+                NumericUpDownCellTemplate?.DecimalPlaces ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (NumericUpDownCellTemplate == null)
@@ -237,9 +231,7 @@ namespace Krypton.Toolkit
         public bool Hexadecimal
         {
             get =>
-                NumericUpDownCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : NumericUpDownCellTemplate.Hexadecimal;
+                NumericUpDownCellTemplate?.Hexadecimal ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (NumericUpDownCellTemplate == null)
@@ -278,9 +270,7 @@ namespace Krypton.Toolkit
         public decimal Increment
         {
             get =>
-                NumericUpDownCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : NumericUpDownCellTemplate.Increment;
+                NumericUpDownCellTemplate?.Increment ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (NumericUpDownCellTemplate == null)
@@ -317,9 +307,7 @@ namespace Krypton.Toolkit
         public decimal Maximum
         {
             get =>
-                NumericUpDownCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : NumericUpDownCellTemplate.Maximum;
+                NumericUpDownCellTemplate?.Maximum ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (NumericUpDownCellTemplate == null)
@@ -358,9 +346,7 @@ namespace Krypton.Toolkit
         public decimal Minimum
         {
             get =>
-                NumericUpDownCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : NumericUpDownCellTemplate.Minimum;
+                NumericUpDownCellTemplate?.Minimum ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (NumericUpDownCellTemplate == null)
@@ -399,9 +385,7 @@ namespace Krypton.Toolkit
         public bool ThousandsSeparator
         {
             get =>
-                NumericUpDownCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : NumericUpDownCellTemplate.ThousandsSeparator;
+                NumericUpDownCellTemplate?.ThousandsSeparator ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (NumericUpDownCellTemplate == null)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxCell.cs
@@ -308,9 +308,9 @@ namespace Krypton.Toolkit
         }
 
         private bool OwnsEditingTextBox(int rowIndex) =>
-            (rowIndex == -1) || (DataGridView == null)
-                ? false
-                : (DataGridView.EditingControl is KryptonDataGridViewTextBoxEditingControl control)
+            rowIndex != -1 
+            && DataGridView != null
+            && (DataGridView.EditingControl is KryptonDataGridViewTextBoxEditingControl control)
                   && (rowIndex == ((IDataGridViewEditingControl)control).EditingControlRowIndex);
 
         private static bool PartPainted(DataGridViewPaintParts paintParts, DataGridViewPaintParts paintPart) => paintParts.HasFlag(paintPart);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxColumn.cs
@@ -103,9 +103,7 @@ namespace Krypton.Toolkit
         public int MaxInputLength
         {
             get =>
-                TextBoxCellTemplate == null
-                    ? throw new InvalidOperationException("KryptonDataGridViewTextBoxColumn cell template required")
-                    : TextBoxCellTemplate.MaxInputLength;
+                TextBoxCellTemplate?.MaxInputLength ?? throw new InvalidOperationException("KryptonDataGridViewTextBoxColumn cell template required");
 
             set
             {
@@ -215,9 +213,7 @@ namespace Krypton.Toolkit
         public bool Multiline
         {
             get =>
-                TextBoxCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : TextBoxCellTemplate.Multiline;
+                TextBoxCellTemplate?.Multiline ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (TextBoxCellTemplate == null)
@@ -253,9 +249,7 @@ namespace Krypton.Toolkit
         public bool MultilineStringEditor
         {
             get =>
-                TextBoxCellTemplate == null
-                    ? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
-                    : TextBoxCellTemplate.MultilineStringEditor;
+                TextBoxCellTemplate?.MultilineStringEditor ?? throw new InvalidOperationException("Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
             set
             {
                 if (TextBoxCellTemplate == null)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDateTimePicker.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDateTimePicker.cs
@@ -867,12 +867,12 @@ namespace Krypton.Toolkit
                 {
                     if (value < EffectiveMinDate(_minDateTime))
                     {
-                        throw new ArgumentOutOfRangeException(@"Date provided is less than the minimum supported date.");
+                        throw new ArgumentOutOfRangeException(nameof(MaxDate), @"Date provided is less than the minimum supported date.");
                     }
 
                     if (value > DateTimePicker.MaximumDateTime)
                     {
-                        throw new ArgumentOutOfRangeException(@"Date provided is greater than the maximum supported date.");
+                        throw new ArgumentOutOfRangeException(nameof(MaxDate), @"Date provided is greater than the maximum supported date.");
                     }
 
                     _maxDateTime = value;
@@ -920,12 +920,12 @@ namespace Krypton.Toolkit
                 {
                     if (value > EffectiveMaxDate(_maxDateTime))
                     {
-                        throw new ArgumentOutOfRangeException(@"Date provided is greater than the maximum supported date.");
+                        throw new ArgumentOutOfRangeException(nameof(MinDate), @"Date provided is greater than the maximum supported date.");
                     }
 
                     if (value < DateTimePicker.MinimumDateTime)
                     {
-                        throw new ArgumentOutOfRangeException(@"Date provided is less than the minimum supported date.");
+                        throw new ArgumentOutOfRangeException(nameof(MinDate), @"Date provided is less than the minimum supported date.");
                     }
 
                     _minDateTime = value;
@@ -1372,7 +1372,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool IsActive => _fixedActive != null ? _fixedActive.Value : DesignMode || AlwaysActive || ContainsFocus || IsMouseOver;
+        public bool IsActive => _fixedActive ?? DesignMode || AlwaysActive || ContainsFocus || IsMouseOver;
 
         /// <summary>
         /// Gets a value indicating if the mouse is over the control.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
@@ -1328,12 +1328,10 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool IsActive =>
-            _fixedActive != null
-                ? _fixedActive.Value
-                : DesignMode || AlwaysActive ||
-                  ContainsFocus || _mouseOver || _domainUpDown.MouseOver ||
-                  _subclassEdit is { MouseOver: true } ||
-                  _subclassButtons is { MouseOver: true };
+            _fixedActive ?? DesignMode || AlwaysActive ||
+            ContainsFocus || _mouseOver || _domainUpDown.MouseOver ||
+            _subclassEdit is { MouseOver: true } ||
+            _subclassButtons is { MouseOver: true };
 
         /// <summary>
         /// Sets input focus to the control.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDropButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDropButton.cs
@@ -768,7 +768,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <returns>Set of button values.</returns>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        protected virtual ButtonValues CreateButtonValues(NeedPaintHandler needPaint) => new ButtonValues(needPaint);
+        protected virtual ButtonValues CreateButtonValues(NeedPaintHandler needPaint) => new (needPaint);
 
         /// <summary>
         /// Gets access to the view element for the button.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonGroupBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonGroupBox.cs
@@ -499,7 +499,7 @@ namespace Krypton.Toolkit
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public CaptionValues Values { get; }
 
-        private bool ShouldSerializeValuesPrimary() => !Values.IsDefault;
+        private bool ShouldSerializeValues() => !Values.IsDefault;
 
         /// <summary>
         /// Get the preferred size of the control based on a proposed size.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListBox.cs
@@ -1205,7 +1205,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool IsActive => _fixedActive != null ? _fixedActive.Value : DesignMode || AlwaysActive || ContainsFocus || _mouseOver || _listBox.MouseOver;
+        public bool IsActive => _fixedActive ?? DesignMode || AlwaysActive || ContainsFocus || _mouseOver || _listBox.MouseOver;
 
         /// <summary>
         /// Sets input focus to the control.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListView.cs
@@ -531,7 +531,9 @@ namespace Krypton.Toolkit
                     View.LargeIcon => _layoutDockerCheckLarge,
                     View.SmallIcon => _layoutDockerSmall,
                     View.Tile => _layoutDockerTile,
-                    _ => throw new ArgumentOutOfRangeException()
+#pragma warning disable CA2208 // Instantiate argument exceptions correctly
+                    _ => throw new ArgumentOutOfRangeException(nameof(View))
+#pragma warning restore CA2208 // Instantiate argument exceptions correctly
                 };
 
                 using (ViewLayoutContext context = new(this, Renderer))

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonManager.cs
@@ -611,71 +611,107 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the single instance of the professional system palette.
         /// </summary>
-        public static PaletteProfessionalSystem PaletteProfessionalSystem => _paletteProfessionalSystem ?? (_paletteProfessionalSystem = new PaletteProfessionalSystem());
+        public static PaletteProfessionalSystem PaletteProfessionalSystem => _paletteProfessionalSystem ??= new PaletteProfessionalSystem();
 
         /// <summary>
         /// Gets the single instance of the professional office palette.
         /// </summary>
-        public static PaletteProfessionalOffice2003 PaletteProfessionalOffice2003 => _paletteProfessionalOffice2003 ?? (_paletteProfessionalOffice2003 = new PaletteProfessionalOffice2003());
+        public static PaletteProfessionalOffice2003 PaletteProfessionalOffice2003 => _paletteProfessionalOffice2003 ??= new PaletteProfessionalOffice2003();
 
         /// <summary>
         /// Gets the single instance of the Blue variant Office 2007 palette.
         /// </summary>
-        public static PaletteOffice2007Blue PaletteOffice2007Blue => _paletteOffice2007Blue ?? (_paletteOffice2007Blue = new PaletteOffice2007Blue());
+        public static PaletteOffice2007Blue PaletteOffice2007Blue => _paletteOffice2007Blue ??= new PaletteOffice2007Blue();
 
-        public static PaletteOffice2007BlueDarkMode PaletteOffice2007BlueDarkMode => _paletteOffice2007BlueDarkMode ?? (_paletteOffice2007BlueDarkMode = new PaletteOffice2007BlueDarkMode());
+        /// <summary>
+        /// Gets the single instance of the ### palette.
+        /// </summary>
+        public static PaletteOffice2007BlueDarkMode PaletteOffice2007BlueDarkMode => _paletteOffice2007BlueDarkMode ??= new PaletteOffice2007BlueDarkMode();
 
-        public static PaletteOffice2007BlueLightMode PaletteOffice2007BlueLightMode => _paletteOffice2007BlueLightMode ?? (_paletteOffice2007BlueLightMode = new PaletteOffice2007BlueLightMode());
+        /// <summary>
+        /// Gets the single instance of the ### palette.
+        /// </summary>
+        public static PaletteOffice2007BlueLightMode PaletteOffice2007BlueLightMode => _paletteOffice2007BlueLightMode ??= new PaletteOffice2007BlueLightMode();
 
         /// <summary>
         /// Gets the single instance of the Silver variant Office 2007 palette.
         /// </summary>
-        public static PaletteOffice2007Silver PaletteOffice2007Silver => _paletteOffice2007Silver ?? (_paletteOffice2007Silver = new PaletteOffice2007Silver());
+        public static PaletteOffice2007Silver PaletteOffice2007Silver => _paletteOffice2007Silver ??= new PaletteOffice2007Silver();
 
-        public static PaletteOffice2007SilverDarkMode PaletteOffice2007SilverDarkMode => _paletteOffice2007SilverDarkMode ?? (_paletteOffice2007SilverDarkMode = new PaletteOffice2007SilverDarkMode());
+        /// <summary>
+        /// Gets the single instance of the ### palette.
+        /// </summary>
+        public static PaletteOffice2007SilverDarkMode PaletteOffice2007SilverDarkMode => _paletteOffice2007SilverDarkMode ??= new PaletteOffice2007SilverDarkMode();
 
-        public static PaletteOffice2007SilverLightMode PaletteOffice2007SilverLightMode => _paletteOffice2007SilverLightMode ?? (_paletteOffice2007SilverLightMode = new PaletteOffice2007SilverLightMode());
+        /// <summary>
+        /// Gets the single instance of the ### palette.
+        /// </summary>
+        public static PaletteOffice2007SilverLightMode PaletteOffice2007SilverLightMode => _paletteOffice2007SilverLightMode ??= new PaletteOffice2007SilverLightMode();
 
-        public static PaletteOffice2007White PaletteOffice2007White => _paletteOffice2007White ?? (_paletteOffice2007White = new PaletteOffice2007White());
+        /// <summary>
+        /// Gets the single instance of the ### palette.
+        /// </summary>
+        public static PaletteOffice2007White PaletteOffice2007White => _paletteOffice2007White ??= new PaletteOffice2007White();
 
         /// <summary>
         /// Gets the single instance of the Black variant Office 2007 palette.
         /// </summary>
-        public static PaletteOffice2007Black PaletteOffice2007Black => _paletteOffice2007Black ?? (_paletteOffice2007Black = new PaletteOffice2007Black());
+        public static PaletteOffice2007Black PaletteOffice2007Black => _paletteOffice2007Black ??= new PaletteOffice2007Black();
 
-        public static PaletteOffice2007BlackDarkMode PaletteOffice2007BlackDarkMode => _paletteOffice2007BlackDarkMode ?? (_paletteOffice2007BlackDarkMode = new PaletteOffice2007BlackDarkMode());
+        /// <summary>
+        /// Gets the single instance of the ### palette.
+        /// </summary>
+        public static PaletteOffice2007BlackDarkMode PaletteOffice2007BlackDarkMode => _paletteOffice2007BlackDarkMode ??= new PaletteOffice2007BlackDarkMode();
 
         /// <summary>
         /// Gets the single instance of the Blue variant Office 2010 palette.
         /// </summary>
-        public static PaletteOffice2010Blue PaletteOffice2010Blue => _paletteOffice2010Blue ?? (_paletteOffice2010Blue = new PaletteOffice2010Blue());
+        public static PaletteOffice2010Blue PaletteOffice2010Blue => _paletteOffice2010Blue ??= new PaletteOffice2010Blue();
 
-        public static PaletteOffice2010BlueDarkMode PaletteOffice2010BlueDarkMode => _paletteOffice2010BlueDarkMode ?? (_paletteOffice2010BlueDarkMode = new PaletteOffice2010BlueDarkMode());
+        /// <summary>
+        /// Gets the single instance of the ### palette.
+        /// </summary>
+        public static PaletteOffice2010BlueDarkMode PaletteOffice2010BlueDarkMode => _paletteOffice2010BlueDarkMode ??= new PaletteOffice2010BlueDarkMode();
 
-        public static PaletteOffice2010BlueLightMode PaletteOffice2010BlueLightMode => _paletteOffice2010BlueLightMode ?? (_paletteOffice2010BlueLightMode = new PaletteOffice2010BlueLightMode());
+        /// <summary>
+        /// Gets the single instance of the ### palette.
+        /// </summary>
+        public static PaletteOffice2010BlueLightMode PaletteOffice2010BlueLightMode => _paletteOffice2010BlueLightMode ??= new PaletteOffice2010BlueLightMode();
 
         /// <summary>
         /// Gets the single instance of the Silver variant Office 2010 palette.
         /// </summary>
-        public static PaletteOffice2010Silver PaletteOffice2010Silver => _paletteOffice2010Silver ?? (_paletteOffice2010Silver = new PaletteOffice2010Silver());
+        public static PaletteOffice2010Silver PaletteOffice2010Silver => _paletteOffice2010Silver ??= new PaletteOffice2010Silver();
 
-        public static PaletteOffice2010SilverDarkMode PaletteOffice2010SilverDarkMode => _paletteOffice2010SilverDarkMode ?? (_paletteOffice2010SilverDarkMode = new PaletteOffice2010SilverDarkMode());
+        /// <summary>
+        /// Gets the single instance of the ### palette.
+        /// </summary>
+        public static PaletteOffice2010SilverDarkMode PaletteOffice2010SilverDarkMode => _paletteOffice2010SilverDarkMode ??= new PaletteOffice2010SilverDarkMode();
 
-        public static PaletteOffice2010SilverLightMode PaletteOffice2010SilverLightMode => _paletteOffice2010SilverLightMode ?? (_paletteOffice2010SilverLightMode = new PaletteOffice2010SilverLightMode());
+        /// <summary>
+        /// Gets the single instance of the ### palette.
+        /// </summary>
+        public static PaletteOffice2010SilverLightMode PaletteOffice2010SilverLightMode => _paletteOffice2010SilverLightMode ??= new PaletteOffice2010SilverLightMode();
 
         /// <summary>
         /// Gets the single instance of the Black variant Office 2010 palette.
         /// </summary>
-        public static PaletteOffice2010Black PaletteOffice2010Black => _paletteOffice2010Black ?? (_paletteOffice2010Black = new PaletteOffice2010Black());
+        public static PaletteOffice2010Black PaletteOffice2010Black => _paletteOffice2010Black ??= new PaletteOffice2010Black();
 
-        public static PaletteOffice2010BlackDarkMode PaletteOffice2010BlackDarkMode => _paletteOffice2010BlackDarkMode ?? (_paletteOffice2010BlackDarkMode = new PaletteOffice2010BlackDarkMode());
+        /// <summary>
+        /// Gets the single instance of the ### palette.
+        /// </summary>
+        public static PaletteOffice2010BlackDarkMode PaletteOffice2010BlackDarkMode => _paletteOffice2010BlackDarkMode ??= new PaletteOffice2010BlackDarkMode();
 
-        public static PaletteOffice2010White PaletteOffice2010White => _paletteOffice2010White ?? (_paletteOffice2010White = new PaletteOffice2010White());
+        /// <summary>
+        /// Gets the single instance of the ### palette.
+        /// </summary>
+        public static PaletteOffice2010White PaletteOffice2010White => _paletteOffice2010White ??= new PaletteOffice2010White();
         
         /// <summary>
         /// Gets the single instance of the Office 2013 palette.
         /// </summary>
-        public static PaletteOffice2013White PaletteOffice2013White => _paletteOffice2013White ?? (_paletteOffice2013White = new PaletteOffice2013White());
+        public static PaletteOffice2013White PaletteOffice2013White => _paletteOffice2013White ??= new PaletteOffice2013White();
 
         /// <summary>
         /// Gets the palette office365 black.
@@ -683,9 +719,12 @@ namespace Krypton.Toolkit
         /// <value>
         /// The palette office365 black.
         /// </value>
-        public static PaletteOffice365Black PaletteOffice365Black => _paletteOffice365Black ?? (_paletteOffice365Black = new PaletteOffice365Black());
+        public static PaletteOffice365Black PaletteOffice365Black => _paletteOffice365Black ??= new PaletteOffice365Black();
 
-        public static PaletteOffice365BlackDarkMode PaletteOffice365BlackDarkMode => _paletteOffice365BlackDarkMode ?? (_paletteOffice365BlackDarkMode = new PaletteOffice365BlackDarkMode());
+        /// <summary>
+        /// Gets the single instance of the ### palette.
+        /// </summary>
+        public static PaletteOffice365BlackDarkMode PaletteOffice365BlackDarkMode => _paletteOffice365BlackDarkMode ??= new PaletteOffice365BlackDarkMode();
 
         /// <summary>
         /// Gets the palette office365 blue.
@@ -693,11 +732,17 @@ namespace Krypton.Toolkit
         /// <value>
         /// The palette office365 blue.
         /// </value>
-        public static PaletteOffice365Blue PaletteOffice365Blue => _paletteOffice365Blue ?? (_paletteOffice365Blue = new PaletteOffice365Blue());
+        public static PaletteOffice365Blue PaletteOffice365Blue => _paletteOffice365Blue ??= new PaletteOffice365Blue();
 
-        public static PaletteOffice365BlueDarkMode PaletteOffice365BlueDarkMode => _paletteOffice365BlueDarkMode ?? (_paletteOffice365BlueDarkMode = new PaletteOffice365BlueDarkMode());
+        /// <summary>
+        /// Gets the single instance of the ### palette.
+        /// </summary>
+        public static PaletteOffice365BlueDarkMode PaletteOffice365BlueDarkMode => _paletteOffice365BlueDarkMode ??= new PaletteOffice365BlueDarkMode();
 
-        public static PaletteOffice365BlueLightMode PaletteOffice365BlueLightMode => _paletteOffice365BlueLightMode ?? (_paletteOffice365BlueLightMode = new PaletteOffice365BlueLightMode());
+        /// <summary>
+        /// Gets the single instance of the ### palette.
+        /// </summary>
+        public static PaletteOffice365BlueLightMode PaletteOffice365BlueLightMode => _paletteOffice365BlueLightMode ??= new PaletteOffice365BlueLightMode();
 
         /// <summary>
         /// Gets the palette office365 silver.
@@ -705,45 +750,67 @@ namespace Krypton.Toolkit
         /// <value>
         /// The palette office365 silver.
         /// </value>
-        public static PaletteOffice365Silver PaletteOffice365Silver => _paletteOffice365Silver ?? (_paletteOffice365Silver = new PaletteOffice365Silver());
+        public static PaletteOffice365Silver PaletteOffice365Silver => _paletteOffice365Silver ??= new PaletteOffice365Silver();
 
-        public static PaletteOffice365SilverDarkMode PaletteOffice365SilverDarkMode => _paletteOffice365SilverDarkMode ?? (_paletteOffice365SilverDarkMode = new PaletteOffice365SilverDarkMode());
-
-        public static PaletteOffice365SilverLightMode PaletteOffice365SilverLightMode => _paletteOffice365SilverLightMode ?? (_paletteOffice365SilverLightMode = new PaletteOffice365SilverLightMode());
         /// <summary>
-        /// Gets the palette office365 white.
+        /// Gets the single instance of the ### palette.
         /// </summary>
-        /// <value>
-        /// The palette office365 white.
-        /// </value>
-        public static PaletteOffice365White PaletteOffice365White => _paletteOffice365White ?? (_paletteOffice365White = new PaletteOffice365White());
+        public static PaletteOffice365SilverDarkMode PaletteOffice365SilverDarkMode => _paletteOffice365SilverDarkMode ??= new PaletteOffice365SilverDarkMode();
+
+        /// <summary>
+        /// Gets the single instance of the ### palette.
+        /// </summary>
+        public static PaletteOffice365SilverLightMode PaletteOffice365SilverLightMode => _paletteOffice365SilverLightMode ??= new PaletteOffice365SilverLightMode();
+
+        /// <summary>
+        /// Gets the single instance of the ### palette.
+        /// </summary>
+        public static PaletteOffice365White PaletteOffice365White => _paletteOffice365White ??= new PaletteOffice365White();
 
         /// <summary>
         /// Gets the single instance of the Blue variant sparkle palette.
         /// </summary>
-        public static PaletteSparkleBlue PaletteSparkleBlue => _paletteSparkleBlue ?? (_paletteSparkleBlue = new PaletteSparkleBlue());
+        public static PaletteSparkleBlue PaletteSparkleBlue => _paletteSparkleBlue ??= new PaletteSparkleBlue();
 
-        public static PaletteSparkleBlueDarkMode PaletteSparkleBlueDarkMode => _paletteSparkleBlueDarkMode ?? (_paletteSparkleBlueDarkMode = new PaletteSparkleBlueDarkMode());
+        /// <summary>
+        /// Gets the single instance of the ### palette.
+        /// </summary>
+        public static PaletteSparkleBlueDarkMode PaletteSparkleBlueDarkMode => _paletteSparkleBlueDarkMode ??= new PaletteSparkleBlueDarkMode();
 
-        public static PaletteSparkleBlueLightMode PaletteSparkleBlueLightMode => _paletteSparkleBlueLightMode ?? (_paletteSparkleBlueLightMode = new PaletteSparkleBlueLightMode());
+        /// <summary>
+        /// Gets the single instance of the ### palette.
+        /// </summary>
+        public static PaletteSparkleBlueLightMode PaletteSparkleBlueLightMode => _paletteSparkleBlueLightMode ??= new PaletteSparkleBlueLightMode();
 
         /// <summary>
         /// Gets the single instance of the Orange variant sparkle palette.
         /// </summary>
-        public static PaletteSparkleOrange PaletteSparkleOrange => _paletteSparkleOrange ?? (_paletteSparkleOrange = new PaletteSparkleOrange());
+        public static PaletteSparkleOrange PaletteSparkleOrange => _paletteSparkleOrange ??= new PaletteSparkleOrange();
 
-        public static PaletteSparkleOrangeDarkMode PaletteSparkleOrangeDarkMode => _paletteSparkleOrangeDarkMode ?? (_paletteSparkleOrangeDarkMode = new PaletteSparkleOrangeDarkMode());
+        /// <summary>
+        /// Gets the single instance of the ### palette.
+        /// </summary>
+        public static PaletteSparkleOrangeDarkMode PaletteSparkleOrangeDarkMode => _paletteSparkleOrangeDarkMode ??= new PaletteSparkleOrangeDarkMode();
 
-        public static PaletteSparkleOrangeLightMode PaletteSparkleOrangeLightMode => _paletteSparkleOrangeLightMode ?? (_paletteSparkleOrangeLightMode = new PaletteSparkleOrangeLightMode());
+        /// <summary>
+        /// Gets the single instance of the ### palette.
+        /// </summary>
+        public static PaletteSparkleOrangeLightMode PaletteSparkleOrangeLightMode => _paletteSparkleOrangeLightMode ??= new PaletteSparkleOrangeLightMode();
 
         /// <summary>
         /// Gets the single instance of the Purple variant sparkle palette.
         /// </summary>
-        public static PaletteSparklePurple PaletteSparklePurple => _paletteSparklePurple ?? (_paletteSparklePurple = new PaletteSparklePurple());
+        public static PaletteSparklePurple PaletteSparklePurple => _paletteSparklePurple ??= new PaletteSparklePurple();
 
-        public static PaletteSparklePurpleDarkMode PaletteSparklePurpleDarkMode => _paletteSparklePurpleDarkMode ?? (_paletteSparklePurpleDarkMode = new PaletteSparklePurpleDarkMode());
+        /// <summary>
+        /// Gets the single instance of the ### palette.
+        /// </summary>
+        public static PaletteSparklePurpleDarkMode PaletteSparklePurpleDarkMode => _paletteSparklePurpleDarkMode ??= new PaletteSparklePurpleDarkMode();
 
-        public static PaletteSparklePurpleLightMode PaletteSparklePurpleLightMode => _paletteSparklePurpleLightMode ?? (_paletteSparklePurpleLightMode = new PaletteSparklePurpleLightMode());
+        /// <summary>
+        /// Gets the single instance of the ### palette.
+        /// </summary>
+        public static PaletteSparklePurpleLightMode PaletteSparklePurpleLightMode => _paletteSparklePurpleLightMode ??= new PaletteSparklePurpleLightMode();
 
 
         /// <summary>
@@ -781,37 +848,37 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the single instance of the Sparkle renderer.
         /// </summary>
-        public static RenderSparkle RenderSparkle => _renderSparkle ?? (_renderSparkle = new RenderSparkle());
+        public static RenderSparkle RenderSparkle => _renderSparkle ??= new RenderSparkle();
 
         /// <summary>
         /// Gets the single instance of the Office 2007 renderer.
         /// </summary>
-        public static RenderOffice2007 RenderOffice2007 => _renderOffice2007 ?? (_renderOffice2007 = new RenderOffice2007());
+        public static RenderOffice2007 RenderOffice2007 => _renderOffice2007 ??= new RenderOffice2007();
 
         /// <summary>
         /// Gets the single instance of the Office 2010 renderer.
         /// </summary>
-        public static RenderOffice2010 RenderOffice2010 => _renderOffice2010 ?? (_renderOffice2010 = new RenderOffice2010());
+        public static RenderOffice2010 RenderOffice2010 => _renderOffice2010 ??= new RenderOffice2010();
 
         /// <summary>
         /// Gets the single instance of the Office 2013 renderer.
         /// </summary>
-        public static RenderOffice2013 RenderOffice2013 => _renderOffice2013 ?? (_renderOffice2013 = new RenderOffice2013());
+        public static RenderOffice2013 RenderOffice2013 => _renderOffice2013 ??= new RenderOffice2013();
 
         /// <summary>
         /// Gets the single instance of the 365 2013 renderer.
         /// </summary>
-        public static RenderOffice365 RenderOffice365 => _renderOffice365 ?? (_renderOffice365 = new RenderOffice365());
+        public static RenderOffice365 RenderOffice365 => _renderOffice365 ??= new RenderOffice365();
 
         /// <summary>
         /// Gets the single instance of the professional renderer.
         /// </summary>
-        public static RenderProfessional RenderProfessional => _renderProfessional ?? (_renderProfessional = new RenderProfessional());
+        public static RenderProfessional RenderProfessional => _renderProfessional ??= new RenderProfessional();
 
         /// <summary>
         /// Gets the single instance of the standard renderer.
         /// </summary>
-        public static RenderStandard RenderStandard => _renderStandard ?? (_renderStandard = new RenderStandard());
+        public static RenderStandard RenderStandard => _renderStandard ??= new RenderStandard();
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs
@@ -1265,9 +1265,7 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool IsActive =>
-            _fixedActive != null
-                ? _fixedActive.Value
-                : DesignMode || AlwaysActive || ContainsFocus || _mouseOver || _maskedTextBox.MouseOver;
+            _fixedActive ?? DesignMode || AlwaysActive || ContainsFocus || _mouseOver || _maskedTextBox.MouseOver;
 
         /// <summary>
         /// Sets input focus to the control.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMonthCalendar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMonthCalendar.cs
@@ -306,12 +306,12 @@ namespace Krypton.Toolkit
                 {
                     if (value > EffectiveMaxDate(_maxDate))
                     {
-                        throw new ArgumentOutOfRangeException(@"Date provided is greater than the maximum supported date.");
+                        throw new ArgumentOutOfRangeException(nameof(MinDate), @"Date provided is greater than the maximum supported date.");
                     }
 
                     if (value < DateTimePicker.MinimumDateTime)
                     {
-                        throw new ArgumentOutOfRangeException(@"Date provided is less than the minimum supported date.");
+                        throw new ArgumentOutOfRangeException(nameof(MinDate), @"Date provided is less than the minimum supported date.");
                     }
 
                     _minDate = value;
@@ -506,12 +506,12 @@ namespace Krypton.Toolkit
                 {
                     if (value < EffectiveMinDate(_minDate))
                     {
-                        throw new ArgumentOutOfRangeException(@"Date provided is less than the minimum supported date.");
+                        throw new ArgumentOutOfRangeException(nameof(MaxDate), @"Date provided is less than the minimum supported date.");
                     }
 
                     if (value > DateTimePicker.MaximumDateTime)
                     {
-                        throw new ArgumentOutOfRangeException(@"Date provided is greater than the maximum supported date.");
+                        throw new ArgumentOutOfRangeException(nameof(MaxDate), @"Date provided is greater than the maximum supported date.");
                     }
 
                     _maxDate = value;
@@ -541,7 +541,7 @@ namespace Krypton.Toolkit
             {
                 if (value < 1)
                 {
-                    throw new ArgumentOutOfRangeException(@"MaxSelectionCount cannot be less than zero.");
+                    throw new ArgumentOutOfRangeException(nameof(MaxSelectionCount), @"MaxSelectionCount cannot be less than zero.");
                 }
 
                 if (value != _maxSelectionCount)
@@ -570,12 +570,12 @@ namespace Krypton.Toolkit
                 {
                     if (value > _maxDate)
                     {
-                        throw new ArgumentOutOfRangeException(@"Date provided is greater than the maximum date.");
+                        throw new ArgumentOutOfRangeException(nameof(SelectionStart), @"Date provided is greater than the maximum date.");
                     }
 
                     if (value < _minDate)
                     {
-                        throw new ArgumentOutOfRangeException(@"Date provided is less than the minimum date.");
+                        throw new ArgumentOutOfRangeException(nameof(SelectionStart), @"Date provided is less than the minimum date.");
                     }
 
                     DateTime endDate = _selectionEnd;
@@ -620,12 +620,12 @@ namespace Krypton.Toolkit
                 {
                     if (value > _maxDate)
                     {
-                        throw new ArgumentOutOfRangeException(@"Date provided is greater than the maximum date.");
+                        throw new ArgumentOutOfRangeException(nameof(SelectionEnd), @"Date provided is greater than the maximum date.");
                     }
 
                     if (value < _minDate)
                     {
-                        throw new ArgumentOutOfRangeException(@"Date provided is less than the minimum date.");
+                        throw new ArgumentOutOfRangeException(nameof(SelectionEnd), @"Date provided is less than the minimum date.");
                     }
 
                     DateTime startDate = _selectionStart;
@@ -692,12 +692,12 @@ namespace Krypton.Toolkit
                 {
                     if (value.Width < 1)
                     {
-                        throw new ArgumentOutOfRangeException(@"CalendarDimension Width must be greater than 0");
+                        throw new ArgumentOutOfRangeException(nameof(CalendarDimensions), @"CalendarDimension Width must be greater than 0");
                     }
 
                     if (value.Height < 1)
                     {
-                        throw new ArgumentOutOfRangeException(@"CalendarDimension Height must be greater than 0");
+                        throw new ArgumentOutOfRangeException(nameof(CalendarDimensions), @"CalendarDimension Height must be greater than 0");
                     }
 
                     _dimensions = value;
@@ -1218,22 +1218,22 @@ namespace Krypton.Toolkit
         {
             if (start.Ticks > _maxDate.Ticks)
             {
-                throw new ArgumentOutOfRangeException(@"Start date provided is greater than the maximum date.");
+                throw new ArgumentOutOfRangeException(nameof(start), @"Start date provided is greater than the maximum date.");
             }
 
             if (start.Ticks < _minDate.Ticks)
             {
-                throw new ArgumentOutOfRangeException(@"Start date provided is less than the minimum date.");
+                throw new ArgumentOutOfRangeException(nameof(start), @"Start date provided is less than the minimum date.");
             }
 
             if (end.Ticks > _maxDate.Ticks)
             {
-                throw new ArgumentOutOfRangeException(@"End date provided is greater than the maximum date.");
+                throw new ArgumentOutOfRangeException(nameof(end), @"End date provided is greater than the maximum date.");
             }
 
             if (end.Ticks < _minDate.Ticks)
             {
-                throw new ArgumentOutOfRangeException(@"End date provided is less than the minimum date.");
+                throw new ArgumentOutOfRangeException(nameof(end), @"End date provided is less than the minimum date.");
             }
 
             if (start > end)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
@@ -1433,12 +1433,10 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool IsActive =>
-            _fixedActive != null
-                ? _fixedActive.Value
-                : DesignMode || AlwaysActive ||
-                  ContainsFocus || _mouseOver || _numericUpDown.MouseOver ||
-                  _subclassEdit is { MouseOver: true } ||
-                  _subclassButtons is { MouseOver: true };
+            _fixedActive ?? DesignMode || AlwaysActive ||
+            ContainsFocus || _mouseOver || _numericUpDown.MouseOver ||
+            _subclassEdit is { MouseOver: true } ||
+            _subclassButtons is { MouseOver: true };
 
         /// <summary>
         /// Sets input focus to the control.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPrintDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPrintDialog.cs
@@ -700,6 +700,7 @@ namespace Krypton.Toolkit
     }
 
     [Flags]
+#pragma warning disable CA1069 // Enums values should not be duplicated
     internal enum PD : uint
     {
         ALLPAGES = 0x00000000,
@@ -726,11 +727,12 @@ namespace Krypton.Toolkit
         DISABLEPRINTTOFILE         = 0x00080000,
         HIDEPRINTTOFILE = 0x00100000,
         NONETWORKBUTTON = 0x00200000,
-        CURRENTPAGE = 0x00400000,
+        CURRENTPAGE = 0x00400000,   
         NOCURRENTPAGE = 0x00800000,
         EXCLUSIONFLAGS = 0x01000000,
         USELARGETEMPLATE = 0x10000000
     }
+#pragma warning restore CA1069 // Enums values should not be duplicated
 
     internal interface PRINTDLG
     {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPropertyGrid.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPropertyGrid.cs
@@ -20,7 +20,7 @@ namespace Krypton.Toolkit
         #region Variables
         private IPalette _palette;
 
-        private PaletteRedirect _paletteRedirect;
+        private readonly PaletteRedirect _paletteRedirect;
 
         private Color _gradientMiddleColour = Color.Gray;
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
@@ -1599,9 +1599,7 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool IsActive =>
-            _fixedActive != null
-                ? _fixedActive.Value
-                : DesignMode || AlwaysActive || ContainsFocus || _mouseOver || _richTextBox.MouseOver;
+            _fixedActive ?? DesignMode || AlwaysActive || ContainsFocus || _mouseOver || _richTextBox.MouseOver;
 
         /// <summary>
         /// Sets input focus to the control.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonSeparator.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonSeparator.cs
@@ -87,17 +87,17 @@ namespace Krypton.Toolkit
         public event EventHandler<SplitterMoveRectMenuArgs> SplitterMoveRect;
 
         /// <summary>
-        /// Occurs when the separator move finishes and a move has occured.
+        /// Occurs when the separator move finishes and a move has occurred.
         /// </summary>
         [Category("Behavior")]
-        [Description("Occurs when the separator move finishes and a move has occured.")]
+        [Description("Occurs when the separator move finishes and a move has occurred.")]
         public event SplitterEventHandler SplitterMoved;
 
         /// <summary>
-        /// Occurs when the separator move finishes and a move has not occured.
+        /// Occurs when the separator move finishes and a move has not occurred.
         /// </summary>
         [Category("Behavior")]
-        [Description("Occurs when the separator move finishes and a move has not occured.")]
+        [Description("Occurs when the separator move finishes and a move has not occurred.")]
         public event EventHandler SplitterNotMoved;
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTableLayoutPanel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTableLayoutPanel.cs
@@ -44,7 +44,7 @@ namespace Krypton.Toolkit
 
         private void State_PropertyChanged(object sender, PropertyChangedEventArgs e) =>
             // Handle explicit settings to the controls
-            _backGroundPanel_Refreshed();
+            BackGroundPanel_Refreshed();
 
         #endregion
 
@@ -66,7 +66,7 @@ namespace Krypton.Toolkit
                 }
 
                 _backGroundPanel.BackColor = value;
-                _backGroundPanel_Refreshed();
+                BackGroundPanel_Refreshed();
             }
         }
 
@@ -143,7 +143,7 @@ namespace Krypton.Toolkit
             set
             {
                 _backGroundPanel.PaletteMode = value;
-                _backGroundPanel_Refreshed();
+                BackGroundPanel_Refreshed();
             }
         }
 
@@ -170,7 +170,7 @@ namespace Krypton.Toolkit
             set
             {
                 _backGroundPanel.Palette = value;
-                _backGroundPanel_Refreshed();
+                BackGroundPanel_Refreshed();
             }
         }
 
@@ -185,7 +185,7 @@ namespace Krypton.Toolkit
             set
             {
                 _backGroundPanel.PanelBackStyle = value;
-                _backGroundPanel_Refreshed();
+                BackGroundPanel_Refreshed();
             }
         }
 
@@ -239,7 +239,7 @@ namespace Krypton.Toolkit
         {
             base.OnEnabledChanged(e);
             _backGroundPanel.Enabled = Enabled;
-            _backGroundPanel_Refreshed();
+            BackGroundPanel_Refreshed();
         }
 
         /// <inheritdoc />
@@ -251,7 +251,7 @@ namespace Krypton.Toolkit
         }
 
         private Bitmap _bm;
-        private void _backGroundPanel_Refreshed()
+        private void BackGroundPanel_Refreshed()
         {
             _bm = new Bitmap(_backGroundPanel.Width, _backGroundPanel.Height, PixelFormat.Format32bppRgb);
             _backGroundPanel.DrawToBitmap(_bm,
@@ -273,7 +273,7 @@ namespace Krypton.Toolkit
                 var index = Parent.Controls.GetChildIndex(this);
                 Parent.Controls.SetChildIndex(_backGroundPanel, index + 1);
             }
-            _backGroundPanel_Refreshed();
+            BackGroundPanel_Refreshed();
         }
 
         /// <inheritdoc />
@@ -338,7 +338,7 @@ namespace Krypton.Toolkit
                     {
                         var index = Parent.Controls.GetChildIndex(this);
                         Parent.Controls.SetChildIndex(_backGroundPanel, index + 1);
-                        _backGroundPanel_Refreshed();
+                        BackGroundPanel_Refreshed();
                     }
                 }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialogCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialogCommand.cs
@@ -326,7 +326,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the item with the provided name.
         /// </summary>
-        /// <param name=(@"Name")>Name to find.</param>
+        /// <param name="name">Name to find.</param>
         /// <returns>Item with matching name.</returns>
         public override KryptonTaskDialogCommand this[string name]
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
@@ -1263,7 +1263,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool IsActive => _fixedActive != null ? _fixedActive.Value : DesignMode || AlwaysActive || ContainsFocus || _mouseOver || _textBox.MouseOver;
+        public bool IsActive => _fixedActive ?? DesignMode || AlwaysActive || ContainsFocus || _mouseOver || _textBox.MouseOver;
 
         /// <summary>
         /// Sets input focus to the control.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit
     public class KryptonThemeComboBox : KryptonComboBox
     {
         #region Instance Fields
-        private List<string> _supportedThemesList;
+        private readonly List<string> _supportedThemesList;
 
         private int _selectedIndex;
 
@@ -50,7 +50,7 @@ namespace Krypton.Toolkit
 
             ThemeSelectedIndex = 22;
 
-            ThemeManager.PropagateSupportedThemeList(_supportedThemesList);
+            _supportedThemesList = ThemeManager.PropagateSupportedThemeList();
         }
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
@@ -1381,7 +1381,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool IsActive => _fixedActive != null ? _fixedActive.Value : DesignMode || AlwaysActive || ContainsFocus || _mouseOver || _treeView.MouseOver;
+        public bool IsActive => _fixedActive ?? DesignMode || AlwaysActive || ContainsFocus || _mouseOver || _treeView.MouseOver;
 
         /// <summary>
         /// Sets input focus to the control.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonWrapLabel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonWrapLabel.cs
@@ -446,10 +446,7 @@ namespace Krypton.Toolkit
             }
 
             // Recover font from state common or as last resort the inherited palette
-            if (font == null)
-            {
-                font = StateCommon.Font ?? _redirector.GetContentShortTextFont(_labelContentStyle, ps);
-            }
+            font ??= StateCommon.Font ?? _redirector.GetContentShortTextFont(_labelContentStyle, ps);
 
             // Recover text color from state common or as last resort the inherited palette
             if (textColor == Color.Empty)
@@ -619,7 +616,7 @@ namespace Krypton.Toolkit
         /// Create the redirector instance.
         /// </summary>
         /// <returns>PaletteRedirect derived class.</returns>
-        private PaletteRedirect CreateRedirector() => new PaletteRedirect(_palette);
+        private PaletteRedirect CreateRedirector() => new (_palette);
 
         /// <summary>
         /// Update the view elements based on the requested label style.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMessageBoxForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMessageBoxForm.cs
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit
         private readonly MessageBoxIcon _messageBoxIcon;
 
         private readonly MessageBoxDefaultButton _defaultButton;
-        private MessageBoxOptions _options; // https://github.com/Krypton-Suite/Standard-Toolkit/issues/313
+        private readonly MessageBoxOptions _options; // https://github.com/Krypton-Suite/Standard-Toolkit/issues/313
         // If help information provided or we are not a service/default desktop application then grab an owner for showing the message box
         private readonly IWin32Window _showOwner;
         private readonly HelpInfo _helpInfo;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContainerControlBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContainerControlBase.cs
@@ -352,7 +352,7 @@ namespace Krypton.Toolkit
                         _paletteMode = PaletteMode.Custom;
                     }
 
-                    // If real change has occured
+                    // If real change has occurred
                     if (old != _localPalette)
                     {
                         // Raise the change event
@@ -717,7 +717,7 @@ namespace Krypton.Toolkit
         /// Create the redirector instance.
         /// </summary>
         /// <returns>PaletteRedirect derived class.</returns>
-        protected virtual PaletteRedirect CreateRedirector() => new PaletteRedirect(_palette);
+        protected virtual PaletteRedirect CreateRedirector() => new (_palette);
         // ReSharper restore VirtualMemberNeverOverridden.Global
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualControlBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualControlBase.cs
@@ -359,7 +359,7 @@ namespace Krypton.Toolkit
                         _paletteMode = PaletteMode.Custom;
                     }
 
-                    // If real change has occured
+                    // If real change has occurred
                     if (old != _localPalette)
                     {
                         // Raise the change event
@@ -769,7 +769,7 @@ namespace Krypton.Toolkit
         /// Create the redirector instance.
         /// </summary>
         /// <returns>PaletteRedirect derived class.</returns>
-        protected virtual PaletteRedirect CreateRedirector() => new PaletteRedirect(_palette);
+        protected virtual PaletteRedirect CreateRedirector() => new (_palette);
 
         /// <summary>
         /// Update global event attachments.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
@@ -909,7 +909,7 @@ namespace Krypton.Toolkit
         /// Create the redirector instance.
         /// </summary>
         /// <returns>PaletteRedirect derived class.</returns>
-        protected virtual PaletteRedirect CreateRedirector() => new PaletteRedirect(_palette);
+        protected virtual PaletteRedirect CreateRedirector() => new (_palette);
 
         /// <summary>
         /// Processes a notification from palette storage of a button spec change.
@@ -1013,7 +1013,6 @@ namespace Krypton.Toolkit
                         OnWM_GETMINMAXINFO(ref m);
                         /* Setting handled to false enables the application to process it's own Min/Max requirements,
                 * as mentioned by jason.bullard (comment from September 22, 2011) on http://gallery.expression.microsoft.com/ZuneWindowBehavior/ */
-                        processed = false;
                         // https://github.com/Krypton-Suite/Standard-Toolkit/issues/459
                         // Still got to call - base - to allow the "application to process it's own Min/Max requirements" !!
                         base.WndProc(ref m);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPanel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPanel.cs
@@ -387,7 +387,7 @@ namespace Krypton.Toolkit
                         _paletteMode = PaletteMode.Custom;
                     }
 
-                    // If real change has occured
+                    // If real change has occurred
                     if (old != _localPalette)
                     {
                         // Raise the change event

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPopupManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPopupManager.cs
@@ -51,7 +51,7 @@ namespace Krypton.Toolkit
         public static VisualPopupManager Singleton
         {
             [DebuggerStepThrough]
-            get => _singleton ?? (_singleton = new VisualPopupManager());
+            get => _singleton ??= new VisualPopupManager();
         }
         #endregion
 
@@ -708,12 +708,12 @@ namespace Krypton.Toolkit
             // so convert to actual int values for the negative positions
             if (clientPt.x >= 32767)
             {
-                clientPt.x = clientPt.x - 65536;
+                clientPt.x -= 65536;
             }
 
             if (clientPt.y >= 32767)
             {
-                clientPt.y = clientPt.y - 65536;
+                clientPt.y -= 65536;
             }
 
             // Convert a 0,0 point from client to screen to find offsetting
@@ -740,8 +740,7 @@ namespace Krypton.Toolkit
             }
 
             return m.Msg is >= PI.WM_.NCMOUSEMOVE and <= PI.WM_.NCMBUTTONDBLCLK
-                ? true
-                : m.Msg is >= PI.WM_.KEYDOWN and <= PI.WM_.KEYLAST;
+                    || m.Msg is >= PI.WM_.KEYDOWN and <= PI.WM_.KEYLAST;
         }
 
         private void FilterMessages(bool filter)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPopupTooltip.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPopupTooltip.cs
@@ -189,7 +189,7 @@ namespace Krypton.Toolkit
                     popupLocation = new Point(positionPlacementRectangle.Left, positionPlacementRectangle.Top - popupSize.Height);
                     break;
                 default:
-                    throw new ArgumentOutOfRangeException();
+                    throw new ArgumentOutOfRangeException(nameof(position.PlacementMode));
             }
             // Show it now!
             Show(popupLocation, popupSize);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualShadowBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualShadowBase.cs
@@ -223,10 +223,10 @@ namespace Krypton.Toolkit
             var w = windowBounds.Width + extraWidth * 2;
             var h = windowBounds.Height + extraWidth * 2;
 
-            int top;
-            int left;
-            int bottom;
-            int right;
+            var top = 0;
+            var left = 0;
+            var bottom = 0;
+            var right = 0;
 
             switch (_visualOrientation)
             {
@@ -254,8 +254,6 @@ namespace Krypton.Toolkit
                     bottom = h;
                     right = w;
                     break;
-                default:
-                    throw new ArgumentOutOfRangeException();
             }
 
             return Rectangle.FromLTRB(left, top, right, bottom);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualTaskDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualTaskDialog.cs
@@ -916,7 +916,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void _linkLabelFooter_LinkClicked(object sender, EventArgs e) => _taskDialog?.RaiseFooterHyperlinkClicked();
+        private void LinkLabelFooter_LinkClicked(object sender, EventArgs e) => _taskDialog?.RaiseFooterHyperlinkClicked();
 
         private void _buttonClose_Click(object sender, EventArgs e) => Close();
 
@@ -1283,7 +1283,7 @@ namespace Krypton.Toolkit
             _linkLabelFooter.Size = new Size(110, 20);
             _linkLabelFooter.TabIndex = 0;
             _linkLabelFooter.Values.Text = "kryptonLinkLabel1";
-            _linkLabelFooter.LinkClicked += _linkLabelFooter_LinkClicked;
+            _linkLabelFooter.LinkClicked += LinkLabelFooter_LinkClicked;
             // 
             // _iconFooter
             // 

--- a/Source/Krypton Components/Krypton.Toolkit/Converters/PaletteDrawBordersConverter.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Converters/PaletteDrawBordersConverter.cs
@@ -49,54 +49,54 @@ namespace Krypton.Toolkit
                 PaletteDrawBorders borders = (PaletteDrawBorders)value;
 
                 // If the inherit flag is set that that is the only flag of interest
-                if ((borders & PaletteDrawBorders.Inherit) == PaletteDrawBorders.Inherit)
+                if (borders.HasFlag(PaletteDrawBorders.Inherit))
                 {
-                    return "Inherit";
+                    return @"Inherit";
                 }
                 else
                 {
                     // Append the names of each border we want
                     StringBuilder sb = new();
 
-                    if ((borders & PaletteDrawBorders.Top) == PaletteDrawBorders.Top)
+                    if (borders.HasFlag(PaletteDrawBorders.Top))
                     {
-                        sb.Append("Top");
+                        sb.Append(@"Top");
                     }
 
-                    if ((borders & PaletteDrawBorders.Bottom) == PaletteDrawBorders.Bottom)
+                    if (borders.HasFlag(PaletteDrawBorders.Bottom))
                     {
                         if (sb.Length > 0)
                         {
-                            sb.Append(",");
+                            sb.Append(',');
                         }
 
-                        sb.Append("Bottom");
+                        sb.Append(@"Bottom");
                     }
 
-                    if ((borders & PaletteDrawBorders.Left) == PaletteDrawBorders.Left)
+                    if (borders.HasFlag(PaletteDrawBorders.Left))
                     {
                         if (sb.Length > 0)
                         {
-                            sb.Append(",");
+                            sb.Append(',');
                         }
 
-                        sb.Append("Left");
+                        sb.Append(@"Left");
                     }
 
-                    if ((borders & PaletteDrawBorders.Right) == PaletteDrawBorders.Right)
+                    if (borders.HasFlag(PaletteDrawBorders.Right))
                     {
                         if (sb.Length > 0)
                         {
-                            sb.Append(",");
+                            sb.Append(',');
                         }
 
-                        sb.Append("Right");
+                        sb.Append(@"Right");
                     }
 
                     // If no border is wanted then return a fixed string
                     if (sb.Length == 0)
                     {
-                        sb.Append("None");
+                        sb.Append(@"None");
                     }
 
                     return sb.ToString();
@@ -127,32 +127,32 @@ namespace Krypton.Toolkit
                 PaletteDrawBorders ret = PaletteDrawBorders.None;
 
                 // If inherit is in the string, we use only that value
-                if (conv.Contains("Inherit"))
+                if (conv.Contains(@"Inherit"))
                 {
                     ret = PaletteDrawBorders.Inherit;
                 }
                 else
                 {
                     // If the word 'none' is found then no value is needed
-                    if (!conv.Contains("None"))
+                    if (!conv.Contains(@"None"))
                     {
                         // Get the borders actually specified
-                        if (conv.Contains("Top"))
+                        if (conv.Contains(@"Top"))
                         {
                             ret |= PaletteDrawBorders.Top;
                         }
 
-                        if (conv.Contains("Bottom"))
+                        if (conv.Contains(@"Bottom"))
                         {
                             ret |= PaletteDrawBorders.Bottom;
                         }
 
-                        if (conv.Contains("Left"))
+                        if (conv.Contains(@"Left"))
                         {
                             ret |= PaletteDrawBorders.Left;
                         }
 
-                        if (conv.Contains("Right"))
+                        if (conv.Contains(@"Right"))
                         {
                             ret |= PaletteDrawBorders.Right;
                         }

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Editors/KryptonBreadCrumbItemsEditor.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Editors/KryptonBreadCrumbItemsEditor.cs
@@ -235,7 +235,7 @@ namespace Krypton.Toolkit
             #endregion
 
             #region Instance Fields
-            private KryptonBreadCrumbItemsEditor _editor;
+            private readonly KryptonBreadCrumbItemsEditor _editor;
             private DictItemBase _beforeItems;
             private readonly Button buttonOK;
             private readonly TreeView treeView1;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/UX/KryptonContextMenuCollectionForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/UX/KryptonContextMenuCollectionForm.cs
@@ -194,7 +194,7 @@ namespace Krypton.Toolkit
 
             #region Instance Fields
             private DictItemBase _beforeItems;
-            private KryptonContextMenuCollectionEditor _editor;
+            private readonly KryptonContextMenuCollectionEditor _editor;
             private Button _buttonOk;
             private TreeView _treeView;
             private Label _label1;

--- a/Source/Krypton Components/Krypton.Toolkit/General/CommonHelper.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/CommonHelper.cs
@@ -43,10 +43,10 @@ namespace Krypton.Toolkit
         private const int VK_MENU = 0x12;
         
         private static readonly char[] _singleDateFormat = { 'd', 'f', 'F', 'g', 'h', 'H', 'K', 'm', 'M', 's', 't', 'y', 'z' };
-        private static readonly int[] _daysInMonth = new int[12] { 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334 };
+        //private static readonly int[] _daysInMonth = new int[12] { 0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334 };
 
         private static int _nextId = 1000;
-        private static DateTime _baseDate = new(2000, 1, 1);
+        //private static readonly DateTime _baseDate = new(2000, 1, 1);
         private static PropertyInfo _cachedShortcutPI;
         private static PropertyInfo _cachedDesignModePI;
         private static MethodInfo _cachedShortcutMI;
@@ -173,7 +173,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets reference to a null implementation of the IContentValues interface.
         /// </summary>
-        public static IContentValues NullContentValues => _nullContentValues ?? (_nullContentValues = new NullContentValues());
+        public static IContentValues NullContentValues => _nullContentValues ??= new NullContentValues();
 
         /// <summary>
         /// Return the provided size with orientation specific padding applied.
@@ -364,9 +364,7 @@ namespace Krypton.Toolkit
         [DebuggerStepThrough]
         public static void SwapRectangleSizes(ref Rectangle rect)
         {
-            var temp = rect.Width;
-            rect.Width = rect.Height;
-            rect.Height = temp;
+            (rect.Width, rect.Height) = (rect.Height, rect.Width);
         }
 
         /// <summary>
@@ -1548,12 +1546,12 @@ namespace Krypton.Toolkit
             // so convert to actual int values for the negative positions
             if (clientPt.x >= 32767)
             {
-                clientPt.x = clientPt.x - 65536;
+                clientPt.x -= 65536;
             }
 
             if (clientPt.y >= 32767)
             {
-                clientPt.y = clientPt.y - 65536;
+                clientPt.y -= 65536;
             }
 
             // Convert a 0,0 point from client to screen to find offsetting

--- a/Source/Krypton Components/Krypton.Toolkit/General/PlatformInvoke.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/PlatformInvoke.cs
@@ -18,6 +18,8 @@
 // ReSharper disable ArrangeTypeMemberModifiers
 // ReSharper disable BuiltInTypeReferenceStyle
 // ReSharper disable ClassNeverInstantiated.Global
+using System.Runtime.Versioning;
+
 #pragma warning disable 649
 
 
@@ -112,7 +114,7 @@ namespace Krypton.Toolkit
             ALL = RANGE | PAGE | POS | TRACKPOS
         }
 
-#pragma warning disable CA1069 // Enums values should not be duplicated
+ #pragma warning disable CA1069 // Enums values should not be duplicated
         internal enum SB_
         {
             LINEUP = 0,
@@ -2520,7 +2522,7 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
 
         internal static int MakeLParam(int LoWord, int HiWord) => (HiWord << 16) | (LoWord & 0xffff);
 
-        internal static IntPtr MakeWParam(int LoWord, int HiWord) => new IntPtr((long)((HiWord << 16) | (LoWord & 0xffff)));
+        internal static IntPtr MakeWParam(int LoWord, int HiWord) => new ((long)((HiWord << 16) | (LoWord & 0xffff)));
 
         /// <summary>
         /// Is the specified key currently pressed down.
@@ -2558,7 +2560,7 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
 
         #region Static User32
 
-        [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+        [DllImport(@"user32.dll", SetLastError = true, EntryPoint = "SetWindowTextW", CharSet = CharSet.Unicode)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         internal static extern bool SetWindowText(IntPtr hwnd, String lpString);
 
@@ -2594,7 +2596,7 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         internal static extern IntPtr GetDlgItem(IntPtr hWnd, int nIDDlgItem);
 
-        [DllImport(@"user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        [DllImport(@"user32.dll", EntryPoint = "GetWindowTextW", CharSet = CharSet.Unicode, SetLastError = true)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         internal static extern int GetWindowText(IntPtr hWnd, StringBuilder lpString, int nMaxCount);
 
@@ -2654,7 +2656,7 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
 
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        [DllImport("user32.dll", EntryPoint = "GetWindowInfo", SetLastError = true)]
+        [DllImport(@"user32.dll", EntryPoint = "GetWindowInfo", SetLastError = true)]
         private static extern bool GetWindowInfoInt(IntPtr hwnd, ref WINDOWINFO pwi);
 
         [StructLayout(LayoutKind.Sequential)]
@@ -2748,11 +2750,11 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         private static extern IntPtr GetClassLongPtr64(IntPtr hWnd, int nIndex);
 
-        [DllImport("user32.dll", EntryPoint = "SetClassLong")]
+        [DllImport(@"user32.dll", EntryPoint = "SetClassLong")]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         internal static extern uint SetClassLongPtr32(IntPtr hWnd, int nIndex, uint dwNewLong);
 
-        [DllImport("user32.dll", EntryPoint = "SetClassLongPtr")]
+        [DllImport(@"user32.dll", EntryPoint = "SetClassLongPtr")]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         internal static extern IntPtr SetClassLongPtr64(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
 
@@ -2761,15 +2763,15 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         internal static extern bool IntersectRect([Out] out RECT lprcDst, [In] ref RECT lprcSrc1, [In] ref RECT lprcSrc2);
 
-        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        [DllImport(@"user32.dll", CharSet = CharSet.Auto)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         internal static extern bool InvalidateRect(IntPtr hWnd, RECT rect, bool erase);
 
-        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        [DllImport(@"user32.dll", CharSet = CharSet.Auto)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         internal static extern bool InvalidateRect(IntPtr hWnd, IntPtr rect, bool erase);
 
-        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        [DllImport(@"user32.dll", CharSet = CharSet.Auto)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         internal static extern bool UpdateWindow(IntPtr hWnd);
 
@@ -2833,7 +2835,7 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         internal static extern ushort GetKeyState(int virtKey);
 
-        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        [DllImport(@"user32.dll", CharSet = CharSet.Auto)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         internal static extern IntPtr SendDlgItemMessage(IntPtr hDlg, int nIDDlgItem, int Msg, IntPtr wParam, IntPtr lParam);
 
@@ -2861,7 +2863,7 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
         {
             if (!PostMessage(hWnd, msg, wParam, lParam))
             {
-                // An error occured
+                // An error occurred
                 throw new Win32Exception(Marshal.GetLastWin32Error());
             }
         }
@@ -3137,11 +3139,11 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
 
         #region Static Gdi32
 
-        [DllImport("gdiplus.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        [DllImport(@"gdiplus.dll", CharSet = CharSet.Unicode, SetLastError = true)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         internal static extern int GdipCreateSolidFill(int color, out IntPtr brush);
 
-        [DllImport("gdiplus.dll", EntryPoint = "GdipDeleteBrush", CharSet = CharSet.Unicode, SetLastError = true)]
+        [DllImport(@"gdiplus.dll", EntryPoint = "GdipDeleteBrush", CharSet = CharSet.Unicode, SetLastError = true)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         internal static extern int GdipDeleteBrush(HandleRef brush);
 
@@ -3493,9 +3495,11 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         internal static extern IntPtr GlobalFree(IntPtr hMem);
 
-        [DllImport(@"kernel32.dll", CharSet = CharSet.Auto)]
+        [DllImport(@"kernel32.dll", CharSet=CharSet.Unicode, BestFitMapping=false, ThrowOnUnmappableChar=true)]
+//        [DllImport(ExternDll.Kernel32, CharSet=CharSet.Auto)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-        internal static extern IntPtr GetModuleHandle(string modName);
+        [ResourceExposure(ResourceScope.Process)]
+        internal static extern IntPtr GetModuleHandle(string moduleName);
 
         [DllImport(@"kernel32.dll")]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]

--- a/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/HScrollSkin.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/HScrollSkin.cs
@@ -29,7 +29,7 @@ namespace Krypton.Toolkit
         [AccessedThroughProperty(@"HScrollBar1")]
         private KryptonScrollBar _HScrollBar1;
 
-        private IContainer components;
+        private readonly IContainer components;
 
         //public WIN32ScrollBars.ScrollInfo si;
         public WIN32ScrollBars.ScrollInfo si2;

--- a/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/ScrollBarExtendedRenderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/ScrollBarExtendedRenderer.cs
@@ -352,7 +352,6 @@ namespace Krypton.Toolkit
             Bitmap btm = new(8, 8);
             btm.SetResolution(72, 72);
             Graphics g = Graphics.FromImage(btm);
-            Rectangle rect = new(0, 0, 8, 8);
 
             g.DrawLine(new Pen(gripColours[1]), new Point(0, 0), new Point(8, 0));//dark
             g.DrawLine(new Pen(gripColours[0]), new Point(1, 1), new Point(7, 1));//light

--- a/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/VScrollSkin.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/VScrollSkin.cs
@@ -29,7 +29,7 @@ namespace Krypton.Toolkit
         [AccessedThroughProperty("HScrollBar1")]
         private KryptonScrollBar _hScrollBar1;
 
-        private IContainer components;
+        private readonly IContainer components;
 
         public WIN32ScrollBars.ScrollInfo si;
 
@@ -646,7 +646,7 @@ namespace Krypton.Toolkit
             var listStyle = PI.GetWindowLong(dgv.Handle, PI.GWL_.STYLE);
             //listStyle |= WIN32ScrollBars.WS_VSCROLL | WIN32ScrollBars.WS_HSCROLL;
             listStyle |= PI.WS_.VSCROLL;
-            listStyle = PI.SetWindowLong(dgv.Handle, PI.GWL_.STYLE, listStyle);
+            _ = PI.SetWindowLong(dgv.Handle, PI.GWL_.STYLE, listStyle);
 
             VScrollBar1.Value = VSB.Value;
             VScrollBar1.Visible = true;
@@ -679,7 +679,7 @@ namespace Krypton.Toolkit
             var listStyle = PI.GetWindowLong(dgv.Handle, PI.GWL_.STYLE);
             //listStyle |= WIN32ScrollBars.WS_VSCROLL | WIN32ScrollBars.WS_HSCROLL;
             listStyle |= PI.WS_.HSCROLL;
-            listStyle = PI.SetWindowLong(dgv.Handle, PI.GWL_.STYLE, listStyle);
+            _ = PI.SetWindowLong(dgv.Handle, PI.GWL_.STYLE, listStyle);
 
             HScrollBar1.Value = HSB.Value;
             HScrollBar1.Visible = true;

--- a/Source/Krypton Components/Krypton.Toolkit/General/Storage.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Storage.cs
@@ -58,7 +58,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the need paint delegate.
         /// </summary>
-        protected NeedPaintHandler NeedPaintDelegate => _needPaintDelegate ?? (_needPaintDelegate = OnNeedPaint);
+        protected NeedPaintHandler NeedPaintDelegate => _needPaintDelegate ??= OnNeedPaint;
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/General/TypedCollection.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/TypedCollection.cs
@@ -242,7 +242,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the item with the provided unique name.
         /// </summary>
-        /// <param name=(@"Name")>Name of the ribbon tab instance.</param>
+        /// <param name="name">Name of the ribbon tab instance.</param>
         /// <returns>Item at specified index.</returns>
         public virtual T this[string name] => null;
 

--- a/Source/Krypton Components/Krypton.Toolkit/General/WindowStylesHelper.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/WindowStylesHelper.cs
@@ -41,77 +41,77 @@ namespace Krypton.Toolkit
             }
 
             str1.Append("Styles: ");
-            if ((WinStyle & 8388608) != 0)
+            if (Border)
             {
                 str1.Append("WS_BORDER");
             }
 
-            if ((WinStyle & 4194304) != 0)
+            if (DlgFrame)
             {
                 str1.Append("+WS_DLGFRAME ");
             }
 
-            if ((WinStyle & 262144) != 0)
+            if (ThickFrame)
             {
                 str1.Append("+WS_THICKFRAME ");
             }
 
-            if ((WinStyle & 134217728) != 0)
+            if (Disabled)
             {
                 str1.Append("+WS_DISABLED ");
             }
 
-            if ((WinStyle & 1048576) != 0)
+            if (HScrollBar)
             {
                 str1.Append("+WS_HSCROLL ");
             }
 
-            if ((WinStyle & 2097152) != 0)
+            if (VScrollBar)
             {
                 str1.Append("+WS_VSCROLL ");
             }
 
-            if ((WinStyle & 131072) != 0)
+            if (MinimizeBox)
             {
                 str1.Append("+WS_MINIMIZEBOX ");
             }
 
-            if ((WinStyle & 65536) != 0)
+            if (MaximizeBox)
             {
                 str1.Append("+WS_MAXIMIZEBOX ");
             }
 
-            if ((WinStyle & 2147483648L) != 0L)
+            if (Popup)
             {
                 str1.Append("+WS_POPUP ");
             }
 
-            if ((WinStyle & 524288) != 0)
+            if (SysMenu)
             {
                 str1.Append("+WS_SYSMENU ");
             }
 
-            if ((WinStyle & 536870912) != 0)
+            if (Minimized)
             {
-                str1.Append("+WS_MINIMIZE ");
+                str1.Append("+WS_MINIMIZED ");
             }
 
-            if ((WinStyle & 16777216) != 0)
+            if (Maximized)
             {
-                str1.Append("+WS_MAXIMIZE ");
+                str1.Append("+WS_MAXIMIZED ");
             }
 
-            if ((WinExStyle & 1) != 0)
+            if (DialogModalFrame)
             {
                 str1.Append("+WS_EX_DLGMODALFRAME ");
             }
 
-            if ((WinExStyle & 512) != 0)
+            if (ClientEdge)
             {
                 str1.Append("+WS_EX_CLIENTEDGE ");
             }
 
-            if ((WinExStyle & 128) != 0)
+            if (ToolWindow)
             {
                 str1.Append("+WS_EX_TOOLWINDOW ");
             }
@@ -123,18 +123,18 @@ namespace Krypton.Toolkit
 
         public uint WinExStyle { get; set; }
 
-        public bool IsEmpty => WinStyle == 0 ? WinExStyle == 0 : false;
+        public bool IsEmpty => WinStyle == 0 && WinExStyle == 0;
 
         public bool Border
         {
             get => (WinStyle & 8388608) != 0;
-            set => WinStyle |= 8388608;
+            //set => WinStyle |= 8388608;
         }
 
         public bool Caption
         {
             get => (WinStyle & 12582912) == 12582912;
-            set => WinStyle |= 12582912;
+            //set => WinStyle |= 12582912;
         }
 
         public bool Child => (WinStyle & 1073741824) != 0;
@@ -142,43 +142,43 @@ namespace Krypton.Toolkit
         public bool ClipChildren
         {
             get => (WinStyle & 33554432) != 0;
-            set => WinStyle |= 33554432;
+            //set => WinStyle |= 33554432;
         }
 
         public bool ClipSiblings
         {
             get => (WinStyle & 67108864) != 0;
-            set => WinStyle |= 67108864;
+            //set => WinStyle |= 67108864;
         }
 
         public bool Disabled
         {
             get => (WinStyle & 134217728) != 0;
-            set => WinStyle |= 134217728;
+            //set => WinStyle |= 134217728;
         }
 
         public bool DlgFrame
         {
             get => (WinStyle & 4194304) != 0;
-            set => WinStyle |= 4194304;
+            //set => WinStyle |= 4194304;
         }
 
         public bool Group
         {
             get => (WinStyle & 131072) != 0;
-            set => WinStyle |= 131072;
+            //set => WinStyle |= 131072;
         }
 
         public bool HScrollBar
         {
             get => (WinStyle & 1048576) != 0;
-            set => WinStyle |= 1048576;
+            //set => WinStyle |= 1048576;
         }
 
         public bool VScrollBar
         {
             get => (WinStyle & 2097152) != 0;
-            set => WinStyle |= 2097152;
+            //set => WinStyle |= 2097152;
         }
 
         public bool ScrollBars => (WinStyle & 3145728) != 0;
@@ -186,19 +186,19 @@ namespace Krypton.Toolkit
         public bool MaximizeBox
         {
             get => (WinStyle & 65536) != 0;
-            set => WinStyle |= 65536;
+            //set => WinStyle |= 65536;
         }
 
         public bool MinimizeBox
         {
             get => (WinStyle & 131072) != 0;
-            set => WinStyle |= 131072;
+            //set => WinStyle |= 131072;
         }
 
         public bool SysMenu
         {
             get => (WinStyle & 524288) != 0;
-            set => WinStyle |= 524288;
+            //set => WinStyle |= 524288;
         }
 
         public bool Minimized => (WinStyle & 536870912) != 0;
@@ -208,19 +208,19 @@ namespace Krypton.Toolkit
         public bool OverlappedWindow
         {
             get => (WinStyle & 13565952) == 13565952;
-            set => WinStyle |= 13565952;
+            //set => WinStyle |= 13565952;
         }
 
         public bool Popup
         {
             get => (WinStyle & 2147483648L) != 0L;
-            set => WinStyle |= 2147483648U;
+            //set => WinStyle |= 2147483648U;
         }
 
         public bool ThickFrame
         {
             get => (WinStyle & 262144) != 0;
-            set => WinStyle |= 262144;
+            //set => WinStyle |= 262144;
         }
 
         public bool Sizable => (WinStyle & 262144) != 0;
@@ -228,7 +228,7 @@ namespace Krypton.Toolkit
         public bool Visible
         {
             get => (WinStyle & 268435456) != 0;
-            set => WinStyle |= 268435456;
+            //set => WinStyle |= 268435456;
         }
 
         public bool ModalDialog => (WinStyle & 12583040) == 12583040;
@@ -252,7 +252,7 @@ namespace Krypton.Toolkit
                     return false;
                 }
 
-                return (WinStyle & 4194304) == 0 ? (WinExStyle & 1) != 0 : true;
+                return (WinStyle & 4194304) != 0 || (WinExStyle & 1) != 0;
             }
         }
 
@@ -261,7 +261,7 @@ namespace Krypton.Toolkit
         public bool ToolWindow
         {
             get => (WinExStyle & 128) != 0;
-            set => WinExStyle |= 128;
+            //set => WinExStyle |= 128;
         }
 
         public bool TopMost => (WinExStyle & 8) != 0;
@@ -271,21 +271,21 @@ namespace Krypton.Toolkit
         public bool Layered
         {
             get => (WinExStyle & 524288) != 0;
-            set => WinExStyle |= 524288;
+            //set => WinExStyle |= 524288;
         }
 
         public bool Transparent
         {
             get => (WinExStyle & 32) != 0;
-            set => WinExStyle |= 32;
+            //set => WinExStyle |= 32;
         }
 
         public bool Composited
         {
             get => (WinExStyle & 33554432) != 0;
-            set => WinExStyle |= 33554432;
+            //set => WinExStyle |= 33554432;
         }
 
-        public bool Framed => (WinStyle & 12845056) == 0 ? (WinExStyle & 513) != 0 : true;
+        public bool Framed => (WinStyle & 12845056) != 0 || (WinExStyle & 513) != 0;
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/General/XmlHelper.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/XmlHelper.cs
@@ -1,4 +1,16 @@
-﻿namespace Krypton.Toolkit
+﻿#region BSD License
+/*
+ * 
+ * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
+ *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
+ * 
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2022. All rights reserved. 
+ *  
+ */
+#endregion
+
+namespace Krypton.Toolkit
 {
     /// <summary>
     /// Explicit helpers for XML Data export and import
@@ -9,7 +21,7 @@
         /// Only persist the provided name/value pair as an Xml attribute if the value is not null/empty and not the default.
         /// </summary>
         /// <param name="xmlWriter">Xml writer to save information into.</param>
-        /// <param name=(@"Name")>Attribute name.</param>
+        /// <param name="name">Attribute name.</param>
         /// <param name="value">Attribute value.</param>
         /// <param name="defaultValue">Default value.</param>
         public static void TextToXmlAttribute(XmlWriter xmlWriter, string name, string value, string defaultValue = @"")
@@ -24,7 +36,7 @@
         /// Read the named attribute value but if no attribute is found then return the provided default.
         /// </summary>
         /// <param name="xmlReader">Xml reader to load information from.</param>
-        /// <param name=(@"Name")>Attribute name.</param>
+        /// <param name="name">Attribute name.</param>
         /// <param name="defaultValue">Default value.</param>
         /// <returns></returns>
         public static string XmlAttributeToText(XmlReader xmlReader, string name, string defaultValue = @"")
@@ -46,7 +58,7 @@
         /// Convert a Image to a culture invariant string value.
         /// </summary>
         /// <param name="xmlWriter">Xml writer to save information into.</param>
-        /// <param name=(@"Name")>Name of image to save.</param>
+        /// <param name="name">Name of image to save.</param>
         /// <param name="image">Image to persist.</param>
         public static void ImageToXmlCData(XmlWriter xmlWriter, string name, Bitmap image)
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBack/PaletteBack.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBack/PaletteBack.cs
@@ -157,7 +157,7 @@ namespace Krypton.Toolkit
                     if (_storage.BackDraw != value)
                     {
                         _storage.BackDraw = value;
-                        OnPropertyChanged("Draw");
+                        OnPropertyChanged(nameof(Draw));
                         PerformNeedPaint();
                     }
                 }
@@ -169,7 +169,7 @@ namespace Krypton.Toolkit
                         {
                             BackDraw = value
                         };
-                        OnPropertyChanged("Draw");
+                        OnPropertyChanged(nameof(Draw));
                         PerformNeedPaint();
                     }
                 }
@@ -204,7 +204,7 @@ namespace Krypton.Toolkit
                     if (_storage.BackGraphicsHint != value)
                     {
                         _storage.BackGraphicsHint = value;
-                        OnPropertyChanged("GraphicsHint");
+                        OnPropertyChanged(nameof(GraphicsHint));
                         PerformNeedPaint();
                     }
                 }
@@ -216,7 +216,7 @@ namespace Krypton.Toolkit
                         {
                             BackGraphicsHint = value
                         };
-                        OnPropertyChanged("GraphicsHint");
+                        OnPropertyChanged(nameof(GraphicsHint));
                         PerformNeedPaint();
                     }
                 }
@@ -252,7 +252,7 @@ namespace Krypton.Toolkit
                     if (_storage.BackColor1 != value)
                     {
                         _storage.BackColor1 = value;
-                        OnPropertyChanged("Color1");
+                        OnPropertyChanged(nameof(Color1));
                         PerformNeedPaint();
                     }
                 }
@@ -264,7 +264,7 @@ namespace Krypton.Toolkit
                         {
                             BackColor1 = value
                         };
-                        OnPropertyChanged("Color1");
+                        OnPropertyChanged(nameof(Color1));
                         PerformNeedPaint();
                     }
                 }
@@ -299,7 +299,7 @@ namespace Krypton.Toolkit
                     if (_storage.BackColor2 != value)
                     {
                         _storage.BackColor2 = value;
-                        OnPropertyChanged("Color2");
+                        OnPropertyChanged(nameof(Color2));
                         PerformNeedPaint();
                     }
                 }
@@ -311,7 +311,7 @@ namespace Krypton.Toolkit
                         {
                             BackColor2 = value
                         };
-                        OnPropertyChanged("Color2");
+                        OnPropertyChanged(nameof(Color2));
                         PerformNeedPaint();
                     }
                 }
@@ -346,7 +346,7 @@ namespace Krypton.Toolkit
                     if (_storage.BackColorStyle != value)
                     {
                         _storage.BackColorStyle = value;
-                        OnPropertyChanged("ColorStyle");
+                        OnPropertyChanged(nameof(ColorStyle));
                         PerformNeedPaint();
                     }
                 }
@@ -358,7 +358,7 @@ namespace Krypton.Toolkit
                         {
                             BackColorStyle = value
                         };
-                        OnPropertyChanged("ColorStyle");
+                        OnPropertyChanged(nameof(ColorStyle));
                         PerformNeedPaint();
                     }
                 }
@@ -393,7 +393,7 @@ namespace Krypton.Toolkit
                     if (_storage.BackColorAlign != value)
                     {
                         _storage.BackColorAlign = value;
-                        OnPropertyChanged("ColorAlign");
+                        OnPropertyChanged(nameof(ColorAlign));
                         PerformNeedPaint();
                     }
                 }
@@ -405,7 +405,7 @@ namespace Krypton.Toolkit
                         {
                             BackColorAlign = value
                         };
-                        OnPropertyChanged("ColorAlign");
+                        OnPropertyChanged(nameof(ColorAlign));
                         PerformNeedPaint();
                     }
                 }
@@ -432,7 +432,7 @@ namespace Krypton.Toolkit
         [RefreshProperties(RefreshProperties.All)]
         public float ColorAngle
         {
-            get => _storage == null ? -1 : _storage.BackColorAngle;
+            get => _storage?.BackColorAngle ?? -1;
 
             set
             {
@@ -441,7 +441,7 @@ namespace Krypton.Toolkit
                     if (_storage.BackColorAngle != value)
                     {
                         _storage.BackColorAngle = value;
-                        OnPropertyChanged("ColorAngle");
+                        OnPropertyChanged(nameof(ColorAngle));
                         PerformNeedPaint();
                     }
                 }
@@ -453,7 +453,7 @@ namespace Krypton.Toolkit
                         {
                             BackColorAngle = value
                         };
-                        OnPropertyChanged("ColorAngle");
+                        OnPropertyChanged(nameof(ColorAngle));
                         PerformNeedPaint();
                     }
                 }
@@ -489,7 +489,7 @@ namespace Krypton.Toolkit
                     if (_storage.BackImage != value)
                     {
                         _storage.BackImage = value;
-                        OnPropertyChanged("Image");
+                        OnPropertyChanged(nameof(Image));
                         PerformNeedPaint();
                     }
                 }
@@ -501,7 +501,7 @@ namespace Krypton.Toolkit
                         {
                             BackImage = value
                         };
-                        OnPropertyChanged("Image");
+                        OnPropertyChanged(nameof(Image));
                         PerformNeedPaint();
                     }
                 }
@@ -536,7 +536,7 @@ namespace Krypton.Toolkit
                     if (_storage.BackImageStyle != value)
                     {
                         _storage.BackImageStyle = value;
-                        OnPropertyChanged("ImageStyle");
+                        OnPropertyChanged(nameof(ImageStyle));
                         PerformNeedPaint();
                     }
                 }
@@ -548,7 +548,7 @@ namespace Krypton.Toolkit
                         {
                             BackImageStyle = value
                         };
-                        OnPropertyChanged("ImageStyle");
+                        OnPropertyChanged(nameof(ImageStyle));
                         PerformNeedPaint();
                     }
                 }
@@ -585,7 +585,7 @@ namespace Krypton.Toolkit
                     if (_storage.BackImageAlign != value)
                     {
                         _storage.BackImageAlign = value;
-                        OnPropertyChanged("ImageAlign");
+                        OnPropertyChanged(nameof(ImageAlign));
                         PerformNeedPaint();
                     }
                 }
@@ -597,7 +597,7 @@ namespace Krypton.Toolkit
                         {
                             BackImageAlign = value
                         };
-                        OnPropertyChanged("ImageAlign");
+                        OnPropertyChanged(nameof(ImageAlign));
                         PerformNeedPaint();
                     }
                 }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBorder/PaletteBorder.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBorder/PaletteBorder.cs
@@ -171,7 +171,7 @@ namespace Krypton.Toolkit
                     if (_storage.BorderDraw != value)
                     {
                         _storage.BorderDraw = value;
-                        OnPropertyChanged("Draw");
+                        OnPropertyChanged(nameof(Draw));
                         PerformNeedPaint();
                     }
                 }
@@ -183,7 +183,7 @@ namespace Krypton.Toolkit
                         {
                             BorderDraw = value
                         };
-                        OnPropertyChanged("Draw");
+                        OnPropertyChanged(nameof(Draw));
                         PerformNeedPaint();
                     }
                 }
@@ -219,7 +219,7 @@ namespace Krypton.Toolkit
                     if (_storage.BorderDrawBorders != value)
                     {
                         _storage.BorderDrawBorders = value;
-                        OnPropertyChanged("DrawBorders");
+                        OnPropertyChanged(nameof(DrawBorders));
                         PerformNeedPaint(true);
                     }
                 }
@@ -231,7 +231,7 @@ namespace Krypton.Toolkit
                         {
                             BorderDrawBorders = value
                         };
-                        OnPropertyChanged("DrawBorders");
+                        OnPropertyChanged(nameof(DrawBorders));
                         PerformNeedPaint(true);
                     }
                 }
@@ -277,7 +277,7 @@ namespace Krypton.Toolkit
                     if (_storage.BorderGraphicsHint != value)
                     {
                         _storage.BorderGraphicsHint = value;
-                        OnPropertyChanged("GraphicsHint");
+                        OnPropertyChanged(nameof(GraphicsHint));
                         PerformNeedPaint();
                     }
                 }
@@ -289,7 +289,7 @@ namespace Krypton.Toolkit
                         {
                             BorderGraphicsHint = value
                         };
-                        OnPropertyChanged("GraphicsHint");
+                        OnPropertyChanged(nameof(GraphicsHint));
                         PerformNeedPaint();
                     }
                 }
@@ -325,7 +325,7 @@ namespace Krypton.Toolkit
                     if (_storage.BorderColor1 != value)
                     {
                         _storage.BorderColor1 = value;
-                        OnPropertyChanged("Color1");
+                        OnPropertyChanged(nameof(Color1));
                         PerformNeedPaint();
                     }
                 }
@@ -337,7 +337,7 @@ namespace Krypton.Toolkit
                         {
                             BorderColor1 = value
                         };
-                        OnPropertyChanged("Color1");
+                        OnPropertyChanged(nameof(Color1));
                         PerformNeedPaint();
                     }
                 }
@@ -373,7 +373,7 @@ namespace Krypton.Toolkit
                     if (_storage.BorderColor2 != value)
                     {
                         _storage.BorderColor2 = value;
-                        OnPropertyChanged("Color2");
+                        OnPropertyChanged(nameof(Color2));
                         PerformNeedPaint();
                     }
                 }
@@ -385,7 +385,7 @@ namespace Krypton.Toolkit
                         {
                             BorderColor2 = value
                         };
-                        OnPropertyChanged("Color2");
+                        OnPropertyChanged(nameof(Color2));
                         PerformNeedPaint();
                     }
                 }
@@ -420,7 +420,7 @@ namespace Krypton.Toolkit
                     if (_storage.BorderColorStyle != value)
                     {
                         _storage.BorderColorStyle = value;
-                        OnPropertyChanged("ColorStyle");
+                        OnPropertyChanged(nameof(ColorStyle));
                         PerformNeedPaint();
                     }
                 }
@@ -432,7 +432,7 @@ namespace Krypton.Toolkit
                         {
                             BorderColorStyle = value
                         };
-                        OnPropertyChanged("ColorStyle");
+                        OnPropertyChanged(nameof(ColorStyle));
                         PerformNeedPaint();
                     }
                 }
@@ -469,7 +469,7 @@ namespace Krypton.Toolkit
                     if (_storage.BorderColorAlign != value)
                     {
                         _storage.BorderColorAlign = value;
-                        OnPropertyChanged("ColorAlign");
+                        OnPropertyChanged(nameof(ColorAlign));
                         PerformNeedPaint();
                     }
                 }
@@ -481,7 +481,7 @@ namespace Krypton.Toolkit
                         {
                             BorderColorAlign = value
                         };
-                        OnPropertyChanged("ColorAlign");
+                        OnPropertyChanged(nameof(ColorAlign));
                         PerformNeedPaint();
                     }
                 }
@@ -508,7 +508,7 @@ namespace Krypton.Toolkit
         [RefreshProperties(RefreshProperties.All)]
         public float ColorAngle
         {
-            get => _storage == null ? -1 : _storage.BorderColorAngle;
+            get => _storage?.BorderColorAngle ?? -1;
 
             set
             {
@@ -517,7 +517,7 @@ namespace Krypton.Toolkit
                     if (_storage.BorderColorAngle != value)
                     {
                         _storage.BorderColorAngle = value;
-                        OnPropertyChanged("ColorAngle");
+                        OnPropertyChanged(nameof(ColorAngle));
                         PerformNeedPaint();
                     }
                 }
@@ -529,7 +529,7 @@ namespace Krypton.Toolkit
                         {
                             BorderColorAngle = value
                         };
-                        OnPropertyChanged("ColorAngle");
+                        OnPropertyChanged(nameof(ColorAngle));
                         PerformNeedPaint();
                     }
                 }
@@ -555,7 +555,7 @@ namespace Krypton.Toolkit
         [RefreshProperties(RefreshProperties.All)]
         public int Width
         {
-            get => _storage == null ? -1 : _storage.BorderWidth;
+            get => _storage?.BorderWidth ?? -1;
 
             set
             {
@@ -564,7 +564,7 @@ namespace Krypton.Toolkit
                     if (_storage.BorderWidth != value)
                     {
                         _storage.BorderWidth = value;
-                        OnPropertyChanged("Width");
+                        OnPropertyChanged(nameof(Width));
                         PerformNeedPaint(true);
                     }
                 }
@@ -576,7 +576,7 @@ namespace Krypton.Toolkit
                         {
                             BorderWidth = value
                         };
-                        OnPropertyChanged("Width");
+                        OnPropertyChanged(nameof(Width));
                         PerformNeedPaint(true);
                     }
                 }
@@ -602,7 +602,7 @@ namespace Krypton.Toolkit
         [RefreshProperties(RefreshProperties.All)]
         public float Rounding
         {
-            get => _storage == null ? GlobalStaticValues.PRIMARY_CORNER_ROUNDING_VALUE : _storage.BorderRounding;
+            get => _storage?.BorderRounding ?? GlobalStaticValues.PRIMARY_CORNER_ROUNDING_VALUE;
 
             set
             {
@@ -611,7 +611,7 @@ namespace Krypton.Toolkit
                     if (_storage.BorderRounding != value)
                     {
                         _storage.BorderRounding = value;
-                        OnPropertyChanged("Rounding");
+                        OnPropertyChanged(nameof(Rounding));
                         PerformNeedPaint(true);
                     }
                 }
@@ -623,7 +623,7 @@ namespace Krypton.Toolkit
                         {
                             BorderRounding = value
                         };
-                        OnPropertyChanged("Rounding");
+                        OnPropertyChanged(nameof(Rounding));
                         PerformNeedPaint(true);
                     }
                 }
@@ -658,7 +658,7 @@ namespace Krypton.Toolkit
                     if (_storage.BorderImage != value)
                     {
                         _storage.BorderImage = value;
-                        OnPropertyChanged("Image");
+                        OnPropertyChanged(nameof(Image));
                         PerformNeedPaint();
                     }
                 }
@@ -670,7 +670,7 @@ namespace Krypton.Toolkit
                         {
                             BorderImage = value
                         };
-                        OnPropertyChanged("Image");
+                        OnPropertyChanged(nameof(Image));
                         PerformNeedPaint();
                     }
                 }
@@ -705,7 +705,7 @@ namespace Krypton.Toolkit
                     if (_storage.BorderImageStyle != value)
                     {
                         _storage.BorderImageStyle = value;
-                        OnPropertyChanged("ImageStyle");
+                        OnPropertyChanged(nameof(ImageStyle));
                         PerformNeedPaint();
                     }
                 }
@@ -717,7 +717,7 @@ namespace Krypton.Toolkit
                         {
                             BorderImageStyle = value
                         };
-                        OnPropertyChanged("ImageStyle");
+                        OnPropertyChanged(nameof(ImageStyle));
                         PerformNeedPaint();
                     }
                 }
@@ -756,7 +756,7 @@ namespace Krypton.Toolkit
                     if (_storage.BorderImageAlign != value)
                     {
                         _storage.BorderImageAlign = value;
-                        OnPropertyChanged("ImageAlign");
+                        OnPropertyChanged(nameof(ImageAlign));
                         PerformNeedPaint();
                     }
                 }
@@ -768,7 +768,7 @@ namespace Krypton.Toolkit
                         {
                             BorderImageAlign = value
                         };
-                        OnPropertyChanged("ImageAlign");
+                        OnPropertyChanged(nameof(ImageAlign));
                         PerformNeedPaint();
                     }
                 }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContent.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContent.cs
@@ -193,7 +193,7 @@ namespace Krypton.Toolkit
                     if (_storage.ContentDraw != value)
                     {
                         _storage.ContentDraw = value;
-                        OnPropertyChanged("Draw");
+                        OnPropertyChanged(nameof(Draw));
                         PerformNeedPaint();
                     }
                 }
@@ -205,7 +205,7 @@ namespace Krypton.Toolkit
                         {
                             ContentDraw = value
                         };
-                        OnPropertyChanged("Draw");
+                        OnPropertyChanged(nameof(Draw));
                         PerformNeedPaint();
                     }
                 }
@@ -242,7 +242,7 @@ namespace Krypton.Toolkit
                     if (_storage.ContentDrawFocus != value)
                     {
                         _storage.ContentDrawFocus = value;
-                        OnPropertyChanged("DrawFocus");
+                        OnPropertyChanged(nameof(DrawFocus));
                         PerformNeedPaint();
                     }
                 }
@@ -254,7 +254,7 @@ namespace Krypton.Toolkit
                         {
                             ContentDrawFocus = value
                         };
-                        OnPropertyChanged("DrawFocus");
+                        OnPropertyChanged(nameof(DrawFocus));
                         PerformNeedPaint();
                     }
                 }
@@ -686,7 +686,7 @@ namespace Krypton.Toolkit
                     if (!value.Equals(_storage.ContentPadding))
                     {
                         _storage.ContentPadding = value;
-                        OnPropertyChanged("Padding");
+                        OnPropertyChanged(nameof(Padding));
                         PerformNeedPaint(true);
                     }
                 }
@@ -698,7 +698,7 @@ namespace Krypton.Toolkit
                         {
                             ContentPadding = value
                         };
-                        OnPropertyChanged("Padding");
+                        OnPropertyChanged(nameof(Padding));
                         PerformNeedPaint(true);
                     }
                 }
@@ -760,7 +760,7 @@ namespace Krypton.Toolkit
         [RefreshProperties(RefreshProperties.All)]
         public virtual int AdjacentGap
         {
-            get => _storage == null ? -1 : _storage.ContentAdjacentGap;
+            get => _storage?.ContentAdjacentGap ?? -1;
 
             set
             {
@@ -769,7 +769,7 @@ namespace Krypton.Toolkit
                     if (_storage.ContentAdjacentGap != value)
                     {
                         _storage.ContentAdjacentGap = value;
-                        OnPropertyChanged("AdjacentGap");
+                        OnPropertyChanged(nameof(AdjacentGap));
                         PerformNeedPaint(true);
                     }
                 }
@@ -781,7 +781,7 @@ namespace Krypton.Toolkit
                         {
                             ContentAdjacentGap = value
                         };
-                        OnPropertyChanged("AdjacentGap");
+                        OnPropertyChanged(nameof(AdjacentGap));
                         PerformNeedPaint(true);
                     }
                 }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentImage.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentImage.cs
@@ -104,7 +104,7 @@ namespace Krypton.Toolkit
                     if (_storage.ContentImageH != value)
                     {
                         _storage.ContentImageH = value;
-                        OnPropertyChanged("ImageH");
+                        OnPropertyChanged(nameof(ImageH));
                         PerformNeedPaint(true);
                     }
                 }
@@ -116,7 +116,7 @@ namespace Krypton.Toolkit
                         {
                             ContentImageH = value
                         };
-                        OnPropertyChanged("ImageH");
+                        OnPropertyChanged(nameof(ImageH));
                         PerformNeedPaint(true);
                     }
                 }
@@ -144,7 +144,7 @@ namespace Krypton.Toolkit
                     if (_storage.ContentImageV != value)
                     {
                         _storage.ContentImageV = value;
-                        OnPropertyChanged("ImageV");
+                        OnPropertyChanged(nameof(ImageV));
                         PerformNeedPaint(true);
                     }
                 }
@@ -156,7 +156,7 @@ namespace Krypton.Toolkit
                         {
                             ContentImageV = value
                         };
-                        OnPropertyChanged("ImageV");
+                        OnPropertyChanged(nameof(ImageV));
                         PerformNeedPaint(true);
                     }
                 }
@@ -184,7 +184,7 @@ namespace Krypton.Toolkit
                     if (_storage.ContentEffect != value)
                     {
                         _storage.ContentEffect = value;
-                        OnPropertyChanged("Effect");
+                        OnPropertyChanged(nameof(Effect));
                         PerformNeedPaint();
                     }
                 }
@@ -196,7 +196,7 @@ namespace Krypton.Toolkit
                         {
                             ContentEffect = value
                         };
-                        OnPropertyChanged("Effect");
+                        OnPropertyChanged(nameof(Effect));
                         PerformNeedPaint();
                     }
                 }
@@ -224,7 +224,7 @@ namespace Krypton.Toolkit
                     if (_storage.ContentImageColorMap != value)
                     {
                         _storage.ContentImageColorMap = value;
-                        OnPropertyChanged("ImageColorMap");
+                        OnPropertyChanged(nameof(ImageColorMap));
                         PerformNeedPaint();
                     }
                 }
@@ -236,7 +236,7 @@ namespace Krypton.Toolkit
                         {
                             ContentImageColorMap = value
                         };
-                        OnPropertyChanged("ImageColorMap");
+                        OnPropertyChanged(nameof(ImageColorMap));
                         PerformNeedPaint();
                     }
                 }
@@ -264,7 +264,7 @@ namespace Krypton.Toolkit
                     if (_storage.ContentImageColorTo != value)
                     {
                         _storage.ContentImageColorTo = value;
-                        OnPropertyChanged("ImageColorTo");
+                        OnPropertyChanged(nameof(ImageColorTo));
                         PerformNeedPaint();
                     }
                 }
@@ -276,7 +276,7 @@ namespace Krypton.Toolkit
                         {
                             ContentImageColorTo = value
                         };
-                        OnPropertyChanged("ImageColorTo");
+                        OnPropertyChanged(nameof(ImageColorTo));
                         PerformNeedPaint();
                     }
                 }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentText.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentText.cs
@@ -135,7 +135,7 @@ namespace Krypton.Toolkit
                     if (_storage.ContentTextFont != value)
                     {
                         _storage.ContentTextFont = value;
-                        OnPropertyChanged("Font");
+                        OnPropertyChanged(nameof(Font));
                         PerformNeedPaint(true);
                     }
                 }
@@ -147,7 +147,7 @@ namespace Krypton.Toolkit
                         {
                             ContentTextFont = value
                         };
-                        OnPropertyChanged("Font");
+                        OnPropertyChanged(nameof(Font));
                         PerformNeedPaint(true);
                     }
                 }
@@ -175,7 +175,7 @@ namespace Krypton.Toolkit
                     if (_storage.ContentTextHint != value)
                     {
                         _storage.ContentTextHint = value;
-                        OnPropertyChanged("Hint");
+                        OnPropertyChanged(nameof(Hint));
                         PerformNeedPaint(true);
                     }
                 }
@@ -187,7 +187,7 @@ namespace Krypton.Toolkit
                         {
                             ContentTextHint = value
                         };
-                        OnPropertyChanged("Hint");
+                        OnPropertyChanged(nameof(Hint));
                         PerformNeedPaint(true);
                     }
                 }
@@ -215,7 +215,7 @@ namespace Krypton.Toolkit
                     if (_storage.ContentTextTrim != value)
                     {
                         _storage.ContentTextTrim = value;
-                        OnPropertyChanged("Trim");
+                        OnPropertyChanged(nameof(Trim));
                         PerformNeedPaint(true);
                     }
                 }
@@ -227,7 +227,7 @@ namespace Krypton.Toolkit
                         {
                             ContentTextTrim = value
                         };
-                        OnPropertyChanged("Trim");
+                        OnPropertyChanged(nameof(Trim));
                         PerformNeedPaint(true);
                     }
                 }
@@ -255,7 +255,7 @@ namespace Krypton.Toolkit
                     if (_storage.ContentTextPrefix != value)
                     {
                         _storage.ContentTextPrefix = value;
-                        OnPropertyChanged("Prefix");
+                        OnPropertyChanged(nameof(Prefix));
                         PerformNeedPaint(true);
                     }
                 }
@@ -267,7 +267,7 @@ namespace Krypton.Toolkit
                         {
                             ContentTextPrefix = value
                         };
-                        OnPropertyChanged("Prefix");
+                        OnPropertyChanged(nameof(Prefix));
                         PerformNeedPaint(true);
                     }
                 }
@@ -295,7 +295,7 @@ namespace Krypton.Toolkit
                     if (_storage.ContentTextH != value)
                     {
                         _storage.ContentTextH = value;
-                        OnPropertyChanged("TextH");
+                        OnPropertyChanged(nameof(TextH));
                         PerformNeedPaint(true);
                     }
                 }
@@ -307,7 +307,7 @@ namespace Krypton.Toolkit
                         {
                             ContentTextH = value
                         };
-                        OnPropertyChanged("TextH");
+                        OnPropertyChanged(nameof(TextH));
                         PerformNeedPaint(true);
                     }
                 }
@@ -335,7 +335,7 @@ namespace Krypton.Toolkit
                     if (_storage.ContentTextV != value)
                     {
                         _storage.ContentTextV = value;
-                        OnPropertyChanged("TextV");
+                        OnPropertyChanged(nameof(TextV));
                         PerformNeedPaint(true);
                     }
                 }
@@ -347,7 +347,7 @@ namespace Krypton.Toolkit
                         {
                             ContentTextV = value
                         };
-                        OnPropertyChanged("TextV");
+                        OnPropertyChanged(nameof(TextV));
                         PerformNeedPaint(true);
                     }
                 }
@@ -375,7 +375,7 @@ namespace Krypton.Toolkit
                     if (_storage.ContentTextMultiLineH != value)
                     {
                         _storage.ContentTextMultiLineH = value;
-                        OnPropertyChanged("MultiLineH");
+                        OnPropertyChanged(nameof(MultiLineH));
                         PerformNeedPaint(true);
                     }
                 }
@@ -387,7 +387,7 @@ namespace Krypton.Toolkit
                         {
                             ContentTextMultiLineH = value
                         };
-                        OnPropertyChanged("MultiLineH");
+                        OnPropertyChanged(nameof(MultiLineH));
                         PerformNeedPaint(true);
                     }
                 }
@@ -415,7 +415,7 @@ namespace Krypton.Toolkit
                     if (_storage.ContentTextMultiLine != value)
                     {
                         _storage.ContentTextMultiLine = value;
-                        OnPropertyChanged("MultiLine");
+                        OnPropertyChanged(nameof(MultiLine));
                         PerformNeedPaint(true);
                     }
                 }
@@ -427,7 +427,7 @@ namespace Krypton.Toolkit
                         {
                             ContentTextMultiLine = value
                         };
-                        OnPropertyChanged("MultiLine");
+                        OnPropertyChanged(nameof(MultiLine));
                         PerformNeedPaint(true);
                     }
                 }
@@ -455,7 +455,7 @@ namespace Krypton.Toolkit
                     if (_storage.ContentTextColor1 != value)
                     {
                         _storage.ContentTextColor1 = value;
-                        OnPropertyChanged("Color1");
+                        OnPropertyChanged(nameof(Color1));
                         PerformNeedPaint();
                     }
                 }
@@ -467,7 +467,7 @@ namespace Krypton.Toolkit
                         {
                             ContentTextColor1 = value
                         };
-                        OnPropertyChanged("Color1");
+                        OnPropertyChanged(nameof(Color1));
                         PerformNeedPaint();
                     }
                 }
@@ -495,7 +495,7 @@ namespace Krypton.Toolkit
                     if (_storage.ContentTextColor2 != value)
                     {
                         _storage.ContentTextColor2 = value;
-                        OnPropertyChanged("Color2");
+                        OnPropertyChanged(nameof(Color2));
                         PerformNeedPaint();
                     }
                 }
@@ -507,7 +507,7 @@ namespace Krypton.Toolkit
                         {
                             ContentTextColor2 = value
                         };
-                        OnPropertyChanged("Color2");
+                        OnPropertyChanged(nameof(Color2));
                         PerformNeedPaint();
                     }
                 }
@@ -535,7 +535,7 @@ namespace Krypton.Toolkit
                     if (_storage.ContentTextColorStyle != value)
                     {
                         _storage.ContentTextColorStyle = value;
-                        OnPropertyChanged("ColorStyle");
+                        OnPropertyChanged(nameof(ColorStyle));
                         PerformNeedPaint();
                     }
                 }
@@ -547,7 +547,7 @@ namespace Krypton.Toolkit
                         {
                             ContentTextColorStyle = value
                         };
-                        OnPropertyChanged("ColorStyle");
+                        OnPropertyChanged(nameof(ColorStyle));
                         PerformNeedPaint();
                     }
                 }
@@ -575,7 +575,7 @@ namespace Krypton.Toolkit
                     if (_storage.ContentTextColorAlign != value)
                     {
                         _storage.ContentTextColorAlign = value;
-                        OnPropertyChanged("ColorAlign");
+                        OnPropertyChanged(nameof(ColorAlign));
                         PerformNeedPaint();
                     }
                 }
@@ -587,7 +587,7 @@ namespace Krypton.Toolkit
                         {
                             ContentTextColorAlign = value
                         };
-                        OnPropertyChanged("ColorAlign");
+                        OnPropertyChanged(nameof(ColorAlign));
                         PerformNeedPaint();
                     }
                 }
@@ -606,7 +606,7 @@ namespace Krypton.Toolkit
         [RefreshProperties(RefreshProperties.All)]
         public virtual float ColorAngle
         {
-            get => _storage == null ? -1f : _storage.ContentTextColorAngle;
+            get => _storage?.ContentTextColorAngle ?? -1f;
 
             set
             {
@@ -615,7 +615,7 @@ namespace Krypton.Toolkit
                     if (_storage.ContentTextColorAngle != value)
                     {
                         _storage.ContentTextColorAngle = value;
-                        OnPropertyChanged("ColorAngle");
+                        OnPropertyChanged(nameof(ColorAngle));
                         PerformNeedPaint();
                     }
                 }
@@ -627,7 +627,7 @@ namespace Krypton.Toolkit
                         {
                             ContentTextColorAngle = value
                         };
-                        OnPropertyChanged("ColorAngle");
+                        OnPropertyChanged(nameof(ColorAngle));
                         PerformNeedPaint();
                     }
                 }
@@ -655,7 +655,7 @@ namespace Krypton.Toolkit
                     if (_storage.ContentTextImage != value)
                     {
                         _storage.ContentTextImage = value;
-                        OnPropertyChanged("Image");
+                        OnPropertyChanged(nameof(Image));
                         PerformNeedPaint();
                     }
                 }
@@ -667,7 +667,7 @@ namespace Krypton.Toolkit
                         {
                             ContentTextImage = value
                         };
-                        OnPropertyChanged("Image");
+                        OnPropertyChanged(nameof(Image));
                         PerformNeedPaint();
                     }
                 }
@@ -695,7 +695,7 @@ namespace Krypton.Toolkit
                     if (_storage.ContentTextImageStyle != value)
                     {
                         _storage.ContentTextImageStyle = value;
-                        OnPropertyChanged("ImageStyle");
+                        OnPropertyChanged(nameof(ImageStyle));
                         PerformNeedPaint();
                     }
                 }
@@ -707,7 +707,7 @@ namespace Krypton.Toolkit
                         {
                             ContentTextImageStyle = value
                         };
-                        OnPropertyChanged("ImageStyle");
+                        OnPropertyChanged(nameof(ImageStyle));
                         PerformNeedPaint();
                     }
                 }
@@ -735,7 +735,7 @@ namespace Krypton.Toolkit
                     if (_storage.ContentTextImageAlign != value)
                     {
                         _storage.ContentTextImageAlign = value;
-                        OnPropertyChanged("ImageAlign");
+                        OnPropertyChanged(nameof(ImageAlign));
                         PerformNeedPaint();
                     }
                 }
@@ -747,7 +747,7 @@ namespace Krypton.Toolkit
                         {
                             ContentTextImageAlign = value
                         };
-                        OnPropertyChanged("ImageAlign");
+                        OnPropertyChanged(nameof(ImageAlign));
                         PerformNeedPaint();
                     }
                 }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Bases/PaletteOffice2007Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Bases/PaletteOffice2007Base.cs
@@ -4685,7 +4685,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the color table instance.
         /// </summary>
-        public override KryptonColorTable ColorTable => _table ?? (_table = new KryptonColorTable2007(_ribbonColors, InheritBool.True, this));
+        public override KryptonColorTable ColorTable => _table ??= new KryptonColorTable2007(_ribbonColors, InheritBool.True, this);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/PaletteOffice2007BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/PaletteOffice2007BlackDarkMode.cs
@@ -5261,7 +5261,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the color table instance.
         /// </summary>
-        public override KryptonColorTable ColorTable => _table ?? (_table = new KryptonColorTable2007(_ribbonColors, InheritBool.True, this));
+        public override KryptonColorTable ColorTable => _table ??= new KryptonColorTable2007(_ribbonColors, InheritBool.True, this);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/PaletteOffice2007BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/PaletteOffice2007BlueDarkMode.cs
@@ -5060,7 +5060,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the color table instance.
         /// </summary>
-        public override KryptonColorTable ColorTable => _table ?? (_table = new KryptonColorTable2007(_ribbonColors, InheritBool.True, this));
+        public override KryptonColorTable ColorTable => _table ??= new KryptonColorTable2007(_ribbonColors, InheritBool.True, this);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/PaletteOffice2007BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/PaletteOffice2007BlueLightMode.cs
@@ -5060,7 +5060,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the color table instance.
         /// </summary>
-        public override KryptonColorTable ColorTable => _table ?? (_table = new KryptonColorTable2007(_ribbonColors, InheritBool.True, this));
+        public override KryptonColorTable ColorTable => _table ??= new KryptonColorTable2007(_ribbonColors, InheritBool.True, this);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/PaletteOffice2007SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/PaletteOffice2007SilverDarkMode.cs
@@ -5029,7 +5029,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the color table instance.
         /// </summary>
-        public override KryptonColorTable ColorTable => _table ?? (_table = new KryptonColorTable2007(_ribbonColors, InheritBool.True, this));
+        public override KryptonColorTable ColorTable => _table ??= new KryptonColorTable2007(_ribbonColors, InheritBool.True, this);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/PaletteOffice2007SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/PaletteOffice2007SilverLightMode.cs
@@ -5029,7 +5029,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the color table instance.
         /// </summary>
-        public override KryptonColorTable ColorTable => _table ?? (_table = new KryptonColorTable2007(_ribbonColors, InheritBool.True, this));
+        public override KryptonColorTable ColorTable => _table ??= new KryptonColorTable2007(_ribbonColors, InheritBool.True, this);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Bases/PaletteOffice2010Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Bases/PaletteOffice2010Base.cs
@@ -4535,7 +4535,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the color table instance.
         /// </summary>
-        public override KryptonColorTable ColorTable => _table ?? (_table = new KryptonColorTable2010(_ribbonColors, InheritBool.True, this));
+        public override KryptonColorTable ColorTable => _table ??= new KryptonColorTable2010(_ribbonColors, InheritBool.True, this);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/PaletteOffice2010BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/PaletteOffice2010BlackDarkMode.cs
@@ -5282,7 +5282,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the color table instance.
         /// </summary>
-        public override KryptonColorTable ColorTable => _table ?? (_table = new KryptonColorTable2010(_ribbonColors, InheritBool.True, this));
+        public override KryptonColorTable ColorTable => _table ??= new KryptonColorTable2010(_ribbonColors, InheritBool.True, this);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/PaletteOffice2010BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/PaletteOffice2010BlueDarkMode.cs
@@ -4902,7 +4902,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the color table instance.
         /// </summary>
-        public override KryptonColorTable ColorTable => _table ?? (_table = new KryptonColorTable2010(_ribbonColors, InheritBool.True, this));
+        public override KryptonColorTable ColorTable => _table ??= new KryptonColorTable2010(_ribbonColors, InheritBool.True, this);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/PaletteOffice2010BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/PaletteOffice2010BlueLightMode.cs
@@ -4902,7 +4902,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the color table instance.
         /// </summary>
-        public override KryptonColorTable ColorTable => _table ?? (_table = new KryptonColorTable2010(_ribbonColors, InheritBool.True, this));
+        public override KryptonColorTable ColorTable => _table ??= new KryptonColorTable2010(_ribbonColors, InheritBool.True, this);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/PaletteOffice2010SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/PaletteOffice2010SilverDarkMode.cs
@@ -4902,7 +4902,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the color table instance.
         /// </summary>
-        public override KryptonColorTable ColorTable => _table ?? (_table = new KryptonColorTable2010(_ribbonColors, InheritBool.True, this));
+        public override KryptonColorTable ColorTable => _table ??= new KryptonColorTable2010(_ribbonColors, InheritBool.True, this);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/PaletteOffice2010SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/PaletteOffice2010SilverLightMode.cs
@@ -4902,7 +4902,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the color table instance.
         /// </summary>
-        public override KryptonColorTable ColorTable => _table ?? (_table = new KryptonColorTable2010(_ribbonColors, InheritBool.True, this));
+        public override KryptonColorTable ColorTable => _table ??= new KryptonColorTable2010(_ribbonColors, InheritBool.True, this);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/PaletteOffice2013White.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/PaletteOffice2013White.cs
@@ -379,6 +379,9 @@ namespace Krypton.Toolkit
 
     #region Class: PaletteOffice2013WhiteBase
 
+    /// <summary>
+    /// Gets the single instance of the ### palette.
+    /// </summary>
     public abstract class PaletteOffice2013WhiteBase : PaletteBase
     {
         #region Static Fields

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 365/PaletteOffice365BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 365/PaletteOffice365BlueDarkMode.cs
@@ -13,6 +13,9 @@
 
 namespace Krypton.Toolkit
 {
+    /// <summary>
+    /// Gets the single instance of the ### palette.
+    /// </summary>
     public class PaletteOffice365BlueDarkMode : PaletteOffice365BlueThemeDarkModeBase
     {
         #region Static Fields

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 365/PaletteOffice365BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 365/PaletteOffice365BlueLightMode.cs
@@ -13,6 +13,9 @@
 
 namespace Krypton.Toolkit
 {
+    /// <summary>
+    /// Gets the single instance of the ### palette.
+    /// </summary>
     public class PaletteOffice365BlueLightMode : PaletteOffice365BlueThemeLightModeBase
     {
         #region Static Fields

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 365/PaletteOffice365DarkGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 365/PaletteOffice365DarkGray.cs
@@ -1,8 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿#region BSD License
+/*
+ * 
+ * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
+ *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
+ * 
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2022. All rights reserved. 
+ *  
+ */
+#endregion
+
 
 namespace Krypton.Toolkit.Palette_Builtin.Office_365
 {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 365/PaletteOffice365LightGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 365/PaletteOffice365LightGray.cs
@@ -1,8 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿#region BSD License
+/*
+ * 
+ * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
+ *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
+ * 
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2022. All rights reserved. 
+ *  
+ */
+#endregion
+
 
 namespace Krypton.Toolkit
 {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 365/PaletteOffice365White.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 365/PaletteOffice365White.cs
@@ -13,6 +13,9 @@
 
 namespace Krypton.Toolkit
 {
+    /// <summary>
+    /// Gets the single instance of the ### palette.
+    /// </summary>
     public class PaletteOffice365White : PaletteOffice365Base
     {
         #region Static Fields

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/PaletteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/PaletteBase.cs
@@ -1162,7 +1162,7 @@ namespace Krypton.Toolkit
         /// </summary>
         public virtual float BaseFontSize
         {
-            get => !_baseFontSize.HasValue ? SystemFonts.MenuFont.SizeInPoints : _baseFontSize.Value;
+            get => _baseFontSize ?? SystemFonts.MenuFont.SizeInPoints;
 
             set
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Professional/PaletteProfessionalSystem.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Professional/PaletteProfessionalSystem.cs
@@ -70,8 +70,8 @@ namespace Krypton.Toolkit
         private static readonly Image _buttonSpecPinHorizontal = ProfessionalPinImageResources.ProfessionalPinHorizontalButton;
         private static readonly Image _buttonSpecWorkspaceMaximize = GenericProfessionalImageResources.ProfessionalMaximize;
         private static readonly Image _buttonSpecWorkspaceRestore = GenericProfessionalImageResources.ProfessionalRestore;
-        private static readonly Image _buttonSpecRibbonMinimize = RibbonArrowImageResources.RibbonUp2010;
-        private static readonly Image _buttonSpecRibbonExpand = RibbonArrowImageResources.RibbonDown2010;
+        //private static readonly Image _buttonSpecRibbonMinimize = RibbonArrowImageResources.RibbonUp2010;
+        //private static readonly Image _buttonSpecRibbonExpand = RibbonArrowImageResources.RibbonDown2010;
         private static readonly Image _systemCloseNormal = ProfessionalControlBoxResources.ProfessionalButtonCloseNormal;
         private static readonly Image _systemCloseDisabled = ProfessionalControlBoxResources.ProfessionalButtonCloseDisabled;
         private static readonly Image _systemMaximiseNormal = ProfessionalControlBoxResources.ProfessionalButtonMaxNormal;
@@ -99,7 +99,7 @@ namespace Krypton.Toolkit
         private static readonly Image _treeCollapseMinus = TreeItemImageResources.TreeCollapseMinus;
 
         private static readonly Color _contextTextColor = Color.White;
-        private static readonly Color _lightGray = Color.FromArgb(242, 242, 242);
+        //private static readonly Color _lightGray = Color.FromArgb(242, 242, 242);
         private static readonly Color _contextCheckedTabBorder1 = Color.FromArgb(223, 119, 0);
         private static readonly Color _contextCheckedTabBorder2 = Color.FromArgb(230, 190, 129);
         private static readonly Color _contextCheckedTabBorder3 = Color.FromArgb(220, 202, 171);
@@ -125,28 +125,28 @@ namespace Krypton.Toolkit
         private Font _italicFont;
         private Image _disabledDropDownImage;
         private Image _normalDropDownImage;
-        private Color _disabledDropDownColor;
-        private Color _normalDropDownColor;
+        //private Color _disabledDropDownColor;
+        //private Color _normalDropDownColor;
         private Color[] _ribbonColors;
         private Color _disabledText;
         private Color _disabledGlyphDark;
         private Color _disabledGlyphLight;
-        private Color _contextCheckedTabBorder;
-        private Color _contextCheckedTabFill;
+        //private Color _contextCheckedTabBorder;
+        //private Color _contextCheckedTabFill;
         private Color _contextGroupAreaBorder;
-        private Color _contextGroupAreaInside;
-        private Color _contextGroupFrameTop;
-        private Color _contextGroupFrameBottom;
+        //private Color _contextGroupAreaInside;
+        //private Color _contextGroupFrameTop;
+        //private Color _contextGroupFrameBottom;
         private Color _contextTabSeparator;
-        private Color _focusTabFill;
+        //private Color _focusTabFill;
         private Color _toolTipBack1;
         private Color _toolTipBack2;
         private Color _toolTipBorder;
         private Color _toolTipText;
-        private Color[] _ribbonGroupCollapsedBackContext;
-        private Color[] _ribbonGroupCollapsedBackContextTracking;
-        private Color[] _ribbonGroupCollapsedBorderContext;
-        private Color[] _ribbonGroupCollapsedBorderContextTracking;
+        //private Color[] _ribbonGroupCollapsedBackContext;
+        //private Color[] _ribbonGroupCollapsedBackContextTracking;
+        //private Color[] _ribbonGroupCollapsedBorderContext;
+        //private Color[] _ribbonGroupCollapsedBorderContextTracking;
         private Color[] _appButtonNormal;
         private Color[] _appButtonTrack;
         private Color[] _appButtonPressed;
@@ -2692,7 +2692,7 @@ namespace Krypton.Toolkit
                 if (_normalDropDownImage == null)
                 {
                     _normalDropDownImage = CreateDropDownImage(SystemColors.ControlText);
-                    _normalDropDownColor = SystemColors.ControlText;
+                    //_normalDropDownColor = SystemColors.ControlText;
                 }
 
                 return _normalDropDownImage;
@@ -2702,7 +2702,7 @@ namespace Krypton.Toolkit
                 if (_disabledDropDownImage == null)
                 {
                     _disabledDropDownImage = CreateDropDownImage(SystemColors.ControlDark);
-                    _disabledDropDownColor = SystemColors.ControlDark;
+                    //_disabledDropDownColor = SystemColors.ControlDark;
                 }
 
                 return _disabledDropDownImage;
@@ -2737,10 +2737,9 @@ namespace Krypton.Toolkit
         {
             return button switch
             {
-                PaletteRibbonGalleryButton.Down => _galleryImageDown ?? (_galleryImageDown = CreateGalleryDownImage(SystemColors.ControlText)),
-                PaletteRibbonGalleryButton.DropDown => _galleryImageDropDown ??
-(_galleryImageDropDown = CreateGalleryDropDownImage(SystemColors.ControlText)),
-                _ => _galleryImageUp ?? (_galleryImageUp = CreateGalleryUpImage(SystemColors.ControlText))
+                PaletteRibbonGalleryButton.Down => _galleryImageDown ??= CreateGalleryDownImage(SystemColors.ControlText),
+                PaletteRibbonGalleryButton.DropDown => _galleryImageDropDown ??= CreateGalleryDropDownImage(SystemColors.ControlText),
+                _ => _galleryImageUp ??= CreateGalleryUpImage(SystemColors.ControlText)
             };
         }
         #endregion
@@ -4191,7 +4190,7 @@ namespace Krypton.Toolkit
         /// </summary>
         public override KryptonColorTable ColorTable => Table;
 
-        internal KryptonProfessionalKCT Table => _table ?? (_table = GenerateColorTable(false));
+        internal KryptonProfessionalKCT Table => _table ??= GenerateColorTable(false);
 
         /// <summary>
         /// Generate an appropriate color table.
@@ -4327,7 +4326,7 @@ namespace Krypton.Toolkit
         private void DefineRibbonColors()
         {
             // Main values
-            Color groupLight = ColorTable.MenuStripGradientEnd;
+            //Color groupLight = ColorTable.MenuStripGradientEnd;
             Color groupStart = ColorTable.RaftingContainerGradientBegin;
             Color groupEnd = ColorTable.MenuBorder;
 
@@ -4338,13 +4337,13 @@ namespace Krypton.Toolkit
                 case -986896:   // Vista Aero/Basic
                 case -1250856:  // XP Themes - Blue & Olive
                 case -2039837:  // XP Themes - Silver
-                    groupLight = MergeColors(groupLight, 0.93f, Color.Black, 0.07f);
+                    //groupLight = MergeColors(groupLight, 0.93f, Color.Black, 0.07f);
                     groupStart = MergeColors(groupStart, 0.93f, Color.Black, 0.07f);
                     groupEnd = MergeColors(groupEnd, 0.93f, Color.Black, 0.07f);
                     break;
                 case -2830136:  // Windows Standard
                 case -4144960:  // Windows Classic
-                    groupLight = MergeColors(groupLight, 0.95f, Color.Black, 0.05f);
+                    //groupLight = MergeColors(groupLight, 0.95f, Color.Black, 0.05f);
                     groupStart = MergeColors(groupStart, 0.95f, Color.Black, 0.05f);
                     groupEnd = MergeColors(groupEnd, 0.95f, Color.Black, 0.05f);
                     break;
@@ -4355,7 +4354,7 @@ namespace Krypton.Toolkit
             Color ribbonGroupsArea2 = MergeColors(groupStart, 0.20f, groupEnd, 0.80f);
             Color ribbonGroupsArea3 = MergeColors(groupStart, 0.10f, Color.White, 0.90f);
             Color ribbonGroupsArea4 = MergeColors(groupStart, 0.70f, Color.White, 0.30f);
-            Color ribbonGroupsArea5 = MergeColors(groupStart, 0.90f, groupEnd, 0.10f);
+            //Color ribbonGroupsArea5 = MergeColors(groupStart, 0.90f, groupEnd, 0.10f);
             Color ribbonGroupBorder1 = Color.FromArgb(128, Color.White);
             Color ribbonGroupBorder2 = Color.FromArgb(196, Color.White);
             Color ribbonGroupBorder3 = MergeColors(groupStart, 0.20f, groupEnd, 0.80f);
@@ -4377,9 +4376,9 @@ namespace Krypton.Toolkit
             Color ribbonTabTracking2 = MergeColors(groupStart, 0.20f, Color.White, 0.80f);
             Color ribbonTabTracking3 = MergeColors(groupStart, 0.50f, Color.White, 0.50f);
             Color ribbonTabTracking4 = MergeColors(groupStart, 0.75f, Color.White, 0.25f);
-            Color ribbonQATOverflowInside = MergeColors(ColorTable.MenuStripGradientEnd, 0.75f, groupStart, 0.25f);
-            Color ribbonQATOverflowInside2 = MergeColors(ColorTable.MenuStripGradientEnd, 0.65f, groupStart, 0.35f);
-            Color ribbonQATMini1 = MergeColors(groupStart, 0.70f, groupEnd, 0.30f);
+            //Color ribbonQATOverflowInside = MergeColors(ColorTable.MenuStripGradientEnd, 0.75f, groupStart, 0.25f);
+            //Color ribbonQATOverflowInside2 = MergeColors(ColorTable.MenuStripGradientEnd, 0.65f, groupStart, 0.35f);
+            //Color ribbonQATMini1 = MergeColors(groupStart, 0.70f, groupEnd, 0.30f);
             Color ribbonQATMini3 = MergeColors(groupStart, 0.90f, groupEnd, 0.10f);
 
             // Generate first set of ribbon colors
@@ -4529,29 +4528,29 @@ namespace Krypton.Toolkit
             _disabledText = SystemColors.ControlDark;
             _disabledGlyphDark = Color.FromArgb(183, 183, 183);
             _disabledGlyphLight = Color.FromArgb(237, 237, 237);
-            _contextCheckedTabBorder = ribbonGroupsArea1;
-            _contextCheckedTabFill = ColorTable.CheckBackground;
+            //_contextCheckedTabBorder = ribbonGroupsArea1;
+            //_contextCheckedTabFill = ColorTable.CheckBackground;
             _contextGroupAreaBorder = ribbonGroupsArea1;
-            _contextGroupAreaInside = ribbonGroupsArea2;
-            _contextGroupFrameTop = Color.FromArgb(250, 250, 250);
-            _contextGroupFrameBottom = _contextGroupFrameTop;
+            //_contextGroupAreaInside = ribbonGroupsArea2;
+            //_contextGroupFrameTop = Color.FromArgb(250, 250, 250);
+            //_contextGroupFrameBottom = _contextGroupFrameTop;
             _contextTabSeparator = ColorTable.MenuBorder;
-            _focusTabFill = ColorTable.CheckBackground;
+            //_focusTabFill = ColorTable.CheckBackground;
             _toolTipBack1 = SystemColors.Info;
             _toolTipBack2 = SystemColors.Info;
             _toolTipBorder = SystemColors.WindowFrame;
             _toolTipText = SystemColors.InfoText;
-            _disabledDropDownColor = Color.Empty;
-            _normalDropDownColor = Color.Empty;
-            _ribbonGroupCollapsedBackContext = new Color[] { Color.FromArgb(48, 235, 235, 235), Color.FromArgb(235, 235, 235) };
-            _ribbonGroupCollapsedBackContextTracking = _ribbonGroupCollapsedBackContext;
-            _ribbonGroupCollapsedBorderContext = new Color[] { Color.FromArgb(160, ribbonGroupBorder1), ribbonGroupBorder1, Color.FromArgb(48, ribbonGroupsArea4), ribbonGroupsArea4 };
-            _ribbonGroupCollapsedBorderContextTracking = new Color[] { Color.FromArgb(200, ribbonGroupBorder1), ribbonGroupBorder1, Color.FromArgb(48, ribbonGroupBorder1), Color.FromArgb(196, ribbonGroupBorder1) };
+            //_disabledDropDownColor = Color.Empty;
+            //_normalDropDownColor = Color.Empty;
+            //_ribbonGroupCollapsedBackContext = new Color[] { Color.FromArgb(48, 235, 235, 235), Color.FromArgb(235, 235, 235) };
+            //_ribbonGroupCollapsedBackContextTracking = _ribbonGroupCollapsedBackContext;
+            //_ribbonGroupCollapsedBorderContext = new Color[] { Color.FromArgb(160, ribbonGroupBorder1), ribbonGroupBorder1, Color.FromArgb(48, ribbonGroupsArea4), ribbonGroupsArea4 };
+            //_ribbonGroupCollapsedBorderContextTracking = new Color[] { Color.FromArgb(200, ribbonGroupBorder1), ribbonGroupBorder1, Color.FromArgb(48, ribbonGroupBorder1), Color.FromArgb(196, ribbonGroupBorder1) };
             Color highlight1 = MergeColors(Color.White, 0.50f, ColorTable.ButtonSelectedGradientEnd, 0.50f);
             Color highlight2 = MergeColors(Color.White, 0.25f, ColorTable.ButtonSelectedGradientEnd, 0.75f);
             Color highlight3 = MergeColors(Color.White, 0.60f, ColorTable.ButtonPressedGradientMiddle, 0.40f);
             Color highlight4 = MergeColors(Color.White, 0.25f, ColorTable.ButtonPressedGradientMiddle, 0.75f);
-            Color pressed3 = MergeColors(Color.White, 0.50f, ColorTable.CheckBackground, 0.50f);
+            //Color pressed3 = MergeColors(Color.White, 0.50f, ColorTable.CheckBackground, 0.50f);
             Color pressed4 = MergeColors(Color.White, 0.25f, ColorTable.CheckPressedBackground, 0.75f);
             _appButtonNormal = new Color[] { ColorTable.SeparatorLight, ColorTable.ImageMarginGradientBegin, ColorTable.ImageMarginGradientMiddle, ColorTable.GripLight, ColorTable.ImageMarginGradientBegin };
             _appButtonTrack = new Color[] { highlight1, highlight2, ColorTable.ButtonSelectedGradientEnd, highlight3, highlight4 };

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/PaletteSparkleBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/PaletteSparkleBase.cs
@@ -4691,8 +4691,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the color table instance.
         /// </summary>
-        public override KryptonColorTable ColorTable => _table ?? (_table =
-                                                            new KryptonColorTableSparkle(_ribbonColors, _sparkleColors, InheritBool.True, this));
+        public override KryptonColorTable ColorTable => _table ??= new KryptonColorTableSparkle(_ribbonColors, _sparkleColors, InheritBool.True, this);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/PaletteSparkleBlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/PaletteSparkleBlueDarkMode.cs
@@ -5012,8 +5012,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the color table instance.
         /// </summary>
-        public override KryptonColorTable ColorTable => _table ?? (_table =
-                                                            new KryptonColorTableSparkle(_ribbonColors, _sparkleColors, InheritBool.True, this));
+        public override KryptonColorTable ColorTable => _table ??= new KryptonColorTableSparkle(_ribbonColors, _sparkleColors, InheritBool.True, this);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonInternalKCT.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonInternalKCT.cs
@@ -636,7 +636,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the font used to draw text on a status strip.
         /// </summary>
-        public override Font MenuStripFont => InternalMenuStripFont == null ? BaseKCT.MenuStripFont : InternalMenuStripFont;
+        public override Font MenuStripFont => InternalMenuStripFont ?? BaseKCT.MenuStripFont;
 
         /// <summary>
         /// Sets and sets the internal MenuStripFont value.
@@ -999,7 +999,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the font used to draw text on a status strip.
         /// </summary>
-        public override Font StatusStripFont => InternalStatusStripFont == null ? BaseKCT.StatusStripFont : InternalStatusStripFont;
+        public override Font StatusStripFont => InternalStatusStripFont ?? BaseKCT.StatusStripFont;
 
         /// <summary>
         /// Sets and sets the internal StatusStripFont value.
@@ -1071,7 +1071,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the font used to draw text on a tool strip.
         /// </summary>
-        public override Font ToolStripFont => InternalToolStripFont == null ? BaseKCT.ToolStripFont : InternalToolStripFont;
+        public override Font ToolStripFont => InternalToolStripFont ?? BaseKCT.ToolStripFont;
 
         /// <summary>
         /// Sets and sets the internal ToolStripFont value.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteNavigatorState.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteNavigatorState.cs
@@ -65,7 +65,7 @@ namespace Krypton.Toolkit
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public KryptonPaletteNavigatorStateBar Bar { get; }
 
-        private bool ShouldSerializeStateCommon() => !Bar.IsDefault;
+        private bool ShouldSerializeBar() => !Bar.IsDefault;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbon.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbon.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit
     public class KryptonPaletteRibbon : Storage
     {
         #region Instance Fields
-        private PaletteRedirect _redirect;
+        private readonly PaletteRedirect _redirect;
         private readonly PaletteRibbonBackInheritRedirect _ribbonAppMenuOuterInherit;
         private readonly PaletteRibbonBackInheritRedirect _ribbonAppMenuInnerInherit;
         private readonly PaletteRibbonBackInheritRedirect _ribbonAppMenuDocsInherit;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonGroupArea.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonGroupArea.cs
@@ -127,7 +127,7 @@ namespace Krypton.Toolkit
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteRibbonBack StateTracking { get; }
 
-        public bool ShouldSerializeStateTracking() => !StateTracking.IsDefault;
+        private bool ShouldSerializeStateTracking() => !StateTracking.IsDefault;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteContentInheritNode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteContentInheritNode.cs
@@ -97,14 +97,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteState state) => TreeNode?.NodeFont != null ? TreeNode.NodeFont : _inherit.GetContentShortTextFont(state);
+        public override Font GetContentShortTextFont(PaletteState state) => TreeNode?.NodeFont ?? _inherit.GetContentShortTextFont(state);
 
         /// <summary>
         /// Gets the font for the short text by generating a new font instance.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteState state) => TreeNode?.NodeFont != null ? TreeNode.NodeFont : _inherit.GetContentShortTextNewFont(state);
+        public override Font GetContentShortTextNewFont(PaletteState state) => TreeNode?.NodeFont ?? _inherit.GetContentShortTextNewFont(state);
 
         /// <summary>
         /// Gets the rendering hint for the short text.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteContextMenuRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteContextMenuRedirect.cs
@@ -222,7 +222,7 @@ namespace Krypton.Toolkit
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteDoubleRedirect ItemSplit { get; }
 
-        private bool ShouldSerializeItemItemSplit() => !ItemSplit.IsDefault;
+        private bool ShouldSerializeItemSplit() => !ItemSplit.IsDefault;
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteCueHintText.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteCueHintText.cs
@@ -28,6 +28,9 @@ namespace Krypton.Toolkit
 
         #endregion
 
+        /// <summary>
+        /// Set a watermark/prompt message for the user.
+        /// </summary>
         [Category("Visuals")]
         [Description("Set a watermark/prompt message for the user.")]
         [RefreshProperties(RefreshProperties.All)]

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteDataGridViewContentCommon.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteDataGridViewContentCommon.cs
@@ -99,7 +99,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteState state) => _font != null ? _font : Inherit.GetContentShortTextFont(state);
+        public override Font GetContentShortTextFont(PaletteState state) => _font ?? Inherit.GetContentShortTextFont(state);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteDataGridViewContentStates.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteDataGridViewContentStates.cs
@@ -575,7 +575,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Image instance.</returns>
-        public Image GetContentShortTextImage(PaletteState state) => _image != null ? _image : Inherit.GetContentShortTextImage(state);
+        public Image GetContentShortTextImage(PaletteState state) => _image ?? Inherit.GetContentShortTextImage(state);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteHeaderPaddingRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteHeaderPaddingRedirect.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit
     public class PaletteHeaderPaddingRedirect : PaletteHeaderButtonRedirect
     {
         #region Instance Fields
-        private PaletteRedirect _redirect;
+        private readonly PaletteRedirect _redirect;
         private Padding _headerPadding;
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteListStateRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteListStateRedirect.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit
                                             
     {
         #region Instance Fields
-        private PaletteRedirect _redirect;
+        private readonly PaletteRedirect _redirect;
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteMonthCalendarState.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteMonthCalendarState.cs
@@ -60,7 +60,7 @@ namespace Krypton.Toolkit
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteTriple Day { get; }
 
-        private bool ShouldSerializeContent() => !Day.IsDefault;
+        private bool ShouldSerializeDay() => !Day.IsDefault;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteMonthCalendarStateRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteMonthCalendarStateRedirect.cs
@@ -79,7 +79,7 @@ namespace Krypton.Toolkit
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteTripleRedirect Day { get; }
 
-        private bool ShouldSerializeContent() => !Day.IsDefault;
+        private bool ShouldSerializeDay() => !Day.IsDefault;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteTreeNodeTriple.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteTreeNodeTriple.cs
@@ -77,7 +77,7 @@ namespace Krypton.Toolkit
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public virtual PaletteTriple Node => _paletteNode;
 
-        private bool ShouldSerializeItem() => !_paletteNode.IsDefault;
+        private bool ShouldSerializeNode() => !_paletteNode.IsDefault;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteTreeNodeTripleRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteTreeNodeTripleRedirect.cs
@@ -61,7 +61,7 @@ namespace Krypton.Toolkit
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteTripleRedirect Node { get; }
 
-        private bool ShouldSerializeItem() => !Node.IsDefault;
+        private bool ShouldSerializeNode() => !Node.IsDefault;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteTreeState.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteTreeState.cs
@@ -70,7 +70,7 @@ namespace Krypton.Toolkit
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteTriple Node { get; }
 
-        private bool ShouldSerializeItem() => !Node.IsDefault;
+        private bool ShouldSerializeNode() => !Node.IsDefault;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteTreeStateRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteTreeStateRedirect.cs
@@ -20,7 +20,7 @@ namespace Krypton.Toolkit
                                             
     {
         #region Instance Fields
-        private PaletteRedirect _redirect;
+        private readonly PaletteRedirect _redirect;
 
         #endregion
 
@@ -75,7 +75,7 @@ namespace Krypton.Toolkit
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteTripleRedirect Node { get; }
 
-        private bool ShouldSerializeItem() => !Node.IsDefault;
+        private bool ShouldSerializeNode() => !Node.IsDefault;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonOffice2010Renderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonOffice2010Renderer.cs
@@ -245,7 +245,6 @@ namespace Krypton.Toolkit
             public override void DrawBack(Graphics g, Rectangle rect)
             {
                 Rectangle inset = new(rect.X + 1, rect.Y + 1, rect.Width - 2, rect.Height - 2);
-                Rectangle insetB = new(rect.X + 2, rect.Y + 2, rect.Width - 3, rect.Height - 3);
 
                 using LinearGradientBrush insideBrush = new(rect, Back2, Back1, 90f);
                 insideBrush.SetSigmaBellShape(0.5f);

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonOffice2013Renderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonOffice2013Renderer.cs
@@ -245,7 +245,6 @@ namespace Krypton.Toolkit
             public override void DrawBack(Graphics g, Rectangle rect)
             {
                 Rectangle inset = new(rect.X + 1, rect.Y + 1, rect.Width - 2, rect.Height - 2);
-                Rectangle insetB = new(rect.X + 2, rect.Y + 2, rect.Width - 3, rect.Height - 3);
 
                 using LinearGradientBrush insideBrush = new(rect, Back2, Back1, 90f);
                 insideBrush.SetSigmaBellShape(0.5f);

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonOffice365Renderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonOffice365Renderer.cs
@@ -246,7 +246,6 @@ namespace Krypton.Toolkit
             public override void DrawBack(Graphics g, Rectangle rect)
             {
                 Rectangle inset = new(rect.X + 1, rect.Y + 1, rect.Width - 2, rect.Height - 2);
-                Rectangle insetB = new(rect.X + 2, rect.Y + 2, rect.Width - 3, rect.Height - 3);
 
                 using LinearGradientBrush insideBrush = new(rect, Back2, Back1, 90f);
                 insideBrush.SetSigmaBellShape(0.5f);

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
@@ -62,12 +62,12 @@ namespace Krypton.Toolkit
 
         private static readonly Color _darken5 = Color.FromArgb(5, Color.Black);
         private static readonly Color _darken8 = Color.FromArgb(8, Color.Black);
-        private static readonly Color _darken12 = Color.FromArgb(12, Color.Black);
+        //private static readonly Color _darken12 = Color.FromArgb(12, Color.Black);
         private static readonly Color _darken16 = Color.FromArgb(16, Color.Black);
         private static readonly Color _darken18 = Color.FromArgb(18, Color.Black);
         private static readonly Color _darken38 = Color.FromArgb(38, Color.Black);
         private static readonly Color _whiten200 = Color.FromArgb(200, Color.White);
-        private static readonly Color _whiten160 = Color.FromArgb(160, Color.White);
+        //private static readonly Color _whiten160 = Color.FromArgb(160, Color.White);
         private static readonly Color _whiten128 = Color.FromArgb(128, Color.White);
         private static readonly Color _whiten120 = Color.FromArgb(120, Color.White);
         private static readonly Color _whiten92 = Color.FromArgb(92, Color.White);
@@ -75,7 +75,7 @@ namespace Krypton.Toolkit
         private static readonly Color _whiten64 = Color.FromArgb(64, Color.White);
         private static readonly Color _whiten60 = Color.FromArgb(60, Color.White);
         private static readonly Color _whiten50 = Color.FromArgb(50, Color.White);
-        private static readonly Color _whiten45 = Color.FromArgb(45, Color.White);
+        //private static readonly Color _whiten45 = Color.FromArgb(45, Color.White);
         private static readonly Color _whiten32 = Color.FromArgb(32, Color.White);
         private static readonly Color _whiten30 = Color.FromArgb(30, Color.White);
         private static readonly Color _whiten10 = Color.FromArgb(10, Color.White);
@@ -106,7 +106,7 @@ namespace Krypton.Toolkit
         private static readonly Pen _light1Pen;
         private static readonly Pen _light2Pen;
         private static readonly Pen _whitenMediumPen;
-        private static readonly Pen _buttonShadowPen;
+        //private static readonly Pen _buttonShadowPen;
         private static readonly Pen _compositionPen;
 
         // Brushes
@@ -337,7 +337,7 @@ namespace Krypton.Toolkit
             _light1Pen = new Pen(Color.FromArgb(150, Color.White));
             _light2Pen = new Pen(Color.FromArgb(100, Color.White));
             _whitenMediumPen = new Pen(_whiten128);
-            _buttonShadowPen = new Pen(Color.FromArgb(48, Color.Black));
+            //_buttonShadowPen = new Pen(Color.FromArgb(48, Color.Black));
             _compositionPen = new Pen(Color.FromArgb(96, Color.Black));
 
             _whitenLightBrush = new SolidBrush(_whiten30);
@@ -1190,9 +1190,7 @@ namespace Krypton.Toolkit
                 // orientation, so we adjust the display rect to that orientation
                 // and then at the end adjust the memento produced back to the
                 // required orientation again. 'AdjustForOrientation'
-                var temp = availableRect.Width;
-                availableRect.Width = availableRect.Height;
-                availableRect.Height = temp;
+                (availableRect.Width, availableRect.Height) = (availableRect.Height, availableRect.Width);
             }
 
             // Apply padding to the rectangle
@@ -1207,9 +1205,7 @@ namespace Krypton.Toolkit
                 // This is the display rect we need to use in 'AdjustForOrientation'
                 // and cache it for later. The displayRect itself is modified during
                 // the below process and so cannot be used directly.
-                var temp = cacheDisplayRect.Width;
-                cacheDisplayRect.Width = cacheDisplayRect.Height;
-                cacheDisplayRect.Height = temp;
+                (cacheDisplayRect.Width, cacheDisplayRect.Height) = (cacheDisplayRect.Height, cacheDisplayRect.Width);
             }
 
             // Track the allocated space in each grid position
@@ -3375,8 +3371,6 @@ namespace Krypton.Toolkit
                                                   IPaletteBorder paletteBorder,
                                                   PaletteState state)
         {
-            var rounding = paletteBorder.GetBorderRounding(state);
-
             // If the border takes up some visual space
             if (paletteBorder.GetBorderWidth(state) > 0)
             {
@@ -12139,9 +12133,7 @@ namespace Krypton.Toolkit
 
             private static void SwapRectangleSizes(ref Rectangle rect)
             {
-                var temp = rect.Width;
-                rect.Width = rect.Height;
-                rect.Height = temp;
+                (rect.Width, rect.Height) = (rect.Height, rect.Width);
             }
         }
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/ThemeManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/ThemeManager.cs
@@ -22,7 +22,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// The supported themes
         /// </summary>
-        private static readonly string[] _supportedThemes = new string[]
+        private static readonly string[] _supportedThemes =
         {
             "Professional - System",
 
@@ -272,12 +272,10 @@ namespace Krypton.Toolkit
                 case "Office 365 - Black (Dark Mode)":
                     ApplyTheme(PaletteModeManager.Office365BlackDarkMode, manager);
                     break;
+                default:
+                    throw new ArgumentNullException(nameof(themeName));
             }
 
-            if (string.IsNullOrEmpty(themeName))
-            {
-                throw new ArgumentNullException();
-            }
         }
 
         /// <summary>
@@ -549,24 +547,22 @@ namespace Krypton.Toolkit
         /// </returns>
         public static string[] ReturnThemeArray() => _supportedThemes;
 
-        public static void PropagateSupportedThemeList(List<string> supportedThemeList)
+        /// <summary>
+        /// 
+        /// </summary>
+        public static List<string> PropagateSupportedThemeList()
         {
             try
             {
-                supportedThemeList = new List<string>();
-
-                foreach (string theme in ReturnThemeArray())
-                {
-                    supportedThemeList.Add(theme);
-                }
+                return ReturnThemeArray().ToList();
             }
             catch (Exception e)
             {
                 ExceptionHandler.CaptureException(e);
             }
-        }
 
-        public static string[] ReturnListToArray(List<string> themeList) => themeList.ToArray();
+            return new List<string>();
+        }
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Utilities/ImageNativeMethods.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Utilities/ImageNativeMethods.cs
@@ -5,17 +5,17 @@
 // *****************************************************************************
 
 namespace Krypton.Toolkit
+{
+    internal class ImageNativeMethods
     {
-     internal class ImageNativeMethods
-     {
-        private const string user32 = "user32.dll";
-        private const string uxtheme = "uxtheme.dll";
-        private const string dwmapi = "dwmapi.dll";
+        private const string USER32 = @"user32.dll";
 
-        [DllImport(user32, SetLastError = true)]
+        [DllImport(USER32, SetLastError = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         public static extern IntPtr SendMessage(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
 
-        [DllImport(user32, SetLastError = true)]
+        [DllImport(USER32, EntryPoint = "LoadImageW", CharSet = CharSet.Unicode, SetLastError = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         public static extern IntPtr LoadImage(IntPtr hinst, string lpszName, uint uType, int cxDesired, int cyDesired, uint fuLoad);
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Utilities/Portable.System.ValueTuple.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Utilities/Portable.System.ValueTuple.cs
@@ -124,7 +124,7 @@ namespace System
             {
                 null => 1,
                 ValueTuple => 0,
-                _ => throw new ArgumentException()
+                _ => throw new ArgumentException(@"Incorrect type", nameof(other))
             };
         }
 
@@ -154,7 +154,7 @@ namespace System
             {
                 null => 1,
                 ValueTuple => 0,
-                _ => throw new ArgumentException()
+                _ => throw new ArgumentException(@"Incorrect type", nameof(other))
             };
         }
 
@@ -276,7 +276,7 @@ namespace System
             return other switch
             {
                 null => 1,
-                not ValueTuple<T1, T2> => throw new ArgumentException(),
+                not ValueTuple<T1, T2> => throw new ArgumentException(@"Incorrect type", nameof(other)),
                 _ => CompareTo((ValueTuple<T1, T2>)other)
             };
         }
@@ -319,7 +319,7 @@ namespace System
                     return c != 0 ? c : comparer.Compare(Item2, item2);
                 }
                 default:
-                    throw new ArgumentException();
+                    throw new ArgumentException(@"Incorrect type", nameof(other));
             }
         }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Values/ButtonValues.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/ButtonValues.cs
@@ -235,7 +235,7 @@ namespace Krypton.Toolkit
         /// Create the storage for the image states.
         /// </summary>
         /// <returns>Storage object.</returns>
-        protected virtual ButtonImageStates CreateImageStates() => new ButtonImageStates();
+        protected virtual ButtonImageStates CreateImageStates() => new ();
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Values/ColorButtonValues.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/ColorButtonValues.cs
@@ -321,7 +321,7 @@ namespace Krypton.Toolkit
         /// Create the storage for the image states.
         /// </summary>
         /// <returns>Storage object.</returns>
-        protected virtual ButtonImageStates CreateImageStates() => new ButtonImageStates();
+        protected virtual ButtonImageStates CreateImageStates() => new ();
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Values/LabelValues.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/LabelValues.cs
@@ -20,7 +20,7 @@ namespace Krypton.Toolkit
                                IContentValues
     {
         #region Static Fields
-        private const string _defaultText = "Label";
+        private const string _defaultText = @"Label";
         private static readonly string _defaultExtraText = string.Empty;
         #endregion
 
@@ -223,8 +223,7 @@ namespace Krypton.Toolkit
         /// </summary>
         public void ResetExtraText()
         {
-            // TODO: What is the intention of this
-            ExtraText = ExtraText;
+            ExtraText = _defaultExtraText;
         }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/View Base/ViewBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Base/ViewBase.cs
@@ -502,7 +502,7 @@ namespace Krypton.Toolkit
             else
             {
                 // Bubble event up to the parent
-                return Parent != null ? Parent.MouseDown(pt, button) : false;
+                return Parent?.MouseDown(pt, button) ?? false;
             }
         }
 
@@ -614,7 +614,7 @@ namespace Krypton.Toolkit
             else
             {
                 // Bubble event up to the parent
-                return Parent != null ? Parent.KeyUp(e) : false;
+                return Parent?.KeyUp(e) ?? false;
             }
         }
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/View Base/ViewComposite.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Base/ViewComposite.cs
@@ -234,7 +234,7 @@ namespace Krypton.Toolkit
         /// <returns>True if view found; otherwise false.</returns>
         public override bool Contains(ViewBase item) =>
             // Let type safe collection perform operation
-            _views != null ? _views.Contains(item) : false;
+            _views?.Contains(item) ?? false;
 
         /// <summary>
         /// Determines whether any part of the view hierarchy is the specified view.
@@ -292,7 +292,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the number of views in collection.
         /// </summary>
-        public override int Count => _views != null ? _views.Count : 0;
+        public override int Count => _views?.Count ?? 0;
 
         /// <summary>
         /// Determines the index of the specified view in the collection.
@@ -301,7 +301,7 @@ namespace Krypton.Toolkit
         /// <returns>-1 if not found; otherwise index position.</returns>
         public override int IndexOf(ViewBase item) =>
             // Let type safe collection perform operation
-            _views != null ? _views.IndexOf(item) : -1;
+            _views?.IndexOf(item) ?? -1;
 
         /// <summary>
         /// Inserts a view to the collection at the specified index.
@@ -386,7 +386,7 @@ namespace Krypton.Toolkit
         /// <returns>Enumerator instance.</returns>
         public override IEnumerator<ViewBase> GetEnumerator() =>
             // Use the boilerplate enumerator exposed from the IList<T>
-            _views != null ? _views.GetEnumerator() : (IEnumerator<ViewBase>)new List<ViewBase>().GetEnumerator();
+            _views?.GetEnumerator() ?? (IEnumerator<ViewBase>)new List<ViewBase>().GetEnumerator();
 
         /// <summary>
         /// Deep enumerate forward over children of the element.

--- a/Source/Krypton Components/Krypton.Toolkit/View Base/ViewContextMenuManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Base/ViewContextMenuManager.cs
@@ -420,7 +420,7 @@ namespace Krypton.Toolkit
         /// <returns>True to become current; otherwise false.</returns>
         public bool DoesStackedClientMouseDownBecomeCurrent(Message m, Point pt) =>
             // Do we have a current target we can ask?
-            _target != null ? _target.DoesStackedClientMouseDownBecomeCurrent(pt) : true;
+            _target?.DoesStackedClientMouseDownBecomeCurrent(pt) ?? true;
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/View Base/ViewDecorator.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Base/ViewDecorator.cs
@@ -318,7 +318,7 @@ namespace Krypton.Toolkit
         /// <returns>True if capturing input; otherwise false.</returns>
         public override bool MouseDown(Point pt, MouseButtons button) =>
             // Bubble event up to the parent
-            Parent != null ? Parent.MouseDown(pt, button) : false;
+            Parent?.MouseDown(pt, button) ?? false;
 
         /// <summary>
         /// Mouse button has been released in the view.
@@ -363,7 +363,7 @@ namespace Krypton.Toolkit
         /// <returns>True if capturing input; otherwise false.</returns>
         public override bool KeyUp(KeyEventArgs e) =>
             // Bubble event up to the parent
-            Parent != null ? Parent.KeyUp(e) : false;
+            Parent?.KeyUp(e) ?? false;
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawCanvas.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawCanvas.cs
@@ -225,7 +225,7 @@ namespace Krypton.Toolkit
         /// </summary>
         public PaletteDrawBorders MaxBorderEdges
         {
-            get => _borderForced == null ? PaletteDrawBorders.All : _borderForced.MaxBorderEdges;
+            get => _borderForced?.MaxBorderEdges ?? PaletteDrawBorders.All;
 
             set 
             {
@@ -269,7 +269,7 @@ namespace Krypton.Toolkit
         /// </summary>
         public PaletteGraphicsHint ForceGraphicsHint
         {
-            get => _borderForced == null ? PaletteGraphicsHint.Inherit : _borderForced.ForceGraphicsHint;
+            get => _borderForced?.ForceGraphicsHint ?? PaletteGraphicsHint.Inherit;
 
             set 
             {
@@ -472,7 +472,9 @@ namespace Krypton.Toolkit
             }
 
             // Do we need to draw the background?
-            if (DrawCanvas &&(_paletteBack.GetBackDraw(State) == InheritBool.True))
+            if (DrawCanvas 
+                && (_paletteBack.GetBackDraw(State) == InheritBool.True)
+                )
             {
                 GraphicsPath borderPath;
                 Padding borderPadding;
@@ -498,7 +500,9 @@ namespace Krypton.Toolkit
                 borderPath.Dispose();
             }
 
-            if (DrawCanvas && (_paletteBorder != null))
+            if (DrawCanvas 
+                && (_paletteBorder != null)
+                )
             {
                 // Do we draw the border before the children?
                 if (!DrawBorderLast)
@@ -515,21 +519,16 @@ namespace Krypton.Toolkit
                     _clipRegion = context.Graphics.Clip.Clone();
 
                     // Restrict the clipping to the area inside the canvas border
-                    GraphicsPath borderPath = DrawTabBorder ? context.Renderer.RenderTabBorder.GetTabBorderPath(context, ClientRectangle, _paletteBorder, Orientation, State, TabBorderStyle) : context.Renderer.RenderStandardBorder.GetBorderPath(context, ClientRectangle, _paletteBorder, Orientation, State);
-
-                    if (borderPath == null)
-                    {
-                        throw new ArgumentNullException(nameof(borderPath));
-                    }
+                    using GraphicsPath borderPath = DrawTabBorder 
+                        ? context.Renderer.RenderTabBorder.GetTabBorderPath(context, ClientRectangle, _paletteBorder, Orientation, State, TabBorderStyle) 
+                        : context.Renderer.RenderStandardBorder.GetBorderPath(context, ClientRectangle, _paletteBorder, Orientation, State);
 
                     // Create a new region the same as the existing clipping region
-                    Region combineRegion = new(borderPath);
+                    var combineRegion = new Region(borderPath);
 
                     // Reduce clipping region down by our border path
                     combineRegion.Intersect(_clipRegion);
                     context.Graphics.Clip = combineRegion;
-
-                    borderPath.Dispose();
                 }
             }
         }
@@ -549,7 +548,9 @@ namespace Krypton.Toolkit
                 throw new ArgumentNullException(nameof(context));
             }
 
-            if (DrawCanvas && (_paletteBorder != null))
+            if (DrawCanvas 
+                && (_paletteBorder != null)
+                )
             {
                 // Do we draw the border after the children?
                 if (DrawBorderLast)

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawContent.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawContent.cs
@@ -396,7 +396,7 @@ namespace Krypton.Toolkit
             // Do we need to draw the content?
             if (_paletteContent.GetContentDraw(State) == InheritBool.True)
             {
-                var allowFocusRect = TestForFocusCues ? ShowFocusCues(context.Control) : true;
+                var allowFocusRect = !TestForFocusCues || ShowFocusCues(context.Control);
 
                 // Draw using memento returned from render layout
                 context.Renderer.RenderStandardContent.DrawContent(context,

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawDateTimeButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawDateTimeButton.cs
@@ -120,7 +120,7 @@ namespace Krypton.Toolkit
         /// <param name="context">Layout context.</param>
         public override Size GetPreferredSize(ViewLayoutContext context) =>
             // We want to be as wide as drop down buttons on standard controls
-            new Size(SystemInformation.VerticalScrollBarWidth - 2, 0);
+            new (SystemInformation.VerticalScrollBarWidth - 2, 0);
 
         /// <summary>
         /// Perform a layout of the elements.

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuCheckBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuCheckBox.cs
@@ -172,7 +172,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Resolves the correct enabled state to use from the menu item.
         /// </summary>
-        public bool ResolveEnabled => _cachedCommand != null ? _cachedCommand.Enabled : KryptonContextMenuCheckBox.Enabled;
+        public bool ResolveEnabled => _cachedCommand?.Enabled ?? KryptonContextMenuCheckBox.Enabled;
 
         #endregion
 
@@ -188,7 +188,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Resolves the correct image transparent color to use from the menu item.
         /// </summary>
-        public Color ResolveImageTransparentColor => _cachedCommand != null ? _cachedCommand.ImageTransparentColor : KryptonContextMenuCheckBox.ImageTransparentColor;
+        public Color ResolveImageTransparentColor => _cachedCommand?.ImageTransparentColor ?? KryptonContextMenuCheckBox.ImageTransparentColor;
 
         #endregion
 
@@ -212,7 +212,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Resolves the correct check state to use from the menu item.
         /// </summary>
-        public CheckState ResolveCheckState => _cachedCommand != null ? _cachedCommand.CheckState : KryptonContextMenuCheckBox.CheckState;
+        public CheckState ResolveCheckState => _cachedCommand?.CheckState ?? KryptonContextMenuCheckBox.CheckState;
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuCheckButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuCheckButton.cs
@@ -153,7 +153,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Resolves the correct enabled state to use from the menu item.
         /// </summary>
-        public bool ResolveEnabled => _cachedCommand != null ? _cachedCommand.Enabled : KryptonContextMenuCheckButton.Enabled;
+        public bool ResolveEnabled => _cachedCommand?.Enabled ?? KryptonContextMenuCheckButton.Enabled;
 
         #endregion
 
@@ -169,7 +169,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Resolves the correct image transparent color to use from the menu item.
         /// </summary>
-        public Color ResolveImageTransparentColor => _cachedCommand != null ? _cachedCommand.ImageTransparentColor : KryptonContextMenuCheckButton.ImageTransparentColor;
+        public Color ResolveImageTransparentColor => _cachedCommand?.ImageTransparentColor ?? KryptonContextMenuCheckButton.ImageTransparentColor;
 
         #endregion
 
@@ -193,7 +193,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Resolves the correct checked state to use from the menu item.
         /// </summary>
-        public bool ResolveChecked => _cachedCommand != null ? _cachedCommand.Checked : KryptonContextMenuCheckButton.Checked;
+        public bool ResolveChecked => _cachedCommand?.Checked ?? KryptonContextMenuCheckButton.Checked;
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuItem.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuItem.cs
@@ -31,7 +31,7 @@ namespace Krypton.Toolkit
         private readonly FixedContentValue _fixedTextExtraText;
         private KryptonCommand _cachedCommand;
         private readonly bool _imageColumn;
-        private bool _standardStyle;
+        private readonly bool _standardStyle;
 
         #endregion
 
@@ -239,7 +239,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Resolves the correct enabled state to use from the menu item.
         /// </summary>
-        public bool ResolveEnabled => _cachedCommand != null ? _cachedCommand.Enabled : KryptonContextMenuItem.Enabled;
+        public bool ResolveEnabled => _cachedCommand?.Enabled ?? KryptonContextMenuItem.Enabled;
 
         #endregion
 
@@ -267,7 +267,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Resolves the correct image transparent color to use from the menu item.
         /// </summary>
-        public Color ResolveImageTransparentColor => _cachedCommand != null ? _cachedCommand.ImageTransparentColor : KryptonContextMenuItem.ImageTransparentColor;
+        public Color ResolveImageTransparentColor => _cachedCommand?.ImageTransparentColor ?? KryptonContextMenuItem.ImageTransparentColor;
 
         #endregion
 
@@ -291,7 +291,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Resolves the correct checked to use from the menu item.
         /// </summary>
-        public bool ResolveChecked => _cachedCommand != null ? _cachedCommand.Checked : KryptonContextMenuItem.Checked;
+        public bool ResolveChecked => _cachedCommand?.Checked ?? KryptonContextMenuItem.Checked;
 
         #endregion
 
@@ -299,7 +299,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Resolves the correct check state to use from the menu item.
         /// </summary>
-        public CheckState ResolveCheckState => _cachedCommand != null ? _cachedCommand.CheckState : KryptonContextMenuItem.CheckState;
+        public CheckState ResolveCheckState => _cachedCommand?.CheckState ?? KryptonContextMenuItem.CheckState;
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuLinkLabel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuLinkLabel.cs
@@ -131,7 +131,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Resolves the correct image transparent color to use from the menu item.
         /// </summary>
-        public Color ResolveImageTransparentColor => _cachedCommand != null ? _cachedCommand.ImageTransparentColor : KryptonContextMenuLinkLabel.ImageTransparentColor;
+        public Color ResolveImageTransparentColor => _cachedCommand?.ImageTransparentColor ?? KryptonContextMenuLinkLabel.ImageTransparentColor;
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMonthUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMonthUpDown.cs
@@ -103,7 +103,7 @@ namespace Krypton.Toolkit
         /// <param name="context">Layout context.</param>
         public override Size GetPreferredSize(ViewLayoutContext context) =>
             // We want to be as wide as drop down buttons on standard controls
-            new Size(SystemInformation.VerticalScrollBarWidth - 2, 0);
+            new (SystemInformation.VerticalScrollBarWidth - 2, 0);
 
         /// <summary>
         /// Perform a layout of the elements.

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawScrollBar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawScrollBar.cs
@@ -161,7 +161,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the current scroll position.
         /// </summary>
-        public int ScrollPosition => _scrollBar != null ? _scrollBar.Value : 0;
+        public int ScrollPosition => _scrollBar?.Value ?? 0;
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawSplitCanvas.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawSplitCanvas.cs
@@ -262,7 +262,7 @@ namespace Krypton.Toolkit
         /// </summary>
         public PaletteDrawBorders MaxBorderEdges
         {
-            get => _borderForced == null ? PaletteDrawBorders.All : _borderForced.MaxBorderEdges;
+            get => _borderForced?.MaxBorderEdges ?? PaletteDrawBorders.All;
 
             set 
             {
@@ -287,7 +287,7 @@ namespace Krypton.Toolkit
         /// </summary>
         public PaletteGraphicsHint ForceGraphicsHint
         {
-            get => _borderForced == null ? PaletteGraphicsHint.Inherit : _borderForced.ForceGraphicsHint;
+            get => _borderForced?.ForceGraphicsHint ?? PaletteGraphicsHint.Inherit;
 
             set 
             {

--- a/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutCrumbs.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutCrumbs.cs
@@ -233,7 +233,7 @@ namespace Krypton.Toolkit
                     // Cast to correct type
 
                     // That are associated with crumb items
-                    if (_buttonToCrumb.TryGetValue(crumbButton, out KryptonBreadCrumbItem crumbItem))
+                    if (_buttonToCrumb.TryGetValue(crumbButton, out KryptonBreadCrumbItem _))
                     {
                         // If the button is pressed then point button downwards, 
                         // otherwise we point in the direction the buttons layed out.

--- a/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutMonths.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutMonths.cs
@@ -634,7 +634,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Private
-        private DateTime JustDay(DateTime dt) => new DateTime(dt.Year, dt.Month, dt.Day);
+        private DateTime JustDay(DateTime dt) => new (dt.Year, dt.Month, dt.Day);
 
         private void OnTodayClick(object sender, EventArgs e)
         {

--- a/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutScrollViewport.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutScrollViewport.cs
@@ -317,7 +317,7 @@ namespace Krypton.Toolkit
 
             } while (relayout);
 
-            // Now all layouts have occured we can actually move child controls
+            // Now all layouts have occurred we can actually move child controls
             context.ViewManager.DoNotLayoutControls = false;
 
             // Perform actual layout of child controls

--- a/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutSeparator.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutSeparator.cs
@@ -78,7 +78,7 @@ namespace Krypton.Toolkit
         /// <param name="context">Layout context.</param>
         public override Size GetPreferredSize(ViewLayoutContext context) =>
             // Always return the same minimum size
-            new Size(_width, _height);
+            new (_width, _height);
 
         /// <summary>
         /// Perform a layout of the elements.

--- a/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutWeekCorner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutWeekCorner.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit
     public class ViewLayoutWeekCorner : ViewLeaf
     {
         #region Instance Fields
-        private IKryptonMonthCalendar _calendar;
+        private readonly IKryptonMonthCalendar _calendar;
         private readonly ViewLayoutMonths _months;
         private readonly PaletteBorder _palette;
         #endregion

--- a/Source/Krypton Components/Krypton.Workspace/Controls Workspace/KryptonWorkspace.cs
+++ b/Source/Krypton Components/Krypton.Workspace/Controls Workspace/KryptonWorkspace.cs
@@ -621,7 +621,7 @@ namespace Krypton.Workspace
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public WorkspaceMenus ContextMenus { get; }
 
-        private bool ShouldSerializeWorkspaceMenus() => !ContextMenus.IsDefault;
+        private bool ShouldSerializeContextMenus() => !ContextMenus.IsDefault;
 
         /// <summary>
         /// Gets access to the root sequence.
@@ -1685,8 +1685,7 @@ namespace Krypton.Workspace
             var visibleCells = 0;
             var numPages = 0;
 
-            if ((MaximizedCell != null)
-                && MaximizedCell.AllowDroppingPages
+            if (MaximizedCell is { AllowDroppingPages: true }
                 )
             {
                 // Generate targets for maximized cell only
@@ -1929,7 +1928,7 @@ namespace Krypton.Workspace
                 }
 
                 // Load the format version number
-                var version = xmlReader.GetAttribute("V");
+                var version = xmlReader.GetAttribute(@"V");
                 var activePageUniqueName = xmlReader.GetAttribute(@"A");
 
                 // Convert format version from string to double
@@ -2356,7 +2355,7 @@ namespace Krypton.Workspace
 
         #region Protected
         /// <summary>
-        /// Change has occured in the hierarchy of children.
+        /// Change has occurred in the hierarchy of children.
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">Arguments associated with the event.</param>
@@ -2567,7 +2566,7 @@ namespace Krypton.Workspace
                 {
                     if (MaximizedCell != null)
                     {
-                        LayoutSequenceMaximized(Root, ClientRectangle, controls, layoutContext);
+                        LayoutSequenceMaximized(Root, ClientRectangle, controls);
                     }
                     else
                     {
@@ -2595,13 +2594,10 @@ namespace Krypton.Workspace
                         ((KryptonReadOnlyControls)Controls).RemoveInternal(c);
 
                         // If the control has the expected interface
-                        if (c is IWorkspaceItem item)
-                        {
+                        if (c is IWorkspaceItem { DisposeOnRemove: true })
                             // Does the item want to be disposed on removal?
-                            if (item.DisposeOnRemove)
-                            {
-                                c.Dispose();
-                            }
+                        {
+                            c.Dispose();
                         }
 
                         // Generate event so users can reverse actions taken when cell was added
@@ -2646,8 +2642,7 @@ namespace Krypton.Workspace
                 }
 
                 // If we have a maximized cell then ensure it has focus and not some other cell
-                if ((MaximizedCell != null)
-                    && !MaximizedCell.ContainsFocus && ContainsFocus
+                if (MaximizedCell is { ContainsFocus: false } && ContainsFocus
                     )
                 {
                     MaximizedCell.Select();
@@ -2909,7 +2904,7 @@ namespace Krypton.Workspace
                     offset = splitter.Y - separator.ClientLocation.Y;
                 }
 
-                // Only need to process if a change has occured
+                // Only need to process if a change has occurred
                 if (offset != 0)
                 {
                     // Update the sizing value for each item in the sequence
@@ -3050,8 +3045,7 @@ namespace Krypton.Workspace
         #region Implementation
         private void LayoutSequenceMaximized(KryptonWorkspaceSequence seq,
                                              Rectangle client,
-                                             ControlList controls,
-                                             ViewLayoutContext layoutContext)
+                                             ControlList controls)
         {
             // Inform the sequence of the client rectangle it occupies
             seq.WorkspaceActualSize = client.Size;
@@ -3575,7 +3569,7 @@ namespace Krypton.Workspace
             return null;
         }
 
-        private void SeparatorToItems(ViewDrawWorkspaceSeparator separator,
+        private static void SeparatorToItems(ViewDrawWorkspaceSeparator separator,
                                       out IWorkspaceItem after,
                                       out IWorkspaceItem before)
         {
@@ -3589,7 +3583,7 @@ namespace Krypton.Workspace
             before = null;
             for (var i = beforeSequence.Children.IndexOf(after) - 1; i >= 0; i--)
             {
-                if ((beforeSequence.Children[i] is IWorkspaceItem item) && item.WorkspaceVisible)
+                if ((beforeSequence.Children[i] is IWorkspaceItem { WorkspaceVisible: true } item))
                 {
                     before = item;
                     break;
@@ -3597,7 +3591,7 @@ namespace Krypton.Workspace
             }
         }
 
-        private void SeparatorToMovement(ViewDrawWorkspaceSeparator separator,
+        private static void SeparatorToMovement(ViewDrawWorkspaceSeparator separator,
                                          IWorkspaceItem after,
                                          IWorkspaceItem before,
                                          out int moveBefore,
@@ -3746,7 +3740,7 @@ namespace Krypton.Workspace
             targets.Add(new DragTargetWorkspaceCellTransfer(screenRect, rectsHot[4], screenRect, this, cell, allowFlags));
         }
 
-        private Rectangle[] SubdivideRectangle(Rectangle area,
+        private static Rectangle[] SubdivideRectangle(Rectangle area,
                                                int divisor,
                                                int maxLength)
         {
@@ -3820,7 +3814,7 @@ namespace Krypton.Workspace
         {
             if (!IsActivePageChangedEventSuspended)
             {
-                // If change occured on the active cell
+                // If change occurred on the active cell
                 KryptonWorkspaceCell cell = (KryptonWorkspaceCell)sender;
                 if (cell == ActiveCell)
                 {
@@ -4137,7 +4131,7 @@ namespace Krypton.Workspace
             }
         }
 
-        private UniqueNameToPage BuildUniqueNameDictionary(KryptonPageCollection pages)
+        private static UniqueNameToPage BuildUniqueNameDictionary(KryptonPageCollection pages)
         {
             UniqueNameToPage dict = new();
 
@@ -4154,7 +4148,7 @@ namespace Krypton.Workspace
             return dict;
         }
 
-        private Bitmap ReadOptionalImageElement(XmlReader xmlReader, string name)
+        private static Bitmap ReadOptionalImageElement(XmlReader xmlReader, string name)
         {
             Bitmap retImage = null;
 

--- a/Source/Krypton Components/Krypton.Workspace/Controls Workspace/KryptonWorkspaceCell.cs
+++ b/Source/Krypton Components/Krypton.Workspace/Controls Workspace/KryptonWorkspaceCell.cs
@@ -36,7 +36,7 @@ namespace Krypton.Workspace
 
         #region Events
         /// <summary>
-        /// Occurs after a change has occured to the collection.
+        /// Occurs after a change has occurred to the collection.
         /// </summary>
         public event PropertyChangedEventHandler PropertyChanged;
 
@@ -232,7 +232,7 @@ namespace Krypton.Workspace
                 }
                 else
                 {
-                    return GetPreferredSize(Size.Empty);
+                    return GetPreferredSize(WorkspaceMinSize);
                 }
             }
         }
@@ -270,7 +270,7 @@ namespace Krypton.Workspace
                 if (!base.MinimumSize.Equals(value))
                 {
                     base.MinimumSize = value;
-                    OnPropertyChanged("MinimumSize");
+                    OnPropertyChanged(nameof(MinimumSize));
                 }
             }
         }
@@ -287,7 +287,7 @@ namespace Krypton.Workspace
                 if (!base.MaximumSize.Equals(value))
                 {
                     base.MaximumSize = value;
-                    OnPropertyChanged("MaximumSize");
+                    OnPropertyChanged(nameof(MaximumSize));
                 }
             }
         }
@@ -334,7 +334,7 @@ namespace Krypton.Workspace
                 if (WorkspaceAllowResizing != value)
                 {
                     WorkspaceAllowResizing = value;
-                    OnPropertyChanged("AllowResizing");
+                    OnPropertyChanged(nameof(AllowResizing));
                 }
             }
         }
@@ -353,7 +353,7 @@ namespace Krypton.Workspace
             set
             {
                 _allowDroppingPages = value;
-                OnPropertyChanged("DroppingPages");
+                OnPropertyChanged(nameof(AllowDroppingPages));
             }
         }
         //end seb
@@ -371,7 +371,7 @@ namespace Krypton.Workspace
             set
             {
                 WorkspaceStarSize.Value = value;
-                OnPropertyChanged("StarSize");
+                OnPropertyChanged(nameof(StarSize));
             }
         }
 
@@ -573,12 +573,12 @@ namespace Krypton.Workspace
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void DebugOutput(int indent)
         {
-            Console.WriteLine("{0}Cell Count:{1} Visible:{2}", new string(' ', indent++ * 2), Pages.Count, LastVisibleSet);
+            Console.WriteLine(@"{0}Cell Count:{1} Visible:{2}", new string(' ', indent++ * 2), Pages.Count, LastVisibleSet);
 
             var prefix = new string(' ', indent * 2);
             foreach (KryptonPage page in Pages)
             {
-                Console.WriteLine("{0}Page Text:{1} Visible:{2} Type:{3}", prefix, page.Text, page.LastVisibleSet, page.GetType().Name);
+                Console.WriteLine(@"{0}Page Text:{1} Visible:{2} Type:{3}", prefix, page.Text, page.LastVisibleSet, page.GetType().Name);
             }
         }
         #endregion
@@ -598,7 +598,7 @@ namespace Krypton.Workspace
             if (WorkspaceVisible != value)
             {
                 WorkspaceVisible = value;
-                OnPropertyChanged("Visible");
+                OnPropertyChanged(nameof(Visible));
             }
 
             base.SetVisibleCore(value);
@@ -653,7 +653,7 @@ namespace Krypton.Workspace
             // a change in pages might cause compacting to perform extra actions.
             if (_events)
             {
-                OnPropertyChanged("Pages");
+                OnPropertyChanged(@"Pages");
             }
         }
 

--- a/Source/Krypton Components/Krypton.Workspace/Controls Workspace/KryptonWorkspaceCollection.cs
+++ b/Source/Krypton Components/Krypton.Workspace/Controls Workspace/KryptonWorkspaceCollection.cs
@@ -29,7 +29,7 @@ namespace Krypton.Workspace
 
         #region Events
         /// <summary>
-        /// Occurs after a change has occured to the collection.
+        /// Occurs after a change has occurred to the collection.
         /// </summary>
         public event PropertyChangedEventHandler PropertyChanged;
 
@@ -70,14 +70,14 @@ namespace Krypton.Workspace
                 foreach (Component c in this)
                 {
                     // If we have a cell and that cell wants to be visible then we are done
-                    if ((c is KryptonWorkspaceCell cell) && cell.WorkspaceVisible)
+                    if ((c is KryptonWorkspaceCell { WorkspaceVisible: true }))
                     {
                         return true;
                     }
                     else
                     {
                         // If we have a sequence and it is visible and contains a visible cell then we are done
-                        if ((c is KryptonWorkspaceSequence sequence) && sequence.WorkspaceVisible && sequence.Children.ContainsVisibleCell)
+                        if ((c is KryptonWorkspaceSequence { WorkspaceVisible: true } sequence) && sequence.Children.ContainsVisibleCell)
                         {
                             return true;
                         }
@@ -114,7 +114,7 @@ namespace Krypton.Workspace
                 sequence.WorkspaceParent = _sequence;
             }
 
-            OnPropertyChanged("Children");
+            OnPropertyChanged(@"Children");
         }
 
         /// <summary>
@@ -141,7 +141,7 @@ namespace Krypton.Workspace
                 sequence.WorkspaceParent = null;
             }
 
-            OnPropertyChanged("Children");
+            OnPropertyChanged(@"Children");
         }
 
         /// <summary>
@@ -180,7 +180,7 @@ namespace Krypton.Workspace
         protected override void OnCleared(EventArgs e)
         {
             base.OnCleared(e);
-            OnPropertyChanged("Children");
+            OnPropertyChanged(@"Children");
         }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Workspace/Controls Workspace/KryptonWorkspaceSequence.cs
+++ b/Source/Krypton Components/Krypton.Workspace/Controls Workspace/KryptonWorkspaceSequence.cs
@@ -35,7 +35,7 @@ namespace Krypton.Workspace
 
         #region Events
         /// <summary>
-        /// Occurs after a change has occured to the workspace.
+        /// Occurs after a change has occurred to the workspace.
         /// </summary>
         [Browsable(false)]
         public event PropertyChangedEventHandler PropertyChanged;
@@ -133,7 +133,7 @@ namespace Krypton.Workspace
                 if (_orientation != value)
                 {
                     _orientation = value;
-                    OnPropertyChanged("Orientation");
+                    OnPropertyChanged(nameof(Orientation));
                 }
             }
         }
@@ -153,7 +153,7 @@ namespace Krypton.Workspace
                 if (_setVisible != value)
                 {
                     _setVisible = value;
-                    OnPropertyChanged("Visible");
+                    OnPropertyChanged(nameof(Visible));
                 }
             }
         }
@@ -181,7 +181,7 @@ namespace Krypton.Workspace
             set
             {
                 WorkspaceStarSize.Value = value;
-                OnPropertyChanged("StarSize");
+                OnPropertyChanged(nameof(StarSize));
             }
         }
 
@@ -259,7 +259,7 @@ namespace Krypton.Workspace
                 foreach (Component component in Children)
                 {
                     // Get can only grab values from the IWorkspaceItem interface
-                    if ((component is IWorkspaceItem item) && item.WorkspaceVisible)
+                    if ((component is IWorkspaceItem { WorkspaceVisible: true } item))
                     {
                         StarSize itemStar = item.WorkspaceStarSize;
                         var preferredWidth = (!itemStar.StarWidth.UsingStar && (itemStar.StarWidth.FixedSize < 0));
@@ -309,7 +309,7 @@ namespace Krypton.Workspace
                 foreach (Component component in Children)
                 {
                     // Get can only grab values from the IWorkspaceItem interface
-                    if ((component is IWorkspaceItem item) && item.WorkspaceVisible)
+                    if ((component is IWorkspaceItem { WorkspaceVisible: true } item))
                     {
                         // Sequence minimum is the largest min value of the children
                         Size itemMin = item.WorkspaceMinSize;
@@ -349,7 +349,7 @@ namespace Krypton.Workspace
                 foreach (Component component in Children)
                 {
                     // Get can only grab values from the IWorkspaceItem interface
-                    if ((component is IWorkspaceItem item) && item.WorkspaceVisible)
+                    if ((component is IWorkspaceItem { WorkspaceVisible: true } item))
                     {
                         // Sequence maximum is the smallest min value of the children
                         Size itemMax = item.WorkspaceMaxSize;
@@ -372,7 +372,7 @@ namespace Krypton.Workspace
                 foreach (Component component in Children)
                 {
                     // Get can only grab values from the IWorkspaceItem interface
-                    if ((component is IWorkspaceItem item) && item.WorkspaceVisible)
+                    if ((component is IWorkspaceItem { WorkspaceVisible: true } item))
                     {
                         // Sequence maximum should be enough to show fixed size items
                         StarSize itemStar = item.WorkspaceStarSize;
@@ -415,7 +415,7 @@ namespace Krypton.Workspace
                 // If any child says no resizing then we cannot be resized
                 foreach (Component component in Children)
                 {
-                    if ((component is IWorkspaceItem item) && item.WorkspaceVisible && !item.WorkspaceAllowResizing)
+                    if ((component is IWorkspaceItem { WorkspaceVisible: true, WorkspaceAllowResizing: false }))
                     {
                         return false;
                     }
@@ -440,7 +440,7 @@ namespace Krypton.Workspace
                     // If we have any visible children then we are visible
                     foreach (Component component in Children)
                     {
-                        if ((component is IWorkspaceItem item) && item.WorkspaceVisible)
+                        if ((component is IWorkspaceItem { WorkspaceVisible: true }))
                         {
                             return true;
                         }

--- a/Source/Krypton Components/Krypton.Workspace/General/StarNumber.cs
+++ b/Source/Krypton Components/Krypton.Workspace/General/StarNumber.cs
@@ -62,11 +62,11 @@ namespace Krypton.Workspace
                 // Validate the incoming value
                 if (value == null)
                 {
-                    throw new ArgumentNullException("Cannot be assigned a null value.");
+                    throw new ArgumentNullException(nameof(value), @"Cannot be assigned a null value.");
                 }
 
                 // If it ends with an asterisk...
-                if (value.EndsWith("*"))
+                if (value.EndsWith(@"*"))
                 {
                     // If there is only an asterisk in the string
                     StarSize = value.Length == 1 ? 1 : double.Parse(value.Substring(0, value.Length - 1));

--- a/Source/Krypton Components/Krypton.Workspace/General/StarSize.cs
+++ b/Source/Krypton Components/Krypton.Workspace/General/StarSize.cs
@@ -56,14 +56,14 @@ namespace Krypton.Workspace
         /// </summary>
         public string Value
         {
-            get => StarWidth.ToString() + "," + StarHeight.ToString();
+            get => $"{StarWidth},{StarHeight}";
 
             set
             {
                 // Validate the incoming value
                 if (value == null)
                 {
-                    throw new ArgumentNullException("Cannot be assigned a null value.");
+                    throw new ArgumentNullException(nameof(Value), @"Cannot be assigned a null value.");
                 }
 
                 // Split the string into comma separated parts
@@ -72,7 +72,7 @@ namespace Krypton.Workspace
                 // Must consist of two values
                 if (parts.Length != 2)
                 {
-                    throw new ArgumentNullException("Value must have two values separated by a comma.");
+                    throw new ArgumentNullException(nameof(Value), @"Value must have two values separated by a comma.");
                 }
 
                 // Parse both halfs, exceptions are thrown if a problem occurs

--- a/Source/Krypton Components/Krypton.Workspace/Palette/WorkspacePageMenu.cs
+++ b/Source/Krypton Components/Krypton.Workspace/Palette/WorkspacePageMenu.cs
@@ -48,7 +48,6 @@ namespace Krypton.Workspace
         /// Initialize a new instance of the WorkspaceMenus class.
         /// </summary>
         public WorkspaceMenus(KryptonWorkspace workspace)
-            : base()
         {
             // Default values
             TextClose = DEFAULT_TEXT_CLOSE;

--- a/Source/Krypton Components/Krypton.Workspace/Workspace/KryptonWorkspaceCollectionEditor.cs
+++ b/Source/Krypton Components/Krypton.Workspace/Workspace/KryptonWorkspaceCollectionEditor.cs
@@ -1513,7 +1513,7 @@ namespace Krypton.Workspace
                 NodeToType((MenuTreeNode)node, out isPage, out isCell, out isSequence);
             }
 
-            private void NodeToType(MenuTreeNode node, out bool isPage, out bool isCell, out bool isSequence)
+            private static void NodeToType(MenuTreeNode node, out bool isPage, out bool isCell, out bool isSequence)
             {
                 isPage = node?.PageItem != null;
                 isCell = node?.CellItem != null;
@@ -1675,7 +1675,7 @@ namespace Krypton.Workspace
                 return null;
             }
 
-            private void SeparatorToItems(ViewDrawWorkspaceSeparator separator,
+            private static void SeparatorToItems(ViewDrawWorkspaceSeparator separator,
                                           out IWorkspaceItem after,
                                           out IWorkspaceItem before)
             {
@@ -1689,7 +1689,7 @@ namespace Krypton.Workspace
                 before = null;
                 for (var i = beforeSequence.Children.IndexOf(after) - 1; i >= 0; i--)
                 {
-                    if ((beforeSequence.Children[i] is IWorkspaceItem item) && item.WorkspaceVisible)
+                    if ((beforeSequence.Children[i] is IWorkspaceItem { WorkspaceVisible: true } item))
                     {
                         before = item;
                         break;


### PR DESCRIPTION
- Sorted out quite a few `ShouldSerilaize####` misuses
- Allow Patterns to be used in code `if` checks
- Remove Unused variables
- Correct some spelling
- Relayout some `if` logic conditions
- Set some fields to be `readonly`
- Add some missing BSD Headers
- Use tuples for variable swapping
- Fix exception creaiton via the use of `nameof`
- Fix event propogation via use of `nameof`
- Mask some intellisense messages in `editorconfig`
- Start to fix minimum control size in Docking

![image](https://user-images.githubusercontent.com/2418812/147222919-bd90438c-7df2-4b85-8583-f1a25c820173.png)

Build-2019:
![image](https://user-images.githubusercontent.com/2418812/147223002-ff54c668-7e48-4e99-9fec-99c801e0122e.png)
