### PR TITLE
- Add `ToolTipShadow` property to things that displaya Krypton Tooltip

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -12,6 +12,7 @@
 * Resolved [#738](https://github.com/Krypton-Suite/Standard-Toolkit/issues/738), "Office 2010 - Blue (Dark Mode)": Form title text cannot be read
 * Implemented [#728](https://github.com/Krypton-Suite/Standard-Toolkit/issues/728), Bring MessageBox `States` inline with latest .Net 6 
 * Made enumeration `SchemeOfficeColors` public, so they can be used to make external themes
+* Resolved [#689](https://github.com/Krypton-Suite/Standard-Toolkit/issues/689), A way to remove border shadows on `KryptonToolTips`
 * Resolved [#666](https://github.com/Krypton-Suite/Standard-Toolkit/issues/666), KryptonTextBox `Validate` / `Validating` / `KeyUp` events are invoked twice
 * Resolved [#660](https://github.com/Krypton-Suite/Standard-Toolkit/issues/660), Krypton DomainUpDown control: Nearly impossible to place the cursor via the mouse
 * Resolved [#748](https://github.com/Krypton-Suite/Standard-Toolkit/issues/748), Navigator text is removed via designer changes for Navigator tabs

--- a/Source/Krypton Components/Krypton.Navigator/Controls Navigator/KryptonNavigator.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Controls Navigator/KryptonNavigator.cs
@@ -2888,7 +2888,7 @@ namespace Krypton.Navigator
                 {
                     IContentValues sourceContent = null;
                     LabelStyle toolTipStyle = LabelStyle.ToolTip;
-
+                    bool shadow = true;
                     // Find the page associated with the tooltip request
                     KryptonPage toolTipPage = ViewBuilder.PageFromView(e.Target);
 
@@ -2909,6 +2909,7 @@ namespace Krypton.Navigator
                             {
                                 sourceContent = pageMapping;
                                 toolTipStyle = toolTipPage.ToolTipStyle;
+                                shadow = toolTipPage.ToolTipShadow;
                             }
                         }
                     }
@@ -2931,6 +2932,7 @@ namespace Krypton.Navigator
                                 {
                                     sourceContent = buttonSpecMapping;
                                     toolTipStyle = buttonSpec.ToolTipStyle;
+                                    shadow = buttonSpec.ToolTipShadow;
                                 }
                             }
                         }
@@ -2947,7 +2949,8 @@ namespace Krypton.Navigator
                                                                      Renderer,
                                                                      PaletteBackStyle.ControlToolTip,
                                                                      PaletteBorderStyle.ControlToolTip,
-                                                                     CommonHelper.ContentStyleFromLabelStyle(toolTipStyle));
+                                                                     CommonHelper.ContentStyleFromLabelStyle(toolTipStyle),
+                                                                     shadow);
 
                         _visualPopupToolTip.Disposed += OnVisualPopupToolTipDisposed;
 

--- a/Source/Krypton Components/Krypton.Navigator/Page/KryptonPage.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Page/KryptonPage.cs
@@ -718,6 +718,22 @@ namespace Krypton.Navigator
         /// </summary>
         public void ResetToolTipStyle() => ToolTipStyle = LabelStyle.ToolTip;
 
+        #region ToolTipShadow
+        /// <summary>
+        /// Gets and sets the tooltip label style.
+        /// </summary>
+        [Category(@"Appearance")]
+        [Description(@"Button tooltip Shadow.")]
+        [DefaultValue(true)]
+        public bool ToolTipShadow { get; set; } = true; // Backward compatible -> "Material Design" suggests this to be false
+
+        private bool ShouldSerializeToolTipShadow() => !ToolTipShadow;
+
+        private void ResetToolTipShadow()
+        {
+            ToolTipShadow = true;
+        }
+        #endregion
         /// <summary>
         /// Gets and sets the unique name of the page.
         /// </summary>

--- a/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonRibbonQATButton.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonRibbonQATButton.cs
@@ -287,6 +287,23 @@ namespace Krypton.Ribbon
         [Localizable(true)]
         public string ToolTipBody { get; set; }
 
+        #region ToolTipShadow
+        /// <summary>
+        /// Gets and sets the tooltip label style.
+        /// </summary>
+        [Category(@"ToolTip")]
+        [Description(@"Button tooltip Shadow.")]
+        [DefaultValue(true)]
+        public bool ToolTipShadow { get; set; } = true; // Backward compatible -> "Material Design" suggests this to be false
+
+        private bool ShouldSerializeToolTipShadow() => !ToolTipShadow;
+
+        private void ResetToolTipShadow()
+        {
+            ToolTipShadow = true;
+        }
+        #endregion
+
         /// <summary>
         /// Gets and sets the associated KryptonCommand.
         /// </summary>
@@ -437,6 +454,8 @@ namespace Krypton.Ribbon
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public string GetToolTipBody() => ToolTipBody;
+
+        public bool GetToolTipShadow() => ToolTipShadow;
 
         /// <summary>
         /// Generates a Click event for a button.

--- a/Source/Krypton Components/Krypton.Ribbon/General/Definitions.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/General/Definitions.cs
@@ -97,6 +97,12 @@ namespace Krypton.Ribbon
         string GetToolTipBody();
 
         /// <summary>
+        /// Does the tooltip have a shadow?
+        /// </summary>
+        /// <returns></returns>
+        bool GetToolTipShadow();
+
+        /// <summary>
         /// Generates a Click event for a button.
         /// </summary>
         void PerformClick();

--- a/Source/Krypton Components/Krypton.Ribbon/Palette/RibbonAppButton.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Palette/RibbonAppButton.cs
@@ -319,6 +319,24 @@ namespace Krypton.Ribbon
 
         #endregion
 
+        #region ToolTipShadow
+        /// <summary>
+        /// Gets and sets the tooltip label style.
+        /// </summary>
+        [Category(@"ToolTip")]
+        [Description(@"Button tooltip Shadow.")]
+        [DefaultValue(true)]
+        public bool ToolTipShadow { get; set; } = true; // Backward compatible -> "Material Design" suggests this to be false
+
+        private bool ShouldSerializeToolTipShadow() => !ToolTipShadow;
+
+        private void ResetToolTipShadow()
+        {
+            ToolTipShadow = true;
+        }
+        #endregion
+
+
         #region AppButtonToolTipImage
         /// <summary>
         /// Gets and sets the image for the item ToolTip.

--- a/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonTabsArea.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonTabsArea.cs
@@ -786,6 +786,7 @@ namespace Krypton.Ribbon
                 {
                     IContentValues sourceContent = null;
                     LabelStyle toolTipStyle = LabelStyle.SuperTip;
+                    bool shadow = true;
                     Rectangle screenRect = new(e.ControlMousePosition, new Size(1, 1));
 
                     // If the target is the application button
@@ -803,6 +804,7 @@ namespace Krypton.Ribbon
 
                                 // Grab the style from the app button settings
                                 toolTipStyle = _ribbon.RibbonAppButton.AppButtonToolTipStyle;
+                                shadow = _ribbon.RibbonAppButton.ToolTipShadow;
 
                                 // Display below the mouse cursor
                                 screenRect.Height += SystemInformation.CursorSize.Height / 3 * 2;
@@ -822,6 +824,7 @@ namespace Krypton.Ribbon
 
                                 // Grab the style from the QAT button settings
                                 toolTipStyle = viewElement1.QATButton.GetToolTipStyle();
+                                shadow = viewElement1.QATButton.GetToolTipShadow();
 
                                 // Display below the mouse cursor
                                 screenRect.Height += SystemInformation.CursorSize.Height / 3 * 2;
@@ -848,6 +851,7 @@ namespace Krypton.Ribbon
 
                                             // Grab the style from the button spec settings
                                             toolTipStyle = buttonSpec.ToolTipStyle;
+                                            shadow = buttonSpec.ToolTipShadow;
 
                                             // Display below the mouse cursor
                                             screenRect.Height += SystemInformation.CursorSize.Height / 3 * 2;
@@ -867,6 +871,7 @@ namespace Krypton.Ribbon
 
                                             // Grab the style from the group radio button button settings
                                             toolTipStyle = groupItem.ToolTipValues.ToolTipStyle;
+                                            shadow = groupItem.ToolTipValues.ToolTipShadow;
 
                                             // Display below the bottom of the ribbon control
                                             Rectangle ribbonScreenRect = _ribbon.ToolTipScreenRectangle;
@@ -894,7 +899,8 @@ namespace Krypton.Ribbon
                                                                      _ribbon.Renderer,
                                                                      PaletteBackStyle.ControlToolTip,
                                                                      PaletteBorderStyle.ControlToolTip,
-                                                                     CommonHelper.ContentStyleFromLabelStyle(toolTipStyle));
+                                                                     CommonHelper.ContentStyleFromLabelStyle(toolTipStyle),
+                                                                     shadow);
 
                         _visualPopupToolTip.Disposed += OnVisualPopupToolTipDisposed;
 

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpec.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpec.cs
@@ -467,6 +467,24 @@ namespace Krypton.Toolkit
         }
         #endregion
 
