### PR TITLE
Alpha 728 m box states

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -5,6 +5,9 @@
 =======
 
 ## 2023-11-xx - Build 2311 - November 2023
+* Resolved [#867](https://github.com/Krypton-Suite/Standard-Toolkit/issues/867), KryptonMessageBox does not show help button
+* Resolved [#728](https://github.com/Krypton-Suite/Standard-Toolkit/issues/728), 
+Bring MessageBox States inline with latest .Net 6
 * Resolved [#861](https://github.com/Krypton-Suite/Standard-Toolkit/issues/861), Ribbon QAT Button downscaled when disabling HiDPI
 * Implemented [#854](https://github.com/Krypton-Suite/Standard-Toolkit/issues/854), Please remove "2019" from the build sequence etc. 
 * Resolved [#848](https://github.com/Krypton-Suite/Standard-Toolkit/issues/848), KryptonTreeView Font Issues

--- a/README.md
+++ b/README.md
@@ -124,14 +124,19 @@ Follow the links to see the different objects and layouts that this framework al
 =======
 
 # Breaking Changes
+## V80.## (2023-11-xx - Build 2311 - November 2023)
+There are list of changes that have occurred during the development of the V70.## version
+### KryptonMessageBoxButtons
+- https://github.com/Krypton-Suite/Standard-Toolkit/issues/728:  
+Bring MessageBox States inline with latest .Net 6 by using a new `KryptonMessageBoxButtons` type, which is effectively the same as .Net6 enum version of `MessageBoxButtons` but backward compatible with .net4.6.x onwards
+
+## V70.## (2022-11-08 - Build 2211 - November 2022)
 There are list of changes that have occurred during the development of the V70.## version
 
 ### Ribbon Tooltips
 - https://github.com/Krypton-Suite/Standard-Toolkit/issues/382
 - https://github.com/Krypton-Suite/Standard-Toolkit/issues/511
 ![][image_ref_tnqwpvc0]### Ribbon Tooltips
-
-## Be Aware
 
 ### `dpiAware`
 If you are getting scaling problems in high dpi monitors, then please add an application manifest to your MainForm application, and uncomment the section that covers the `dpiAware` setting.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonButton.cs
@@ -12,9 +12,6 @@
 
 // ReSharper disable MemberCanBePrivate.Global
 
-using System.Runtime.InteropServices;
-using System.Windows.Forms;
-
 namespace Krypton.Toolkit
 {
     /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonButton.cs
@@ -12,6 +12,9 @@
 
 // ReSharper disable MemberCanBePrivate.Global
 
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+
 namespace Krypton.Toolkit
 {
     /// <summary>
@@ -576,7 +579,24 @@ namespace Krypton.Toolkit
             if (owner != null)
             {
                 // Update owner with our dialog result setting
-                owner.DialogResult = DialogResult;
+                try
+                {
+                    owner.DialogResult = DialogResult;
+                }
+                catch (InvalidEnumArgumentException )
+                {
+                    // Is it https://github.com/Krypton-Suite/Standard-Toolkit/issues/728
+                    if (owner is KryptonMessageBoxForm)
+                    {
+                        // need to gain access to `dialogResult` and set it forcefully
+                        FieldInfo fi = typeof(Form).GetField("dialogResult", BindingFlags.NonPublic | BindingFlags.Instance);
+                        fi.SetValue(owner, DialogResult);
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
             }
 
             // Let base class fire standard event

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonColorButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonColorButton.cs
@@ -1287,7 +1287,7 @@ namespace Krypton.Toolkit
             HookContextMenuEvents(_kryptonContextMenu.Items, false);
         }
 
-        void OnButtonSelect(object sender, MouseEventArgs e)
+        private void OnButtonSelect(object sender, MouseEventArgs e)
         {
             // Take the focus if allowed
             if (CanFocus)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownColumn.cs
@@ -29,10 +29,8 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the KryptonDataGridViewDomainUpDownColumn class.
         /// </summary>
         public KryptonDataGridViewDomainUpDownColumn()
-            : base(new KryptonDataGridViewDomainUpDownCell())
-        {
+            : base(new KryptonDataGridViewDomainUpDownCell()) =>
             Items = new StringCollection();
-        }
 
         /// <summary>
         /// Returns a standard compact string representation of the column.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxColumn.cs
@@ -31,10 +31,8 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the KryptonDataGridViewTextBoxColumn class.
         /// </summary>
         public KryptonDataGridViewTextBoxColumn()
-            : base(new KryptonDataGridViewTextBoxCell())
-        {
+            : base(new KryptonDataGridViewTextBoxCell()) =>
             SortMode = DataGridViewColumnSortMode.Automatic;
-        }
 
         /// <summary>
         /// Returns a String that represents the current Object.
@@ -78,7 +76,7 @@ namespace Krypton.Toolkit
 
             base.Dispose(disposing);
         }
-        
+
         #endregion
 
         #region Public

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDropButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDropButton.cs
@@ -915,7 +915,7 @@ namespace Krypton.Toolkit
             ContextMenuClosed();
         }
 
-        void OnButtonSelect(object sender, MouseEventArgs e)
+        private void OnButtonSelect(object sender, MouseEventArgs e)
         {
             // Take the focus if allowed
             if (CanFocus)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonFontDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonFontDialog.cs
@@ -104,7 +104,7 @@ namespace Krypton.Toolkit
         //    //return ret;// || _commonDialogHandler._T;
         //}
 
-        const int CLR_COMBOBOX_ID = 1139;
+        private const int CLR_COMBOBOX_ID = 1139;
         private IntPtr clrComboBoxHwnd;
         /// <inheritdoc />
         protected override IntPtr HookProc(IntPtr hWnd, int msg, IntPtr wparam, IntPtr lparam)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMessageBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMessageBox.cs
@@ -33,7 +33,7 @@ namespace Krypton.Toolkit
         /// <param name="showCtrlCopy">Show extraText in title. If null(default) then only when Warning or Error icon is used.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
         public static DialogResult Show(string text, string caption, bool? showCtrlCopy = null) =>
-            InternalShow(null, text, caption, MessageBoxButtons.OK, KryptonMessageBoxIcon.None,
+            InternalShow(null, text, caption, KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.None,
                 KryptonMessageBoxDefaultButton.Button4,
                 0, null, showCtrlCopy, null, null, @"", null);
 
@@ -44,7 +44,7 @@ namespace Krypton.Toolkit
         /// <param name="showCtrlCopy">Show extraText in title. If null(default) then only when Warning or Error icon is used.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
         public static DialogResult Show(string text, bool? showCtrlCopy = null) =>
-            InternalShow(null, text, @"", MessageBoxButtons.OK, KryptonMessageBoxIcon.None,
+            InternalShow(null, text, @"", KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.None,
                 KryptonMessageBoxDefaultButton.Button4,
                 0, null, showCtrlCopy, false, null, @"", null);
 
@@ -56,7 +56,7 @@ namespace Krypton.Toolkit
         /// <param name="showCtrlCopy">Show extraText in title. If null(default) then only when Warning or Error icon is used.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
         public static DialogResult Show(IWin32Window owner, string text, bool? showCtrlCopy = null) =>
-            InternalShow(owner, text, @"", MessageBoxButtons.OK, KryptonMessageBoxIcon.None,
+            InternalShow(owner, text, @"", KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.None,
                 KryptonMessageBoxDefaultButton.Button4,
                 0, null, showCtrlCopy, false, null, @"", null);
 
@@ -69,7 +69,7 @@ namespace Krypton.Toolkit
         /// <param name="showCtrlCopy">Show extraText in title. If null(default) then only when Warning or Error icon is used.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
         public static DialogResult Show(IWin32Window owner, string text, string caption, bool? showCtrlCopy = null) =>
-            InternalShow(owner, text, caption, MessageBoxButtons.OK, KryptonMessageBoxIcon.None,
+            InternalShow(owner, text, caption, KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.None,
                 KryptonMessageBoxDefaultButton.Button4,
                 0, null, showCtrlCopy, false, null, @"", null);
 
@@ -78,12 +78,12 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="text">The text to display in the message box.</param>
         /// <param name="caption" default="string.Empty">The text to display in the title bar of the message box. default="string.Empty"</param>
-        /// <param name="buttons">One of the System.Windows.Forms.MessageBoxButtons values that specifies which buttons to display in the message box.</param>
+        /// <param name="buttons">One of the System.Windows.Forms.KryptonMessageBoxButtons values that specifies which buttons to display in the message box.</param>
         /// <param name="showCtrlCopy">Show extraText in title. If null(default) then only when Warning or Error icon is used.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
-        public static DialogResult Show(string text, string caption, MessageBoxButtons buttons,
+        public static DialogResult Show(string text, string caption, KryptonMessageBoxButtons buttons,
             bool? showCtrlCopy = null) =>
-                                       InternalShow(null, text, caption, buttons, KryptonMessageBoxIcon.None, 
+                                       InternalShow(null, text, caption, buttons, KryptonMessageBoxIcon.None,
                                            KryptonMessageBoxDefaultButton.Button1, 0,
                                            new HelpInfo(@"", 0, null), showCtrlCopy,
                                            null, null, @"", null);
@@ -93,7 +93,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="text">The text to display in the message box.</param>
         /// <param name="caption" default="string.Empty">The text to display in the title bar of the message box. default="string.Empty"</param>
-        /// <param name="buttons">One of the System.Windows.Forms.MessageBoxButtons values that specifies which buttons to display in the message box.</param>
+        /// <param name="buttons">One of the System.Windows.Forms.KryptonMessageBoxButtons values that specifies which buttons to display in the message box.</param>
         /// <param name="icon" >One of the KryptonMessageBoxIcon values that specifies which icon to display in the message box.</param>
         /// <param name="defaultButton" default="KryptonMessageBoxDefaultButton.Button4">One of the KryptonMessageBoxDefaultButton values that specifies the default button for the message box.</param>
         /// <param name="options" default="0">One of the System.Windows.Forms.MessageBoxOptions values that specifies which display and association options will be used for the message box. You may pass in 0 if you wish to use the defaults.</param>
@@ -106,7 +106,7 @@ namespace Krypton.Toolkit
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
         public static DialogResult Show(string text,
             string caption,
-            MessageBoxButtons buttons,
+            KryptonMessageBoxButtons buttons,
             KryptonMessageBoxIcon icon,
             KryptonMessageBoxDefaultButton defaultButton = KryptonMessageBoxDefaultButton.Button4,
             MessageBoxOptions options = 0,
@@ -115,10 +115,10 @@ namespace Krypton.Toolkit
             bool? showHelpButton = null,
             bool? showActionButton = null,
             string actionButtonText = @"",
-            KryptonCommand actionButtonCommand = null) 
+            KryptonCommand actionButtonCommand = null)
             =>
                 InternalShow(null, text, caption, buttons, icon, defaultButton, options,
-                             displayHelpButton ? new HelpInfo() : null, showCtrlCopy, 
+                             displayHelpButton ? new HelpInfo() : null, showCtrlCopy,
                              showHelpButton, showActionButton,
                              actionButtonText, actionButtonCommand);
 
@@ -129,7 +129,7 @@ namespace Krypton.Toolkit
         /// <param name="owner">Owner of the modal dialog box.</param>
         /// <param name="text">The text to display in the message box.</param>
         /// <param name="caption">The text to display in the title bar of the message box. default="string.Empty"</param>
-        /// <param name="buttons">One of the System.Windows.Forms.MessageBoxButtons values that specifies which buttons to display in the message box.</param>
+        /// <param name="buttons">One of the System.Windows.Forms.KryptonMessageBoxButtons values that specifies which buttons to display in the message box.</param>
         /// <param name="icon">One of the KryptonMessageBoxIcon values that specifies which icon to display in the message box.</param>
         /// <param name="defaultButton" default="KryptonMessageBoxDefaultButton.Button4">One of the KryptonMessageBoxDefaultButton values that specifies the default button for the message box.</param>
         /// <param name="options" default="0">One of the System.Windows.Forms.MessageBoxOptions values that specifies which display and association options will be used for the message box. You may pass in 0 if you wish to use the defaults.</param>
@@ -140,27 +140,27 @@ namespace Krypton.Toolkit
         /// <param name="actionButtonText">The action button text.</param>
         /// <param name="actionButtonCommand">The <see cref="KryptonCommand"/> attached to the action button.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
-        public static DialogResult Show(IWin32Window owner, string text, 
-            string caption, 
-            MessageBoxButtons buttons, 
-            KryptonMessageBoxIcon icon, 
-            KryptonMessageBoxDefaultButton defaultButton = KryptonMessageBoxDefaultButton.Button4, 
-            MessageBoxOptions options = 0, 
+        public static DialogResult Show(IWin32Window owner, string text,
+            string caption,
+            KryptonMessageBoxButtons buttons,
+            KryptonMessageBoxIcon icon,
+            KryptonMessageBoxDefaultButton defaultButton = KryptonMessageBoxDefaultButton.Button4,
+            MessageBoxOptions options = 0,
             bool displayHelpButton = false,
             bool? showCtrlCopy = null,
             bool? showHelpButton = null,
             bool? showActionButton = null,
             string actionButtonText = @"",
-            KryptonCommand actionButtonCommand = null) 
+            KryptonCommand actionButtonCommand = null)
             =>
                 InternalShow(owner, text, caption, buttons, icon, defaultButton, options,
-                             displayHelpButton ? new HelpInfo() : null, showCtrlCopy, 
+                             displayHelpButton ? new HelpInfo() : null, showCtrlCopy,
                              showHelpButton, showActionButton, actionButtonText,
                              actionButtonCommand);
 
         /// <param name="text">The text to display in the message box.</param>
         /// <param name="caption" >The text to display in the title bar of the message box. default="string.Empty"</param>
-        /// <param name="buttons" >One of the System.Windows.Forms.MessageBoxButtons values that specifies which buttons to display in the message box.</param>
+        /// <param name="buttons" >One of the System.Windows.Forms.KryptonMessageBoxButtons values that specifies which buttons to display in the message box.</param>
         /// <param name="icon" >One of the KryptonMessageBoxIcon values that specifies which icon to display in the message box.</param>
         /// <param name="defaultButton" >One of the KryptonMessageBoxDefaultButton values that specifies the default button for the message box.</param>
         /// <param name="options" >One of the System.Windows.Forms.MessageBoxOptions values that specifies which display and association options will be used for the message box. You may pass in 0 if you wish to use the defaults.</param>
@@ -173,7 +173,7 @@ namespace Krypton.Toolkit
         /// <param name="actionButtonText">The action button text.</param>
         /// <param name="actionButtonCommand">The <see cref="KryptonCommand"/> attached to the action button.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
-        public static DialogResult Show(string text, string caption, MessageBoxButtons buttons, KryptonMessageBoxIcon icon, KryptonMessageBoxDefaultButton defaultButton, 
+        public static DialogResult Show(string text, string caption, KryptonMessageBoxButtons buttons, KryptonMessageBoxIcon icon, KryptonMessageBoxDefaultButton defaultButton,
             MessageBoxOptions options, string helpFilePath, HelpNavigator navigator, object param, bool? showCtrlCopy = null,
             bool? showHelpButton = null,
             bool? showActionButton = null,
@@ -190,7 +190,7 @@ namespace Krypton.Toolkit
         /// <param name="owner">Owner of the modal dialog box.</param>
         /// <param name="text">The text to display in the message box.</param>
         /// <param name="caption">The text to display in the title bar of the message box.</param>
-        /// <param name="buttons">One of the System.Windows.Forms.MessageBoxButtons values that specifies which buttons to display in the message box.</param>
+        /// <param name="buttons">One of the System.Windows.Forms.KryptonMessageBoxButtons values that specifies which buttons to display in the message box.</param>
         /// <param name="icon">One of the KryptonMessageBoxIcon values that specifies which icon to display in the message box.</param>
         /// <param name="defaultButton">One of the KryptonMessageBoxDefaultButton values that specifies the default button for the message box.</param>
         /// <param name="options">One of the System.Windows.Forms.MessageBoxOptions values that specifies which display and association options will be used for the message box. You may pass in 0 if you wish to use the defaults.</param>
@@ -203,14 +203,14 @@ namespace Krypton.Toolkit
         /// <param name="actionButtonText">The action button text.</param>
         /// <param name="actionButtonCommand">The <see cref="KryptonCommand"/> attached to the action button.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
-        public static DialogResult Show(IWin32Window owner, string text, string caption, MessageBoxButtons buttons, KryptonMessageBoxIcon icon, KryptonMessageBoxDefaultButton defaultButton,
+        public static DialogResult Show(IWin32Window owner, string text, string caption, KryptonMessageBoxButtons buttons, KryptonMessageBoxIcon icon, KryptonMessageBoxDefaultButton defaultButton,
             MessageBoxOptions options, string helpFilePath, HelpNavigator navigator, object param, bool? showCtrlCopy = null,
             bool? showHelpButton = null,
             bool? showActionButton = null,
             string actionButtonText = @"",
             KryptonCommand actionButtonCommand = null)
             => InternalShow(owner, text, caption, buttons, icon, defaultButton, options,
-                            new HelpInfo(helpFilePath, navigator, param), showCtrlCopy, 
+                            new HelpInfo(helpFilePath, navigator, param), showCtrlCopy,
                             showHelpButton, showActionButton, actionButtonText,
                             actionButtonCommand);
         #endregion
@@ -222,7 +222,7 @@ namespace Krypton.Toolkit
         /// <param name="owner">Owner of the modal dialog box.</param>
         /// <param name="text">The text to display in the message box.</param>
         /// <param name="caption">The text to display in the title bar of the message box.</param>
-        /// <param name="buttons">One of the System.Windows.Forms.MessageBoxButtons values that specifies which buttons to display in the message box.</param>
+        /// <param name="buttons">One of the System.Windows.Forms.KryptonMessageBoxButtons values that specifies which buttons to display in the message box.</param>
         /// <param name="icon">One of the KryptonMessageBoxIcon values that specifies which icon to display in the message box.</param>
         /// <param name="defaultButton">One of the KryptonMessageBoxDefaultButton values that specifies the default button for the message box.</param>
         /// <param name="options">One of the System.Windows.Forms.MessageBoxOptions values that specifies which display and association options will be used for the message box. You may pass in 0 if you wish to use the defaults.</param>
@@ -235,11 +235,11 @@ namespace Krypton.Toolkit
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
         private static DialogResult InternalShow(IWin32Window owner,
                                                  string text, string caption,
-                                                 MessageBoxButtons buttons,
+                                                 KryptonMessageBoxButtons buttons,
                                                  KryptonMessageBoxIcon icon,
                                                  KryptonMessageBoxDefaultButton defaultButton,
                                                  MessageBoxOptions options,
-                                                 HelpInfo helpInfo, bool? showCtrlCopy, 
+                                                 HelpInfo helpInfo, bool? showCtrlCopy,
                                                  bool? showHelpButton,
                                                  bool? showActionButton, string actionButtonText,
                                                  KryptonCommand actionButtonCommand)
@@ -292,7 +292,7 @@ namespace Krypton.Toolkit
 
         #endregion
 
-        
+
         #endregion
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPalette.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPalette.cs
@@ -324,7 +324,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Cue Hint
-        
+
         /// <summary>Gets or sets the cue hint text.</summary>
         /// <value>The cue hint text.</value>
         [KryptonPersist]
@@ -332,8 +332,8 @@ namespace Krypton.Toolkit
         [Description(@"Cue hint values.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteCueHintText CueHintText { get; }
-        
-        public bool ShouldSerializeCueHintText() => !CueHintText.IsDefault;
+
+        private bool ShouldSerializeCueHintText() => !CueHintText.IsDefault;
 
         #endregion
 
@@ -2070,7 +2070,7 @@ namespace Krypton.Toolkit
 
                     KryptonMessageBox.Show("Reset of palette is completed.",
                                     "Palette Reset",
-                                    MessageBoxButtons.OK);
+                                    KryptonMessageBoxButtons.OK);
                 }
             }
             catch (Exception ex)
@@ -2079,7 +2079,7 @@ namespace Krypton.Toolkit
                 {
                     KryptonMessageBox.Show("Reset failed.\n\n Error:" + ex.Message,
                                     "Palette Reset",
-                                    MessageBoxButtons.OK,
+                                    KryptonMessageBoxButtons.OK,
                                     KryptonMessageBoxIcon.Error);
                 }
             }
@@ -2112,7 +2112,7 @@ namespace Krypton.Toolkit
 
                     KryptonMessageBox.Show("Relevant values have been populated.",
                                     "Populate Values",
-                                    MessageBoxButtons.OK);
+                                    KryptonMessageBoxButtons.OK);
                 }
             }
             catch (Exception ex)
@@ -2121,7 +2121,7 @@ namespace Krypton.Toolkit
                 {
                     KryptonMessageBox.Show("Reset failed.\n\n Error:" + ex.Message,
                                     "Populate Values",
-                                    MessageBoxButtons.OK,
+                                    KryptonMessageBoxButtons.OK,
                                     KryptonMessageBoxIcon.Error);
                 }
             }
@@ -2198,7 +2198,7 @@ namespace Krypton.Toolkit
 
                     KryptonMessageBox.Show($"Import from file '{filename}' completed.",
                                     @"Palette Import",
-                                    MessageBoxButtons.OK, KryptonMessageBoxIcon.Information);
+                                    KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.Information);
                 }
             }
             catch (Exception ex)
@@ -2207,7 +2207,7 @@ namespace Krypton.Toolkit
                 {
                     KryptonMessageBox.Show($"Import from file '{filename}' failed.\n\n Error:{ex.Message}",
                                     @"Palette Import",
-                                    MessageBoxButtons.OK,
+                                    KryptonMessageBoxButtons.OK,
                                     KryptonMessageBoxIcon.Error);
                 }
 
@@ -2254,7 +2254,7 @@ namespace Krypton.Toolkit
 
                     KryptonMessageBox.Show(@"Import completed with success.",
                                     @"Palette Import",
-                                    MessageBoxButtons.OK, KryptonMessageBoxIcon.Information);
+                                    KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.Information);
                 }
             }
             catch (Exception ex)
@@ -2263,7 +2263,7 @@ namespace Krypton.Toolkit
                 {
                     KryptonMessageBox.Show(@"Import has failed.\n\n Error:" + ex.Message,
                                     @"Palette Import",
-                                    MessageBoxButtons.OK,
+                                    KryptonMessageBoxButtons.OK,
                                     KryptonMessageBoxIcon.Error);
                 }
 
@@ -2308,7 +2308,7 @@ namespace Krypton.Toolkit
 
                     KryptonMessageBox.Show(@"Import completed with success.",
                                     @"Palette Import",
-                                    MessageBoxButtons.OK, KryptonMessageBoxIcon.Information);
+                                    KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.Information);
                 }
             }
             catch (Exception ex)
@@ -2317,7 +2317,7 @@ namespace Krypton.Toolkit
                 {
                     KryptonMessageBox.Show(@"Import has failed.\n\n Error:" + ex.Message,
                                     @"Palette Import",
-                                    MessageBoxButtons.OK,
+                                    KryptonMessageBoxButtons.OK,
                                     KryptonMessageBoxIcon.Error);
                 }
 
@@ -2393,7 +2393,7 @@ namespace Krypton.Toolkit
 
                     KryptonMessageBox.Show($"Export to file '{filename}' completed.",
                                     @"Palette Export",
-                                    MessageBoxButtons.OK, KryptonMessageBoxIcon.Information);
+                                    KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.Information);
                 }
             }
             catch (Exception ex)
