### PR TITLE
* New `Collapse` & `Expand` strings

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -5,7 +5,8 @@
 =======
 
 ## 2022-11-xx - Build 2211 - November 2022
-* Removed Visual Studio 2019 solution (*.sln) files, as 2022 is considered to be stable enougth
+* New `Collapse` & `Expand` strings for use in expandable footers, or in other custom situations
+* Removed Visual Studio 2019 solution (*.sln) files, as 2022 is considered to be stable enough
 * Resolved [#777](https://github.com/Krypton-Suite/Standard-Toolkit/issues/777), KryptonTreeView can throw exception on changing palette via KryptonManager. Note: unknown can still be set when deleting selected node
 * Resolved [#774](https://github.com/Krypton-Suite/Standard-Toolkit/issues/774), `KryptonTableLayoutPanel` throwing exception when a form is minimized (thanks to [ZXBITLES](https://github.com/ZXBITLES))
 * New `UseCustomPreviewShape` property for `KryptonColorButton` to allow configuration of a custom colour preview shape

--- a/Source/Krypton Components/Krypton.Toolkit/General/GlobalStrings.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/GlobalStrings.cs
@@ -37,6 +37,10 @@ namespace Krypton.Toolkit
         // NET 6 & newer
         private const string DEFAULT_CONTINUE = "Co&ntinue";
         private const string DEFAULT_TRY_AGAIN = "&Try Again";
+
+        // Custom
+        private const string DEFAULT_COLLAPSE = "C&ollapse";
+        private const string DEFAULT_EXPAND = "E&xpand";
         
         #endregion
 
@@ -79,7 +83,9 @@ namespace Krypton.Toolkit
                                  Today.Equals(DEFAULT_TODAY) &&
                                  Help.Equals(DEFAULT_HELP) &&
                                  Continue.Equals(DEFAULT_CONTINUE) &&
-                                 TryAgain.Equals(DEFAULT_TRY_AGAIN);
+                                 TryAgain.Equals(DEFAULT_TRY_AGAIN) &&
+                                 Collapse.Equals(DEFAULT_COLLAPSE) &&
+                                 Expand.Equals(DEFAULT_EXPAND);
 
         /// <summary>
         /// Reset all strings to default values.
@@ -194,7 +200,7 @@ namespace Krypton.Toolkit
         public string Today { get; set; }
 
         /// <summary>
-        /// Gets and sets the Close string used in calendars.
+        /// Gets and sets the Help string used in message box buttons.
         /// </summary>
         [Localizable(true)]
         [Category(@"Visuals")]
@@ -204,7 +210,7 @@ namespace Krypton.Toolkit
         public string Help { get; set; }
 
         /// <summary>
-        /// Gets and sets the Continue string used in calendars.
+        /// Gets and sets the Continue string used in message box buttons.
         /// </summary>
         [Localizable(true)]
         [Category(@"Visuals")]
@@ -213,13 +219,27 @@ namespace Krypton.Toolkit
         public string Continue { get; set; }
 
         /// <summary>
-        /// Gets and sets the Try Again string used in calendars.
+        /// Gets and sets the Try Again string used in message box buttons.
         /// </summary>
         [Localizable(true)]
         [Category(@"Visuals")]
         [Description(@"Try Again string used for Message Box Buttons.")]
         [DefaultValue(DEFAULT_TRY_AGAIN)]
         public string TryAgain { get; set; }
+
+        /// <summary>Gets or sets the collapse string used in expandable footers.</summary>
+        [Localizable(true)]
+        [Category(@"Visuals")]
+        [Description(@"Collapse string used in expandable footers.")]
+        [DefaultValue(DEFAULT_COLLAPSE)]
+        public string Collapse { get; set; }
+
+        /// <summary>Gets or sets the expand string used in expandable footers.</summary>
+        [Localizable(true)]
+        [Category(@"Visuals")]
+        [Description(@"Expand string used in expandable footers.")]
+        [DefaultValue(DEFAULT_EXPAND)]
+        public string Expand { get; set; }
 #endregion
     }
 }


### PR DESCRIPTION
* New `Collapse` & `Expand` strings for use in expandable footers, or in other custom situations

![image](https://user-images.githubusercontent.com/949607/183281237-c3075db4-4681-4705-83fb-717402e3f88a.png)