+        #region ToolTipShadow
+
+        /// <summary>
+        /// Gets and sets the tooltip label style.
+        /// </summary>
+        [Category(@"ToolTip")]
+        [Description(@"Button tooltip Shadow.")]
+        [DefaultValue(true)]
+        public bool ToolTipShadow { get; set; } = true;
+
+        private bool ShouldSerializeToolTipShadow() => !ToolTipShadow;
+
+        private void ResetToolTipShadow()
+        {
+            ToolTipShadow = true;
+        }
+        #endregion
+
         #region UniqueName
         /// <summary>
         /// Gets and sets the unique name of the ButtonSpec.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonBreadCrumb.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonBreadCrumb.cs
@@ -693,7 +693,7 @@ namespace Krypton.Toolkit
                 {
                     IContentValues sourceContent = null;
                     LabelStyle toolTipStyle = LabelStyle.ToolTip;
-
+                    bool shadow = true;
                     // Find the button spec associated with the tooltip request
                     ButtonSpec buttonSpec = _buttonManager.ButtonSpecFromView(e.Target);
 
@@ -711,6 +711,7 @@ namespace Krypton.Toolkit
                             {
                                 sourceContent = buttonSpecMapping;
                                 toolTipStyle = buttonSpec.ToolTipStyle;
+                                shadow = buttonSpec.ToolTipShadow;
                             }
                         }
                     }
