### PR TITLE
- Add `FactorDpi#`'s to relevant sections that need to resize Form im…

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -1,6 +1,7 @@
 # <img src="https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/Krypton.png"> Standard Toolkit - ChangeLog
 
 ## 2022-02-01 - Build 2202 - February 2022
+* Fixed [#487](https://github.com/Krypton-Suite/Standard-Toolkit/issues/487), The position of the KryptonForm Control Buttons are too low, when no desktop scaling preference is applied
 * Implemented [#53](https://github.com/Krypton-Suite/Standard-Toolkit/issues/53), Need images of what this toolkit can give a developer on landing page 
 * Fixed [#34](https://github.com/Krypton-Suite/Standard-Toolkit/issues/34), KryptonRibbon.RibbonAppButton.AppButtonMenuItems has error
 * Fixed [#204](https://github.com/Krypton-Suite/Standard-Toolkit/issues/204), When A drop Button is disabled, it should also colour the drop item as disabled

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecView.cs
@@ -306,14 +306,55 @@ namespace Krypton.Toolkit
         #endregion
 
         #region IContentValues
+
+        private float _lastFactorDpiX;
+        private float _lastFactorDpiY;
+        private readonly Dictionary<Image, Image> _cachedImages = new();
         /// <summary>
         /// Gets the content image.
         /// </summary>
         /// <param name="state">The state for which the image is needed.</param>
         /// <returns>Image value.</returns>
-        public Image GetImage(PaletteState state) =>
+        public Image GetImage(PaletteState state)
+        {
             // Get value from button spec passing inheritance redirector
-            ButtonSpec.GetImage(_redirector, state);
+            var baseImage = ButtonSpec.GetImage(_redirector, state);
+            if (baseImage == null)
+            {
+                return null;
+            }
+
+            // Currently the `ViewButton.FactorDpi#`'s do _NOT_ change whilst the app is running
+            if (/*(ViewButton.FactorDpiX != _lastFactorDpiX)
+                || (ViewButton.FactorDpiY != _lastFactorDpiY)
+                ||*/ !_cachedImages.ContainsKey(baseImage)
+               )
+            {
+                // Image needs to be regenerated
+                _lastFactorDpiX = ViewButton.FactorDpiX;
+                _lastFactorDpiY = ViewButton.FactorDpiY;
+                var currentWidth = (int)(baseImage.Width * _lastFactorDpiX);
+                var currentHeight = (int)(baseImage.Height * _lastFactorDpiY);
+                if (currentHeight == baseImage.Height)
+                {
+                    // Need to workaround the image drawing off the bottom of the form title bar when scaling @ 100%
+                    currentHeight -= 2; // Has to be even to ensure that horizontal lines are still drawn.
+                }
+
+                var newImage = new Bitmap(currentWidth, currentHeight);
+                using Graphics gr = Graphics.FromImage(newImage);
+                gr.Clear(Color.Transparent);
+                gr.SmoothingMode = SmoothingMode.HighQuality;
+                // Got to be careful with this setting, otherwise "Purple" artifacts will be introduced !
+                gr.InterpolationMode = InterpolationMode.NearestNeighbor;
+                gr.PixelOffsetMode = PixelOffsetMode.HighQuality;
+                gr.DrawImage(baseImage, new Rectangle(0, 0, currentWidth, currentHeight));
+                _cachedImages[baseImage] = newImage;
+            }
+
+            //return baseImage;
+            return _cachedImages[baseImage];
+        }
 
         /// <summary>
         /// Gets the content image transparent color.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMessageBoxForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMessageBoxForm.cs
@@ -434,10 +434,8 @@ namespace Krypton.Toolkit
 
                 var messageXSize = Math.Max(messageSize.Width, captionSize.Width);
                 // Work out DPI adjustment factor
-                var factorX = g.DpiX > 96 ? (1.0f * g.DpiX / 96) : 1.0f;
-                var factorY = g.DpiY > 96 ? (1.0f * g.DpiY / 96) : 1.0f;
-                messageSize.Width = messageXSize * factorX;
-                messageSize.Height *= factorY;
+                messageSize.Width = messageXSize * FactorDpiX;
+                messageSize.Height *= FactorDpiY;
 
                 // Always add on ad extra 5 pixels as sometimes the measure size does not draw the last 
                 // character it contains, this ensures there is always definitely enough space for it all

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
@@ -127,6 +127,10 @@ namespace Krypton.Toolkit
             ShadowValues = new ShadowValues();
             BlurValues = new BlurValues();
 
+            // Note: Will not handle movement between monitors
+            using Graphics graphics = Graphics.FromHwnd(IntPtr.Zero);
+            FactorDpiX = graphics.DpiX > 96 ? (1f * graphics.DpiX / 96) : 1f;
+            FactorDpiY = graphics.DpiY > 96 ? (1f * graphics.DpiY / 96) : 1f;
         }
 
         /// <summary>
@@ -166,6 +170,31 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Public
+
+        /// <summary>
+        /// Gets the DpiX of the view.
+        /// </summary>
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public float FactorDpiX
+        {
+            [DebuggerStepThrough]
+            get;
+        }
+
+        /// <summary>
+        /// Gets the DpiY of the view.
+        /// </summary>
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public float FactorDpiY
+        {
+            [DebuggerStepThrough]
+            get;
+        }
+
         /// <summary>
         /// Gets and sets a value indicating if palette chrome should be applied.
         /// </summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualTaskDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualTaskDialog.cs
@@ -600,12 +600,10 @@ namespace Krypton.Toolkit
                 }
 
                 // Work out DPI adjustment factor
-                var factorX = g.DpiX > 96 ? (1.0f * g.DpiX / 96) : 1.0f;
-                var factorY = g.DpiY > 96 ? (1.0f * g.DpiY / 96) : 1.0f;
-                messageMainSize.Width = (int)(messageMainSize.Width * factorX);
-                messageMainSize.Height = (int)(messageMainSize.Height * factorY);
-                messageContentSize.Width = (int)(messageContentSize.Width * factorX);
-                messageContentSize.Height = (int)(messageContentSize.Height * factorY);
+                messageMainSize.Width = (int)(messageMainSize.Width * FactorDpiX);
+                messageMainSize.Height = (int)(messageMainSize.Height * FactorDpiY);
+                messageContentSize.Width = (int)(messageContentSize.Width * FactorDpiX);
+                messageContentSize.Height = (int)(messageContentSize.Height * FactorDpiY);
 
                 // Always add on an extra 5 pixels as sometimes the measure size does not draw the last 
                 // character it contains, this ensures there is always definitely enough space for it all

--- a/Source/Krypton Components/Krypton.Toolkit/General/CommonHelper.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/CommonHelper.cs
@@ -1197,7 +1197,7 @@ namespace Krypton.Toolkit
             PI.AdjustWindowRectEx(ref rect, cp.Style, false, cp.ExStyle);
 
             // Return the per side border values
-            return new Padding(-rect.left, Math.Max(16,-rect.top), rect.right, rect.bottom);
+            return new Padding(-rect.left, -rect.top, rect.right, rect.bottom);
         }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
@@ -5767,24 +5767,38 @@ namespace Krypton.Toolkit
             {
                 try
                 {
+                    // Check for enough space to show all of the image
+                    if ((displayRect.Width < memento.Image.Width) ||
+                        (displayRect.Height < memento.Image.Height))
+                    {
+                        // Resize image to fit display area
+                        var currentWidth = Math.Min(displayRect.Width, memento.Image.Width);
+                        var currentHeight = Math.Min(displayRect.Height, memento.Image.Height);
+
+                        var newImage = new Bitmap(currentWidth, currentHeight);
+                        using Graphics gr = Graphics.FromImage(newImage);
+                        gr.Clear(Color.Transparent);
+                        gr.SmoothingMode = SmoothingMode.HighQuality;
+                        // Got to be careful with this setting, otherwise "Purple" artifacts will be introduced !
+                        gr.InterpolationMode = InterpolationMode.NearestNeighbor;
+                        gr.PixelOffsetMode = PixelOffsetMode.HighQuality;
+                        gr.DrawImage(memento.Image, new Rectangle(0, 0, currentWidth, currentHeight));
+                        memento.Image = newImage;
+
+                    }
                     // Cache the size of the image
                     memento.ImageRect.Size = memento.Image.Size;
 
-                    // Check for enough space to show all of the image
-                    if ((displayRect.Width >= memento.ImageRect.Width) &&
-                        (displayRect.Height >= memento.ImageRect.Height))
-                    {
-                        // Convert from alignment enums to integers
-                        var alignHIndex = RightToLeftIndex(rtl, paletteContent.GetContentImageH(state));
-                        var alignVIndex = (int)paletteContent.GetContentImageV(state);
+                    // Convert from alignment enums to integers
+                    var alignHIndex = RightToLeftIndex(rtl, paletteContent.GetContentImageH(state));
+                    var alignVIndex = (int)paletteContent.GetContentImageV(state);
 
-                        // Bump the allocated space in the destination grid cell
-                        allocation[alignHIndex, alignVIndex].Width += memento.ImageRect.Width;
-                        allocation[alignHIndex, alignVIndex].Height += memento.ImageRect.Height;
+                    // Bump the allocated space in the destination grid cell
+                    allocation[alignHIndex, alignVIndex].Width += memento.ImageRect.Width;
+                    allocation[alignHIndex, alignVIndex].Height += memento.ImageRect.Height;
 
-                        // Yes, we do want to draw the image/icon
-                        memento.DrawImage = true;
-                    }
+                    // Yes, we do want to draw the image/icon
+                    memento.DrawImage = true;
                 }
                 catch
                 {

--- a/Source/Krypton Components/Krypton.Toolkit/View Base/ViewBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Base/ViewBase.cs
@@ -54,7 +54,7 @@ namespace Krypton.Toolkit
             // Default the initial state
             _elementState = PaletteState.Normal;
 
-            //seb Dpi aware
+            // This does mean that the app will not change it's dpi awareness until restarted !
             using Graphics graphics = Graphics.FromHwnd(IntPtr.Zero);
             FactorDpiX = graphics.DpiX > 96 ? (1f * graphics.DpiX / 96) : 1f;
             FactorDpiY = graphics.DpiY > 96 ? (1f * graphics.DpiY / 96) : 1f;


### PR DESCRIPTION
…ages

- Add image caching for resized images
- Try to locate the `g.DpiX > 96` into a single area for reuse
- Make sure images in the Form bar are always attempted to be drawn
Fixes: #487

![image](https://user-images.githubusercontent.com/2418812/147816929-ab8a94d4-a274-429c-aa8e-a50dc3133751.png)
