### PR TITLE
* Add links to the NuGet version information in the package descriptions

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -1,6 +1,7 @@
 # <img src="https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/Krypton.png"> Standard Toolkit - ChangeLog
 
 ## 2022-02-01 - Build 2202 - February 2022
+* Add links to the NuGet version information in the package descriptions
 * Updated NuGet package information to aid deployment to GitHub
 * Versions have now been changed to the following format `Major.yy.MM.dayofyear`, but for convenience, builds will still be referenced as `yyMM` in documentation
 * Overhauled `run.cmd`

--- a/Source/Krypton Components/Directory.Build.targets
+++ b/Source/Krypton Components/Directory.Build.targets
@@ -169,6 +169,8 @@
 					This package supports all .NET Framework versions starting .NET Framework 4.6.2 - 4.8, .NET Core 3.1 and .NET 5/6.
 					Also, all libraries are included targeting each specific framework version for performance purposes.
 
+					To view all of the standard toolkit package latest version information, please visit: https://github.com/Krypton-Suite/Krypton-Toolkit-Suite-Version-Dashboard/blob/main/Documents/Modules/Standard/Krypton-Toolkit-Suite-Standard-Modules.md
+
 					This package is for those who want to try out the latest features before deployment. Please use $(PackageId) or $(PackageId).Signed if deployment is intended.
 				</Description>
 			</PropertyGroup>
@@ -183,6 +185,8 @@
 
 					This package supports all .NET Framework versions starting .NET Framework 4.6.2 - 4.8, .NET Core 3.1 and .NET 5/6.
 					Also, all libraries are included targeting each specific framework version for performance purposes.
+
+					To view all of the standard toolkit package latest version information, please visit: https://github.com/Krypton-Suite/Krypton-Toolkit-Suite-Version-Dashboard/blob/main/Documents/Modules/Standard/Krypton-Toolkit-Suite-Standard-Modules.md
 
 					The binaries contained in this package have been digitally signed.
 				</Description>
@@ -199,6 +203,8 @@
 					This package supports all .NET Framework versions starting .NET Framework 4.6.2 - 4.8, .NET Core 3.1 and .NET 5/6.
 					Also, all libraries are included targeting each specific framework version for performance purposes.
 
+					To view all of the standard toolkit package latest version information, please visit: https://github.com/Krypton-Suite/Krypton-Toolkit-Suite-Version-Dashboard/blob/main/Documents/Modules/Standard/Krypton-Toolkit-Suite-Standard-Modules.md
+
 					This package is for those who want to try out the latest cutting edge features before deployment. Please use $(PackageId) or $(PackageId).Signed if deployment is intended.
 				</Description>
 			</PropertyGroup>
@@ -214,6 +220,8 @@
 					This package supports all .NET Framework versions starting .NET Framework 4.6.2 - 4.8, .NET Core 3.1 and .NET 5/6.
 					Also, all libraries are included targeting each specific framework version for performance purposes.
 
+					To view all of the standard toolkit package latest version information, please visit: https://github.com/Krypton-Suite/Krypton-Toolkit-Suite-Version-Dashboard/blob/main/Documents/Modules/Standard/Krypton-Toolkit-Suite-Standard-Modules.md
+
 					FOR USE WITH DEMO INSTALLERS ONLY! Please use $(PackageId) or $(PackageId).Signed if deployment is intended.
 				</Description>
 			</PropertyGroup>
@@ -226,6 +234,8 @@
 
 					This package supports all .NET Framework versions starting .NET Framework 4.6.2 - 4.8, .NET Core 3.1 and .NET 5/6.
 					Also, all libraries are included targeting each specific framework version for performance purposes.
+
+					To view all of the standard toolkit package latest version information, please visit: https://github.com/Krypton-Suite/Krypton-Toolkit-Suite-Version-Dashboard/blob/main/Documents/Modules/Standard/Krypton-Toolkit-Suite-Standard-Modules.md
 				</Description>
 			</PropertyGroup>
 		</Otherwise>


### PR DESCRIPTION
* Add links to the NuGet version information in the package descriptions as per https://github.com/Krypton-Suite/Krypton-Toolkit-Suite-Version-Dashboard/issues/1