### PR TITLE
* Implement #551

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -2,7 +2,13 @@
 
 <!--* Added the ability to control the `CueHint` values through `KryptonPalette`-->
 
-## 2022-06-xx - Build 2206 - June 2022
+## 2022-11-xx - Build 2211 - Novmber 2022
+* Implemented [#551](https://github.com/Krypton-Suite/Standard-Toolkit/issues/551), `DropShadow` should now be off and deprecated
+* Support for `.NET 7`
+
+=======
+
+## 2022-06-01 - Build 2206 - June 2022
 * Improvements to all 'Black/Blue (Dark Mode)' themes
 * Silver dark/light mode themes are now implemented
 * Full/Lite NuGet packages - as support for .NET 5 ended in May, there are now 2 types of NuGet package.
@@ -17,7 +23,9 @@
 * Resolved [#693](https://github.com/Krypton-Suite/Standard-Toolkit/issues/693), Docked controls are rendered with smaller size which hides the caption/title text.
 * Resolved [#653](https://github.com/Krypton-Suite/Standard-Toolkit/issues/653), Page Drag&Drop/Floating exception
 * Resolved bug where the colour value for `PaletteBackStyle.ControlToolTip` was 'out of range' in certain themes
-* Implement [#691](https://github.com/Krypton-Suite/Standard-Toolkit/issues/691), Update Project landing pages with links to Help file downloads
+* Implemented [#691](https://github.com/Krypton-Suite/Standard-Toolkit/issues/691), Update Project landing pages with links to Help file downloads
+
+=======
 
 ## 2022-04-04 - Build 2204 - April 2022
 * Resolved [#678](https://github.com/Krypton-Suite/Standard-Toolkit/issues/678), Dropdown list background & text colour are the same (Office 2010 - Black (Dark Mode))

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -191,6 +191,9 @@ namespace Krypton.Toolkit
 
             // Set the CornerRoundingRadius to 'GlobalStaticValues.PRIMARY_CORNER_ROUNDING_VALUE', default value
             CornerRoundingRadius = GlobalStaticValues.PRIMARY_CORNER_ROUNDING_VALUE;
+
+            // Disable 'UseDropShadow' on creation
+            UseDropShadow = false;
         }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -187,17 +187,6 @@ namespace Krypton.Toolkit
             // Create the view manager instance
             ViewManager = new ViewManager(this, _drawDocker);
 
-            // Set the UseDropShadow to true
-            // Check OS version for compatibility (can be overriden if needed)
-            if (Environment.OSVersion.Version.Major == 10)
-            {
-                UseDropShadow = true;
-            }
-            else if (Environment.OSVersion.Version.Major <= 6)
-            {
-                UseDropShadow = false;
-            }
-
             //DisableCloseButton = false;
 
             // Set the CornerRoundingRadius to 'GlobalStaticValues.PRIMARY_CORNER_ROUNDING_VALUE', default value
@@ -397,7 +386,8 @@ namespace Krypton.Toolkit
         /// </summary>
         [Category(@"Visuals")]
         [Description(@"Allows the use of drop shadow around the form.")]
-        [DefaultValue(true)]
+        [DefaultValue(false)]
+        [Obsolete("Deprecated - Only use if you are using Windows 7, 8 or 8.1.")]
         public bool UseDropShadow
         {
             get => _useDropShadow;


### PR DESCRIPTION
* Implement #551

![image](https://user-images.githubusercontent.com/949607/168993538-1245b931-1d1e-4952-9dab-73a71e49bc42.png)

(Increase of warnings is due to the new 'Obsolete' tag for `UseDropShadow` will fix in a future PR :))