### PR TITLE
- Implement Text rendering hint for "Cue Text"

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,9 @@
 <!--* Added the ability to control the `CueHint` values through `KryptonPalette`-->
 
 =======
+## 2023-11-xx - Build 2312 - December 2023
+* Implemented [#535](https://github.com/Krypton-Suite/Standard-Toolkit/issues/535), [Feature Request]: A way to set the textbox / combobox / RichTextBox Cue font Rendering hint style
+
 
 ## 2023-11-xx - Build 2311 - November 2023
 * Applied toolbox images to `KryptonColorDialog`, `KryptonFontDialog` & `KryptonPrintDialog`

--- a/Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln
+++ b/Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln
@@ -89,6 +89,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Licenses", "Licenses", "{80
 		..\..\Documents\License\License.md = ..\..\Documents\License\License.md
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestForm", "TestForm\TestForm.csproj", "{6CFB046A-0239-4395-BA64-C4DBDD19AFE4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Canary|Any CPU = Canary|Any CPU
@@ -148,6 +150,16 @@ Global
 		{44D3FB26-8CF6-45E1-8036-93F111EC3287}.Nightly|Any CPU.Build.0 = Nightly|Any CPU
 		{44D3FB26-8CF6-45E1-8036-93F111EC3287}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{44D3FB26-8CF6-45E1-8036-93F111EC3287}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6CFB046A-0239-4395-BA64-C4DBDD19AFE4}.Canary|Any CPU.ActiveCfg = Debug|Any CPU
+		{6CFB046A-0239-4395-BA64-C4DBDD19AFE4}.Canary|Any CPU.Build.0 = Debug|Any CPU
+		{6CFB046A-0239-4395-BA64-C4DBDD19AFE4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6CFB046A-0239-4395-BA64-C4DBDD19AFE4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6CFB046A-0239-4395-BA64-C4DBDD19AFE4}.Installer|Any CPU.ActiveCfg = Debug|Any CPU
+		{6CFB046A-0239-4395-BA64-C4DBDD19AFE4}.Installer|Any CPU.Build.0 = Debug|Any CPU
+		{6CFB046A-0239-4395-BA64-C4DBDD19AFE4}.Nightly|Any CPU.ActiveCfg = Debug|Any CPU
+		{6CFB046A-0239-4395-BA64-C4DBDD19AFE4}.Nightly|Any CPU.Build.0 = Debug|Any CPU
+		{6CFB046A-0239-4395-BA64-C4DBDD19AFE4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6CFB046A-0239-4395-BA64-C4DBDD19AFE4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/CheckBoxController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/CheckBoxController.cs
@@ -13,7 +13,7 @@
 namespace Krypton.Toolkit
 {
     /// <summary>
-    /// Controller used to manage keyboard and mouse interaction withe a check box.
+    /// Controller used to manage keyboard and mouse interaction with a check box.
     /// </summary>
     public class CheckBoxController : GlobalId,
                                       IMouseController,

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -1196,6 +1196,8 @@ namespace Krypton.Toolkit
             set => StateCommon.ComboBox.Border.Rounding = value;
         }
 
+        private bool ShouldSerializeCornerRoundingRadius() => StateCommon.ComboBox.Border.Rounding != -1;
+
         /// <summary>
         /// Gets access to the common textbox appearance entries that other states can override.
         /// </summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteCueHintText.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteCueHintText.cs
@@ -19,6 +19,7 @@ namespace Krypton.Toolkit
     {
         #region Identity
         internal PaletteRelativeAlign _shortTextV;
+        private PaletteTextHint _contentTextHint;
 
         /// <summary>
         /// Initialize a new instance of the PaletteCueHintText class.
@@ -30,6 +31,7 @@ namespace Krypton.Toolkit
             _padding = Padding.Empty;
             _shortTextV = PaletteRelativeAlign.Center;
             _shortTextH = PaletteRelativeAlign.Near;
+            _contentTextHint = PaletteTextHint.AntiAlias;
         }
 
         #endregion
@@ -49,6 +51,38 @@ namespace Krypton.Toolkit
         /// </summary>
         private void ResetCueHintText() => CueHintText = string.Empty;
 
+        #region Hint
+        /// <summary>
+        /// Gets the text rendering hint for the text.
+        /// </summary>
+        [KryptonPersist(false)]
+        [Category(@"Visuals")]
+        [Description(@"Text rendering hint for the content text. (No `Inherit`)")]
+        [DefaultValue(typeof(PaletteTextHint), "AntiAlias")]
+        [RefreshProperties(RefreshProperties.All)]
+        public virtual PaletteTextHint Hint
+        {
+            get => _contentTextHint;
+
+            set
+            {
+                if (_contentTextHint != value)
+                {
+                    _contentTextHint = value == PaletteTextHint.Inherit ? PaletteTextHint.AntiAlias : value;
+                    PerformNeedPaint(true);
+                }
+            }
+        }
+
+        private bool ShouldSerializeHint() => _contentTextHint != PaletteTextHint.Inherit;
+
+        /// <summary>
+        /// Resets the Image property to its default value.
+        /// </summary>
+        private void ResetHint() => _contentTextHint = PaletteTextHint.Inherit;
+
+        #endregion
+
 
         public override bool IsDefault =>
              (Font == null) &&
@@ -56,7 +90,8 @@ namespace Krypton.Toolkit
              Padding.Equals(Padding.Empty)      // <- This is not the same as the base
              && (TextH == PaletteRelativeAlign.Near) // <- This is not the same as the base
              && string.IsNullOrWhiteSpace(CueHintText)
-             && (_shortTextV == PaletteRelativeAlign.Center);
+             && (_shortTextV == PaletteRelativeAlign.Center)
+            && !ShouldSerializeHint();
 
         /// <summary>
         /// Gets the actual content draw value.
@@ -89,8 +124,8 @@ namespace Krypton.Toolkit
 
         internal void PerformPaint(VisualControlBase textBox, Graphics g, PI.RECT rect, SolidBrush backBrush)
         {
-            g.SmoothingMode = SmoothingMode.HighQuality;
-            g.TextRenderingHint = TextRenderingHint.AntiAlias;
+            using var old = new GraphicsHint( g, PaletteGraphicsHint.HighQuality);
+            using var old1 = new GraphicsTextHint( g, CommonHelper.PaletteTextHintToRenderingHint( _contentTextHint) );
             // Define the string formatting requirements
             var stringFormat = new StringFormat
             {


### PR DESCRIPTION
- Implement Text rendering hint for "Cue Text"
- Also, Add missing `ShouldSerializeCornerRoundingRadius`

#535

![image](https://user-images.githubusercontent.com/2418812/205440465-34008909-e4aa-452e-b98a-d38de1822c14.png)

Note: @Wagnerp The alpha examples no longer build, due to changes in the toolkit (e.g. MessageBox icons etc.)