@@ -731,7 +732,8 @@ namespace Krypton.Toolkit
                                                                      Renderer,
                                                                      PaletteBackStyle.ControlToolTip,
                                                                      PaletteBorderStyle.ControlToolTip,
-                                                                     CommonHelper.ContentStyleFromLabelStyle(toolTipStyle));
+                                                                     CommonHelper.ContentStyleFromLabelStyle(toolTipStyle),
+                                                                     shadow);
 
                         _visualPopupToolTip.Disposed += OnVisualPopupToolTipDisposed;
                         _visualPopupToolTip.ShowRelativeTo(e.Target, e.ControlMousePosition);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -3050,7 +3050,7 @@ namespace Krypton.Toolkit
                 {
                     IContentValues sourceContent = null;
                     LabelStyle toolTipStyle = LabelStyle.ToolTip;
-
+                    bool shadow = true;
                     // Find the button spec associated with the tooltip request
                     ButtonSpec buttonSpec = _buttonManager.ButtonSpecFromView(e.Target);
 
@@ -3068,6 +3068,7 @@ namespace Krypton.Toolkit
                             {
                                 sourceContent = buttonSpecMapping;
                                 toolTipStyle = buttonSpec.ToolTipStyle;
+                                shadow = buttonSpec.ToolTipShadow;
                             }
                         }
                     }
