### PR TITLE
2 Fixes for ArgumentNullException when saving palette.xml files with serialized Image objects

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPalette.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPalette.cs
@@ -3342,7 +3342,7 @@ namespace Krypton.Toolkit
                                 BinaryFormatter formatter = new();
                                 var old = (Image)formatter.Deserialize(memory);
 #pragma warning restore SYSLIB0011
-                                resurect = new Bitmap(old);
+                                resurect = old is Bitmap bitmap ? bitmap : new Bitmap(old);
                             }
 
 
@@ -3517,7 +3517,11 @@ namespace Krypton.Toolkit
                     // Convert the Image into base64 so it can be used in xml
                     using MemoryStream memory = new();
 
-                    entry.Key.Save(memory, entry.Key.RawFormat);
+                    var imageFormat = entry.Key.RawFormat;
+                    if (imageFormat.Equals(ImageFormat.MemoryBmp))
+                        imageFormat = ImageFormat.Bmp;
+
+                    entry.Key.Save(memory, imageFormat);
                     memory.Position = 0;
                     var base64 = Convert.ToBase64String(memory.ToArray());
 


### PR DESCRIPTION
See issue: https://github.com/Krypton-Suite/Standard-Toolkit/issues/758

This pullrequest fixes the issue by:

1. When the deserialized Image class is of type Bitmap, keep this bitmap, as opposed to painting it on a new in-memory bitmap. This keeps the original Format (as opposed, changing it to MemoryBMP.
2. When the format of an Image is of Format MemoryBMP, save the image as format BMP.