@@ -2402,7 +2402,7 @@ namespace Krypton.Toolkit
                 {
                     KryptonMessageBox.Show($"Export to file '{filename}' failed.\n\n Error:{ex.Message}",
                                     @"Palette Export",
-                                    MessageBoxButtons.OK,
+                                    KryptonMessageBoxButtons.OK,
                                     KryptonMessageBoxIcon.Error);
                 }
 
@@ -2452,7 +2452,7 @@ namespace Krypton.Toolkit
 
                     KryptonMessageBox.Show(@"Export completed with success.",
                                     @"Palette Export",
-                                    MessageBoxButtons.OK, KryptonMessageBoxIcon.Information);
+                                    KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.Information);
                 }
             }
             catch (Exception ex)
@@ -2461,7 +2461,7 @@ namespace Krypton.Toolkit
                 {
                     KryptonMessageBox.Show(@"Export has failed.\n\n Error:" + ex.Message,
                                     @"Palette Export",
-                                    MessageBoxButtons.OK,
+                                    KryptonMessageBoxButtons.OK,
                                     KryptonMessageBoxIcon.Error);
                 }
 
@@ -2508,7 +2508,7 @@ namespace Krypton.Toolkit
 
                     KryptonMessageBox.Show(@"Export completed with success.",
                                     @"Palette Export",
-                                    MessageBoxButtons.OK, KryptonMessageBoxIcon.Information);
+                                    KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.Information);
                 }
             }
             catch (Exception ex)