@@ -3088,7 +3089,8 @@ namespace Krypton.Toolkit
                                                                      Renderer,
                                                                      PaletteBackStyle.ControlToolTip,
                                                                      PaletteBorderStyle.ControlToolTip,
-                                                                     CommonHelper.ContentStyleFromLabelStyle(toolTipStyle));
+                                                                     CommonHelper.ContentStyleFromLabelStyle(toolTipStyle),
+                                                                     shadow);
 
                         _visualPopupToolTip.Disposed += OnVisualPopupToolTipDisposed;
                         _visualPopupToolTip.ShowRelativeTo(e.Target, e.ControlMousePosition);
@@ -3121,7 +3123,8 @@ namespace Krypton.Toolkit
             PaletteRedirect redirector = new(KryptonManager.CurrentGlobalPalette);
             _toolTip = new VisualPopupToolTip(redirector,
                 new ButtonSpecToContent(redirector, _toolTipSpec), KryptonManager
-                    .CurrentGlobalPalette.GetRenderer());
+                    .CurrentGlobalPalette.GetRenderer(),
+                ToolTipValues.ToolTipShadow);
             return _toolTip;
         }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -828,6 +828,24 @@ namespace Krypton.Toolkit
             _restrictColumnsSearch = columnsIndex;
             Invalidate();
         }
+
+        #region ToolTipShadow
+
+        /// <summary>
+        /// Gets and sets the tooltip label style.
+        /// </summary>
+        [Category(@"ToolTip")]
+        [Description(@"Button tooltip Shadow.")]
+        [DefaultValue(true)]
+        public bool ToolTipShadow { get; set; } = true;
+
+        private bool ShouldSerializeToolTipShadow() => !ToolTipShadow;
+
+        private void ResetToolTipShadow()
+        {
+            ToolTipShadow = true;
+        }
+        #endregion
         #endregion
 
         #region Protected
@@ -2338,7 +2356,8 @@ namespace Krypton.Toolkit
                                                                  Renderer,
                                                                  PaletteBackStyle.ControlToolTip,
                                                                  PaletteBorderStyle.ControlToolTip,
-                                                                 PaletteContentStyle.LabelToolTip);
+                                                                 PaletteContentStyle.LabelToolTip,
+                                                                 ToolTipShadow);
 
                     _visualPopupToolTip.Disposed += OnVisualPopupToolTipDisposed;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDateTimePicker.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDateTimePicker.cs
@@ -2094,7 +2094,7 @@ namespace Krypton.Toolkit
                 {
                     IContentValues sourceContent = null;
                     LabelStyle toolTipStyle = LabelStyle.ToolTip;
-
+                    bool shadow = true;
                     // Find the button spec associated with the tooltip request
                     ButtonSpec buttonSpec = _buttonManager.ButtonSpecFromView(e.Target);
 
@@ -2112,6 +2112,7 @@ namespace Krypton.Toolkit
                             {
                                 sourceContent = buttonSpecMapping;
                                 toolTipStyle = buttonSpec.ToolTipStyle;
+                                shadow = buttonSpec.ToolTipShadow;
                             }
                         }
                     }
@@ -2132,7 +2133,8 @@ namespace Krypton.Toolkit
                                                                      Renderer,
                                                                      PaletteBackStyle.ControlToolTip,
                                                                      PaletteBorderStyle.ControlToolTip,
-                                                                     CommonHelper.ContentStyleFromLabelStyle(toolTipStyle));
+                                                                     CommonHelper.ContentStyleFromLabelStyle(toolTipStyle),
+                                                                     shadow);
 
                         _visualPopupToolTip.Disposed += OnVisualPopupToolTipDisposed;
                         _visualPopupToolTip.ShowRelativeTo(e.Target, e.ControlMousePosition);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
