### PR TITLE
- only fire events when treeview is in stable state (i.e. not before …

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -5,6 +5,7 @@
 =======
 
 ## 2022-11-xx - Build 2211 - November 2022
+* Resolved [#777](https://github.com/Krypton-Suite/Standard-Toolkit/issues/777), KryptonTreeView can throw exception on changing palette via KryptonManager. Note: unknown can still be set when deleting selected node
 * Resolved [#774](https://github.com/Krypton-Suite/Standard-Toolkit/issues/774), `KryptonTableLayoutPanel` throwing exception when a form is minimized (thanks to [ZXBITLES](https://github.com/ZXBITLES))
 * New `UseCustomPreviewShape` property for `KryptonColorButton` to allow configuration of a custom colour preview shape
 * Updated the `KryptonTaskDialog` to use the `KryptonMessageBoxIcon` instead of the standard `System.Windows.Forms.MessageBoxIcon`

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
@@ -200,6 +200,11 @@ namespace Krypton.Toolkit
                         }
                         base.WndProc(ref m);
                         break;
+                    case PI.WM_.CREATE:
+                        _kryptonTreeView._isRecreating = true;
+                        base.WndProc(ref m);
+                        _kryptonTreeView._isRecreating = false;
+                        break;
                     default:
                         base.WndProc(ref m);
                         break;
@@ -325,6 +330,7 @@ namespace Krypton.Toolkit
         private bool _alwaysActive;
         private bool _forcedLayout;
         private bool _trackingMouseEnter;
+        private bool _isRecreating; // https://github.com/Krypton-Suite/Standard-Toolkit/issues/777
         #endregion
 
         #region Events
@@ -1411,95 +1417,202 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Protected Virtual
+
         /// <summary>
         /// Raises the AfterCheck event.
         /// </summary>
         /// <param name="e">An TreeViewEventArgs that contains the event data.</param>
-        protected virtual void OnAfterCheck(TreeViewEventArgs e) => AfterCheck?.Invoke(this, e);
+        /// <remarks>If overriden directly, will fire when palette changes</remarks>
+        protected virtual void OnAfterCheck(TreeViewEventArgs e)
+        {
+            if (!_isRecreating)
+            {
+                AfterCheck?.Invoke(this, e);
+            }
+        }
 
         /// <summary>
         /// Raises the AfterCollapse event.
         /// </summary>
         /// <param name="e">An TreeViewEventArgs that contains the event data.</param>
-        protected virtual void OnAfterCollapse(TreeViewEventArgs e) => AfterCollapse?.Invoke(this, e);
+        /// <remarks>If overriden directly, will fire when palette changes</remarks>
+        protected virtual void OnAfterCollapse(TreeViewEventArgs e)
+        {
+            if (!_isRecreating)
+            {
+                AfterCollapse?.Invoke(this, e);
+            }
+        }
 
         /// <summary>
         /// Raises the AfterExpand event.
         /// </summary>
         /// <param name="e">An TreeViewEventArgs that contains the event data.</param>
-        protected virtual void OnAfterExpand(TreeViewEventArgs e) => AfterExpand?.Invoke(this, e);
+        /// <remarks>If overriden directly, will fire when palette changes</remarks>
+        protected virtual void OnAfterExpand(TreeViewEventArgs e)
+        {
+            if (!_isRecreating)
+            {
+                AfterExpand?.Invoke(this, e);
+            }
+        }
 
         /// <summary>
         /// Raises the AfterLabelEdit event.
         /// </summary>
         /// <param name="e">An NodeLabelEditEventArgs that contains the event data.</param>
-        protected virtual void OnAfterLabelEdit(NodeLabelEditEventArgs e) => AfterLabelEdit?.Invoke(this, e);
+        /// <remarks>If overriden directly, will fire when palette changes</remarks>
+        protected virtual void OnAfterLabelEdit(NodeLabelEditEventArgs e)
+        {
+            if (!_isRecreating)
+            {
+                AfterLabelEdit?.Invoke(this, e);
+            }
+        }
 
         /// <summary>
         /// Raises the AfterSelect event.
         /// </summary>
         /// <param name="e">An TreeViewEventArgs that contains the event data.</param>
-        protected virtual void OnAfterSelect(TreeViewEventArgs e) => AfterSelect?.Invoke(this, e);
+        /// <remarks>If overriden directly, will fire when palette changes</remarks>
+        protected virtual void OnAfterSelect(TreeViewEventArgs e)
+        {
+            if (!_isRecreating)
+            {
+                AfterSelect?.Invoke(this, e);
+            }
+        }
 
         /// <summary>
         /// Raises the BeforeCheck event.
         /// </summary>
         /// <param name="e">An TreeViewCancelEventArgs that contains the event data.</param>
-        protected virtual void OnBeforeCheck(TreeViewCancelEventArgs e) => BeforeCheck?.Invoke(this, e);
+        /// <remarks>If overriden directly, will fire when palette changes</remarks>
+        protected virtual void OnBeforeCheck(TreeViewCancelEventArgs e)
+        {
+            if (!_isRecreating)
+            {
+                BeforeCheck?.Invoke(this, e);
+            }
+        }
 
         /// <summary>
         /// Raises the BeforeCollapse event.
         /// </summary>
         /// <param name="e">An TreeViewCancelEventArgs that contains the event data.</param>
-        protected virtual void OnBeforeCollapse(TreeViewCancelEventArgs e) => BeforeCollapse?.Invoke(this, e);
+        /// <remarks>If overriden directly, will fire when palette changes</remarks>
+        protected virtual void OnBeforeCollapse(TreeViewCancelEventArgs e)
+        {
+            if (!_isRecreating)
+            {
+                BeforeCollapse?.Invoke(this, e);
+            }
+        }
 
         /// <summary>
         /// Raises the BeforeExpand event.
         /// </summary>
         /// <param name="e">An TreeViewCancelEventArgs that contains the event data.</param>
-        protected virtual void OnBeforeExpand(TreeViewCancelEventArgs e) => BeforeExpand?.Invoke(this, e);
+        /// <remarks>If overriden directly, will fire when palette changes</remarks>
+        protected virtual void OnBeforeExpand(TreeViewCancelEventArgs e)
+        {
+            if (!_isRecreating)
+            {
+                BeforeExpand?.Invoke(this, e);
+            }
+        }
 
         /// <summary>
         /// Raises the BeforeLabelEdit event.
         /// </summary>
         /// <param name="e">An NodeLabelEditEventArgs that contains the event data.</param>
-        protected virtual void OnBeforeLabelEdit(NodeLabelEditEventArgs e) => BeforeLabelEdit?.Invoke(this, e);
+        /// <remarks>If overriden directly, will fire when palette changes</remarks>
+        protected virtual void OnBeforeLabelEdit(NodeLabelEditEventArgs e)
+        {
+            if (!_isRecreating)
+            {
+                BeforeLabelEdit?.Invoke(this, e);
+            }
+        }
 
         /// <summary>
         /// Raises the BeforeSelect event.
         /// </summary>
         /// <param name="e">An TreeViewCancelEventArgs that contains the event data.</param>
-        protected virtual void OnBeforeSelect(TreeViewCancelEventArgs e) => BeforeSelect?.Invoke(this, e);
+        /// <remarks>If overriden directly, will fire when palette changes</remarks>
+        protected virtual void OnBeforeSelect(TreeViewCancelEventArgs e)
+        {
+            if (!_isRecreating)
+            {
+                BeforeSelect?.Invoke(this, e);
+            }
+        }
 
         /// <summary>
         /// Raises the ItemDrag event.
         /// </summary>
         /// <param name="e">An ItemDragEventArgs that contains the event data.</param>
-        protected virtual void OnItemDrag(ItemDragEventArgs e) => ItemDrag?.Invoke(this, e);
+        /// <remarks>If overriden directly, will fire when palette changes</remarks>
+        protected virtual void OnItemDrag(ItemDragEventArgs e)
+        {
+            if (!_isRecreating)
+            {
+                ItemDrag?.Invoke(this, e);
+            }
+        }
 
         /// <summary>
         /// Raises the NodeMouseClick event.
         /// </summary>
         /// <param name="e">An TreeNodeMouseClickEventArgs that contains the event data.</param>
-        protected virtual void OnNodeMouseClick(TreeNodeMouseClickEventArgs e) => NodeMouseClick?.Invoke(this, e);
+        /// <remarks>If overriden directly, will fire when palette changes</remarks>
+        protected virtual void OnNodeMouseClick(TreeNodeMouseClickEventArgs e)
+        {
+            if (!_isRecreating)
+            {
+                NodeMouseClick?.Invoke(this, e);
+            }
+        }
 
         /// <summary>
         /// Raises the NodeMouseDoubleClick event.
         /// </summary>
         /// <param name="e">An TreeNodeMouseClickEventArgs that contains the event data.</param>
-        protected virtual void OnNodeMouseDoubleClick(TreeNodeMouseClickEventArgs e) => NodeMouseDoubleClick?.Invoke(this, e);
+        /// <remarks>If overriden directly, will fire when palette changes</remarks>
+        protected virtual void OnNodeMouseDoubleClick(TreeNodeMouseClickEventArgs e)
+        {
+            if (!_isRecreating)
+            {
+                NodeMouseDoubleClick?.Invoke(this, e);
+            }
+        }
 
         /// <summary>
         /// Raises the NodeMouseHover event.
         /// </summary>
         /// <param name="e">An TreeNodeMouseHoverEventArgs that contains the event data.</param>
-        protected virtual void OnNodeMouseHover(TreeNodeMouseHoverEventArgs e) => NodeMouseHover?.Invoke(this, e);
+        /// <remarks>If overriden directly, will fire when palette changes</remarks>
+        protected virtual void OnNodeMouseHover(TreeNodeMouseHoverEventArgs e)
+        {
+            if (!_isRecreating)
+            {
+                NodeMouseHover?.Invoke(this, e);
+            }
+        }
 
         /// <summary>
         /// Raises the RightToLeftLayoutChanged event.
         /// </summary>
         /// <param name="e">An EventArgs that contains the event data.</param>
-        protected virtual void OnRightToLeftLayoutChanged(EventArgs e) => RightToLeftLayoutChanged?.Invoke(this, e);
+        /// <remarks>If overriden directly, will fire when palette changes</remarks>
+        protected virtual void OnRightToLeftLayoutChanged(EventArgs e)
+        {
+            if (!_isRecreating)
+            {
+                RightToLeftLayoutChanged?.Invoke(this, e);
+            }
+        }
+
         #endregion
 
         #region Protected Override

--- a/Source/Krypton Components/Krypton.Toolkit/General/PlatformInvoke.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/PlatformInvoke.cs
@@ -19,6 +19,7 @@
 // ReSharper disable BuiltInTypeReferenceStyle
 // ReSharper disable ClassNeverInstantiated.Global
 using System.Runtime.Versioning;
+using System.Security.Permissions;
 
 #pragma warning disable 649
 
@@ -1747,6 +1748,10 @@ namespace Krypton.Toolkit
             // </summary>
             INITMENUPOPUP = 0x0117,
             // <summary>
+            // Windows uses WM_SYSTIMER for internal actions like scrolling.
+            // </summary>
+            SYSTIMER = 0x0118,
+            // <summary>
             // The WM_MENUSELECT message is sent to a menu's owner window when the user selects a menu item.
             // </summary>
             MENUSELECT = 0x011F,
@@ -2221,10 +2226,18 @@ namespace Krypton.Toolkit
             // The WM_CPL_LAUNCHED message is sent when a Control Panel application, started by the WM_CPL_LAUNCH message, has closed. The WM_CPL_LAUNCHED message is sent to the window identified by the wParam parameter of the WM_CPL_LAUNCH message that started the application.
             // </summary>
             CPL_LAUNCHED = USER + 0x1001,
-            // <summary>
-            // WM_SYSTIMER is a well-known yet still undocumented message. Windows uses WM_SYSTIMER for internal actions like scrolling.
-            // </summary>
-            SYSTIMER = 0x118,
+            // if ( msg.Msg == PI.WM_.OCM_NOTIFY )
+            //{
+            //    PI.NMHEADER h2 = (PI.NMHEADER)m.GetLParam(typeof(PI.NMHEADER));
+            //      if (h2.nmhdr.hwndFrom == Handle)
+            //    if ( (h2.nmhdr.code == (int)Win32.NM.NM_CUSTOMDRAW))
+            //    {
+            //        Win32.NMCUSTOMDRAW nmcd = (Win32.NMCUSTOMDRAW)msg.GetLParam( typeof( Win32.NMCUSTOMDRAW ) );
+            //        msg.Result = (IntPtr)OnCustomDraw( (int)msg.WParam.ToInt32(), ref nmcd );
+            //        messageHandled = true;
+            //    }
+            //}
+            OCM_NOTIFY = 0x0204E,   // https://wiki.winehq.org/List_Of_Windows_Messages
 
 
             // Following are the ShellProc messages via RegisterShellHookWindow 
@@ -2687,7 +2700,7 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
         internal static IntPtr MakeLParam(int LoWord, int HiWord) => new((long)((HiWord << 16) | (LoWord & 0xffff)));
 
         internal static IntPtr MakeWParam(int LoWord, int HiWord) => new((long)((HiWord << 16) | (LoWord & 0xffff)));
-
+        
         /// <summary>
         /// Is the specified key currently pressed down.
         /// </summary>
@@ -3902,6 +3915,40 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
         #endregion Static Comdlg32
 
         #region Structures
+        [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Auto)]
+        public struct LVFINDINFO {
+            public int      flags;
+            public string   psz;
+            public IntPtr   lParam;
+            public int      ptX; // was POINT pt
+            public int      ptY;
+            public int      vkDirection;
+        }
+        
+        [StructLayout(LayoutKind.Sequential)]
+        public struct NMLVFINDITEM
+        {
+            public NMHDR hdr;
+            public int iStart;
+            public LVFINDINFO lvfi;
+        }
+    
+        [StructLayout(LayoutKind.Sequential)]
+        public struct NMHDR
+        {
+            public IntPtr hwndFrom;
+            public IntPtr idFrom; //This is declared as UINT_PTR in winuser.h
+            public int code;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public class NMHEADER {
+            public NMHDR nmhdr;
+            public int iItem = 0;
+            public int iButton = 0;
+            public IntPtr pItem = IntPtr.Zero;    // HDITEM*
+        }
+
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
         public struct TV_ITEM
         {


### PR DESCRIPTION
…creation finished, or when recreating due to palette changes)

#777

![image](https://user-images.githubusercontent.com/2418812/179358324-51e613eb-a54b-41b8-8eae-3b8cdbe1ed6d.png)