@@ -2517,7 +2517,7 @@ namespace Krypton.Toolkit
                 {
                     KryptonMessageBox.Show(@"Export has failed.\n\n Error:" + ex.Message,
                                     @"Palette Export",
-                                    MessageBoxButtons.OK,
+                                    KryptonMessageBoxButtons.OK,
                                     KryptonMessageBoxIcon.Error);
                 }
 
@@ -3653,7 +3653,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        static readonly Dictionary<Type, string> _typeTests = new()
+        private static readonly Dictionary<Type, string> _typeTests = new()
         {
             [typeof(int)] = @"Int", //nameof(Int32),
             [typeof(string)] = nameof(String),

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonProgressBar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonProgressBar.cs
@@ -28,10 +28,7 @@ namespace Krypton.Toolkit
 
         #region Constructor
 
-        public KryptonProgressBar()
-        {
-            _useKrypton = true;
-        }
+        public KryptonProgressBar() => _useKrypton = true;
 
         #endregion
 
@@ -54,7 +51,7 @@ namespace Krypton.Toolkit
 
             base.OnPaint(e);
         }
-        
+
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMessageBoxForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMessageBoxForm.cs
@@ -24,7 +24,7 @@ namespace Krypton.Toolkit
         private readonly bool _showHelpButton;
         private readonly string _text;
         private readonly string _caption;