@@ -1951,7 +1951,7 @@ namespace Krypton.Toolkit
                 {
                     IContentValues sourceContent = null;
                     LabelStyle toolTipStyle = LabelStyle.ToolTip;
-
+                    bool shadow = true;
                     // Find the button spec associated with the tooltip request
                     ButtonSpec buttonSpec = _buttonManager.ButtonSpecFromView(e.Target);
 
@@ -1969,6 +1969,7 @@ namespace Krypton.Toolkit
                             {
                                 sourceContent = buttonSpecMapping;
                                 toolTipStyle = buttonSpec.ToolTipStyle;
+                                shadow = buttonSpec.ToolTipShadow;
                             }
                         }
                     }
@@ -1989,7 +1990,8 @@ namespace Krypton.Toolkit
                                                                      Renderer,
                                                                      PaletteBackStyle.ControlToolTip,
                                                                      PaletteBorderStyle.ControlToolTip,
-                                                                     CommonHelper.ContentStyleFromLabelStyle(toolTipStyle));
+                                                                     CommonHelper.ContentStyleFromLabelStyle(toolTipStyle),
+                                                                     shadow);
 
                         _visualPopupToolTip.Disposed += OnVisualPopupToolTipDisposed;
                         _visualPopupToolTip.ShowRelativeTo(e.Target, e.ControlMousePosition);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -1588,6 +1588,8 @@ namespace Krypton.Toolkit
                 if (!DesignMode)
                 {
                     IContentValues sourceContent = null;
+                    LabelStyle toolTipStyle = LabelStyle.ToolTip;
+                    bool shadow = true;
 
                     // Find the button spec associated with the tooltip request
                     ButtonSpec buttonSpec = _buttonManager.ButtonSpecFromView(e.Target);
@@ -1605,6 +1607,8 @@ namespace Krypton.Toolkit
                             if (buttonSpecMapping.HasContent)
                             {
                                 sourceContent = buttonSpecMapping;
+                                toolTipStyle = buttonSpec.ToolTipStyle;
+                                shadow = buttonSpec.ToolTipShadow;
                             }
                         }
                     }
@@ -1620,7 +1624,8 @@ namespace Krypton.Toolkit
                                                                      Renderer,
                                                                      PaletteBackStyle.ControlToolTip,
                                                                      PaletteBorderStyle.ControlToolTip,
-                                                                     PaletteContentStyle.LabelToolTip);
+                                                                     CommonHelper.ContentStyleFromLabelStyle(toolTipStyle),
+                                                                     shadow);
 
                         _visualPopupToolTip.Disposed += OnVisualPopupToolTipDisposed;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonHeader.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonHeader.cs
@@ -532,7 +532,7 @@ namespace Krypton.Toolkit
                 {
                     IContentValues sourceContent = null;
                     LabelStyle toolTipStyle = LabelStyle.ToolTip;
-
+                    bool shadow = true;
                     // Find the button spec associated with the tooltip request
                     ButtonSpec buttonSpec = _buttonManager.ButtonSpecFromView(e.Target);
 
@@ -550,6 +550,7 @@ namespace Krypton.Toolkit
                             {
                                 sourceContent = buttonSpecMapping;
                                 toolTipStyle = buttonSpec.ToolTipStyle;
+                                shadow = buttonSpec.ToolTipShadow;
                             }
                         }
                     }
@@ -570,7 +571,8 @@ namespace Krypton.Toolkit
                                                                      Renderer,
                                                                      PaletteBackStyle.ControlToolTip,
                                                                      PaletteBorderStyle.ControlToolTip,
-                                                                     CommonHelper.ContentStyleFromLabelStyle(toolTipStyle));
+                                                                     CommonHelper.ContentStyleFromLabelStyle(toolTipStyle),
+                                                                     shadow);
 
                         _visualPopupToolTip.Disposed += OnVisualPopupToolTipDisposed;
                         _visualPopupToolTip.ShowRelativeTo(e.Target, e.ControlMousePosition);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonHeaderGroup.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonHeaderGroup.cs
