### PR TITLE
- Make sure that the `Padding` is created before the control initialises with it

### DIFF
--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupButton.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupButton.cs
@@ -65,8 +65,8 @@ namespace Krypton.Ribbon
             _needPaint = needPaint;
             _currentSize = GroupButton.ItemSizeCurrent;
 
-            _largeImagePadding = new Padding((int)(30 * FactorDpiX), (int)(2 * FactorDpiY), (int)(3 * FactorDpiX), (int)(3 * FactorDpiY));
-            _smallImagePadding = new Padding((int)(30 * FactorDpiX), (int)(3 * FactorDpiY), (int)(3 * FactorDpiX), (int)(3 * FactorDpiY));
+            _largeImagePadding = new Padding((int)(3 * FactorDpiX), (int)(2 * FactorDpiY), (int)(3 * FactorDpiX), (int)(3 * FactorDpiY));
+            _smallImagePadding = new Padding((int)(3 * FactorDpiX), (int)(3 * FactorDpiY), (int)(3 * FactorDpiX), (int)(3 * FactorDpiY));
 
 
             // Associate this view with the source component (required for design time selection)

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupButton.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupButton.cs
@@ -65,6 +65,10 @@ namespace Krypton.Ribbon
             _needPaint = needPaint;
             _currentSize = GroupButton.ItemSizeCurrent;
 
+            _largeImagePadding = new Padding((int)(30 * FactorDpiX), (int)(2 * FactorDpiY), (int)(3 * FactorDpiX), (int)(3 * FactorDpiY));
+            _smallImagePadding = new Padding((int)(30 * FactorDpiX), (int)(3 * FactorDpiY), (int)(3 * FactorDpiX), (int)(3 * FactorDpiY));
+
+
             // Associate this view with the source component (required for design time selection)
             Component = GroupButton;
 
@@ -80,8 +84,6 @@ namespace Krypton.Ribbon
 
             // Hook into changes in the ribbon button definition
             GroupButton.PropertyChanged += OnButtonPropertyChanged;
-            _largeImagePadding = new Padding((int)(3 * FactorDpiX), (int)(2 * FactorDpiY), (int)(3 * FactorDpiX), (int)(3 * FactorDpiY));
-            _smallImagePadding = new Padding((int)(3 * FactorDpiX), (int)(3 * FactorDpiY), (int)(3 * FactorDpiX), (int)(3 * FactorDpiY));
         }
 
         /// <summary>


### PR DESCRIPTION
#808
There is now pixel space "Around" the image:
![image](https://user-images.githubusercontent.com/2418812/198869378-28c12d60-65d5-4f39-8ffa-4741dd1a53a8.png)

Note:

What are these warnings??
![image](https://user-images.githubusercontent.com/2418812/198869429-d5365574-a59c-4451-b912-4ca5527a47b7.png)

