### PR TITLE
* Fixes #562 - Help Icon is not clearly visible in a lot of themes

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -5,6 +5,7 @@
 * Versions have now been changed to the following format `Major.yy.MM.dayofyear`, but for convenience, builds will still be referenced as `yyMM` in documentation
 * Overhauled `run.cmd`
 * Build scripts are now stored in the `Scripts` folder, though it is now recommended to utilise `run.cmd`
+* Fixed [#562](https://github.com/Krypton-Suite/Standard-Toolkit/issues/562), Help Icon is not clearly visible in a lot of themes
 * Fixed [#380](https://github.com/Krypton-Suite/Standard-Toolkit/issues/380), MDI Child form not fully maximizing not merging on the ribbon
 * Fixed [#571](https://github.com/Krypton-Suite/Standard-Toolkit/issues/571), CenterScreen start on Form is no longer respected
 * Fixed [#441](https://github.com/Krypton-Suite/Standard-Toolkit/issues/441), Wrong Ribbon Form Height when Windows is using scaling; e.g. 200% dpi

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/PaletteOffice2007Black.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/PaletteOffice2007Black.cs
@@ -39,7 +39,7 @@ namespace Krypton.Toolkit
         private static readonly Image _blackRestoreHover = Office2007ControlBoxResources.Office2007ControlBoxBlackRestoreHover_24_x_24;
         private static readonly Image _blackRestoreDisabled = Office2007ControlBoxResources.Office2007ControlBoxBlackRestoreDisabled_24_x_24;
         private static readonly Image _blackRestorePressed = Office2007ControlBoxResources.Office2007ControlBoxBlackRestorePressed_24_x_24;
-        private static readonly Image _blackHelpNormal = HelpIconResources.GenericPre2010HelpIconBlack;
+        private static readonly Image _blackHelpNormal = HelpIconResources.GenericPre2010HelpIcon;
         private static readonly Image _blackHelpHover = HelpIconResources.GenericPre2010HelpIconHover;
         private static readonly Image _blackHelpDisabled = HelpIconResources.GenericPre2010HelpIconDisabled;
         private static readonly Image _blackRibbonMinimize = GenericImageResources.BlackButtonCollapse;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/PaletteOffice2007BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/PaletteOffice2007BlackDarkMode.cs
@@ -39,7 +39,7 @@ namespace Krypton.Toolkit
         private static readonly Image _blackRestoreHover = Office2007ControlBoxResources.Office2007ControlBoxBlackRestoreHover_24_x_24;
         private static readonly Image _blackRestoreDisabled = Office2007ControlBoxResources.Office2007ControlBoxBlackRestoreDisabled_24_x_24;
         private static readonly Image _blackRestorePressed = Office2007ControlBoxResources.Office2007ControlBoxBlackRestorePressed_24_x_24;
-        private static readonly Image _blackHelpNormal = HelpIconResources.GenericPre2010HelpIconBlack;
+        private static readonly Image _blackHelpNormal = HelpIconResources.GenericPre2010HelpIcon;
         private static readonly Image _blackHelpHover = HelpIconResources.GenericPre2010HelpIconHover;
         private static readonly Image _blackHelpDisabled = HelpIconResources.GenericPre2010HelpIconDisabled;
         private static readonly Image _blackRibbonMinimize = GenericImageResources.BlackButtonCollapse;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/PaletteOffice2007Blue.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/PaletteOffice2007Blue.cs
@@ -39,7 +39,7 @@ namespace Krypton.Toolkit
         private static readonly Image _blueRestoreHover = Office2007ControlBoxResources.Office2007ControlBoxBlueRestoreHover_24_x_24;
         private static readonly Image _blueRestoreDisabled = Office2007ControlBoxResources.Office2007ControlBoxBlueRestoreDisabled_24_x_24;
         private static readonly Image _blueRestorePressed = Office2007ControlBoxResources.Office2007ControlBoxBlueRestorePressed_24_x_24;
-        private static readonly Image _blueHelpNormal = HelpIconResources.GenericPre2010HelpIconBlue;
+        private static readonly Image _blueHelpNormal = HelpIconResources.GenericPre2010HelpIcon;
         private static readonly Image _blueHelpDisabled = HelpIconResources.GenericPre2010HelpIconDisabled;
         private static readonly Image _contextMenuSubMenu = GenericImageResources.BlueContextMenuSub;
         private static readonly Color[] _trackBarColors = { Color.FromArgb(116, 150, 194),      // Tick marks

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/PaletteOffice2007BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/PaletteOffice2007BlueDarkMode.cs
@@ -39,7 +39,7 @@ namespace Krypton.Toolkit
         private static readonly Image _blueRestoreHover = Office2007ControlBoxResources.Office2007ControlBoxBlueRestoreHover_24_x_24;
         private static readonly Image _blueRestoreDisabled = Office2007ControlBoxResources.Office2007ControlBoxBlueRestoreDisabled_24_x_24;
         private static readonly Image _blueRestorePressed = Office2007ControlBoxResources.Office2007ControlBoxBlueRestorePressed_24_x_24;
-        private static readonly Image _blueHelpNormal = HelpIconResources.GenericPre2010HelpIconBlue;
+        private static readonly Image _blueHelpNormal = HelpIconResources.GenericPre2010HelpIcon;
         private static readonly Image _blueHelpDisabled = HelpIconResources.GenericPre2010HelpIconDisabled;
         private static readonly Image _contextMenuSubMenu = GenericImageResources.BlueContextMenuSub;
         private static readonly Color[] _trackBarColors = { Color.FromArgb(116, 150, 194),      // Tick marks

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/PaletteOffice2007BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/PaletteOffice2007BlueLightMode.cs
@@ -39,7 +39,7 @@ namespace Krypton.Toolkit
         private static readonly Image _blueRestoreHover = Office2007ControlBoxResources.Office2007ControlBoxBlueRestoreHover_24_x_24;
         private static readonly Image _blueRestoreDisabled = Office2007ControlBoxResources.Office2007ControlBoxBlueRestoreDisabled_24_x_24;
         private static readonly Image _blueRestorePressed = Office2007ControlBoxResources.Office2007ControlBoxBlueRestorePressed_24_x_24;
-        private static readonly Image _blueHelpNormal = HelpIconResources.GenericPre2010HelpIconBlue;
+        private static readonly Image _blueHelpNormal = HelpIconResources.GenericPre2010HelpIcon;
         private static readonly Image _blueHelpDisabled = HelpIconResources.GenericPre2010HelpIconDisabled;
         private static readonly Image _contextMenuSubMenu = GenericImageResources.BlueContextMenuSub;
         private static readonly Color[] _trackBarColors = { Color.FromArgb(116, 150, 194),      // Tick marks

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/PaletteOffice2007Silver.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/PaletteOffice2007Silver.cs
@@ -39,7 +39,7 @@ namespace Krypton.Toolkit
         private static readonly Image _silverRestoreHover = Office2007ControlBoxResources.Office2007ControlBoxSilverRestoreHover_24_x_24;
         private static readonly Image _silverRestoreDisabled = Office2007ControlBoxResources.Office2007ControlBoxSilverRestoreDisabled_24_x_24;
         private static readonly Image _silverRestorePressed = Office2007ControlBoxResources.Office2007ControlBoxSilverRestorePressed_24_x_24;
-        private static readonly Image _silverHelpNormal = HelpIconResources.GenericPre2010HelpIconSilver;
+        private static readonly Image _silverHelpNormal = HelpIconResources.GenericPre2010HelpIcon;
         private static readonly Image _silverHelpDisabled = HelpIconResources.GenericPre2010HelpIconDisabled;
         private static readonly Image _contextMenuSubMenu = GenericImageResources.SilverContextMenuSub;
         private static readonly Color[] _trackBarColors = { Color.FromArgb(130, 130, 130),      // Tick marks

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/PaletteOffice2007SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/PaletteOffice2007SilverDarkMode.cs
@@ -39,7 +39,7 @@ namespace Krypton.Toolkit
         private static readonly Image _silverRestoreHover = Office2007ControlBoxResources.Office2007ControlBoxSilverRestoreHover_24_x_24;
         private static readonly Image _silverRestoreDisabled = Office2007ControlBoxResources.Office2007ControlBoxSilverRestoreDisabled_24_x_24;
         private static readonly Image _silverRestorePressed = Office2007ControlBoxResources.Office2007ControlBoxSilverRestorePressed_24_x_24;
-        private static readonly Image _silverHelpNormal = HelpIconResources.GenericPre2010HelpIconSilver;
+        private static readonly Image _silverHelpNormal = HelpIconResources.GenericPre2010HelpIcon;
         private static readonly Image _silverHelpDisabled = HelpIconResources.GenericPre2010HelpIconDisabled;
         private static readonly Image _contextMenuSubMenu = GenericImageResources.SilverContextMenuSub;
         private static readonly Color[] _trackBarColors = { Color.FromArgb(130, 130, 130),      // Tick marks

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/PaletteOffice2007SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/PaletteOffice2007SilverLightMode.cs
@@ -39,7 +39,7 @@ namespace Krypton.Toolkit
         private static readonly Image _silverRestoreHover = Office2007ControlBoxResources.Office2007ControlBoxSilverRestoreHover_24_x_24;
         private static readonly Image _silverRestoreDisabled = Office2007ControlBoxResources.Office2007ControlBoxSilverRestoreDisabled_24_x_24;
         private static readonly Image _silverRestorePressed = Office2007ControlBoxResources.Office2007ControlBoxSilverRestorePressed_24_x_24;
-        private static readonly Image _silverHelpNormal = HelpIconResources.GenericPre2010HelpIconSilver;
+        private static readonly Image _silverHelpNormal = HelpIconResources.GenericPre2010HelpIcon;
         private static readonly Image _silverHelpDisabled = HelpIconResources.GenericPre2010HelpIconDisabled;
         private static readonly Image _contextMenuSubMenu = GenericImageResources.SilverContextMenuSub;
         private static readonly Color[] _trackBarColors = { Color.FromArgb(130, 130, 130),      // Tick marks

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/PaletteOffice2007White.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/PaletteOffice2007White.cs
@@ -36,7 +36,7 @@ namespace Krypton.Toolkit
         private static readonly Image _silverRestoreHover = Office2007ControlBoxResources.Office2007ControlBoxSilverRestoreHover_24_x_24;
         private static readonly Image _silverRestoreDisabled = Office2007ControlBoxResources.Office2007ControlBoxSilverRestoreDisabled_24_x_24;
         private static readonly Image _silverRestorePressed = Office2007ControlBoxResources.Office2007ControlBoxSilverRestorePressed_24_x_24;
-        private static readonly Image _silverHelpNormal = HelpIconResources.GenericPre2010HelpIconWhite;
+        private static readonly Image _silverHelpNormal = HelpIconResources.GenericPre2010HelpIcon;
         private static readonly Image _silverHelpDisabled = HelpIconResources.GenericPre2010HelpIconDisabled;
         private static readonly Image _contextMenuSubMenu = GenericImageResources.SilverContextMenuSub;
         private static readonly Color[] _trackBarColors = new Color[] { Color.Red,      // Tick marks

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/PaletteOffice2010Black.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/PaletteOffice2010Black.cs
@@ -40,7 +40,7 @@ namespace Krypton.Toolkit
         private static readonly Image _formRestoreDisabled = Office2010ControlBoxResources.Office2010BlackRestoreDisabled_25_x_23;
         private static readonly Image _formRestoreHover = Office2010ControlBoxResources.Office2010BlackRestoreHover_25_x_23;
         private static readonly Image _formRestorePressed = Office2010ControlBoxResources.Office2010BlackRestorePressed_25_x_23;
-        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice2010HelpIconBlack;
+        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice2010HelpIcon;
         private static readonly Image _formHelpHover = HelpIconResources.GenericOffice2010HelpIconHover;
         private static readonly Image _formHelpDisabled = HelpIconResources.GenericOffice2010HelpIconDisabled;
         private static readonly Image _buttonSpecPendantClose = Office2010ControlBoxResources._2010ButtonMDICloseBlack;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/PaletteOffice2010BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/PaletteOffice2010BlackDarkMode.cs
@@ -40,7 +40,7 @@ namespace Krypton.Toolkit
         private static readonly Image _formRestoreDisabled = Office2010ControlBoxResources.Office2010BlackRestoreDisabled_25_x_23;
         private static readonly Image _formRestoreHover = Office2010ControlBoxResources.Office2010BlackRestoreHover_25_x_23;
         private static readonly Image _formRestorePressed = Office2010ControlBoxResources.Office2010BlackRestorePressed_25_x_23;
-        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice2010HelpIconBlack;
+        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice2010HelpIcon;
         private static readonly Image _formHelpHover = HelpIconResources.GenericOffice2010HelpIconHover;
         private static readonly Image _formHelpDisabled = HelpIconResources.GenericOffice2010HelpIconDisabled;
         private static readonly Image _buttonSpecPendantClose = Office2010ControlBoxResources._2010ButtonMDICloseBlack;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/PaletteOffice2010Blue.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/PaletteOffice2010Blue.cs
@@ -40,7 +40,7 @@ namespace Krypton.Toolkit
         private static readonly Image _formRestoreDisabled = Office2010ControlBoxResources.Office2010BlueRestoreDisabled_25_x_23;
         private static readonly Image _formRestoreHover = Office2010ControlBoxResources.Office2010BlueRestoreHover_25_x_23;
         private static readonly Image _formRestorePressed = Office2010ControlBoxResources.Office2010BlueRestorePressed_25_x_23;
-        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice2010HelpIconBlue;
+        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice2010HelpIcon;
         private static readonly Image _formHelpHover = HelpIconResources.GenericOffice2010HelpIconHover;
         private static readonly Image _formHelpDisabled = HelpIconResources.GenericOffice2010HelpIconDisabled;
         private static readonly Color[] _trackBarColors = { Color.FromArgb(116, 150, 194),      // Tick marks

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/PaletteOffice2010BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/PaletteOffice2010BlueDarkMode.cs
@@ -40,7 +40,7 @@ namespace Krypton.Toolkit
         private static readonly Image _formRestoreDisabled = Office2010ControlBoxResources.Office2010BlueRestoreDisabled_25_x_23;
         private static readonly Image _formRestoreHover = Office2010ControlBoxResources.Office2010BlueRestoreHover_25_x_23;
         private static readonly Image _formRestorePressed = Office2010ControlBoxResources.Office2010BlueRestorePressed_25_x_23;
-        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice2010HelpIconBlue;
+        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice2010HelpIcon;
         private static readonly Image _formHelpHover = HelpIconResources.GenericOffice2010HelpIconHover;
         private static readonly Image _formHelpDisabled = HelpIconResources.GenericOffice2010HelpIconDisabled;
         private static readonly Color[] _trackBarColors = { Color.FromArgb(116, 150, 194),      // Tick marks

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/PaletteOffice2010BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/PaletteOffice2010BlueLightMode.cs
@@ -40,7 +40,7 @@ namespace Krypton.Toolkit
         private static readonly Image _formRestoreDisabled = Office2010ControlBoxResources.Office2010BlueRestoreDisabled_25_x_23;
         private static readonly Image _formRestoreHover = Office2010ControlBoxResources.Office2010BlueRestoreHover_25_x_23;
         private static readonly Image _formRestorePressed = Office2010ControlBoxResources.Office2010BlueRestorePressed_25_x_23;
-        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice2010HelpIconBlue;
+        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice2010HelpIcon;
         private static readonly Image _formHelpHover = HelpIconResources.GenericOffice2010HelpIconHover;
         private static readonly Image _formHelpDisabled = HelpIconResources.GenericOffice2010HelpIconDisabled;
         private static readonly Color[] _trackBarColors = { Color.FromArgb(116, 150, 194),      // Tick marks

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/PaletteOffice2010Silver.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/PaletteOffice2010Silver.cs
@@ -40,7 +40,7 @@ namespace Krypton.Toolkit
         private static readonly Image _formRestoreDisabled = Office2010ControlBoxResources.Office2010SilverRestoreDisabled_25_x_23;
         private static readonly Image _formRestoreHover = Office2010ControlBoxResources.Office2010SilverRestoreHover_25_x_23;
         private static readonly Image _formRestorePressed = Office2010ControlBoxResources.Office2010SilverRestorePressed_25_x_23;
-        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice2010HelpIconSilver;
+        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice2010HelpIcon;
         private static readonly Image _formHelpHover = HelpIconResources.GenericOffice2010HelpIconHover;
         private static readonly Image _formHelpDisabled = HelpIconResources.GenericOffice2010HelpIconDisabled;
         private static readonly Color[] _trackBarColors = new Color[] { Color.FromArgb(170, 170, 170),      // Tick marks

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/PaletteOffice2010SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/PaletteOffice2010SilverDarkMode.cs
@@ -40,7 +40,7 @@ namespace Krypton.Toolkit
         private static readonly Image _formRestoreDisabled = Office2010ControlBoxResources.Office2010SilverRestoreDisabled_25_x_23;
         private static readonly Image _formRestoreHover = Office2010ControlBoxResources.Office2010SilverRestoreHover_25_x_23;
         private static readonly Image _formRestorePressed = Office2010ControlBoxResources.Office2010SilverRestorePressed_25_x_23;
-        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice2010HelpIconSilver;
+        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice2010HelpIcon;
         private static readonly Image _formHelpHover = HelpIconResources.GenericOffice2010HelpIconHover;
         private static readonly Image _formHelpDisabled = HelpIconResources.GenericOffice2010HelpIconDisabled;
         private static readonly Color[] _trackBarColors = new[] { Color.FromArgb(170, 170, 170),      // Tick marks

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/PaletteOffice2010SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/PaletteOffice2010SilverLightMode.cs
@@ -40,7 +40,7 @@ namespace Krypton.Toolkit
         private static readonly Image _formRestoreDisabled = Office2010ControlBoxResources.Office2010SilverRestoreDisabled_25_x_23;
         private static readonly Image _formRestoreHover = Office2010ControlBoxResources.Office2010SilverRestoreHover_25_x_23;
         private static readonly Image _formRestorePressed = Office2010ControlBoxResources.Office2010SilverRestorePressed_25_x_23;
-        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice2010HelpIconSilver;
+        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice2010HelpIcon;
         private static readonly Image _formHelpHover = HelpIconResources.GenericOffice2010HelpIconHover;
         private static readonly Image _formHelpDisabled = HelpIconResources.GenericOffice2010HelpIconDisabled;
         private static readonly Color[] _trackBarColors = new[] { Color.FromArgb(170, 170, 170),      // Tick marks

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/PaletteOffice2010White.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/PaletteOffice2010White.cs
@@ -40,7 +40,7 @@ namespace Krypton.Toolkit
         private static readonly Image _formRestoreDisabled = Office2010ControlBoxResources.Office2010SilverRestoreDisabled_25_x_23;
         private static readonly Image _formRestoreHover = Office2010ControlBoxResources.Office2010SilverRestoreHover_25_x_23;
         private static readonly Image _formRestorePressed = Office2010ControlBoxResources.Office2010SilverRestorePressed_25_x_23;
-        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice2010HelpIconWhite;
+        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice2010HelpIcon;
         private static readonly Image _formHelpHover = HelpIconResources.GenericOffice2010HelpIconHover;
         private static readonly Image _formHelpDisabled = HelpIconResources.GenericOffice2010HelpIconDisabled;
         private static readonly Color[] _trackBarColors = new Color[] { Color.Red,      // Tick marks

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/PaletteOffice2013White.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/PaletteOffice2013White.cs
@@ -40,7 +40,7 @@ namespace Krypton.Toolkit
         private static readonly Image _formRestoreDisabled = Office2010ControlBoxResources.Office2010SilverRestoreDisabled_25_x_23;
         private static readonly Image _formRestoreHover = Office2010ControlBoxResources.Office2010SilverRestoreHover_25_x_23;
         private static readonly Image _formRestorePressed = Office2010ControlBoxResources.Office2010SilverRestorePressed_25_x_23;
-        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice365HelpIconWhite;
+        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice365HelpIcon;
         private static readonly Image _formHelpHover = HelpIconResources.GenericOffice365HelpIconHover;
         private static readonly Image _formHelpDisabled = HelpIconResources.GenericOffice365HelpIconDisabled;
         private static readonly Color[] _trackBarColors = new[] { Color.Red,      // Tick marks

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 365/PaletteOffice365Black.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 365/PaletteOffice365Black.cs
@@ -40,7 +40,7 @@ namespace Krypton.Toolkit
         private static readonly Image _formRestoreDisabled = Office2010ControlBoxResources.Office2010BlackRestoreDisabled_25_x_23;
         private static readonly Image _formRestoreHover = Office2010ControlBoxResources.Office2010BlackRestoreHover_25_x_23;
         private static readonly Image _formRestorePressed = Office2010ControlBoxResources.Office2010BlackRestorePressed_25_x_23;
-        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice2010HelpIconBlack;
+        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice2010HelpIcon;
         private static readonly Image _formHelpHover = HelpIconResources.GenericOffice2010HelpIconHover;
         private static readonly Image _formHelpDisabled = HelpIconResources.GenericOffice2010HelpIconDisabled;
         private static readonly Image _buttonSpecPendantClose = Office2010ControlBoxResources._2010ButtonMDICloseBlack;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 365/PaletteOffice365BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 365/PaletteOffice365BlackDarkMode.cs
@@ -40,7 +40,7 @@ namespace Krypton.Toolkit
         private static readonly Image _formRestoreDisabled = Office2010ControlBoxResources.Office2010BlackRestoreDisabled_25_x_23;
         private static readonly Image _formRestoreHover = Office2010ControlBoxResources.Office2010BlackRestoreHover_25_x_23;
         private static readonly Image _formRestorePressed = Office2010ControlBoxResources.Office2010BlackRestorePressed_25_x_23;
-        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice2010HelpIconBlack;
+        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice2010HelpIcon;
         private static readonly Image _formHelpHover = HelpIconResources.GenericOffice2010HelpIconHover;
         private static readonly Image _formHelpDisabled = HelpIconResources.GenericOffice365HelpIconDisabled;
         private static readonly Image _buttonSpecPendantClose = Office2010ControlBoxResources._2010ButtonMDICloseBlack;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 365/PaletteOffice365Blue.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 365/PaletteOffice365Blue.cs
@@ -37,7 +37,7 @@ namespace Krypton.Toolkit
         private static readonly Image _formRestoreDisabled = Office2010ControlBoxResources.Office2010BlueRestoreDisabled_25_x_23;
         private static readonly Image _formRestoreHover = Office2010ControlBoxResources.Office2010BlueRestoreHover_25_x_23;
         private static readonly Image _formRestorePressed = Office2010ControlBoxResources.Office2010BlueRestorePressed_25_x_23;
-        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice365HelpIconBlue;
+        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice365HelpIcon;
         private static readonly Image _formHelpHover = HelpIconResources.GenericOffice365HelpIconHover;
         private static readonly Image _formHelpDisabled = HelpIconResources.GenericOffice365HelpIconDisabled;
         private static readonly Color[] _trackBarColors = { Color.FromArgb(116, 150, 194),      // Tick marks

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 365/PaletteOffice365BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 365/PaletteOffice365BlueDarkMode.cs
@@ -40,7 +40,7 @@ namespace Krypton.Toolkit
         private static readonly Image _formRestoreDisabled = Office2010ControlBoxResources.Office2010BlueRestoreDisabled_25_x_23;
         private static readonly Image _formRestoreHover = Office2010ControlBoxResources.Office2010BlueRestoreHover_25_x_23;
         private static readonly Image _formRestorePressed = Office2010ControlBoxResources.Office2010BlueRestorePressed_25_x_23;
-        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice365HelpIconBlue;
+        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice365HelpIcon;
         private static readonly Image _formHelpHover = HelpIconResources.GenericOffice365HelpIconHover;
         private static readonly Image _formHelpDisabled = HelpIconResources.GenericOffice365HelpIconDisabled;
         private static readonly Color[] _trackBarColors = { Color.FromArgb(116, 150, 194),      // Tick marks

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 365/PaletteOffice365BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 365/PaletteOffice365BlueLightMode.cs
@@ -40,7 +40,7 @@ namespace Krypton.Toolkit
         private static readonly Image _formRestoreDisabled = Office2010ControlBoxResources.Office2010BlueRestoreDisabled_25_x_23;
         private static readonly Image _formRestoreHover = Office2010ControlBoxResources.Office2010BlueRestoreHover_25_x_23;
         private static readonly Image _formRestorePressed = Office2010ControlBoxResources.Office2010BlueRestorePressed_25_x_23;
-        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice365HelpIconBlue;
+        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice365HelpIcon;
         private static readonly Image _formHelpHover = HelpIconResources.GenericOffice365HelpIconHover;
         private static readonly Image _formHelpDisabled = HelpIconResources.GenericOffice365HelpIconDisabled;
         private static readonly Color[] _trackBarColors = { Color.FromArgb(116, 150, 194),      // Tick marks

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 365/PaletteOffice365Silver.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 365/PaletteOffice365Silver.cs
@@ -40,7 +40,7 @@ namespace Krypton.Toolkit
         private static readonly Image _formRestoreDisabled = Office2010ControlBoxResources.Office2010SilverRestoreDisabled_25_x_23;
         private static readonly Image _formRestoreHover = Office2010ControlBoxResources.Office2010SilverRestoreHover_25_x_23;
         private static readonly Image _formRestorePressed = Office2010ControlBoxResources.Office2010SilverRestorePressed_25_x_23;
-        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice365HelpIconSilver;
+        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice365HelpIcon;
         private static readonly Image _formHelpHover = HelpIconResources.GenericOffice365HelpIconHover;
         private static readonly Image _formHelpDisabled = HelpIconResources.GenericOffice365HelpIconDisabled;
         private static readonly Color[] _trackBarColors = { Color.FromArgb(170, 170, 170),      // Tick marks

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 365/PaletteOffice365SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 365/PaletteOffice365SilverDarkMode.cs
@@ -40,7 +40,7 @@ namespace Krypton.Toolkit
         private static readonly Image _formRestoreDisabled = Office2010ControlBoxResources.Office2010SilverRestoreDisabled_25_x_23;
         private static readonly Image _formRestoreHover = Office2010ControlBoxResources.Office2010SilverRestoreHover_25_x_23;
         private static readonly Image _formRestorePressed = Office2010ControlBoxResources.Office2010SilverRestorePressed_25_x_23;
-        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice365HelpIconSilver;
+        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice365HelpIcon;
         private static readonly Image _formHelpHover = HelpIconResources.GenericOffice365HelpIconHover;
         private static readonly Image _formHelpDisabled = HelpIconResources.GenericOffice365HelpIconDisabled;
         private static readonly Color[] _trackBarColors = { Color.FromArgb(170, 170, 170),      // Tick marks

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 365/PaletteOffice365SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 365/PaletteOffice365SilverLightMode.cs
@@ -40,7 +40,7 @@ namespace Krypton.Toolkit
         private static readonly Image _formRestoreDisabled = Office2010ControlBoxResources.Office2010SilverRestoreDisabled_25_x_23;
         private static readonly Image _formRestoreHover = Office2010ControlBoxResources.Office2010SilverRestoreHover_25_x_23;
         private static readonly Image _formRestorePressed = Office2010ControlBoxResources.Office2010SilverRestorePressed_25_x_23;
-        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice365HelpIconSilver;
+        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice365HelpIcon;
         private static readonly Image _formHelpHover = HelpIconResources.GenericOffice365HelpIconHover;
         private static readonly Image _formHelpDisabled = HelpIconResources.GenericOffice365HelpIconDisabled;
         private static readonly Color[] _trackBarColors = { Color.FromArgb(170, 170, 170),      // Tick marks

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 365/PaletteOffice365White.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 365/PaletteOffice365White.cs
@@ -40,7 +40,7 @@ namespace Krypton.Toolkit
         private static readonly Image _formRestoreDisabled = Office2010ControlBoxResources.Office2010SilverRestoreDisabled_25_x_23;
         private static readonly Image _formRestoreHover = Office2010ControlBoxResources.Office2010SilverRestoreHover_25_x_23;
         private static readonly Image _formRestorePressed = Office2010ControlBoxResources.Office2010SilverRestorePressed_25_x_23;
-        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice365HelpIconWhite;
+        private static readonly Image _formHelpNormal = HelpIconResources.GenericOffice365HelpIcon;
         private static readonly Image _formHelpHover = HelpIconResources.GenericOffice365HelpIconHover;
         private static readonly Image _formHelpDisabled = HelpIconResources.GenericOffice365HelpIconDisabled;
         private static readonly Color[] _trackBarColors = new Color[] { Color.Red,      // Tick marks


### PR DESCRIPTION
* Fixes #562 

![image](https://user-images.githubusercontent.com/949607/148678927-5187fa81-66ea-4db8-b83e-dc968a31fe5e.png)

![HelpIcon](https://user-images.githubusercontent.com/949607/148679117-ed5c3f12-98b4-42f3-92f5-076f3b4686d4.gif)