@@ -1076,7 +1076,7 @@ namespace Krypton.Toolkit
                 {
                     IContentValues sourceContent = null;
                     LabelStyle toolTipStyle = LabelStyle.ToolTip;
-
+                    bool shadow = true;
                     // Find the button spec associated with the tooltip request
                     ButtonSpec buttonSpec = _buttonManager.ButtonSpecFromView(e.Target);
 
@@ -1094,6 +1094,7 @@ namespace Krypton.Toolkit
                             {
                                 sourceContent = buttonSpecMapping;
                                 toolTipStyle = buttonSpec.ToolTipStyle;
+                                shadow = buttonSpec.ToolTipShadow;
                             }
                         }
                     }
@@ -1114,7 +1115,8 @@ namespace Krypton.Toolkit
                                                                      Renderer,
                                                                      PaletteBackStyle.ControlToolTip,
                                                                      PaletteBorderStyle.ControlToolTip,
-                                                                     CommonHelper.ContentStyleFromLabelStyle(toolTipStyle));
+                                                                     CommonHelper.ContentStyleFromLabelStyle(toolTipStyle),
+                                                                     shadow);
 
                         _visualPopupToolTip.Disposed += OnVisualPopupToolTipDisposed;
                         _visualPopupToolTip.ShowRelativeTo(e.Target, e.ControlMousePosition);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs
@@ -1853,7 +1853,7 @@ namespace Krypton.Toolkit
                 {
                     IContentValues sourceContent = null;
                     LabelStyle toolTipStyle = LabelStyle.ToolTip;
-
+                    bool shadow = true;
                     // Find the button spec associated with the tooltip request
                     ButtonSpec buttonSpec = _buttonManager.ButtonSpecFromView(e.Target);
 
@@ -1871,6 +1871,7 @@ namespace Krypton.Toolkit
                             {
                                 sourceContent = buttonSpecMapping;
                                 toolTipStyle = buttonSpec.ToolTipStyle;
+                                shadow = buttonSpec.ToolTipShadow;
                             }
                         }
                     }
@@ -1891,7 +1892,8 @@ namespace Krypton.Toolkit
                                                                      Renderer,
                                                                      PaletteBackStyle.ControlToolTip,
                                                                      PaletteBorderStyle.ControlToolTip,
-                                                                     CommonHelper.ContentStyleFromLabelStyle(toolTipStyle));
+                                                                     CommonHelper.ContentStyleFromLabelStyle(toolTipStyle),
+                                                                     shadow);
 
                         _visualPopupToolTip.Disposed += OnVisualPopupToolTipDisposed;
                         _visualPopupToolTip.ShowRelativeTo(e.Target, e.ControlMousePosition);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
@@ -2064,7 +2064,7 @@ namespace Krypton.Toolkit
                 {
                     IContentValues sourceContent = null;
                     LabelStyle toolTipStyle = LabelStyle.ToolTip;
-
+                    bool shadow = true;
                     // Find the button spec associated with the tooltip request
                     ButtonSpec buttonSpec = _buttonManager.ButtonSpecFromView(e.Target);
 
@@ -2082,6 +2082,7 @@ namespace Krypton.Toolkit
                             {
                                 sourceContent = buttonSpecMapping;
                                 toolTipStyle = buttonSpec.ToolTipStyle;
+                                shadow = buttonSpec.ToolTipShadow;
                             }
                         }
                     }
@@ -2102,7 +2103,8 @@ namespace Krypton.Toolkit
                                                                      Renderer,
                                                                      PaletteBackStyle.ControlToolTip,
                                                                      PaletteBorderStyle.ControlToolTip,
