### PR TITLE
- Always resize form icon to ensure that whatever icon size is retrieved, it will be correct when displayed

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -6,6 +6,7 @@
 * Versions have now been changed to the following format `Major.yy.MM.dayofyear`, i.e. `60.22.02.32`, but for convenience, builds will still be referenced as `yyMM` in documentation
 * Overhauled `run.cmd`
 * Build scripts are now stored in the `Scripts` folder, though it is now recommended to utilise `run.cmd`
+* Fixed [#601](https://github.com/Krypton-Suite/Standard-Toolkit/issues/601), Form icon is displaying stretched width
 * Fixed [#562](https://github.com/Krypton-Suite/Standard-Toolkit/issues/562), Help Icon is not clearly visible in a lot of themes
 * Fixed [#380](https://github.com/Krypton-Suite/Standard-Toolkit/issues/380), MDI Child form not fully maximizing not merging on the ribbon
 * Fixed [#571](https://github.com/Krypton-Suite/Standard-Toolkit/issues/571), CenterScreen start on Form is no longer respected

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -744,26 +744,27 @@ namespace Krypton.Toolkit
                 var currentWidth = (int)(CAPTION_ICON_SIZE.Width * FactorDpiX);
                 var currentHeight = (int)(CAPTION_ICON_SIZE.Height * FactorDpiY);
                 //}
+                Bitmap resizedBitmap = null;
                 try
                 {
                     using var temp = new Icon(_cacheIcon, currentWidth, currentHeight);
-                    _cacheBitmap = temp.ToBitmap();
+                    resizedBitmap = temp.ToBitmap();
                 }
                 catch
                 {
                     try
                     {
                         // Failed so we convert the Icon directly instead of trying to get a sized version first
-                        using Bitmap resizedBitmap = _cacheIcon.ToBitmap();
-                        // Cache for future access
-                        _cacheBitmap = CommonHelper.ScaleImageForSizedDisplay(resizedBitmap, currentWidth, currentHeight);
+                        resizedBitmap = _cacheIcon.ToBitmap();
                     }
                     catch
                     {
                         //
                     }
                 }
-
+                // Cache for future access
+                if (resizedBitmap != null)
+                    _cacheBitmap = CommonHelper.ScaleImageForSizedDisplay(resizedBitmap, currentWidth, currentHeight);
             }
 
             return _cacheBitmap;


### PR DESCRIPTION


Fixes: #601