-        private readonly MessageBoxButtons _buttons;
+        private readonly KryptonMessageBoxButtons _buttons;
         private readonly KryptonMessageBoxIcon _kryptonMessageBoxIcon;
 
         private readonly KryptonMessageBoxDefaultButton _defaultButton;
@@ -51,7 +51,7 @@ namespace Krypton.Toolkit
 
 
         internal KryptonMessageBoxForm(IWin32Window showOwner, string text, string caption,
-                                       MessageBoxButtons buttons, KryptonMessageBoxIcon icon,
+                                       KryptonMessageBoxButtons buttons, KryptonMessageBoxIcon icon,
                                        KryptonMessageBoxDefaultButton defaultButton, MessageBoxOptions options,
                                        HelpInfo helpInfo, bool? showCtrlCopy, bool? showHelpButton,
                                        bool? showActionButton, string actionButtonText,
@@ -66,7 +66,7 @@ namespace Krypton.Toolkit
             _options = options;
             _helpInfo = helpInfo;
             _showOwner = showOwner;
-            _showHelpButton = showHelpButton ?? false;
+            _showHelpButton = showHelpButton ?? (helpInfo!=null);
             _showActionButton = showActionButton ?? false;
             _actionButtonText = actionButtonText ?? string.Empty;
             _actionButtonCommand = actionButtonCommand;
@@ -214,13 +214,13 @@ namespace Krypton.Toolkit
         {
             switch (_buttons)
             {
-                case MessageBoxButtons.OK:
+                case KryptonMessageBoxButtons.OK:
                     _button1.Text = KryptonManager.Strings.OK;
                     _button1.DialogResult = DialogResult.OK;
                     _button1.Visible = true;
                     _button1.Enabled = true;
                     break;
-                case MessageBoxButtons.OKCancel:
+                case KryptonMessageBoxButtons.OKCancel:
                     _button1.Text = KryptonManager.Strings.OK;
                     _button2.Text = KryptonManager.Strings.Cancel;
                     _button1.DialogResult = DialogResult.OK;
@@ -230,7 +230,7 @@ namespace Krypton.Toolkit
                     _button2.Visible = true;
                     _button2.Enabled = true;
                     break;
-                case MessageBoxButtons.YesNo:
+                case KryptonMessageBoxButtons.YesNo:
                     _button1.Text = KryptonManager.Strings.Yes;
                     _button2.Text = KryptonManager.Strings.No;
                     _button1.DialogResult = DialogResult.Yes;
@@ -241,7 +241,7 @@ namespace Krypton.Toolkit
                     _button2.Enabled = true;
                     ControlBox = false;
                     break;
-                case MessageBoxButtons.YesNoCancel:
+                case KryptonMessageBoxButtons.YesNoCancel:
                     _button1.Text = KryptonManager.Strings.Yes;
                     _button2.Text = KryptonManager.Strings.No;
                     _button3.Text = KryptonManager.Strings.Cancel;
@@ -255,7 +255,7 @@ namespace Krypton.Toolkit
                     _button3.Visible = true;
                     _button3.Enabled = true;
                     break;
-                case MessageBoxButtons.RetryCancel:
+                case KryptonMessageBoxButtons.RetryCancel:
                     _button1.Text = KryptonManager.Strings.Retry;
                     _button2.Text = KryptonManager.Strings.Cancel;
                     _button1.DialogResult = DialogResult.Retry;
@@ -265,7 +265,7 @@ namespace Krypton.Toolkit
                     _button2.Visible = true;
                     _button2.Enabled = true;
                     break;
-                case MessageBoxButtons.AbortRetryIgnore:
+                case KryptonMessageBoxButtons.AbortRetryIgnore:
                     _button1.Text = KryptonManager.Strings.Abort;
                     _button2.Text = KryptonManager.Strings.Retry;
                     _button3.Text = KryptonManager.Strings.Ignore;
@@ -280,14 +280,18 @@ namespace Krypton.Toolkit
                     _button3.Enabled = true;
                     ControlBox = false;
                     break;
-#if NET6_0_OR_GREATER
-                case MessageBoxButtons.CancelTryContinue:
+                case KryptonMessageBoxButtons.CancelTryContinue:
                     _button1.Text = KryptonManager.Strings.Cancel;
                     _button2.Text = KryptonManager.Strings.TryAgain;
                     _button3.Text = KryptonManager.Strings.Continue;
                     _button1.DialogResult = DialogResult.Cancel;
+#if NET6_0_OR_GREATER
                     _button2.DialogResult = DialogResult.TryAgain;
                     _button3.DialogResult = DialogResult.Continue;
+#else
+                    _button2.DialogResult = (DialogResult)10;
+                    _button3.DialogResult = (DialogResult)11;
+#endif
                     _button1.Visible = true;
                     _button1.Enabled = true;
                     _button2.Visible = true;
@@ -295,7 +299,6 @@ namespace Krypton.Toolkit
                     _button3.Visible = true;
                     _button3.Enabled = true;
                     break;
-#endif
             }
 
             if (_showActionButton)
@@ -304,13 +307,6 @@ namespace Krypton.Toolkit
                 _button5.Visible = true;
                 _button5.Enabled = true;
                 _button5.KryptonCommand = _actionButtonCommand;
-            }
-            else
-            {
-                _button5.Text = @"B5";
-                _button5.Visible = false;
-                _button5.Enabled = false;
-                _button5.KryptonCommand = null;
             }
 
             // Do we ignore the Alt+F4 on the buttons?
@@ -341,51 +337,30 @@ namespace Krypton.Toolkit
                     AcceptButton = _button3;
                     break;
                 case KryptonMessageBoxDefaultButton.Button4:
-                    if (_showHelpButton)
-                    {
-                        AcceptButton = _button4;
-                    }
-                    else
-                    {
-                        AcceptButton = _button1;
-                    }
+                    AcceptButton = _showHelpButton ? _button4 : _button1;
                     break;
                 case KryptonMessageBoxDefaultButton.Button5:
-                    if (_showActionButton)
-                    {
-                        AcceptButton = _button5;
-                    }
-                    else
-                    {
-                        AcceptButton = _button1;
-                    }
+                    AcceptButton = _showActionButton ? _button5 : _button1;
 
                     break;
                 default:
-                    if (_showHelpButton)
-                    {
-                        AcceptButton = _button4;
-                    }
-                    else
-                    {
-                        AcceptButton = _button1;
-                    }
+                    AcceptButton = _showHelpButton ? _button4 : _button1;
                     break;
             }
         }
 
         private void UpdateHelp()
         {
-            if (_helpInfo == null)
+            if (!_showHelpButton)
             {
                 return;
             }
 
             MessageButton helpButton = _buttons switch
             {
-                MessageBoxButtons.OK => _button2,
-                MessageBoxButtons.OKCancel or MessageBoxButtons.YesNo or MessageBoxButtons.RetryCancel => _button3,
-                MessageBoxButtons.AbortRetryIgnore or MessageBoxButtons.YesNoCancel => _button4,
+                KryptonMessageBoxButtons.OK => _button2,
+                KryptonMessageBoxButtons.OKCancel or KryptonMessageBoxButtons.YesNo or KryptonMessageBoxButtons.RetryCancel => _button3,
+                KryptonMessageBoxButtons.AbortRetryIgnore or KryptonMessageBoxButtons.YesNoCancel => _button4,
                 _ => throw new ArgumentOutOfRangeException()
             };
             if (helpButton != null)
@@ -412,18 +387,21 @@ namespace Krypton.Toolkit
                 MethodInfo mInfoMethod = control.GetType().GetMethod(@"OnHelpRequested", BindingFlags.Instance | BindingFlags.NonPublic,
                     Type.DefaultBinder, new[] { typeof(HelpEventArgs) }, null);
                 mInfoMethod?.Invoke(control, new object[] { new HelpEventArgs(MousePosition) });
-                if (string.IsNullOrWhiteSpace(_helpInfo.HelpFilePath))
+                if (_helpInfo != null)
                 {
-                    return;
-                }
+                    if (string.IsNullOrWhiteSpace(_helpInfo.HelpFilePath))
+                    {
+                        return;
+                    }
 
-                if (!string.IsNullOrWhiteSpace(_helpInfo.Keyword))
-                {
-                    Help.ShowHelp(control, _helpInfo.HelpFilePath, _helpInfo.Keyword);
-                }
-                else
-                {
-                    Help.ShowHelp(control, _helpInfo.HelpFilePath, _helpInfo.Navigator, _helpInfo.Param);
+                    if (!string.IsNullOrWhiteSpace(_helpInfo.Keyword))
+                    {
+                        Help.ShowHelp(control, _helpInfo.HelpFilePath, _helpInfo.Keyword);
+                    }
+                    else
+                    {
+                        Help.ShowHelp(control, _helpInfo.HelpFilePath, _helpInfo.Navigator, _helpInfo.Param);
+                    }
                 }
             }
             catch