-                                                                     CommonHelper.ContentStyleFromLabelStyle(toolTipStyle));
+                                                                     CommonHelper.ContentStyleFromLabelStyle(toolTipStyle),
+                                                                     shadow);
 
                         _visualPopupToolTip.Disposed += OnVisualPopupToolTipDisposed;
                         _visualPopupToolTip.ShowRelativeTo(e.Target, e.ControlMousePosition);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
@@ -2213,7 +2213,7 @@ namespace Krypton.Toolkit
                 {
                     IContentValues sourceContent = null;
                     LabelStyle toolTipStyle = LabelStyle.ToolTip;
-
+                    bool shadow = true;
                     // Find the button spec associated with the tooltip request
                     ButtonSpec buttonSpec = _buttonManager.ButtonSpecFromView(e.Target);
 
@@ -2231,6 +2231,7 @@ namespace Krypton.Toolkit
                             {
                                 sourceContent = buttonSpecMapping;
                                 toolTipStyle = buttonSpec.ToolTipStyle;
+                                shadow = buttonSpec.ToolTipShadow;
                             }
                         }
                     }
@@ -2251,7 +2252,8 @@ namespace Krypton.Toolkit
                                                                      Renderer,
                                                                      PaletteBackStyle.ControlToolTip,
                                                                      PaletteBorderStyle.ControlToolTip,
-                                                                     CommonHelper.ContentStyleFromLabelStyle(toolTipStyle));
+                                                                     CommonHelper.ContentStyleFromLabelStyle(toolTipStyle),
+                                                                     shadow);
 
                         _visualPopupToolTip.Disposed += OnVisualPopupToolTipDisposed;
                         _visualPopupToolTip.ShowRelativeTo(e.Target, e.ControlMousePosition);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
@@ -1868,7 +1868,7 @@ namespace Krypton.Toolkit
                 {
                     IContentValues sourceContent = null;
                     LabelStyle toolTipStyle = LabelStyle.ToolTip;
-
+                    bool shadow = true;
                     // Find the button spec associated with the tooltip request
                     ButtonSpec buttonSpec = _buttonManager.ButtonSpecFromView(e.Target);
 
@@ -1886,6 +1886,7 @@ namespace Krypton.Toolkit
                             {
                                 sourceContent = buttonSpecMapping;
                                 toolTipStyle = buttonSpec.ToolTipStyle;
+                                shadow = buttonSpec.ToolTipShadow;
                             }
                         }
                     }
@@ -1906,7 +1907,8 @@ namespace Krypton.Toolkit
                                                                      Renderer,
                                                                      PaletteBackStyle.ControlToolTip,
                                                                      PaletteBorderStyle.ControlToolTip,
-                                                                     CommonHelper.ContentStyleFromLabelStyle(toolTipStyle));
+                                                                     CommonHelper.ContentStyleFromLabelStyle(toolTipStyle),
+                                                                     shadow);
 
                         _visualPopupToolTip.Disposed += OnVisualPopupToolTipDisposed;
                         _visualPopupToolTip.ShowRelativeTo(e.Target, e.ControlMousePosition);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualControlBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualControlBase.cs
@@ -1315,7 +1315,8 @@ namespace Krypton.Toolkit
                         Renderer,
                         PaletteBackStyle.ControlToolTip,
                         PaletteBorderStyle.ControlToolTip,
-                        CommonHelper.ContentStyleFromLabelStyle(ToolTipValues.ToolTipStyle));
+                        CommonHelper.ContentStyleFromLabelStyle(ToolTipValues.ToolTipStyle),
+                        ToolTipValues.ToolTipShadow);
 
                     visualBasePopupToolTip.Disposed += OnVisualPopupToolTipDisposed;
                     visualBasePopupToolTip.ShowRelativeTo(e.Target, e.ControlMousePosition);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPopupTooltip.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPopupTooltip.cs
@@ -32,13 +32,16 @@ namespace Krypton.Toolkit
         /// <param name="redirector">Redirector for recovering palette values.</param>
         /// <param name="contentValues">Source of content values.</param>
         /// <param name="renderer">Drawing renderer.</param>
+        /// <param name="shadow">Does the Tooltip need a shadow effect.</param>
         public VisualPopupToolTip(PaletteRedirect redirector,
                                   IContentValues contentValues,
-                                  IRenderer renderer)
+                                  IRenderer renderer,
+                                  bool shadow)
             : this(redirector, contentValues, renderer,
                    PaletteBackStyle.ControlToolTip,
                    PaletteBorderStyle.ControlToolTip,
-                   PaletteContentStyle.LabelToolTip)
+                   PaletteContentStyle.LabelToolTip,
+                   shadow)
         {
         }
 
@@ -51,13 +54,15 @@ namespace Krypton.Toolkit
         /// <param name="backStyle">Style for the tooltip background.</param>
         /// <param name="borderStyle">Style for the tooltip border.</param>
         /// <param name="contentStyle">Style for the tooltip content.</param>
+        /// <param name="shadow">Does the Tooltip need a shadow effect.</param>
         public VisualPopupToolTip(PaletteRedirect redirector,
                                   IContentValues contentValues,
                                   IRenderer renderer,
                                   PaletteBackStyle backStyle,
                                   PaletteBorderStyle borderStyle,
-                                  PaletteContentStyle contentStyle)
-            : base(renderer, true)
+                                  PaletteContentStyle contentStyle,
+                                  bool shadow)
+            : base(renderer, shadow)
         {
             Debug.Assert(contentValues != null);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Values/ToolTipValues.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/ToolTipValues.cs
@@ -66,6 +66,23 @@ namespace Krypton.Toolkit
             EnableToolTips = false;
         }
 
+        #region ToolTipShadow
+        /// <summary>
+        /// Gets and sets the tooltip label style.
+        /// </summary>
+        [Category(@"ToolTip")]
+        [Description(@"Button tooltip Shadow.")]
+        [DefaultValue(true)]
+        public bool ToolTipShadow { get; set; } = true; // Backward compatible -> "Material Design" suggests this to be false
+
+        private bool ShouldSerializeToolTipShadow() => !ToolTipShadow;
+
+        private void ResetToolTipShadow()
+        {
+            ToolTipShadow = true;
+        }
+        #endregion
+
         /// <summary>
         /// Gets and sets the EnableToolTips
         /// </summary>

--- a/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutMonths.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutMonths.cs
@@ -803,7 +803,7 @@ namespace Krypton.Toolkit
                 {
                     IContentValues sourceContent = null;
                     LabelStyle toolTipStyle = LabelStyle.ToolTip;
-
+                    bool shadow = true;
                     // Find the button spec associated with the tooltip request
                     ButtonSpec buttonSpec = ButtonManager.ButtonSpecFromView(e.Target);
 
@@ -821,6 +821,7 @@ namespace Krypton.Toolkit
                             {
                                 sourceContent = buttonSpecMapping;
                                 toolTipStyle = buttonSpec.ToolTipStyle;
+                                shadow = buttonSpec.ToolTipShadow;
                             }
                         }
                     }
@@ -836,7 +837,8 @@ namespace Krypton.Toolkit
                                                                      Calendar.GetRenderer(),
                                                                      PaletteBackStyle.ControlToolTip,
                                                                      PaletteBorderStyle.ControlToolTip,
-                                                                     CommonHelper.ContentStyleFromLabelStyle(toolTipStyle));
+                                                                     CommonHelper.ContentStyleFromLabelStyle(toolTipStyle),
+                                                                     shadow);
 
                         _visualPopupToolTip.Disposed += OnVisualPopupToolTipDisposed;
 


### PR DESCRIPTION
#689

![image](https://user-images.githubusercontent.com/2418812/175775493-a786ea37-95a0-4a2d-8fdb-5fadc47d3dda.png)