@@ -472,7 +450,7 @@ namespace Krypton.Toolkit
                 textSize = Size.Ceiling(messageSize);
             }
 
-            return new Size(textSize.Width + _messageIcon.Width + _messageIcon.Margin.Left + _messageIcon.Margin.Right + 
+            return new Size(textSize.Width + _messageIcon.Width + _messageIcon.Margin.Left + _messageIcon.Margin.Right +
                             _messageText.Margin.Left + _messageText.Margin.Right,
                 Math.Max(_messageIcon.Height + 10, textSize.Height));
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonFormActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonFormActionList.cs
@@ -12,7 +12,7 @@
 
 namespace Krypton.Toolkit
 {
-    class KryptonFormActionList
+    internal class KryptonFormActionList
     {
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/General/PlatformInvoke.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/PlatformInvoke.cs
@@ -3570,7 +3570,7 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
             }
 
             // Values designating how Flip3D treats a given window.
-            enum DWMFLIP3DWINDOWPOLICY : uint
+            private enum DWMFLIP3DWINDOWPOLICY : uint
             {
                 Default, // Hide or include the window in Flip3D based on window style and visibility.
                 ExcludeBelow, // Display the window under Flip3D and disabled.

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
@@ -6409,7 +6409,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        RadioButtonState DiscoverRadioButtonState(bool enabled,
+        private RadioButtonState DiscoverRadioButtonState(bool enabled,
                                                   bool checkState,
                                                   bool tracking,
                                                   bool pressed)

--- a/Source/Krypton Components/Krypton.Toolkit/Tooling/DebugTools.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Tooling/DebugTools.cs
@@ -19,11 +19,13 @@ namespace Krypton.Toolkit
         {
             if (lineNumber > 0)
             {
-                KryptonMessageBox.Show($"If you are seeing this message, please submit a new bug report at: https://github.com/Krypton-Suite/Standard-Toolkit/issues/new/choose.\n\nAdditional details:-\nMethod Signature: {methodSignature}\nClass Name: {className}\nLine Number: {lineNumber}", "Not Implemented", MessageBoxButtons.OK, KryptonMessageBoxIcon.Information);
+                KryptonMessageBox.Show($"If you are seeing this message, please submit a new bug report at: https://github.com/Krypton-Suite/Standard-Toolkit/issues/new/choose.\n\nAdditional details:-\nMethod Signature: {methodSignature}\nClass Name: {className}\nLine Number: {lineNumber}", 
+                    "Not Implemented", KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.Information);
             }
             else
             {
-                KryptonMessageBox.Show($"If you are seeing this message, please submit a new bug report at: https://github.com/Krypton-Suite/Standard-Toolkit/issues/new/choose.\n\nAdditional details:-\nMethod Signature: {methodSignature}\nClass Name: {className}", "Not Implemented", MessageBoxButtons.OK, KryptonMessageBoxIcon.Information);
+                KryptonMessageBox.Show($"If you are seeing this message, please submit a new bug report at: https://github.com/Krypton-Suite/Standard-Toolkit/issues/new/choose.\n\nAdditional details:-\nMethod Signature: {methodSignature}\nClass Name: {className}", 
+                    "Not Implemented", KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.Information);
             }
         }
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Tooling/ExceptionHandler.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Tooling/ExceptionHandler.cs
@@ -33,7 +33,7 @@ namespace Krypton.Toolkit
         /// <param name="icon">The icon.</param>
         /// <param name="className">Name of the class.</param>
         /// <param name="methodSignature">The method signature.</param>
-        public static void CaptureException(Exception exception, string title = @"Exception Caught", MessageBoxButtons buttons = MessageBoxButtons.OK, KryptonMessageBoxIcon icon = KryptonMessageBoxIcon.Error, string className = "", string methodSignature = "")
+        public static void CaptureException(Exception exception, string title = @"Exception Caught", KryptonMessageBoxButtons buttons = KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon icon = KryptonMessageBoxIcon.Error, string className = "", string methodSignature = "")
         {
             if (className != "")
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Utilities/General.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Utilities/General.cs
@@ -14,6 +14,50 @@ namespace Krypton.Toolkit
 {
     #region Enumerations
 
+    /// <summary>Specifies constants defining which buttons to display on a <see cref="T:KryptonMessageBox" />.</summary>
+    public enum KryptonMessageBoxButtons
+    {
+        /// <summary>
+        ///  Specifies that the message box contains an OK button.
+        /// </summary>
+        OK = MessageBoxButtons.OK,
+
+        /// <summary>
+        ///  Specifies that the message box contains OK and Cancel buttons.
+        /// </summary>
+        OKCancel = MessageBoxButtons.OKCancel,
+
+        /// <summary>
+        ///  Specifies that the message box contains Abort, Retry, and Ignore buttons.
+        /// </summary>
+        AbortRetryIgnore = MessageBoxButtons.AbortRetryIgnore,
+
+        /// <summary>
+        ///  Specifies that the message box contains Yes, No, and Cancel buttons.
+        /// </summary>
+        YesNoCancel = MessageBoxButtons.YesNoCancel,
+
+        /// <summary>
+        ///  Specifies that the message box contains Yes and No buttons.
+        /// </summary>
+        YesNo = MessageBoxButtons.YesNo,
+
+        /// <summary>
+        ///  Specifies that the message box contains Retry and Cancel buttons.
+        /// </summary>
+        RetryCancel = MessageBoxButtons.RetryCancel,
+
+        /// <summary>
+        ///  Specifies that the message box contains Cancel, Try Again, and Continue buttons.
+        /// </summary>
+#if NET60_OR_GREATER
+            CancelTryContinue = MessageBoxButtons.CancelTryContinue
+#else
+        CancelTryContinue = 0x00000006
+#endif 
+    }
+
+
     /// <summary>Specifies constants defining the default button on a <seealso cref="KryptonMessageBox"/>.</summary>
     public enum KryptonMessageBoxDefaultButton
     {


### PR DESCRIPTION
- Add in new KryptonMessageBoxButtons type that emulates the .net6 `MessageBoxButtons`

- Fix fallout for the new `DialogResult` type
- Fix Help button not being shown
- Add missing `private` monikers
- Fix usage of controls in the `KryptonMessageBox` demo
- Remove some usages of .net 5
- Remove some compile warnings / messages from Example projects

#https://github.com/Krypton-Suite/Standard-Toolkit/issues/867
#https://github.com/Krypton-Suite/Standard-Toolkit/issues/728)

![image](https://user-images.githubusercontent.com/2418812/206916539-daffe992-b144-4e16-9fe4-ed8332e5cf98.png)
