### PR TITLE
- Remove `IPalette` and use `PaletteBase` instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,11 +128,17 @@ Follow the links to see the different objects and layouts that this framework al
 =======
 
 # Breaking Changes
+
 ## V80.## (2023-11-xx - Build 2311 - November 2023)
 There are list of changes that have occurred during the development of the V70.## version
+
 ### KryptonMessageBoxButtons
 - https://github.com/Krypton-Suite/Standard-Toolkit/issues/728:  
-Bring MessageBox States inline with latest .Net 6 by using a new `KryptonMessageBoxButtons` type, which is effectively the same as .Net6 enum version of `MessageBoxButtons` but backward compatible with .net4.6.x onwards
+Bring MessageBox States inline with latest .Net 6 by using a new `KryptonMessageBoxButtons` type, which is effectively the same as .Net6 enum version of `MessageBoxButtons` but backward compatible with .net4.6.x onwards.
+
+### Palette usages
+-`KryptonPalette` has become `KryptonCustomPaletteBase` to better signify it's usage.
+- `IPalette` has been removed, and the usage of `PaletteBase` throughout the toolkit is used; to ensure consistent usage.
 
 ## V70.## (2022-11-08 - Build 2211 - November 2022)
 There are list of changes that have occurred during the development of the V70.## version

--- a/Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln.DotSettings
+++ b/Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln.DotSettings
@@ -1,3 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Coghlan/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Maximise/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=Minimise/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Minimise/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Wagnerp/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavClose.cs
+++ b/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavClose.cs
@@ -25,7 +25,7 @@ namespace Krypton.Navigator
         public ButtonSpecNavClose(KryptonNavigator navigator)
             : base(navigator, PaletteButtonSpecStyle.Close)
         {
-        }         
+        }
         #endregion
 
         #region IButtonSpecValues
@@ -33,8 +33,8 @@ namespace Krypton.Navigator
         /// Gets the button visible value.
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
-        /// <returns>Button visibiliy.</returns>
-        public override bool GetVisible(IPalette palette)
+        /// <returns>Button visibility.</returns>
+        public override bool GetVisible(PaletteBase palette)
         {
             switch (Navigator.Button.CloseButtonDisplay)
             {
@@ -59,7 +59,7 @@ namespace Krypton.Navigator
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button enabled state.</returns>
-        public override ButtonEnabled GetEnabled(IPalette palette)
+        public override ButtonEnabled GetEnabled(PaletteBase palette)
         {
             switch (Navigator.Button.CloseButtonDisplay)
             {
@@ -85,10 +85,10 @@ namespace Krypton.Navigator
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button checked state.</returns>
-        public override ButtonCheckState GetChecked(IPalette palette) =>
+        public override ButtonCheckState GetChecked(PaletteBase palette) =>
             // Close button is never shown as checked
             ButtonCheckState.NotCheckButton;
 
-        #endregion    
+        #endregion
     }
 }

--- a/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavContext.cs
+++ b/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavContext.cs
@@ -38,7 +38,7 @@ namespace Krypton.Navigator
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibiliy.</returns>
-        public override bool GetVisible(IPalette palette)
+        public override bool GetVisible(PaletteBase palette)
         {
             switch (Navigator.Button.ContextButtonDisplay)
             {
@@ -76,7 +76,7 @@ namespace Krypton.Navigator
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button enabled state.</returns>
-        public override ButtonEnabled GetEnabled(IPalette palette)
+        public override ButtonEnabled GetEnabled(PaletteBase palette)
         {
             switch (Navigator.Button.ContextButtonDisplay)
             {
@@ -103,7 +103,7 @@ namespace Krypton.Navigator
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button checked state.</returns>
-        public override ButtonCheckState GetChecked(IPalette palette) =>
+        public override ButtonCheckState GetChecked(PaletteBase palette) =>
             // Context button is never shown as checked
             ButtonCheckState.NotCheckButton;
 

--- a/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavFixed.cs
+++ b/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavFixed.cs
@@ -42,15 +42,15 @@ namespace Krypton.Navigator
 
             // Default other properties
             _location = HeaderLocation.PrimaryHeader;
-        }      
-        #endregion   
+        }
+        #endregion
 
         #region IsDefault
         /// <summary>
         /// Gets a value indicating if all values are default.
         /// </summary>
         [Browsable(false)]
-        public override bool IsDefault => (base.IsDefault && 
+        public override bool IsDefault => (base.IsDefault &&
                                            (HeaderLocation == HeaderLocation.PrimaryHeader));
 
         #endregion
@@ -83,7 +83,7 @@ namespace Krypton.Navigator
                 if (_location != value)
                 {
                     _location = value;
-                    OnButtonSpecPropertyChanged("Location");
+                    OnButtonSpecPropertyChanged(@"Location");
                 }
             }
         }
@@ -103,7 +103,7 @@ namespace Krypton.Navigator
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button location.</returns>
-        public override HeaderLocation GetLocation(IPalette palette) =>
+        public override HeaderLocation GetLocation(PaletteBase palette) =>
             // Ask the view builder to recover the correct location
             Navigator.ViewBuilder.GetFixedButtonLocation(this);
 

--- a/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavNext.cs
+++ b/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavNext.cs
@@ -34,7 +34,7 @@ namespace Krypton.Navigator
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibiliy.</returns>
-        public override bool GetVisible(IPalette palette)
+        public override bool GetVisible(PaletteBase palette)
         {
             switch (Navigator.Button.NextButtonDisplay)
             {
@@ -72,7 +72,7 @@ namespace Krypton.Navigator
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button enabled state.</returns>
-        public override ButtonEnabled GetEnabled(IPalette palette)
+        public override ButtonEnabled GetEnabled(PaletteBase palette)
         {
             switch (Navigator.Button.NextButtonDisplay)
             {
@@ -98,7 +98,7 @@ namespace Krypton.Navigator
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button checked state.</returns>
-        public override ButtonCheckState GetChecked(IPalette palette) =>
+        public override ButtonCheckState GetChecked(PaletteBase palette) =>
             // Next button is never shown as checked
             ButtonCheckState.NotCheckButton;
 

--- a/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavPrevious.cs
+++ b/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavPrevious.cs
@@ -34,7 +34,7 @@ namespace Krypton.Navigator
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibiliy.</returns>
-        public override bool GetVisible(IPalette palette)
+        public override bool GetVisible(PaletteBase palette)
         {
             switch (Navigator.Button.PreviousButtonDisplay)
             {
@@ -72,7 +72,7 @@ namespace Krypton.Navigator
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button enabled state.</returns>
-        public override ButtonEnabled GetEnabled(IPalette palette)
+        public override ButtonEnabled GetEnabled(PaletteBase palette)
         {
             switch (Navigator.Button.PreviousButtonDisplay)
             {
@@ -97,7 +97,7 @@ namespace Krypton.Navigator
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button checked state.</returns>
-        public override ButtonCheckState GetChecked(IPalette palette) =>
+        public override ButtonCheckState GetChecked(PaletteBase palette) =>
             // Previous button is never shown as checked
             ButtonCheckState.NotCheckButton;
 

--- a/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavRemap.cs
+++ b/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavRemap.cs
@@ -127,7 +127,7 @@ namespace Krypton.Navigator
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="buttonSpec">Reference to button specification.</param>
         /// <param name="remapTarget">Target for remapping the color onto.</param>
-        public ButtonSpecNavRemap(IPalette target,
+        public ButtonSpecNavRemap(PaletteBase target,
                                   ButtonSpec buttonSpec,
                                   ButtonSpecRemapTarget remapTarget)
             : base(target)

--- a/Source/Krypton Components/Krypton.Navigator/Dragging/DragManager.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Dragging/DragManager.cs
@@ -15,7 +15,7 @@ namespace Krypton.Navigator
     /// <summary>
     /// Specialise the generic collection with type specific rules for item accessor.
     /// </summary>
-    public class DragTargetProviderCollection : TypedCollection<IDragTargetProvider> {}
+    public class DragTargetProviderCollection : TypedCollection<IDragTargetProvider> { }
 
     /// <summary>
     /// Manage a dragging operation.
@@ -29,8 +29,8 @@ namespace Krypton.Navigator
         #endregion
 
         #region Instance Fields
-        private IPalette _dragPalette;
-        private IPalette _localPalette;
+        private PaletteBase _dragPalette;
+        private PaletteBase _localPalette;
         private IRenderer _dragRenderer;
         private PaletteMode _paletteMode;
         private readonly PaletteRedirect _redirector;
@@ -137,7 +137,7 @@ namespace Krypton.Navigator
         {
             get => _paletteMode;
 
-            set 
+            set
             {
                 if (_paletteMode != value)
                 {
@@ -158,11 +158,11 @@ namespace Krypton.Navigator
         /// <summary>
         /// Gets and sets the custom palette implementation.
         /// </summary>
-        public IPalette Palette
+        public PaletteBase Palette
         {
             get => _localPalette;
 
-            set 
+            set
             {
                 if (_localPalette != value)
                 {
@@ -178,7 +178,7 @@ namespace Krypton.Navigator
         public DragTargetProviderCollection DragTargetProviders { get; }
 
         /// <summary>
-        /// Gets a value indicating if dragging is currently occuring.
+        /// Gets a value indicating if dragging is currently occurring.
         /// </summary>
         public bool IsDragging { get; private set; }
 
@@ -189,7 +189,7 @@ namespace Krypton.Navigator
         {
             get => _documentCursor;
 
-            set 
+            set
             {
                 if (IsDragging)
                 {
@@ -207,7 +207,7 @@ namespace Krypton.Navigator
         /// </summary>
         /// <param name="screenPt">Mouse screen point at start of drag.</param>
         /// <param name="dragEndData">Data to be dropped at destination.</param>
-        /// <returns>True if dragging waas started; otherwise false.</returns>
+        /// <returns>True if dragging was started; otherwise false.</returns>
         public virtual bool DragStart(Point screenPt, PageDragEndData dragEndData)
         {
             if (IsDisposed)
@@ -222,7 +222,7 @@ namespace Krypton.Navigator
 
             if (dragEndData == null)
             {
-                throw new ArgumentNullException(nameof(dragEndData), "Cannot provide a null DragEndData.");
+                throw new ArgumentNullException(nameof(dragEndData), @"Cannot provide a null DragEndData.");
             }
 
             // Generate drag targets from the set of target provides
@@ -273,7 +273,7 @@ namespace Krypton.Navigator
                 throw new InvalidOperationException("Cannot DragMove when DragStart has not been called.");
             }
 
-            // Different feedback objects implement visual feeback differently and so only the feedback
+            // Different feedback objects implement visual feedback differently and so only the feedback
             // instance knows the correct target to use for the given screen point and drag data.
             _currentTarget = _dragFeedback.Feedback(screenPt, _currentTarget);
 
@@ -298,7 +298,7 @@ namespace Krypton.Navigator
                 throw new InvalidOperationException("Cannot DragEnd when DragStart has not been called.");
             }
 
-            // Different feedback objects implement visual feeback differently and so only the feedback
+            // Different feedback objects implement visual feedback differently and so only the feedback
             // instance knows the correct target to use for the given screen point and drag data.
             _currentTarget = _dragFeedback.Feedback(screenPt, _currentTarget);
 
@@ -456,7 +456,7 @@ namespace Krypton.Navigator
             if (dragFeedback == PaletteDragFeedback.Rounded)
             {
                 // Rounded feedback uses a per-pixel alpha blending and so we need to be on a machine that supports
-                // more than 256 colors and also allows the layered windows feature. If not then revert to sqaures
+                // more than 256 colors and also allows the layered windows feature. If not then revert to squares
                 if ((OSFeature.Feature.GetVersionPresent(OSFeature.LayeredWindows) == null) || (CommonHelper.ColorDepth() <= 8))
                 {
                     dragFeedback = PaletteDragFeedback.Square;

--- a/Source/Krypton Components/Krypton.Navigator/Page/KryptonPage.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Page/KryptonPage.cs
@@ -167,7 +167,7 @@ namespace Krypton.Navigator
         public KryptonPage(string text, Bitmap imageSmall, string uniqueName)
             : this(text, imageSmall, uniqueName, new Size(150, 50))
         {
-            
+
         }
 
         /// <summary>
@@ -286,7 +286,7 @@ namespace Krypton.Navigator
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public new IPalette Palette
+        public new PaletteBase Palette
         {
             [DebuggerStepThrough]
             get => base.Palette;
@@ -733,7 +733,7 @@ namespace Krypton.Navigator
             ToolTipShadow = true;
         }
         #endregion
-        
+
         /// <summary>
         /// Gets and sets the unique name of the page.
         /// </summary>

--- a/Source/Krypton Components/Krypton.Navigator/Palette/PaletteRedirectRibbonTabContent.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Palette/PaletteRedirectRibbonTabContent.cs
@@ -43,8 +43,8 @@ namespace Krypton.Navigator
         /// Initialize a new instance of the PaletteRedirectRibbonDouble class.
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
-        public PaletteRedirectRibbonTabContent(IPalette target)
-            : this(target, 
+        public PaletteRedirectRibbonTabContent(PaletteBase target)
+            : this(target,
                    null, null, null, null, null, null,
                    null, null, null, null, null, null,
                    null, null, null, null, null, null)
@@ -73,7 +73,7 @@ namespace Krypton.Navigator
         /// <param name="trackingContent">Redirection for content tracking state requests.</param>
         /// <param name="selectedContent">Redirection for content selected states requests.</param>
         /// <param name="focusOverrideContent">Redirection for content focus override state requests.</param>
-        public PaletteRedirectRibbonTabContent(IPalette target,
+        public PaletteRedirectRibbonTabContent(PaletteBase target,
                                                IPaletteRibbonBack disabledBack,
                                                IPaletteRibbonBack normalBack,
                                                IPaletteRibbonBack pressedBack,

--- a/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecExpandRibbon.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecExpandRibbon.cs
@@ -35,7 +35,7 @@ namespace Krypton.Ribbon
 
             // Fix the type
             ProtectedType = PaletteButtonSpecStyle.RibbonExpand;
-        }         
+        }
         #endregion
 
         #region AllowComponent
@@ -64,22 +64,22 @@ namespace Krypton.Ribbon
         /// Gets the button visible value.
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
-        /// <returns>Button visibiliy.</returns>
-        public override bool GetVisible(IPalette palette) => _ribbon.ShowMinimizeButton && _ribbon.MinimizedMode;
+        /// <returns>Button visibility.</returns>
+        public override bool GetVisible(PaletteBase palette) => _ribbon.ShowMinimizeButton && _ribbon.MinimizedMode;
 
         /// <summary>
         /// Gets the button enabled state.
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button enabled state.</returns>
-        public override ButtonEnabled GetEnabled(IPalette palette) => ButtonEnabled.True;
+        public override ButtonEnabled GetEnabled(PaletteBase palette) => ButtonEnabled.True;
 
         /// <summary>
         /// Gets the button checked state.
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button checked state.</returns>
-        public override ButtonCheckState GetChecked(IPalette palette) =>
+        public override ButtonCheckState GetChecked(PaletteBase palette) =>
             // Close button is never shown as checked
             ButtonCheckState.NotCheckButton;
 
@@ -88,11 +88,12 @@ namespace Krypton.Ribbon
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button style.</returns>
-        public override ButtonStyle GetStyle(IPalette palette) => ButtonStyle.ButtonSpec;
+        public override ButtonStyle GetStyle(PaletteBase palette) => ButtonStyle.ButtonSpec;
 
         #endregion    
 
         #region Protected Overrides
+
         /// <summary>
         /// Raises the Click event.
         /// </summary>

--- a/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecMdiChildClose.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecMdiChildClose.cs
@@ -33,7 +33,7 @@ namespace Krypton.Ribbon
         {
             Debug.Assert(ribbon != null);
             _ribbon = ribbon;
-        }         
+        }
         #endregion
 
         #region IButtonSpecValues
@@ -42,7 +42,7 @@ namespace Krypton.Ribbon
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibility.</returns>
-        public override bool GetVisible(IPalette palette)
+        public override bool GetVisible(PaletteBase palette)
         {
             // Cannot be seen if not attached to an mdi child window and cannot be seen
             // if the window is not maximized and so needing the pendant buttons
@@ -60,14 +60,14 @@ namespace Krypton.Ribbon
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button enabled state.</returns>
-        public override ButtonEnabled GetEnabled(IPalette palette) => ButtonEnabled.True;
+        public override ButtonEnabled GetEnabled(PaletteBase palette) => ButtonEnabled.True;
 
         /// <summary>
         /// Gets the button checked state.
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button checked state.</returns>
-        public override ButtonCheckState GetChecked(IPalette palette) =>
+        public override ButtonCheckState GetChecked(PaletteBase palette) =>
             // Close button is never shown as checked
             ButtonCheckState.NotCheckButton;
 

--- a/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecMdiChildFixed.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecMdiChildFixed.cs
@@ -69,7 +69,7 @@ namespace Krypton.Ribbon
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button style.</returns>
-        public override ButtonStyle GetStyle(IPalette palette) => ButtonStyle.ButtonSpec;
+        public override ButtonStyle GetStyle(PaletteBase palette) => ButtonStyle.ButtonSpec;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecMdiChildMin.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecMdiChildMin.cs
@@ -33,7 +33,7 @@ namespace Krypton.Ribbon
         {
             Debug.Assert(ribbon != null);
             _ribbon = ribbon;
-        }         
+        }
         #endregion
 
         #region IButtonSpecValues
@@ -42,7 +42,7 @@ namespace Krypton.Ribbon
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibiliy.</returns>
-        public override bool GetVisible(IPalette palette)
+        public override bool GetVisible(PaletteBase palette)
         {
             // Cannot be seen if not attached to an mdi child window and cannot be seen
             // if the window is not maximized and so needing the pendant buttons
@@ -74,7 +74,7 @@ namespace Krypton.Ribbon
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button enabled state.</returns>
-        public override ButtonEnabled GetEnabled(IPalette palette)
+        public override ButtonEnabled GetEnabled(PaletteBase palette)
         {
             // Cannot be enabled if not attached to an mdi child window
             if (MdiChild == null || MdiChild.IsDisposed || !MdiChild.IsHandleCreated || MdiChild.Disposing)
@@ -91,7 +91,7 @@ namespace Krypton.Ribbon
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button checked state.</returns>
-        public override ButtonCheckState GetChecked(IPalette palette) =>
+        public override ButtonCheckState GetChecked(PaletteBase palette) =>
             // Close button is never shown as checked
             ButtonCheckState.NotCheckButton;
 

--- a/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecMdiChildRestore.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecMdiChildRestore.cs
@@ -33,7 +33,7 @@ namespace Krypton.Ribbon
         {
             Debug.Assert(ribbon != null);
             _ribbon = ribbon;
-        }         
+        }
         #endregion
 
         #region IButtonSpecValues
@@ -42,7 +42,7 @@ namespace Krypton.Ribbon
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibiliy.</returns>
-        public override bool GetVisible(IPalette palette)
+        public override bool GetVisible(PaletteBase palette)
         {
             // Cannot be seen if not attached to an mdi child window and cannot be seen
             // if the window is not maximized and so needing the pendant buttons
@@ -74,7 +74,7 @@ namespace Krypton.Ribbon
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button enabled state.</returns>
-        public override ButtonEnabled GetEnabled(IPalette palette)
+        public override ButtonEnabled GetEnabled(PaletteBase palette)
         {
             // Cannot be enabled if not attached to an mdi child window
             if (MdiChild == null)
@@ -91,7 +91,7 @@ namespace Krypton.Ribbon
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button checked state.</returns>
-        public override ButtonCheckState GetChecked(IPalette palette) =>
+        public override ButtonCheckState GetChecked(PaletteBase palette) =>
             // Close button is never shown as checked
             ButtonCheckState.NotCheckButton;
 

--- a/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecMinimizeRibbon.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecMinimizeRibbon.cs
@@ -35,7 +35,7 @@ namespace Krypton.Ribbon
 
             // Fix the type
             ProtectedType = PaletteButtonSpecStyle.RibbonMinimize;
-        }         
+        }
         #endregion
 
         #region AllowComponent
@@ -65,21 +65,21 @@ namespace Krypton.Ribbon
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibiliy.</returns>
-        public override bool GetVisible(IPalette palette) => _ribbon.ShowMinimizeButton && !_ribbon.MinimizedMode;
+        public override bool GetVisible(PaletteBase palette) => _ribbon.ShowMinimizeButton && !_ribbon.MinimizedMode;
 
         /// <summary>
         /// Gets the button enabled state.
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button enabled state.</returns>
-        public override ButtonEnabled GetEnabled(IPalette palette) => ButtonEnabled.True;
+        public override ButtonEnabled GetEnabled(PaletteBase palette) => ButtonEnabled.True;
 
         /// <summary>
         /// Gets the button checked state.
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button checked state.</returns>
-        public override ButtonCheckState GetChecked(IPalette palette) =>
+        public override ButtonCheckState GetChecked(PaletteBase palette) =>
             // Close button is never shown as checked
             ButtonCheckState.NotCheckButton;
 
@@ -88,7 +88,7 @@ namespace Krypton.Ribbon
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button style.</returns>
-        public override ButtonStyle GetStyle(IPalette palette) => ButtonStyle.ButtonSpec;
+        public override ButtonStyle GetStyle(PaletteBase palette) => ButtonStyle.ButtonSpec;
 
         #endregion    
 

--- a/Source/Krypton Components/Krypton.Ribbon/Controls Visuals/VisualPopupAppMenu.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controls Visuals/VisualPopupAppMenu.cs
@@ -18,7 +18,7 @@ namespace Krypton.Ribbon
     {
         #region Instance Fields
         private readonly KryptonRibbon _ribbon;
-        private IPalette _palette;
+        private PaletteBase _palette;
         private IPaletteBack _drawOutsideBack;
         private IPaletteBorder _drawOutsideBorder;
         private readonly AppButtonMenuProvider _provider;
@@ -47,7 +47,7 @@ namespace Krypton.Ribbon
         /// <param name="keyboardActivated">Was the context menu activated by a keyboard action.</param>
         public VisualPopupAppMenu(KryptonRibbon ribbon,
                                   RibbonAppButton appButton,
-                                  IPalette palette,
+                                  PaletteBase palette,
                                   PaletteMode paletteMode,
                                   PaletteRedirect redirector,
                                   Rectangle rectAppButtonTopHalf,
@@ -404,7 +404,7 @@ namespace Krypton.Ribbon
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override IPalette GetResolvedPalette() => _palette;
+        public override PaletteBase GetResolvedPalette() => _palette;
 
         #endregion
 
@@ -496,7 +496,7 @@ namespace Krypton.Ribbon
             }
         }
 
-        private void SetPalette(IPalette palette)
+        private void SetPalette(PaletteBase palette)
         {
             if (palette != _palette)
             {

--- a/Source/Krypton Components/Krypton.Ribbon/General/AppButtonMenuProvider.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/General/AppButtonMenuProvider.cs
@@ -58,7 +58,7 @@ namespace Krypton.Ribbon
         public AppButtonMenuProvider(ViewContextMenuManager viewManager,
                                      KryptonContextMenuItemCollection menuCollection,
                                      ViewLayoutStack viewColumns,
-                                     IPalette palette,
+                                     PaletteBase palette,
                                      PaletteMode paletteMode,
                                      PaletteRedirect redirector,
                                      NeedPaintHandler needPaintDelegate)
@@ -184,8 +184,8 @@ namespace Krypton.Ribbon
         /// <summary>
         /// Sets the reason for the context menu being closed.
         /// </summary>
-        public ToolStripDropDownCloseReason? ProviderCloseReason 
-        { 
+        public ToolStripDropDownCloseReason? ProviderCloseReason
+        {
             get => _parent?.ProviderCloseReason ?? _closeReason;
 
             set
@@ -254,7 +254,7 @@ namespace Krypton.Ribbon
         /// <summary>
         /// Gets access to the custom palette.
         /// </summary>
-        public IPalette ProviderPalette { get; }
+        public PaletteBase ProviderPalette { get; }
 
         /// <summary>
         /// Gets access to the palette mode.

--- a/Source/Krypton Components/Krypton.Ribbon/Palette/PaletteCaptionRedirect.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Palette/PaletteCaptionRedirect.cs
@@ -24,7 +24,7 @@ namespace Krypton.Ribbon
         /// Initialize a new instance of the PaletteCaptionRedirect class.
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
-        public PaletteCaptionRedirect(IPalette target)
+        public PaletteCaptionRedirect(PaletteBase target)
             : base(target)
         {
         }

--- a/Source/Krypton Components/Krypton.Ribbon/Palette/RibbonThemeManager.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Palette/RibbonThemeManager.cs
@@ -7,8 +7,6 @@
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
  *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
  *  
- *  Modified: Monday 12th April, 2021 @ 18:00 GMT
- *
  */
 #endregion
 
@@ -26,17 +24,9 @@ namespace Krypton.Ribbon
         /// <param name="target">The target.</param>
         public static void PropagateThemeSelector(KryptonRibbonGroupComboBox target)
         {
-            try
+            foreach (var theme in ThemeManager.SupportedInternalThemeNames)
             {
-                foreach (var theme in ThemeManager.SupportedThemeArray)
-                {
-                    target.Items.Add(theme);
-                }
-            }
-            catch
-            {
-
-                throw;
+                target.Items.Add(theme);
             }
         }
 
@@ -46,171 +36,13 @@ namespace Krypton.Ribbon
         /// <param name="target">The target.</param>
         public static void PropagateThemeSelector(KryptonRibbonGroupDomainUpDown target)
         {
-            try
+            foreach (var theme in ThemeManager.SupportedInternalThemeNames)
             {
-                foreach (var theme in ThemeManager.SupportedThemeArray)
-                {
-                    target.Items.Add(theme);
-                }
-            }
-            catch
-            {
-
-                throw;
+                target.Items.Add(theme);
             }
         }
 
         #region Built-in Redundancy        
-        /// <summary>
-        /// Applies the theme.
-        /// </summary>
-        /// <param name="paletteMode">The palette mode.</param>
-        /// <param name="manager">The manager.</param>
-        private static void ApplyTheme(PaletteModeManager paletteMode, KryptonManager manager)
-        {
-            switch (paletteMode)
-            {
-                case PaletteModeManager.ProfessionalSystem:
-                    manager.GlobalPaletteMode = PaletteModeManager.ProfessionalSystem;
-                    break;
-                case PaletteModeManager.ProfessionalOffice2003:
-                    manager.GlobalPaletteMode = PaletteModeManager.ProfessionalOffice2003;
-                    break;
-                case PaletteModeManager.Office2007Blue:
-                    manager.GlobalPaletteMode = PaletteModeManager.Office2007Blue;
-                    break;
-                case PaletteModeManager.Office2007Silver:
-                    manager.GlobalPaletteMode = PaletteModeManager.Office2007Silver;
-                    break;
-                case PaletteModeManager.Office2007White:
-                    manager.GlobalPaletteMode = PaletteModeManager.Office2007White;
-                    break;
-                case PaletteModeManager.Office2007Black:
-                    manager.GlobalPaletteMode = PaletteModeManager.Office2007Black;
-                    break;
-                case PaletteModeManager.Office2010Blue:
-                    manager.GlobalPaletteMode = PaletteModeManager.Office2010Blue;
-                    break;
-                case PaletteModeManager.Office2010Silver:
-                    manager.GlobalPaletteMode = PaletteModeManager.Office2010Silver;
-                    break;
-                case PaletteModeManager.Office2010White:
-                    manager.GlobalPaletteMode = PaletteModeManager.Office2010White;
-                    break;
-                case PaletteModeManager.Office2010Black:
-                    manager.GlobalPaletteMode = PaletteModeManager.Office2010Black;
-                    break;
-                /*case PaletteModeManager.Office2013:
-                    manager.GlobalPaletteMode = PaletteModeManager.Office2013;
-                    break;*/
-                case PaletteModeManager.Office2013White:
-                    manager.GlobalPaletteMode = PaletteModeManager.Office2013White;
-                    break;
-                case PaletteModeManager.Microsoft365Black:
-                    manager.GlobalPaletteMode = PaletteModeManager.Microsoft365Black;
-                    break;
-                case PaletteModeManager.Microsoft365Blue:
-                    manager.GlobalPaletteMode = PaletteModeManager.Microsoft365Blue;
-                    break;
-                case PaletteModeManager.Microsoft365Silver:
-                    manager.GlobalPaletteMode = PaletteModeManager.Microsoft365Silver;
-                    break;
-                case PaletteModeManager.Microsoft365White:
-                    manager.GlobalPaletteMode = PaletteModeManager.Microsoft365White;
-                    break;
-                case PaletteModeManager.SparkleBlue:
-                    manager.GlobalPaletteMode = PaletteModeManager.SparkleBlue;
-                    break;
-                case PaletteModeManager.SparkleOrange:
-                    manager.GlobalPaletteMode = PaletteModeManager.SparkleOrange;
-                    break;
-                case PaletteModeManager.SparklePurple:
-                    manager.GlobalPaletteMode = PaletteModeManager.SparklePurple;
-                    break;
-                case PaletteModeManager.Custom:
-                    manager.GlobalPaletteMode = PaletteModeManager.Custom;
-                    break;
-                default:
-                    break;
-            }
-        }
-
-        /// <summary>
-        /// Applies the theme.
-        /// </summary>
-        /// <param name="themeName">Name of the theme.</param>
-        /// <param name="manager">The manager.</param>
-        /// <exception cref="ArgumentNullException"></exception>
-        private static void ApplyTheme(string themeName, KryptonManager manager)
-        {
-            switch (themeName)
-            {
-                case "Custom":
-                    ApplyTheme(PaletteModeManager.Custom, manager);
-                    break;
-                case "Professional - System":
-                    ApplyTheme(PaletteModeManager.ProfessionalSystem, manager);
-                    break;
-                case "Professional - Office 2003":
-                    ApplyTheme(PaletteModeManager.ProfessionalOffice2003, manager);
-                    break;
-                case "Office 2007 - Blue":
-                    ApplyTheme(PaletteModeManager.Office2007Blue, manager);
-                    break;
-                case "Office 2007 - Silver":
-                    ApplyTheme(PaletteModeManager.Office2007Silver, manager);
-                    break;
-                case "Office 2007 - White":
-                    ApplyTheme(PaletteModeManager.Office2007White, manager);
-                    break;
-                case "Office 2007 - Black":
-                    ApplyTheme(PaletteModeManager.Office2007Black, manager);
-                    break;
-                case "Office 2010 - Blue":
-                    ApplyTheme(PaletteModeManager.Office2010Blue, manager);
-                    break;
-                case "Office 2010 - Silver":
-                    ApplyTheme(PaletteModeManager.Office2010Silver, manager);
-                    break;
-                case "Office 2010 - White":
-                    ApplyTheme(PaletteModeManager.Office2010White, manager);
-                    break;
-                case "Office 2010 - Black":
-                    ApplyTheme(PaletteModeManager.Office2010Black, manager);
-                    break;
-                /*if (themeName == "Office 2013")
-            {
-                ApplyTheme(PaletteModeManager.Office2013, manager);
-            }*/
-                case "Office 2013 - White":
-                    ApplyTheme(PaletteModeManager.Office2013White, manager);
-                    break;
-                case "Sparkle - Blue":
-                    ApplyTheme(PaletteModeManager.SparkleBlue, manager);
-                    break;
-                case "Sparkle - Orange":
-                    ApplyTheme(PaletteModeManager.SparkleOrange, manager);
-                    break;
-                case "Sparkle - Purple":
-                    ApplyTheme(PaletteModeManager.SparklePurple, manager);
-                    break;
-                case "Microsoft 365 - Black":
-                    ApplyTheme(PaletteModeManager.Microsoft365Black, manager);
-                    break;
-                case "Microsoft 365 - Blue":
-                    ApplyTheme(PaletteModeManager.Microsoft365Blue, manager);
-                    break;
-                case "Microsoft 365 - Silver":
-                    ApplyTheme(PaletteModeManager.Microsoft365Silver, manager);
-                    break;
-                case "Microsoft 365 - White":
-                    ApplyTheme(PaletteModeManager.Microsoft365White, manager);
-                    break;
-                default:
-                    throw new ArgumentNullException(nameof(themeName));
-            }
-        }
-
         /// <summary>
         /// Gets the current palette mode.
         /// </summary>
@@ -225,16 +57,7 @@ namespace Krypton.Ribbon
         /// <param name="manager">The manager.</param>
         public static void SetTheme(string themeName, KryptonManager manager)
         {
-            try
-            {
-                ApplyTheme(themeName, manager);
-
-                ApplyGlobalTheme(manager, GetCurrentPaletteMode(manager));
-            }
-            catch
-            {
-                // Swallow ?
-            }
+            ThemeManager.SetTheme(themeName, manager);
         }
 
         /// <summary>
@@ -245,94 +68,7 @@ namespace Krypton.Ribbon
         /// <returns>The current <see cref="PaletteModeManager"/> as a string.</returns>
         public static string ReturnPaletteModeManagerAsString(PaletteModeManager paletteModeManager, KryptonManager manager = null)
         {
-            string result = null;
-
-            if (manager != null)
-            {
-                if (manager.GlobalPaletteMode == PaletteModeManager.Custom) result = "Custom";
-
-                if (manager.GlobalPaletteMode == PaletteModeManager.ProfessionalSystem) result = "Professional - System";
-
-                if (manager.GlobalPaletteMode == PaletteModeManager.ProfessionalOffice2003) result = "Professional - Office 2003";
-
-                if (manager.GlobalPaletteMode == PaletteModeManager.Office2007Blue) result = "Office 2007 - Blue";
-
-                if (manager.GlobalPaletteMode == PaletteModeManager.Office2007Silver) result = "Office 2007 - Silver";
-
-                if (manager.GlobalPaletteMode == PaletteModeManager.Office2007White) result = "Office 2007 - White";
-
-                if (manager.GlobalPaletteMode == PaletteModeManager.Office2007Black) result = "Office 2007 - Black";
-
-                if (manager.GlobalPaletteMode == PaletteModeManager.Office2010Blue) result = "Office 2010 - Blue";
-
-                if (manager.GlobalPaletteMode == PaletteModeManager.Office2010Silver) result = "Office 2010 - Silver";
-
-                if (manager.GlobalPaletteMode == PaletteModeManager.Office2010White) result = "Office 2010 - White";
-
-                if (manager.GlobalPaletteMode == PaletteModeManager.Office2010Black) result = "Office 2010 - Black";
-
-                //if (manager.GlobalPaletteMode == PaletteModeManager.Office2013) result = "Office 2013";
-
-                if (manager.GlobalPaletteMode == PaletteModeManager.Office2013White) result = "Office 2013 - White";
-
-                if (manager.GlobalPaletteMode == PaletteModeManager.SparkleBlue) result = "Sparkle - Blue";
-
-                if (manager.GlobalPaletteMode == PaletteModeManager.SparkleOrange) result = "Sparkle - Orange";
-
-                if (manager.GlobalPaletteMode == PaletteModeManager.SparklePurple) result = "Sparkle - Purple";
-
-                if (manager.GlobalPaletteMode == PaletteModeManager.Microsoft365Blue) result = "Microsoft 365 - Blue";
-
-                if (manager.GlobalPaletteMode == PaletteModeManager.Microsoft365Silver) result = "Microsoft 365 - Silver";
-
-                if (manager.GlobalPaletteMode == PaletteModeManager.Microsoft365White) result = "Microsoft 365 - White";
-
-                if (manager.GlobalPaletteMode == PaletteModeManager.Microsoft365Black) result = "Microsoft 365 - Black";
-            }
-            else
-            {
-                if (paletteModeManager == PaletteModeManager.Custom) result = "Custom";
-
-                if (paletteModeManager == PaletteModeManager.ProfessionalSystem) result = "Professional - System";
-
-                if (paletteModeManager == PaletteModeManager.ProfessionalOffice2003) result = "Professional - Office 2003";
-
-                if (paletteModeManager == PaletteModeManager.Office2007Blue) result = "Office 2007 - Blue";
-
-                if (paletteModeManager == PaletteModeManager.Office2007Silver) result = "Office 2007 - Silver";
-
-                if (paletteModeManager == PaletteModeManager.Office2007White) result = "Office 2007 - White";
-
-                if (paletteModeManager == PaletteModeManager.Office2007Black) result = "Office 2007 - Black";
-
-                if (paletteModeManager == PaletteModeManager.Office2010Blue) result = "Office 2010 - Blue";
-
-                if (paletteModeManager == PaletteModeManager.Office2010Silver) result = "Office 2010 - Silver";
-
-                if (paletteModeManager == PaletteModeManager.Office2010White) result = "Office 2010 - White";
-
-                if (paletteModeManager == PaletteModeManager.Office2010Black) result = "Office 2010 - Black";
-
-                //if (paletteModeManager == PaletteModeManager.Office2013) result = "Office 2013";
-
-                if (paletteModeManager == PaletteModeManager.Office2013White) result = "Office 2013 - White";
-
-                if (paletteModeManager == PaletteModeManager.SparkleBlue) result = "Sparkle - Blue";
-
-                if (paletteModeManager == PaletteModeManager.SparkleOrange) result = "Sparkle - Orange";
-
-                if (paletteModeManager == PaletteModeManager.SparklePurple) result = "Sparkle - Purple";
-
-                if (paletteModeManager == PaletteModeManager.Microsoft365Blue) result = "Microsoft 365 - Blue";
-
-                if (paletteModeManager == PaletteModeManager.Microsoft365Silver) result = "Microsoft 365 - Silver";
-
-                if (paletteModeManager == PaletteModeManager.Microsoft365White) result = "Microsoft 365 - White";
-
-                if (paletteModeManager == PaletteModeManager.Microsoft365Black) result = "Microsoft 365 - Black";
-            }
-
-            return result;
+            return ThemeManager.ReturnPaletteModeManagerAsString(paletteModeManager, manager);
         }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGalleryButton.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGalleryButton.cs
@@ -20,7 +20,7 @@ namespace Krypton.Ribbon
     internal class ViewDrawRibbonGalleryButton : ViewLeaf, IContentValues
     {
         #region Instance Fields
-        private readonly IPalette _palette;
+        private readonly PaletteBase _palette;
         private readonly GalleryImages _images;
         private readonly GalleryButtonController _controller;
         private readonly PaletteRibbonGalleryButton _button;
@@ -49,7 +49,7 @@ namespace Krypton.Ribbon
         /// <param name="button">Button content to display.</param>
         /// <param name="images">Button images.</param>
         /// <param name="needPaint">Paint event delegate.</param>
-        public ViewDrawRibbonGalleryButton(IPalette palette,
+        public ViewDrawRibbonGalleryButton(PaletteBase palette,
                                            PaletteRelativeAlign alignment,
                                            PaletteRibbonGalleryButton button,
                                            GalleryImages images,
@@ -65,7 +65,7 @@ namespace Krypton.Ribbon
             _paletteContent = new PaletteContentToPalette(palette, PaletteContentStyle.ButtonGallery);
             _controller = new GalleryButtonController(this, needPaint, alignment != PaletteRelativeAlign.Far);
             _controller.Click += OnButtonClick;
-            MouseController = _controller;
+            base.MouseController = _controller;
         }
 
         /// <summary>
@@ -123,7 +123,7 @@ namespace Krypton.Ribbon
             // We take on all the available display area
             ClientRectangle = context.DisplayRectangle;
 
-            // Dispose of any current memnto
+            // Dispose of any current memento
             if (_mementoContent != null)
             {
                 _mementoContent.Dispose();
@@ -260,26 +260,25 @@ namespace Krypton.Ribbon
 
             // Get image based on state
             Image image = null;
-            switch (State)
+            if (images != null)
             {
-                case PaletteState.Disabled:
-                    image = images.Disabled;
-                    break;
-                case PaletteState.Normal:
-                    image = images.Normal;
-                    break;
-                case PaletteState.Tracking:
-                    image = images.Tracking;
-                    break;
-                case PaletteState.Pressed:
-                    image = images.Pressed;
-                    break;
-            }
-
-            // If no image then get the common image
-            if (image == null)
-            {
-                image = images.Common;
+                switch (State)
+                {
+                    case PaletteState.Disabled:
+                        image = images.Disabled;
+                        break;
+                    case PaletteState.Normal:
+                        image = images.Normal;
+                        break;
+                    case PaletteState.Tracking:
+                        image = images.Tracking;
+                        break;
+                    case PaletteState.Pressed:
+                        image = images.Pressed;
+                        break;
+                }
+                // If no image then get the common image
+                image ??= images.Common;
             }
 
             // If still no image then get is from the palette

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupButtonBackBorder.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupButtonBackBorder.cs
@@ -229,7 +229,7 @@ namespace Krypton.Ribbon
         /// Perform rendering before child elements are rendered.
         /// </summary>
         /// <param name="context">Rendering context.</param>
-        public override void RenderBefore(RenderContext context) 
+        public override void RenderBefore(RenderContext context)
         {
             // Get that basic drawing state that does not reflect checked state
             PaletteState drawState = State;
@@ -477,7 +477,7 @@ namespace Krypton.Ribbon
             Rectangle splitRectangle = Controller.SplitRectangle;
             Rectangle beforeSplitRect = new(ClientLocation, new Size(splitRectangle.X - ClientLocation.X, ClientHeight));
             Rectangle splitterRect = new(splitRectangle.Location, new Size(1, ClientHeight));
-            Rectangle afterSplitRect = new(splitRectangle.X, ClientLocation.Y , splitRectangle.Width, ClientHeight);
+            Rectangle afterSplitRect = new(splitRectangle.X, ClientLocation.Y, splitRectangle.Width, ClientHeight);
 
             var splitWithFading = SplitWithFading(drawState);
             switch (drawState)
@@ -509,7 +509,7 @@ namespace Krypton.Ribbon
                             }
                         }
 
-                        Rectangle afterSplitRect1 = new(afterSplitRect.X + 1, afterSplitRect.Y, afterSplitRect.Width - 1, afterSplitRect.Height); 
+                        Rectangle afterSplitRect1 = new(afterSplitRect.X + 1, afterSplitRect.Y, afterSplitRect.Width - 1, afterSplitRect.Height);
                         using (Clipping clipToSplitter = new(context.Graphics, afterSplitRect1))
                         {
                             DrawBackground(_paletteBack, context, ClientRectangle, PaletteState.Tracking);
@@ -675,7 +675,7 @@ namespace Krypton.Ribbon
 
         private void DrawBackground(IPaletteBack paletteBack,
                                     RenderContext context,
-                                    Rectangle rect, 
+                                    Rectangle rect,
                                     PaletteState state)
         {
             // Do we need to draw the background?
@@ -710,7 +710,7 @@ namespace Krypton.Ribbon
 
         private bool SplitWithFading(PaletteState drawState)
         {
-            IPalette palette = _ribbon.GetRedirector();
+            var palette = _ribbon.GetRedirector();
             return palette.GetMetricBool(drawState, PaletteMetricBool.SplitWithFading) == InheritBool.True;
         }
 
@@ -726,7 +726,7 @@ namespace Krypton.Ribbon
                 }
             }
 
-            // Remove any popups that result from an action occuring
+            // Remove any popups that result from an action occurring
             if ((_ribbon != null) && fireAction)
             {
                 _ribbon.Actionoccurred();

--- a/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonGalleryItems.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonGalleryItems.cs
@@ -56,7 +56,7 @@ namespace Krypton.Ribbon
         /// <param name="buttonUp">Reference to the up button.</param>
         /// <param name="buttonDown">Reference to the down button.</param>
         /// <param name="buttonContext">Reference to the context button.</param>
-        public ViewLayoutRibbonGalleryItems(IPalette palette,
+        public ViewLayoutRibbonGalleryItems(PaletteBase palette,
                                             KryptonGallery gallery,
                                             NeedPaintHandler needPaint,
                                             ViewDrawRibbonGalleryButton buttonUp,

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpec.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpec.cs
@@ -888,7 +888,7 @@ namespace Krypton.Toolkit
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <param name="state">State for which an image is needed.</param>
         /// <returns>Button image.</returns>
-        public virtual Image GetImage(IPalette palette, PaletteState state)
+        public virtual Image GetImage(PaletteBase palette, PaletteState state)
         {
             Image image = null;
 
@@ -919,7 +919,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetImageTransparentColor(IPalette palette)
+        public virtual Color GetImageTransparentColor(PaletteBase palette)
         {
             if (KryptonCommand != null)
             {
@@ -934,7 +934,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Short text string.</returns>
-        public virtual string GetShortText(IPalette palette)
+        public virtual string GetShortText(PaletteBase palette)
         {
             if (KryptonCommand != null)
             {
@@ -949,7 +949,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Long text string.</returns>
-        public virtual string GetLongText(IPalette palette)
+        public virtual string GetLongText(PaletteBase palette)
         {
             if (KryptonCommand != null)
             {
@@ -963,7 +963,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Tooltip title string.</returns>
-        public virtual string GetToolTipTitle(IPalette palette) =>
+        public virtual string GetToolTipTitle(PaletteBase palette) =>
             !string.IsNullOrEmpty(ToolTipTitle) || !AllowInheritToolTipTitle
                 ? ToolTipTitle
                 : palette.GetButtonSpecToolTipTitle(ProtectedType);
@@ -973,7 +973,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetColorMap(IPalette palette) =>
+        public virtual Color GetColorMap(PaletteBase palette) =>
             ColorMap != Color.Empty ? ColorMap : palette.GetButtonSpecColorMap(ProtectedType);
 
         /// <summary>
@@ -981,7 +981,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button style.</returns>
-        public virtual ButtonStyle GetStyle(IPalette palette) =>
+        public virtual ButtonStyle GetStyle(PaletteBase palette) =>
             ConvertToButtonStyle(
                 Style != PaletteButtonStyle.Inherit ? Style : palette.GetButtonSpecStyle(ProtectedType));
 
@@ -990,7 +990,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button orientation.</returns>
-        public virtual ButtonOrientation GetOrientation(IPalette palette) => ConvertToButtonOrientation(
+        public virtual ButtonOrientation GetOrientation(PaletteBase palette) => ConvertToButtonOrientation(
             Orientation != PaletteButtonOrientation.Inherit
                 ? Orientation
                 : palette.GetButtonSpecOrientation(ProtectedType));
@@ -1000,7 +1000,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button edge.</returns>
-        public virtual RelativeEdgeAlign GetEdge(IPalette palette) =>
+        public virtual RelativeEdgeAlign GetEdge(PaletteBase palette) =>
             ConvertToRelativeEdgeAlign(Edge != PaletteRelativeEdgeAlign.Inherit
                 ? Edge
                 : palette.GetButtonSpecEdge(ProtectedType));
@@ -1010,14 +1010,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button location.</returns>
-        public virtual HeaderLocation GetLocation(IPalette palette) => HeaderLocation.PrimaryHeader;
+        public virtual HeaderLocation GetLocation(PaletteBase palette) => HeaderLocation.PrimaryHeader;
 
         /// <summary>
         /// Gets the button enabled state.
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button enabled state.</returns>
-        public abstract ButtonEnabled GetEnabled(IPalette palette);
+        public abstract ButtonEnabled GetEnabled(PaletteBase palette);
 
         /// <summary>
         /// Sets the current view associated with the button spec.
@@ -1042,14 +1042,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibility.</returns>
-        public abstract bool GetVisible(IPalette palette);
+        public abstract bool GetVisible(PaletteBase palette);
 
         /// <summary>
         /// Gets the button checked state.
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button checked state.</returns>
-        public abstract ButtonCheckState GetChecked(IPalette palette);
+        public abstract ButtonCheckState GetChecked(PaletteBase palette);
         #endregion
 
         #region Protected

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecAny.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecAny.cs
@@ -252,21 +252,21 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibility.</returns>
-        public override bool GetVisible(IPalette palette) => Visible;
+        public override bool GetVisible(PaletteBase palette) => Visible;
 
         /// <summary>
         /// Gets the button enabled state.
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button enabled state.</returns>
-        public override ButtonEnabled GetEnabled(IPalette palette) => Enabled;
+        public override ButtonEnabled GetEnabled(PaletteBase palette) => Enabled;
 
         /// <summary>
         /// Gets the button checked state.
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button checked state.</returns>
-        public override ButtonCheckState GetChecked(IPalette palette) => Checked;
+        public override ButtonCheckState GetChecked(PaletteBase palette) => Checked;
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecCalendar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecCalendar.cs
@@ -65,28 +65,28 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibility.</returns>
-        public override bool GetVisible(IPalette palette) => Visible;
+        public override bool GetVisible(PaletteBase palette) => Visible;
 
         /// <summary>
         /// Gets the button enabled state.
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button enabled state.</returns>
-        public override ButtonEnabled GetEnabled(IPalette palette) => Enabled ? ButtonEnabled.Container : ButtonEnabled.False;
+        public override ButtonEnabled GetEnabled(PaletteBase palette) => Enabled ? ButtonEnabled.Container : ButtonEnabled.False;
 
         /// <summary>
         /// Gets the button checked state.
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button checked state.</returns>
-        public override ButtonCheckState GetChecked(IPalette palette) => ButtonCheckState.Unchecked;
+        public override ButtonCheckState GetChecked(PaletteBase palette) => ButtonCheckState.Unchecked;
 
         /// <summary>
         /// Gets the button edge to position against.
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Edge position.</returns>
-        public override RelativeEdgeAlign GetEdge(IPalette palette) => _edge;
+        public override RelativeEdgeAlign GetEdge(PaletteBase palette) => _edge;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecFormWindowClose.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecFormWindowClose.cs
@@ -59,7 +59,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibility.</returns>
-        public override bool GetVisible(IPalette palette)
+        public override bool GetVisible(PaletteBase palette)
         {
             // We do not show if the custom chrome is combined with composition,
             // in which case the form buttons are handled by the composition
@@ -77,14 +77,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button enabled state.</returns>
-        public override ButtonEnabled GetEnabled(IPalette palette) => KryptonForm.CloseBox && Enabled ? ButtonEnabled.True: ButtonEnabled.False;
+        public override ButtonEnabled GetEnabled(PaletteBase palette) => KryptonForm.CloseBox && Enabled ? ButtonEnabled.True: ButtonEnabled.False;
 
         /// <summary>
         /// Gets the button checked state.
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button checked state.</returns>
-        public override ButtonCheckState GetChecked(IPalette palette) =>
+        public override ButtonCheckState GetChecked(PaletteBase palette) =>
             // Close button is never shown as checked
             ButtonCheckState.NotCheckButton;
 

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecFormWindowMax.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecFormWindowMax.cs
@@ -34,7 +34,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibility.</returns>
-        public override bool GetVisible(IPalette palette)
+        public override bool GetVisible(PaletteBase palette)
         {
             // We do not show if the custom chrome is combined with composition,
             // in which case the form buttons are handled by the composition
@@ -66,7 +66,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button enabled state.</returns>
-        public override ButtonEnabled GetEnabled(IPalette palette) =>
+        public override ButtonEnabled GetEnabled(PaletteBase palette) =>
             // Has the maximize buttons been turned off?
             KryptonForm.MaximizeBox ? ButtonEnabled.True : ButtonEnabled.False;
 
@@ -75,7 +75,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button checked state.</returns>
-        public override ButtonCheckState GetChecked(IPalette palette) =>
+        public override ButtonCheckState GetChecked(PaletteBase palette) =>
             // Close button is never shown as checked
             ButtonCheckState.NotCheckButton;
 

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecFormWindowMin.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecFormWindowMin.cs
@@ -34,7 +34,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibility.</returns>
-        public override bool GetVisible(IPalette palette)
+        public override bool GetVisible(PaletteBase palette)
         {
             // We do not show if the custom chrome is combined with composition,
             // in which case the form buttons are handled by the composition
@@ -66,7 +66,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button enabled state.</returns>
-        public override ButtonEnabled GetEnabled(IPalette palette) =>
+        public override ButtonEnabled GetEnabled(PaletteBase palette) =>
             // Has the minimize buttons been turned off?
             !KryptonForm.MinimizeBox ? ButtonEnabled.False : ButtonEnabled.True;
 
@@ -75,7 +75,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button checked state.</returns>
-        public override ButtonCheckState GetChecked(IPalette palette) =>
+        public override ButtonCheckState GetChecked(PaletteBase palette) =>
             // Close button is never shown as checked
             ButtonCheckState.NotCheckButton;
 

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecHeaderGroup.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecHeaderGroup.cs
@@ -92,7 +92,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button location.</returns>
-        public override HeaderLocation GetLocation(IPalette palette) => HeaderLocation;
+        public override HeaderLocation GetLocation(PaletteBase palette) => HeaderLocation;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecRemapByContentBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecRemapByContentBase.cs
@@ -27,7 +27,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="buttonSpec">Reference to button specification.</param>
-        protected ButtonSpecRemapByContentBase(IPalette target,
+        protected ButtonSpecRemapByContentBase(PaletteBase target,
                                             ButtonSpec buttonSpec)
             : base(target)
         {

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecRemapByContentCache.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecRemapByContentCache.cs
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="buttonSpec">Reference to button specification.</param>
-        public ButtonSpecRemapByContentCache(IPalette target,
+        public ButtonSpecRemapByContentCache(PaletteBase target,
                                              ButtonSpec buttonSpec)
             : base(target, buttonSpec)
         {

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecRemapByContentView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecRemapByContentView.cs
@@ -27,7 +27,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="buttonSpec">Reference to button specification.</param>
-        public ButtonSpecRemapByContentView(IPalette target,
+        public ButtonSpecRemapByContentView(PaletteBase target,
                                             ButtonSpec buttonSpec)
             : base(target, buttonSpec)
         {

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecToContent.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecToContent.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit
     {
         #region Instance Fields
         private readonly ButtonSpec _buttonSpec;
-        private readonly IPalette _palette;
+        private readonly PaletteBase _palette;
         #endregion
 
         #region Identity
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette for sourcing information.</param>
         /// <param name="buttonSpec">Source button spec instance.</param>
-        public ButtonSpecToContent(IPalette palette,
+        public ButtonSpecToContent(PaletteBase palette,
                                    ButtonSpec buttonSpec)
         {
             Debug.Assert(palette != null);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonContextMenu.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonContextMenu.cs
@@ -229,7 +229,7 @@ namespace Krypton.Toolkit
         [Category(@"Visuals")]
         [Description(@"Custom palette applied to drawing.")]
         [DefaultValue(null)]
-        public IPalette Palette
+        public PaletteBase Palette
         {
             [DebuggerStepThrough]
             get;
@@ -431,7 +431,7 @@ namespace Krypton.Toolkit
         /// <param name="keyboardActivated">True is menu was keyboard initiated.</param>
         /// <returns>VisualContextMenu reference.</returns>
         protected virtual VisualContextMenu CreateContextMenu(KryptonContextMenu kcm,
-                                                              IPalette palette,
+                                                              PaletteBase palette,
                                                               PaletteMode paletteMode,
                                                               PaletteRedirect redirector,
                                                               PaletteRedirectContextMenu redirectorImages,

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -97,8 +97,8 @@ namespace Krypton.Toolkit
         private bool _paintTransparent;
         private bool _evalTransparent;
         private Size _lastLayoutSize;
-        private IPalette _localPalette;
-        private IPalette _palette;
+        private PaletteBase _localPalette;
+        private PaletteBase _palette;
         private PaletteMode _paletteMode;
         private ViewDrawPanel _drawPanel;
         private SimpleCall _refreshCall;
@@ -488,7 +488,7 @@ namespace Krypton.Toolkit
         [Category(@"Visuals")]
         [Description(@"Custom palette applied to drawing.")]
         [DefaultValue(null)]
-        public IPalette Palette
+        public PaletteBase Palette
         {
             [DebuggerStepThrough]
             get => _localPalette;
@@ -499,7 +499,7 @@ namespace Krypton.Toolkit
                 if (_localPalette != value)
                 {
                     // Remember the starting palette
-                    IPalette old = _localPalette;
+                    PaletteBase old = _localPalette;
 
                     // Use the provided palette value
                     SetPalette(value);
@@ -796,7 +796,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public IPalette GetResolvedPalette() => _palette;
+        public PaletteBase GetResolvedPalette() => _palette;
 
         /// <summary>
         /// Gets or Sets the internal KryptonDataGridView CellOver
@@ -2491,7 +2491,7 @@ namespace Krypton.Toolkit
             return toolTipText;
         }
 
-        private void SetPalette(IPalette palette)
+        private void SetPalette(PaletteBase palette)
         {
             if (palette != _palette)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDateTimePicker.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDateTimePicker.cs
@@ -1121,7 +1121,7 @@ namespace Krypton.Toolkit
         [Category(@"Visuals - DateTimePicker")]
         [Description(@"Custom palette applied to drawing.")]
         [DefaultValue(null)]
-        public new IPalette Palette
+        public new PaletteBase Palette
         {
             get => base.Palette;
             set => base.Palette = value;
@@ -2382,7 +2382,7 @@ namespace Krypton.Toolkit
         /// <param name="keyboardActivated">True is menu was keyboard initiated.</param>
         /// <returns>VisualContextMenu reference.</returns>
         protected override VisualContextMenu CreateContextMenu(KryptonContextMenu kcm,
-                                                               IPalette palette,
+                                                               PaletteBase palette,
                                                                PaletteMode paletteMode,
                                                                PaletteRedirect redirector,
                                                                PaletteRedirectContextMenu redirectorImages,

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -823,7 +823,7 @@ namespace Krypton.Toolkit
         {
             private readonly KryptonForm _kryptonForm;
 
-            public FormPaletteRedirect(IPalette palette, KryptonForm kryptonForm)
+            public FormPaletteRedirect(PaletteBase palette, KryptonForm kryptonForm)
                 : base(palette) =>
                 _kryptonForm = kryptonForm;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonGroupPanel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonGroupPanel.cs
@@ -314,7 +314,7 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public new IPalette Palette
+        public new PaletteBase Palette
         {
             get => base.Palette;
             set => base.Palette = value;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListView.cs
@@ -27,8 +27,8 @@ namespace Krypton.Toolkit
     public class KryptonListView : ListView
     {
         #region Variables
-        private IPalette _localPalette;
-        private IPalette _palette;
+        private PaletteBase _localPalette;
+        private PaletteBase _palette;
         private PaletteMode _paletteMode;
         private bool _layoutDirty;
         private bool _refreshAll;
@@ -251,7 +251,7 @@ namespace Krypton.Toolkit
         [Category(@"Visuals")]
         [Description(@"Custom palette applied to drawing.")]
         [DefaultValue(null)]
-        public IPalette Palette
+        public PaletteBase Palette
         {
             [DebuggerStepThrough] get => this._localPalette;
             set
@@ -265,7 +265,7 @@ namespace Krypton.Toolkit
                 if (value == null)
                 {
                     _paletteMode = PaletteMode.Global;
-                    _localPalette = (IPalette) null;
+                    _localPalette = null;
                     CacheNewPalette(KryptonManager.GetPaletteForMode(this._paletteMode));
                 }
                 else
@@ -775,7 +775,7 @@ namespace Krypton.Toolkit
 
                 // Unhook from the static events, otherwise we cannot be garbage collected
                 KryptonManager.GlobalPaletteChanged -= OnGlobalPaletteChanged;
-                this._localPalette = (IPalette) null;
+                _localPalette = null;
             }
 
             base.Dispose(disposing);
@@ -1068,7 +1068,7 @@ namespace Krypton.Toolkit
             Invalidate();
         }
 
-        private void CacheNewPalette(IPalette palette)
+        private void CacheNewPalette(PaletteBase palette)
         {
             if (palette != _palette)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonManager.cs
@@ -35,7 +35,7 @@ namespace Krypton.Toolkit
         private static PaletteProfessionalOffice2003 _paletteProfessionalOffice2003;
         private static PaletteProfessionalSystem _paletteProfessionalSystem;
 
-        private static IPalette _customPalette;
+        private static PaletteBase _customPalette;
 
         #region Office 2007 Themes
 
@@ -239,7 +239,7 @@ namespace Krypton.Toolkit
                         default:
                             // Cache the new values
                             PaletteModeManager tempMode = InternalGlobalPaletteMode;
-                            IPalette tempPalette = InternalGlobalPalette;
+                            PaletteBase tempPalette = InternalGlobalPalette;
 
                             // Use the new value
                             InternalGlobalPaletteMode = value;
@@ -283,7 +283,7 @@ namespace Krypton.Toolkit
         [Category(@"Visuals")]
         [Description(@"Global custom palette applied to drawing.")]
         [DefaultValue(null)]
-        public IPalette GlobalPalette
+        public PaletteBase GlobalPalette
         {
             get => InternalGlobalPalette;
 
@@ -294,7 +294,7 @@ namespace Krypton.Toolkit
                 {
                     // Cache the current values
                     PaletteModeManager tempMode = InternalGlobalPaletteMode;
-                    IPalette tempPalette = InternalGlobalPalette;
+                    PaletteBase tempPalette = InternalGlobalPalette;
 
                     // Use the new values
                     InternalGlobalPaletteMode = (value == null) ? PaletteModeManager.Microsoft365Blue : PaletteModeManager.Custom;
@@ -393,14 +393,22 @@ namespace Krypton.Toolkit
         [Category(@"Visuals")]
         [Description(@"")]
         [DefaultValue(null)]
-        public KryptonCustomPaletteManager CustomPaletteManager { get => _customPaletteManager; set => _customPaletteManager = value; }
+        public KryptonCustomPaletteManager CustomPaletteManager 
+        { 
+            get => _customPaletteManager; 
+            set => _customPaletteManager = value; 
+        }
 
         /// <summary>Specify a custom palette outside the existing palettes.</summary>
         /// <value>A custom palette.</value>
         [Category(@"Visuals")]
         [Description(@"Specify a custom palette outside the existing palettes.")]
         [DefaultValue(null)]
-        public IPalette CustomPalette { get => _customPalette; set => _customPalette = value; }
+        public PaletteBase CustomPalette 
+        { 
+            get => _customPalette; 
+            set => _customPalette = value; 
+        }
 
         #endregion
 
@@ -469,7 +477,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the current global palette instance given the manager settings.
         /// </summary>
-        public static IPalette CurrentGlobalPalette
+        public static PaletteBase CurrentGlobalPalette
         {
             get
             {
@@ -584,8 +592,8 @@ namespace Krypton.Toolkit
         /// Gets the implementation for the requested palette mode.
         /// </summary>
         /// <param name="mode">Requested palette mode.</param>
-        /// <returns>IPalette reference is available; otherwise false.</returns>
-        public static IPalette GetPaletteForMode(PaletteMode mode)
+        /// <returns>PaletteBase reference is available; otherwise false.</returns>
+        public static PaletteBase GetPaletteForMode(PaletteMode mode)
         {
             switch (mode)
             {
@@ -596,7 +604,7 @@ namespace Krypton.Toolkit
                 case PaletteMode.Office2007Blue:
                     return PaletteOffice2007Blue;
                 case PaletteMode.Office2007Custom:
-                    // Note: Do something...
+                // Note: Do something...
                 case PaletteMode.Office2007DarkGray:
                     return PaletteOffice2007DarkGray;
                 case PaletteMode.Office2007BlueDarkMode:
@@ -918,7 +926,7 @@ namespace Krypton.Toolkit
         /// </summary>
         public static PaletteSparklePurpleLightMode PaletteSparklePurpleLightMode => _paletteSparklePurpleLightMode ??= new PaletteSparklePurpleLightMode();
 
-        //public static PaletteBase CustomPaletteBase => _customPalette ??= new PaletteBase();
+        //public static PaletteBase CustomPaletteBase => _customPalette ??= new PaletteBase ();
 
         /// <summary>
         /// Gets the implementation for the requested renderer mode.
@@ -992,14 +1000,14 @@ namespace Krypton.Toolkit
         #region Static Internal
         internal static PaletteModeManager InternalGlobalPaletteMode { get; private set; } = PaletteModeManager.Microsoft365Blue;
 
-        internal static IPalette InternalGlobalPalette { get; private set; } = CurrentGlobalPalette;
+        internal static PaletteBase InternalGlobalPalette { get; private set; } = CurrentGlobalPalette;
 
         internal static bool HasCircularReference()
         {
             // Use a dictionary as a set to check for existence
-            var paletteSet = new Dictionary<IPalette, bool>();
+            var paletteSet = new Dictionary<PaletteBase, bool>();
 
-            IPalette palette = null;
+            PaletteBase palette = null;
 
             // Get the next palette up in hierarchy
             if (InternalGlobalPaletteMode == PaletteModeManager.Custom)
@@ -1022,7 +1030,7 @@ namespace Krypton.Toolkit
                     // Cast to correct type
 
                     // If this is a KryptonPalette instance
-                    if (palette is KryptonPalette owner)
+                    if (palette is KryptonCustomPaletteBase owner)
                     {
                         // Get the next palette up in hierarchy
                         palette = owner.BasePaletteMode switch
@@ -1101,7 +1109,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private static void SetPalette(IPalette globalPalette)
+        private static void SetPalette(PaletteBase globalPalette)
         {
             if (globalPalette != InternalGlobalPalette)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPalette.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPalette.cs
@@ -16,13 +16,13 @@ namespace Krypton.Toolkit
     /// Define and modify a palette for styling Krypton controls.
     /// </summary>
     [ToolboxItem(true)]
-    [ToolboxBitmap(typeof(KryptonPalette), "ToolboxBitmaps.KryptonPalette.bmp")]
+    [ToolboxBitmap(typeof(KryptonCustomPaletteBase), "ToolboxBitmaps.KryptonPalette.bmp")]
     [DefaultEvent("PalettePaint")]
     [DefaultProperty("BasePaletteMode")]
     [DesignerCategory(@"code")]
     [Designer("Krypton.Toolkit.KryptonPaletteDesigner, Krypton.Toolkit")]
     [Description(@"A customisable palette component.")]
-    public class KryptonPalette : Component, IPalette
+    public class KryptonCustomPaletteBase : PaletteBase
     {
         #region Type Definitions
         private class ImageDictionary : Dictionary<Bitmap, string> { }
@@ -39,7 +39,7 @@ namespace Krypton.Toolkit
         private int _suspendCount;
         private IRenderer _baseRenderer;
         private RendererMode _baseRenderMode;
-        private IPalette _basePalette;
+        private PaletteBase _basePalette;
         private PaletteMode _basePaletteMode;
         private InheritBool _allowFormChrome;
         private readonly PaletteRedirect _redirector;
@@ -47,48 +47,11 @@ namespace Krypton.Toolkit
         private readonly NeedPaintHandler _needPaintDelegate;
         #endregion
 
-        #region Events
-        /// <summary>
-        /// Occurs when a palette change requires a repaint.
-        /// </summary>
-        [Category(@"Action")]
-        [Description(@"Occurs when a change requires a repaint to reflect the update.")]
-        public event EventHandler<PaletteLayoutEventArgs> PalettePaint;
-
-        /// <summary>
-        /// Occurs when the AllowFormChrome setting changes.
-        /// </summary>
-        [Category(@"Action")]
-        [Description(@"Occurs when the AllowFormChrome setting changes.")]
-        public event EventHandler AllowFormChromeChanged;
-
-        /// <summary>
-        /// Occurs when the BasePalette/BasePaletteMode setting changes.
-        /// </summary>
-        [Category(@"Action")]
-        [Description(@"Occurs when a base palette setting change occurs.")]
-        public event EventHandler BasePaletteChanged;
-
-        /// <summary>
-        /// Occurs when the BaseRenderer/BaseRendererMode setting changes.
-        /// </summary>
-        [Category(@"Action")]
-        [Description(@"Occurs when a base renderer setting change occurs.")]
-        public event EventHandler BaseRendererChanged;
-
-        /// <summary>
-        /// Occurs when a button spec change occurs.
-        /// </summary>
-        [Category(@"Action")]
-        [Description(@"Occurs when a button spec change occurs.")]
-        public event EventHandler ButtonSpecChanged;
-        #endregion
-
         #region Identity
         /// <summary>
         /// Initialize a new instance of the KryptonPalette class.
         /// </summary>
-        public KryptonPalette()
+        public KryptonCustomPaletteBase()
         {
             // Setup the need paint delegate
             _needPaintDelegate = OnNeedPaint;
@@ -155,7 +118,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the KryptonPalette class.
         /// </summary>
         /// <param name="container">Container that owns the component.</param>
-        public KryptonPalette(IContainer container)
+        public KryptonCustomPaletteBase(IContainer container)
             : this()
         {
             Debug.Assert(container != null);
@@ -405,7 +368,7 @@ namespace Krypton.Toolkit
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public KryptonPaletteHeaders HeaderStyles { get; set; }
 
-        private bool ShouldSerializeHeaders() => !HeaderStyles.IsDefault;
+        private bool ShouldSerializeHeaderStyles() => !HeaderStyles.IsDefault;
 
         #endregion
 
@@ -568,7 +531,7 @@ namespace Krypton.Toolkit
         /// Gets the renderer to use for this palette.
         /// </summary>
         /// <returns>Renderer to use for drawing palette settings.</returns>
-        public IRenderer GetRenderer()
+        public override IRenderer GetRenderer()
         => _baseRenderMode switch
         {
             RendererMode.Inherit => _basePalette.GetRenderer(),
@@ -582,17 +545,17 @@ namespace Krypton.Toolkit
         /// Gets a value indicating if KryptonForm instances should show custom chrome.
         /// </summary>
         /// <returns>InheritBool value.</returns>
-        public InheritBool GetAllowFormChrome() => AllowFormChrome == InheritBool.Inherit ? _basePalette.GetAllowFormChrome() : AllowFormChrome;
+        public override InheritBool GetAllowFormChrome() => AllowFormChrome == InheritBool.Inherit ? _basePalette.GetAllowFormChrome() : AllowFormChrome;
         #endregion
 
-        #region IPalette Back
+        #region PaletteBase Back
         /// <summary>
         /// Gets a value indicating if background should be drawn.
         /// </summary>
         /// <param name="style">Background style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>InheritBool value.</returns>
-        public InheritBool GetBackDraw(PaletteBackStyle style, PaletteState state) =>
+        public override InheritBool GetBackDraw(PaletteBackStyle style, PaletteState state) =>
             // Find the correct destination in the palette and pass on request
             GetPaletteBack(style, state).GetBackDraw(state);
 
@@ -602,7 +565,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Background style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>PaletteGraphicsHint value.</returns>
-        public PaletteGraphicsHint GetBackGraphicsHint(PaletteBackStyle style, PaletteState state) =>
+        public override PaletteGraphicsHint GetBackGraphicsHint(PaletteBackStyle style, PaletteState state) =>
             // Find the correct destination in the palette and pass on request
             GetPaletteBack(style, state).GetBackGraphicsHint(state);
 
@@ -612,7 +575,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Background style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetBackColor1(PaletteBackStyle style, PaletteState state) =>
+        public override Color GetBackColor1(PaletteBackStyle style, PaletteState state) =>
             // Find the correct destination in the palette and pass on request
             GetPaletteBack(style, state).GetBackColor1(state);
 
@@ -622,7 +585,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Background style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetBackColor2(PaletteBackStyle style, PaletteState state) =>
+        public override Color GetBackColor2(PaletteBackStyle style, PaletteState state) =>
             // Find the correct destination in the palette and pass on request
             GetPaletteBack(style, state).GetBackColor2(state);
 
@@ -632,7 +595,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Background style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color drawing style.</returns>
-        public PaletteColorStyle GetBackColorStyle(PaletteBackStyle style, PaletteState state) =>
+        public override PaletteColorStyle GetBackColorStyle(PaletteBackStyle style, PaletteState state) =>
             // Find the correct destination in the palette and pass on request
             GetPaletteBack(style, state).GetBackColorStyle(state);
 
@@ -642,7 +605,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Background style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color alignment style.</returns>
-        public PaletteRectangleAlign GetBackColorAlign(PaletteBackStyle style, PaletteState state)
+        public override PaletteRectangleAlign GetBackColorAlign(PaletteBackStyle style, PaletteState state)
         => GetPaletteBack(style, state).GetBackColorAlign(state);
 
         /// <summary>
@@ -651,7 +614,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Background style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Angle used for color drawing.</returns>
-        public float GetBackColorAngle(PaletteBackStyle style, PaletteState state) =>
+        public override float GetBackColorAngle(PaletteBackStyle style, PaletteState state) =>
             // Find the correct destination in the palette and pass on request
             GetPaletteBack(style, state).GetBackColorAngle(state);
 
@@ -661,7 +624,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Background style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Image instance.</returns>
-        public Image GetBackImage(PaletteBackStyle style, PaletteState state)
+        public override Image GetBackImage(PaletteBackStyle style, PaletteState state)
         => GetPaletteBack(style, state).GetBackImage(state);
 
         /// <summary>
@@ -670,7 +633,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Background style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Image style value.</returns>
-        public PaletteImageStyle GetBackImageStyle(PaletteBackStyle style, PaletteState state)
+        public override PaletteImageStyle GetBackImageStyle(PaletteBackStyle style, PaletteState state)
         => GetPaletteBack(style, state).GetBackImageStyle(state);
 
         /// <summary>
@@ -679,18 +642,18 @@ namespace Krypton.Toolkit
         /// <param name="style">Background style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Image alignment style.</returns>
-        public PaletteRectangleAlign GetBackImageAlign(PaletteBackStyle style, PaletteState state)
+        public override PaletteRectangleAlign GetBackImageAlign(PaletteBackStyle style, PaletteState state)
         => GetPaletteBack(style, state).GetBackImageAlign(state);
         #endregion
 
-        #region IPalette Border
+        #region PaletteBase Border
         /// <summary>
         /// Gets a value indicating if border should be drawn.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="style">Border style.</param>
         /// <returns>InheritBool value.</returns>
-        public InheritBool GetBorderDraw(PaletteBorderStyle style, PaletteState state)
+        public override InheritBool GetBorderDraw(PaletteBorderStyle style, PaletteState state)
         => GetPaletteBorder(style, state).GetBorderDraw(state);
 
         /// <summary>
@@ -699,7 +662,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Border style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>PaletteDrawBorders value.</returns>
-        public PaletteDrawBorders GetBorderDrawBorders(PaletteBorderStyle style, PaletteState state)
+        public override PaletteDrawBorders GetBorderDrawBorders(PaletteBorderStyle style, PaletteState state)
         => GetPaletteBorder(style, state).GetBorderDrawBorders(state);
 
         /// <summary>
@@ -708,7 +671,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Border style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>PaletteGraphicsHint value.</returns>
-        public PaletteGraphicsHint GetBorderGraphicsHint(PaletteBorderStyle style, PaletteState state)
+        public override PaletteGraphicsHint GetBorderGraphicsHint(PaletteBorderStyle style, PaletteState state)
         => GetPaletteBorder(style, state).GetBorderGraphicsHint(state);
 
         /// <summary>
@@ -717,7 +680,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Border style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetBorderColor1(PaletteBorderStyle style, PaletteState state)
+        public override Color GetBorderColor1(PaletteBorderStyle style, PaletteState state)
         => GetPaletteBorder(style, state).GetBorderColor1(state);
 
         /// <summary>
@@ -726,7 +689,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Border style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetBorderColor2(PaletteBorderStyle style, PaletteState state)
+        public override Color GetBorderColor2(PaletteBorderStyle style, PaletteState state)
         => GetPaletteBorder(style, state).GetBorderColor2(state);
 
         /// <summary>
@@ -735,7 +698,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Border style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color drawing style.</returns>
-        public PaletteColorStyle GetBorderColorStyle(PaletteBorderStyle style, PaletteState state)
+        public override PaletteColorStyle GetBorderColorStyle(PaletteBorderStyle style, PaletteState state)
         => GetPaletteBorder(style, state).GetBorderColorStyle(state);
 
         /// <summary>
@@ -744,7 +707,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Border style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color alignment style.</returns>
-        public PaletteRectangleAlign GetBorderColorAlign(PaletteBorderStyle style, PaletteState state)
+        public override PaletteRectangleAlign GetBorderColorAlign(PaletteBorderStyle style, PaletteState state)
         => GetPaletteBorder(style, state).GetBorderColorAlign(state);
 
         /// <summary>
@@ -753,7 +716,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Border style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Angle used for color drawing.</returns>
-        public float GetBorderColorAngle(PaletteBorderStyle style, PaletteState state)
+        public override float GetBorderColorAngle(PaletteBorderStyle style, PaletteState state)
         => GetPaletteBorder(style, state).GetBorderColorAngle(state);
 
         /// <summary>
@@ -762,7 +725,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Border style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Integer width.</returns>
-        public int GetBorderWidth(PaletteBorderStyle style, PaletteState state)
+        public override int GetBorderWidth(PaletteBorderStyle style, PaletteState state)
         => GetPaletteBorder(style, state).GetBorderWidth(state);
 
         /// <summary>
@@ -771,7 +734,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Border style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Float rounding.</returns>
-        public float GetBorderRounding(PaletteBorderStyle style, PaletteState state)
+        public override float GetBorderRounding(PaletteBorderStyle style, PaletteState state)
         => GetPaletteBorder(style, state).GetBorderRounding(state);
 
         /// <summary>
@@ -780,7 +743,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Border style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Image instance.</returns>
-        public Image GetBorderImage(PaletteBorderStyle style, PaletteState state)
+        public override Image GetBorderImage(PaletteBorderStyle style, PaletteState state)
         => GetPaletteBorder(style, state).GetBorderImage(state);
 
         /// <summary>
@@ -789,7 +752,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Border style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Image style value.</returns>
-        public PaletteImageStyle GetBorderImageStyle(PaletteBorderStyle style, PaletteState state)
+        public override PaletteImageStyle GetBorderImageStyle(PaletteBorderStyle style, PaletteState state)
         => GetPaletteBorder(style, state).GetBorderImageStyle(state);
 
         /// <summary>
@@ -798,18 +761,18 @@ namespace Krypton.Toolkit
         /// <param name="style">Border style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Image alignment style.</returns>
-        public PaletteRectangleAlign GetBorderImageAlign(PaletteBorderStyle style, PaletteState state)
+        public override PaletteRectangleAlign GetBorderImageAlign(PaletteBorderStyle style, PaletteState state)
         => GetPaletteBorder(style, state).GetBorderImageAlign(state);
         #endregion
 
-        #region IPalette Content
+        #region PaletteBase Content
         /// <summary>
         /// Gets a value indicating if content should be drawn.
         /// </summary>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>InheritBool value.</returns>
-        public InheritBool GetContentDraw(PaletteContentStyle style, PaletteState state)
+        public override InheritBool GetContentDraw(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentDraw(state);
 
         /// <summary>
@@ -818,7 +781,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>InheritBool value.</returns>
-        public InheritBool GetContentDrawFocus(PaletteContentStyle style, PaletteState state)
+        public override InheritBool GetContentDrawFocus(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentDrawFocus(state);
 
         /// <summary>
@@ -827,7 +790,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>RelativeAlignment value.</returns>
-        public PaletteRelativeAlign GetContentImageH(PaletteContentStyle style, PaletteState state)
+        public override PaletteRelativeAlign GetContentImageH(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentImageH(state);
 
         /// <summary>
@@ -836,7 +799,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>RelativeAlignment value.</returns>
-        public PaletteRelativeAlign GetContentImageV(PaletteContentStyle style, PaletteState state)
+        public override PaletteRelativeAlign GetContentImageV(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentImageV(state);
 
         /// <summary>
@@ -845,7 +808,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>PaletteImageEffect value.</returns>
-        public PaletteImageEffect GetContentImageEffect(PaletteContentStyle style, PaletteState state)
+        public override PaletteImageEffect GetContentImageEffect(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentImageEffect(state);
 
         /// <summary>
@@ -854,7 +817,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetContentImageColorMap(PaletteContentStyle style, PaletteState state)
+        public override Color GetContentImageColorMap(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentImageColorMap(state);
 
         /// <summary>
@@ -863,8 +826,10 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetContentImageColorTo(PaletteContentStyle style, PaletteState state)
+        public override Color GetContentImageColorTo(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentImageColorTo(state);
+
+        public override Color GetContentImageColorTransparent(PaletteContentStyle style, PaletteState state) => throw new NotImplementedException();
 
         /// <summary>
         /// Gets the font for the short text.
@@ -872,7 +837,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentShortTextFont(state);
 
         /// <summary>
@@ -881,7 +846,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentShortTextFont(state);
 
         /// <summary>
@@ -890,7 +855,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>PaletteTextHint value.</returns>
-        public PaletteTextHint GetContentShortTextHint(PaletteContentStyle style, PaletteState state)
+        public override PaletteTextHint GetContentShortTextHint(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentShortTextHint(state);
 
         /// <summary>
@@ -899,7 +864,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>InheritBool value.</returns>
-        public InheritBool GetContentShortTextMultiLine(PaletteContentStyle style, PaletteState state)
+        public override InheritBool GetContentShortTextMultiLine(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentShortTextMultiLine(state);
 
         /// <summary>
@@ -908,7 +873,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>PaletteTextTrim value.</returns>
-        public PaletteTextTrim GetContentShortTextTrim(PaletteContentStyle style, PaletteState state)
+        public override PaletteTextTrim GetContentShortTextTrim(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentShortTextTrim(state);
 
         /// <summary>
@@ -917,7 +882,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>PaletteTextPrefix value.</returns>
-        public PaletteTextHotkeyPrefix GetContentShortTextPrefix(PaletteContentStyle style, PaletteState state)
+        public override PaletteTextHotkeyPrefix GetContentShortTextPrefix(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentShortTextPrefix(state);
 
         /// <summary>
@@ -926,7 +891,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>RelativeAlignment value.</returns>
-        public PaletteRelativeAlign GetContentShortTextH(PaletteContentStyle style, PaletteState state)
+        public override PaletteRelativeAlign GetContentShortTextH(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentShortTextH(state);
 
         /// <summary>
@@ -935,7 +900,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>RelativeAlignment value.</returns>
-        public PaletteRelativeAlign GetContentShortTextV(PaletteContentStyle style, PaletteState state)
+        public override PaletteRelativeAlign GetContentShortTextV(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentShortTextV(state);
 
         /// <summary>
@@ -944,7 +909,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>RelativeAlignment value.</returns>
-        public PaletteRelativeAlign GetContentShortTextMultiLineH(PaletteContentStyle style, PaletteState state)
+        public override PaletteRelativeAlign GetContentShortTextMultiLineH(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentShortTextMultiLineH(state);
 
         /// <summary>
@@ -953,7 +918,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetContentShortTextColor1(PaletteContentStyle style, PaletteState state)
+        public override Color GetContentShortTextColor1(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentShortTextColor1(state);
 
         /// <summary>
@@ -962,7 +927,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetContentShortTextColor2(PaletteContentStyle style, PaletteState state)
+        public override Color GetContentShortTextColor2(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentShortTextColor2(state);
 
         /// <summary>
@@ -971,7 +936,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color drawing style.</returns>
-        public PaletteColorStyle GetContentShortTextColorStyle(PaletteContentStyle style, PaletteState state)
+        public override PaletteColorStyle GetContentShortTextColorStyle(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentShortTextColorStyle(state);
 
         /// <summary>
@@ -980,7 +945,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color alignment style.</returns>
-        public PaletteRectangleAlign GetContentShortTextColorAlign(PaletteContentStyle style, PaletteState state)
+        public override PaletteRectangleAlign GetContentShortTextColorAlign(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentShortTextColorAlign(state);
 
         /// <summary>
@@ -989,7 +954,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Angle used for color drawing.</returns>
-        public float GetContentShortTextColorAngle(PaletteContentStyle style, PaletteState state)
+        public override float GetContentShortTextColorAngle(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentShortTextColorAngle(state);
 
         /// <summary>
@@ -998,7 +963,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Image instance.</returns>
-        public Image GetContentShortTextImage(PaletteContentStyle style, PaletteState state)
+        public override Image GetContentShortTextImage(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentShortTextImage(state);
 
         /// <summary>
@@ -1007,7 +972,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Image style value.</returns>
-        public PaletteImageStyle GetContentShortTextImageStyle(PaletteContentStyle style, PaletteState state)
+        public override PaletteImageStyle GetContentShortTextImageStyle(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentShortTextImageStyle(state);
 
         /// <summary>
@@ -1016,7 +981,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Image alignment style.</returns>
-        public PaletteRectangleAlign GetContentShortTextImageAlign(PaletteContentStyle style, PaletteState state)
+        public override PaletteRectangleAlign GetContentShortTextImageAlign(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentShortTextImageAlign(state);
 
         /// <summary>
@@ -1025,7 +990,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentLongTextFont(state);
 
         /// <summary>
@@ -1034,7 +999,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentLongTextFont(state);
 
         /// <summary>
@@ -1043,7 +1008,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>TextRenderingHint value.</returns>
-        public PaletteTextHint GetContentLongTextHint(PaletteContentStyle style, PaletteState state)
+        public override PaletteTextHint GetContentLongTextHint(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentLongTextHint(state);
 
         /// <summary>
@@ -1052,7 +1017,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>PaletteTextPrefix value.</returns>
-        public PaletteTextHotkeyPrefix GetContentLongTextPrefix(PaletteContentStyle style, PaletteState state)
+        public override PaletteTextHotkeyPrefix GetContentLongTextPrefix(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentLongTextPrefix(state);
 
         /// <summary>
@@ -1061,7 +1026,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>InheritBool value.</returns>
-        public InheritBool GetContentLongTextMultiLine(PaletteContentStyle style, PaletteState state)
+        public override InheritBool GetContentLongTextMultiLine(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentLongTextMultiLine(state);
 
         /// <summary>
@@ -1070,7 +1035,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>PaletteTextTrim value.</returns>
-        public PaletteTextTrim GetContentLongTextTrim(PaletteContentStyle style, PaletteState state)
+        public override PaletteTextTrim GetContentLongTextTrim(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentLongTextTrim(state);
 
         /// <summary>
@@ -1079,7 +1044,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>RelativeAlignment value.</returns>
-        public PaletteRelativeAlign GetContentLongTextH(PaletteContentStyle style, PaletteState state)
+        public override PaletteRelativeAlign GetContentLongTextH(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentLongTextH(state);
 
         /// <summary>
@@ -1088,7 +1053,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>RelativeAlignment value.</returns>
-        public PaletteRelativeAlign GetContentLongTextV(PaletteContentStyle style, PaletteState state)
+        public override PaletteRelativeAlign GetContentLongTextV(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentLongTextV(state);
 
         /// <summary>
@@ -1097,7 +1062,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>RelativeAlignment value.</returns>
-        public PaletteRelativeAlign GetContentLongTextMultiLineH(PaletteContentStyle style, PaletteState state)
+        public override PaletteRelativeAlign GetContentLongTextMultiLineH(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentLongTextMultiLineH(state);
 
         /// <summary>
@@ -1106,7 +1071,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetContentLongTextColor1(PaletteContentStyle style, PaletteState state)
+        public override Color GetContentLongTextColor1(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentLongTextColor1(state);
 
         /// <summary>
@@ -1115,7 +1080,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetContentLongTextColor2(PaletteContentStyle style, PaletteState state)
+        public override Color GetContentLongTextColor2(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentLongTextColor2(state);
 
         /// <summary>
@@ -1124,7 +1089,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color drawing style.</returns>
-        public PaletteColorStyle GetContentLongTextColorStyle(PaletteContentStyle style, PaletteState state)
+        public override PaletteColorStyle GetContentLongTextColorStyle(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentLongTextColorStyle(state);
 
         /// <summary>
@@ -1133,7 +1098,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color alignment style.</returns>
-        public PaletteRectangleAlign GetContentLongTextColorAlign(PaletteContentStyle style, PaletteState state)
+        public override PaletteRectangleAlign GetContentLongTextColorAlign(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentLongTextColorAlign(state);
 
         /// <summary>
@@ -1142,7 +1107,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Angle used for color drawing.</returns>
-        public float GetContentLongTextColorAngle(PaletteContentStyle style, PaletteState state)
+        public override float GetContentLongTextColorAngle(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentLongTextColorAngle(state);
 
         /// <summary>
@@ -1151,7 +1116,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Image instance.</returns>
-        public Image GetContentLongTextImage(PaletteContentStyle style, PaletteState state)
+        public override Image GetContentLongTextImage(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentLongTextImage(state);
 
         /// <summary>
@@ -1160,7 +1125,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Image style value.</returns>
-        public PaletteImageStyle GetContentLongTextImageStyle(PaletteContentStyle style, PaletteState state)
+        public override PaletteImageStyle GetContentLongTextImageStyle(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentLongTextImageStyle(state);
 
         /// <summary>
@@ -1169,7 +1134,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Image alignment style.</returns>
-        public PaletteRectangleAlign GetContentLongTextImageAlign(PaletteContentStyle style, PaletteState state)
+        public override PaletteRectangleAlign GetContentLongTextImageAlign(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentLongTextImageAlign(state);
 
         /// <summary>
@@ -1178,7 +1143,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentPadding(state);
 
         /// <summary>
@@ -1187,18 +1152,18 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Integer value.</returns>
-        public int GetContentAdjacentGap(PaletteContentStyle style, PaletteState state)
+        public override int GetContentAdjacentGap(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentAdjacentGap(state);
         #endregion
 
-        #region IPalette Metric
+        #region PaletteBase Metric
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
         {
             return metric switch
             {
@@ -1222,7 +1187,7 @@ namespace Krypton.Toolkit
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>InheritBool value.</returns>
-        public InheritBool GetMetricBool(PaletteState state, PaletteMetricBool metric)
+        public override InheritBool GetMetricBool(PaletteState state, PaletteMetricBool metric)
         {
             if (metric == PaletteMetricBool.HeaderGroupOverlay)
             {
@@ -1239,7 +1204,7 @@ namespace Krypton.Toolkit
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -1344,13 +1309,13 @@ namespace Krypton.Toolkit
 
         #endregion
 
-        #region IPalette Images
+        #region PaletteBase Images
         /// <summary>
         /// Gets a tree view image appropriate for the provided state.
         /// </summary>
         /// <param name="expanded">Is the node expanded</param>
         /// <returns>Appropriate image for drawing; otherwise null.</returns>
-        public Image GetTreeViewImage(bool expanded) =>
+        public override Image GetTreeViewImage(bool expanded) =>
             // Not found, then inherit from target
             (expanded ? Images.TreeView.Minus : Images.TreeView.Plus) ?? _redirector.GetTreeViewImage(expanded);
 
@@ -1362,7 +1327,7 @@ namespace Krypton.Toolkit
         /// <param name="tracking">Is the check box being hot tracked.</param>
         /// <param name="pressed">Is the check box being pressed.</param>
         /// <returns>Appropriate image for drawing; otherwise null.</returns>
-        public Image GetCheckBoxImage(bool enabled, CheckState checkState, bool tracking, bool pressed)
+        public override Image GetCheckBoxImage(bool enabled, CheckState checkState, bool tracking, bool pressed)
         {
             Image retImage = null;
 
@@ -1443,7 +1408,7 @@ namespace Krypton.Toolkit
         /// <param name="tracking">Is the radio button being hot tracked.</param>
         /// <param name="pressed">Is the radio button being pressed.</param>
         /// <returns>Appropriate image for drawing; otherwise null.</returns>
-        public Image GetRadioButtonImage(bool enabled, bool checkState, bool tracking, bool pressed)
+        public override Image GetRadioButtonImage(bool enabled, bool checkState, bool tracking, bool pressed)
         {
             Image retImage;
 
@@ -1498,7 +1463,7 @@ namespace Krypton.Toolkit
         /// Gets a drop down button image appropriate for the provided state.
         /// </summary>
         /// <param name="state">PaletteState for which image is required.</param>
-        public Image GetDropDownButtonImage(PaletteState state)
+        public override Image GetDropDownButtonImage(PaletteState state)
         {
             // Grab state specific image
             Image retImage = state switch
@@ -1521,7 +1486,7 @@ namespace Krypton.Toolkit
         /// Gets a checked image appropriate for a context menu item.
         /// </summary>
         /// <returns>Appropriate image for drawing; otherwise null.</returns>
-        public Image GetContextMenuCheckedImage()
+        public override Image GetContextMenuCheckedImage()
         {
             Image retImage = Images.ContextMenu.Checked;
 
@@ -1533,7 +1498,7 @@ namespace Krypton.Toolkit
         /// Gets a indeterminate image appropriate for a context menu item.
         /// </summary>
         /// <returns>Appropriate image for drawing; otherwise null.</returns>
-        public Image GetContextMenuIndeterminateImage()
+        public override Image GetContextMenuIndeterminateImage()
         {
             Image retImage = Images.ContextMenu.Indeterminate;
 
@@ -1545,7 +1510,7 @@ namespace Krypton.Toolkit
         /// Gets an image indicating a sub-menu on a context menu item.
         /// </summary>
         /// <returns>Appropriate image for drawing; otherwise null.</returns>
-        public Image GetContextMenuSubMenuImage()
+        public override Image GetContextMenuSubMenuImage()
         {
             Image retImage = Images.ContextMenu.SubMenu;
 
@@ -1559,7 +1524,7 @@ namespace Krypton.Toolkit
         /// <param name="button">Enum of the button to fetch.</param>
         /// <param name="state">State of the button to fetch.</param>
         /// <returns>Appropriate image for drawing; otherwise null.</returns>
-        public Image GetGalleryButtonImage(PaletteRibbonGalleryButton button, PaletteState state)
+        public override Image GetGalleryButtonImage(PaletteRibbonGalleryButton button, PaletteState state)
         {
             Image retImage = null;
             KryptonPaletteImagesGalleryButton images = button switch
@@ -1587,13 +1552,13 @@ namespace Krypton.Toolkit
         }
         #endregion
 
-        #region IPalette ButtonSpec
+        #region PaletteBase ButtonSpec
         /// <summary>
         /// Gets the icon to display for the button.
         /// </summary>
         /// <param name="style">Style of button spec.</param>
         /// <returns>Icon value.</returns>
-        public Icon GetButtonSpecIcon(PaletteButtonSpecStyle style)
+        public override Icon GetButtonSpecIcon(PaletteButtonSpecStyle style)
         => GetPaletteButtonSpec(style).GetButtonSpecIcon(style);
 
         /// <summary>
@@ -1602,7 +1567,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Style of button spec.</param>
         /// <param name="state">State for which image is required.</param>
         /// <returns>Image value.</returns>
-        public Image GetButtonSpecImage(PaletteButtonSpecStyle style, PaletteState state)
+        public override Image GetButtonSpecImage(PaletteButtonSpecStyle style, PaletteState state)
         => GetPaletteButtonSpec(style).GetButtonSpecImage(style, state);
 
         /// <summary>
@@ -1610,7 +1575,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="style">Style of button spec.</param>
         /// <returns>Color value.</returns>
-        public Color GetButtonSpecImageTransparentColor(PaletteButtonSpecStyle style)
+        public override Color GetButtonSpecImageTransparentColor(PaletteButtonSpecStyle style)
         => GetPaletteButtonSpec(style).GetButtonSpecImageTransparentColor(style);
 
         /// <summary>
@@ -1618,7 +1583,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="style">Style of button spec.</param>
         /// <returns>String value.</returns>
-        public string GetButtonSpecShortText(PaletteButtonSpecStyle style)
+        public override string GetButtonSpecShortText(PaletteButtonSpecStyle style)
         => GetPaletteButtonSpec(style).GetButtonSpecShortText(style);
 
         /// <summary>
@@ -1626,7 +1591,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="style">Style of button spec.</param>
         /// <returns>String value.</returns>
-        public string GetButtonSpecLongText(PaletteButtonSpecStyle style)
+        public override string GetButtonSpecLongText(PaletteButtonSpecStyle style)
         => GetPaletteButtonSpec(style).GetButtonSpecLongText(style);
 
         /// <summary>
@@ -1634,7 +1599,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="style">Style of button spec.</param>
         /// <returns>String value.</returns>
-        public string GetButtonSpecToolTipTitle(PaletteButtonSpecStyle style)
+        public override string GetButtonSpecToolTipTitle(PaletteButtonSpecStyle style)
         => GetPaletteButtonSpec(style).GetButtonSpecToolTipTitle(style);
 
         /// <summary>
@@ -1642,15 +1607,17 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="style">Style of button spec.</param>
         /// <returns>Color value.</returns>
-        public Color GetButtonSpecColorMap(PaletteButtonSpecStyle style)
+        public override Color GetButtonSpecColorMap(PaletteButtonSpecStyle style)
         => GetPaletteButtonSpec(style).GetButtonSpecColorMap(style);
+
+        public override Color GetButtonSpecColorTransparent(PaletteButtonSpecStyle style) => throw new NotImplementedException();
 
         /// <summary>
         /// Gets the button style used for drawing the button.
         /// </summary>
         /// <param name="style">Style of button spec.</param>
         /// <returns>PaletteButtonStyle value.</returns>
-        public PaletteButtonStyle GetButtonSpecStyle(PaletteButtonSpecStyle style)
+        public override PaletteButtonStyle GetButtonSpecStyle(PaletteButtonSpecStyle style)
         => GetPaletteButtonSpec(style).GetButtonSpecStyle(style);
 
         /// <summary>
@@ -1658,7 +1625,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="style">Style of button spec.</param>
         /// <returns>HeaderLocation value.</returns>
-        public HeaderLocation GetButtonSpecLocation(PaletteButtonSpecStyle style)
+        public override HeaderLocation GetButtonSpecLocation(PaletteButtonSpecStyle style)
         => GetPaletteButtonSpec(style).GetButtonSpecLocation(style);
 
         /// <summary>
@@ -1666,7 +1633,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="style">Style of button spec.</param>
         /// <returns>PaletteRelativeEdgeAlign value.</returns>
-        public PaletteRelativeEdgeAlign GetButtonSpecEdge(PaletteButtonSpecStyle style)
+        public override PaletteRelativeEdgeAlign GetButtonSpecEdge(PaletteButtonSpecStyle style)
         => GetPaletteButtonSpec(style).GetButtonSpecEdge(style);
 
         /// <summary>
@@ -1674,16 +1641,16 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="style">Style of button spec.</param>
         /// <returns>PaletteButtonOrientation value.</returns>
-        public PaletteButtonOrientation GetButtonSpecOrientation(PaletteButtonSpecStyle style)
+        public override PaletteButtonOrientation GetButtonSpecOrientation(PaletteButtonSpecStyle style)
         => GetPaletteButtonSpec(style).GetButtonSpecOrientation(style);
         #endregion
 
-        #region IPalette RibbonGeneral
+        #region PaletteBase RibbonGeneral
         /// <summary>
         /// Gets the ribbon shape that should be used.
         /// </summary>
         /// <returns>Ribbon shape value.</returns>
-        public PaletteRibbonShape GetRibbonShape()
+        public override PaletteRibbonShape GetRibbonShape()
         => GetPaletteRibbonGeneral().GetRibbonShape();
 
         /// <summary>
@@ -1691,14 +1658,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public virtual PaletteRelativeAlign GetRibbonContextTextAlign(PaletteState state) => GetPaletteRibbonGeneral().GetRibbonContextTextAlign(state);
+        public override PaletteRelativeAlign GetRibbonContextTextAlign(PaletteState state) => GetPaletteRibbonGeneral().GetRibbonContextTextAlign(state);
 
         /// <summary>
         /// Gets the font for the ribbon context text.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public Font GetRibbonContextTextFont(PaletteState state)
+        public override Font GetRibbonContextTextFont(PaletteState state)
         => GetPaletteRibbonGeneral().GetRibbonContextTextFont(state);
 
         /// <summary>
@@ -1706,7 +1673,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public Color GetRibbonContextTextColor(PaletteState state)
+        public override Color GetRibbonContextTextColor(PaletteState state)
         => GetPaletteRibbonGeneral().GetRibbonContextTextColor(state);
 
         /// <summary>
@@ -1714,7 +1681,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetRibbonDisabledDark(PaletteState state)
+        public override Color GetRibbonDisabledDark(PaletteState state)
         => GetPaletteRibbonGeneral(state).GetRibbonDisabledDark(state);
 
         /// <summary>
@@ -1722,7 +1689,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetRibbonDisabledLight(PaletteState state)
+        public override Color GetRibbonDisabledLight(PaletteState state)
         => GetPaletteRibbonGeneral(state).GetRibbonDisabledLight(state);
 
         /// <summary>
@@ -1730,7 +1697,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetRibbonDropArrowLight(PaletteState state)
+        public override Color GetRibbonDropArrowLight(PaletteState state)
         => GetPaletteRibbonGeneral(state).GetRibbonDropArrowLight(state);
 
         /// <summary>
@@ -1738,7 +1705,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetRibbonDropArrowDark(PaletteState state)
+        public override Color GetRibbonDropArrowDark(PaletteState state)
         => GetPaletteRibbonGeneral(state).GetRibbonDropArrowDark(state);
 
         /// <summary>
@@ -1746,7 +1713,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetRibbonGroupDialogDark(PaletteState state)
+        public override Color GetRibbonGroupDialogDark(PaletteState state)
         => GetPaletteRibbonGeneral(state).GetRibbonGroupDialogDark(state);
 
         /// <summary>
@@ -1754,7 +1721,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetRibbonGroupDialogLight(PaletteState state)
+        public override Color GetRibbonGroupDialogLight(PaletteState state)
         => GetPaletteRibbonGeneral(state).GetRibbonGroupDialogLight(state);
 
         /// <summary>
@@ -1762,7 +1729,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetRibbonGroupSeparatorDark(PaletteState state)
+        public override Color GetRibbonGroupSeparatorDark(PaletteState state)
         => GetPaletteRibbonGeneral(state).GetRibbonGroupSeparatorDark(state);
 
         /// <summary>
@@ -1770,7 +1737,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetRibbonGroupSeparatorLight(PaletteState state)
+        public override Color GetRibbonGroupSeparatorLight(PaletteState state)
         => GetPaletteRibbonGeneral(state).GetRibbonGroupSeparatorLight(state);
 
         /// <summary>
@@ -1778,7 +1745,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetRibbonMinimizeBarDark(PaletteState state)
+        public override Color GetRibbonMinimizeBarDark(PaletteState state)
         => GetPaletteRibbonGeneral(state).GetRibbonMinimizeBarDark(state);
 
         /// <summary>
@@ -1786,7 +1753,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetRibbonMinimizeBarLight(PaletteState state)
+        public override Color GetRibbonMinimizeBarLight(PaletteState state)
         => GetPaletteRibbonGeneral(state).GetRibbonMinimizeBarLight(state);
 
         /// <summary>
@@ -1794,7 +1761,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public Font GetRibbonTextFont(PaletteState state)
+        public override Font GetRibbonTextFont(PaletteState state)
         => GetPaletteRibbonGeneral(state).GetRibbonTextFont(state);
 
         /// <summary>
@@ -1802,7 +1769,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>PaletteTextHint value.</returns>
-        public PaletteTextHint GetRibbonTextHint(PaletteState state)
+        public override PaletteTextHint GetRibbonTextHint(PaletteState state)
         => GetPaletteRibbonGeneral(state).GetRibbonTextHint(state);
 
         /// <summary>
@@ -1810,7 +1777,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetRibbonTabSeparatorColor(PaletteState state)
+        public override Color GetRibbonTabSeparatorColor(PaletteState state)
         => GetPaletteRibbonGeneral(state).GetRibbonTabSeparatorColor(state);
 
         /// <summary>
@@ -1818,14 +1785,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetRibbonTabSeparatorContextColor(PaletteState state) => GetPaletteRibbonGeneral(state).GetRibbonTabSeparatorContextColor(state);
+        public override Color GetRibbonTabSeparatorContextColor(PaletteState state) => GetPaletteRibbonGeneral(state).GetRibbonTabSeparatorContextColor(state);
 
         /// <summary>
         /// Gets the color for the extra QAT button dark content color.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetRibbonQATButtonDark(PaletteState state)
+        public override Color GetRibbonQATButtonDark(PaletteState state)
         => GetPaletteRibbonGeneral(state).GetRibbonQATButtonDark(state);
 
         /// <summary>
@@ -1833,18 +1800,18 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetRibbonQATButtonLight(PaletteState state)
+        public override Color GetRibbonQATButtonLight(PaletteState state)
         => GetPaletteRibbonGeneral(state).GetRibbonQATButtonLight(state);
         #endregion
 
-        #region IPalette RibbonBack
+        #region PaletteBase RibbonBack
         /// <summary>
         /// Gets the method used to draw the background of a ribbon item.
         /// </summary>
         /// <param name="style">Background style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>PaletteRibbonBackStyle value.</returns>
-        public PaletteRibbonColorStyle GetRibbonBackColorStyle(PaletteRibbonBackStyle style, PaletteState state)
+        public override PaletteRibbonColorStyle GetRibbonBackColorStyle(PaletteRibbonBackStyle style, PaletteState state)
         => GetPaletteRibbonBack(style, state).GetRibbonBackColorStyle(state);
 
         /// <summary>
@@ -1853,7 +1820,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Background style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetRibbonBackColor1(PaletteRibbonBackStyle style, PaletteState state)
+        public override Color GetRibbonBackColor1(PaletteRibbonBackStyle style, PaletteState state)
         => GetPaletteRibbonBack(style, state).GetRibbonBackColor1(state);
 
         /// <summary>
@@ -1862,7 +1829,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Background style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetRibbonBackColor2(PaletteRibbonBackStyle style, PaletteState state)
+        public override Color GetRibbonBackColor2(PaletteRibbonBackStyle style, PaletteState state)
         => GetPaletteRibbonBack(style, state).GetRibbonBackColor2(state);
 
         /// <summary>
@@ -1871,7 +1838,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Background style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetRibbonBackColor3(PaletteRibbonBackStyle style, PaletteState state)
+        public override Color GetRibbonBackColor3(PaletteRibbonBackStyle style, PaletteState state)
         => GetPaletteRibbonBack(style, state).GetRibbonBackColor3(state);
 
         /// <summary>
@@ -1880,7 +1847,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Background style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetRibbonBackColor4(PaletteRibbonBackStyle style, PaletteState state)
+        public override Color GetRibbonBackColor4(PaletteRibbonBackStyle style, PaletteState state)
         => GetPaletteRibbonBack(style, state).GetRibbonBackColor4(state);
 
         /// <summary>
@@ -1889,29 +1856,29 @@ namespace Krypton.Toolkit
         /// <param name="style">Background style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetRibbonBackColor5(PaletteRibbonBackStyle style, PaletteState state)
+        public override Color GetRibbonBackColor5(PaletteRibbonBackStyle style, PaletteState state)
         => GetPaletteRibbonBack(style, state).GetRibbonBackColor5(state);
         #endregion
 
-        #region IPalette RibbonText
+        #region PaletteBase RibbonText
         /// <summary>
         /// Gets the tab color for the item text.
         /// </summary>
         /// <param name="style">Text style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetRibbonTextColor(PaletteRibbonTextStyle style, PaletteState state)
+        public override Color GetRibbonTextColor(PaletteRibbonTextStyle style, PaletteState state)
         => GetPaletteRibbonText(style, state).GetRibbonTextColor(state);
         #endregion
 
-        #region IPalette ElementColor
+        #region PaletteBase ElementColor
         /// <summary>
         /// Gets the first element color.
         /// </summary>
         /// <param name="element">Element for which color is required.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetElementColor1(PaletteElement element, PaletteState state)
+        public override Color GetElementColor1(PaletteElement element, PaletteState state)
         => GetTrackBar(element, state).GetElementColor1(state);
 
         /// <summary>
@@ -1920,7 +1887,7 @@ namespace Krypton.Toolkit
         /// <param name="element">Element for which color is required.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetElementColor2(PaletteElement element, PaletteState state)
+        public override Color GetElementColor2(PaletteElement element, PaletteState state)
         => GetTrackBar(element, state).GetElementColor2(state);
 
         /// <summary>
@@ -1929,7 +1896,7 @@ namespace Krypton.Toolkit
         /// <param name="element">Element for which color is required.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetElementColor3(PaletteElement element, PaletteState state)
+        public override Color GetElementColor3(PaletteElement element, PaletteState state)
         => GetTrackBar(element, state).GetElementColor3(state);
 
         /// <summary>
@@ -1938,7 +1905,7 @@ namespace Krypton.Toolkit
         /// <param name="element">Element for which color is required.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetElementColor4(PaletteElement element, PaletteState state)
+        public override Color GetElementColor4(PaletteElement element, PaletteState state)
         => GetTrackBar(element, state).GetElementColor4(state);
 
         /// <summary>
@@ -1947,66 +1914,8 @@ namespace Krypton.Toolkit
         /// <param name="element">Element for which color is required.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public Color GetElementColor5(PaletteElement element, PaletteState state)
+        public override Color GetElementColor5(PaletteElement element, PaletteState state)
         => GetTrackBar(element, state).GetElementColor5(state);
-        #endregion
-
-        #region IPalette DragDrop
-        /// <summary>
-        /// Gets the feedback drawing method used.
-        /// </summary>
-        /// <returns>Feedback enumeration value.</returns>
-        public PaletteDragFeedback GetDragDropFeedback()
-        => DragDrop.GetDragDropFeedback();
-
-        /// <summary>
-        /// Gets the background color for a solid drag drop area.
-        /// </summary>
-        /// <returns>Color value.</returns>
-        public Color GetDragDropSolidBack()
-        => DragDrop.GetDragDropSolidBack();
-
-        /// <summary>
-        /// Gets the border color for a solid drag drop area.
-        /// </summary>
-        /// <returns>Color value.</returns>
-        public Color GetDragDropSolidBorder()
-        => DragDrop.GetDragDropSolidBorder();
-
-        /// <summary>
-        /// Gets the opacity of the solid area.
-        /// </summary>
-        /// <returns>Opacity ranging from 0 to 1.</returns>
-        public float GetDragDropSolidOpacity()
-        => DragDrop.GetDragDropSolidOpacity();
-
-        /// <summary>
-        /// Gets the background color for the docking indicators area.
-        /// </summary>
-        /// <returns>Color value.</returns>
-        public Color GetDragDropDockBack()
-        => DragDrop.GetDragDropDockBack();
-
-        /// <summary>
-        /// Gets the border color for the docking indicators area.
-        /// </summary>
-        /// <returns>Color value.</returns>
-        public Color GetDragDropDockBorder()
-        => DragDrop.GetDragDropDockBorder();
-
-        /// <summary>
-        /// Gets the active color for docking indicators.
-        /// </summary>
-        /// <returns>Color value.</returns>
-        public Color GetDragDropDockActive()
-        => DragDrop.GetDragDropDockActive();
-
-        /// <summary>
-        /// Gets the inactive color for docking indicators.
-        /// </summary>
-        /// <returns>Color value.</returns>
-        public Color GetDragDropDockInactive()
-        => DragDrop.GetDragDropDockInactive();
         #endregion
 
         #region Public Methods
@@ -2609,7 +2518,7 @@ namespace Krypton.Toolkit
                         default:
                             // Cache the original values
                             PaletteMode tempMode = _basePaletteMode;
-                            IPalette tempPalette = _basePalette;
+                            PaletteBase tempPalette = _basePalette;
 
                             // Use the new value
                             _basePaletteMode = value;
@@ -2656,7 +2565,7 @@ namespace Krypton.Toolkit
         [Category(@"Visuals")]
         [Description(@"KryptonPalette used to inherit from.")]
         [DefaultValue(null)]
-        public IPalette BasePalette
+        public PaletteBase BasePalette
         {
             get => _basePalette;
 
@@ -2667,7 +2576,7 @@ namespace Krypton.Toolkit
                 {
                     // Store the original values
                     PaletteMode tempMode = _basePaletteMode;
-                    IPalette tempPalette = _basePalette;
+                    PaletteBase tempPalette = _basePalette;
 
                     // Find the new palette mode based on the incoming value
                     _basePaletteMode = value == null ? PaletteMode.Microsoft365Blue : PaletteMode.Custom;
@@ -2793,11 +2702,16 @@ namespace Krypton.Toolkit
         private bool ShouldSerializeBaseRenderer() => BaseRenderer != null;
         private void ResetBaseRenderer() => BaseRenderer = null;
 
+        protected override void DefineFonts()
+        {
+            throw new NotImplementedException();
+        }
+
         /// <summary>
         /// Gets access to the color table instance.
         /// </summary>
         [Browsable(false)]
-        public KryptonColorTable ColorTable => ToolMenuStatus.InternalKCT;
+        public override KryptonColorTable ColorTable => ToolMenuStatus.InternalKCT;
 
         #endregion
 
@@ -2813,12 +2727,12 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">An PaintLayoutEventArgs containing event data.</param>
-        protected virtual void OnPalettePaint(object sender, PaletteLayoutEventArgs e)
+        protected override void OnPalettePaint(object sender, PaletteLayoutEventArgs e)
         {
             // Can only generate change events if not suspended
             if (_suspendCount == 0)
             {
-                PalettePaint?.Invoke(this, e);
+                base.OnPalettePaint(this, e);
             }
         }
 
@@ -2827,12 +2741,12 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">An EventArgs containing event data.</param>
-        protected virtual void OnAllowFormChromeChanged(object sender, EventArgs e)
+        protected override void OnAllowFormChromeChanged(object sender, EventArgs e)
         {
             // Can only generate change events if not suspended
             if (_suspendCount == 0)
             {
-                AllowFormChromeChanged?.Invoke(this, e);
+                base.OnAllowFormChromeChanged(this, e);
             }
         }
 
@@ -2841,12 +2755,12 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">An EventArgs containing event data.</param>
-        protected virtual void OnBasePaletteChanged(object sender, EventArgs e)
+        protected override void OnBasePaletteChanged(object sender, EventArgs e)
         {
             // Can only generate change events if not suspended
             if (_suspendCount == 0)
             {
-                BasePaletteChanged?.Invoke(this, e);
+                base.OnBasePaletteChanged(this, e);
             }
         }
 
@@ -2855,12 +2769,12 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">An EventArgs containing event data.</param>
-        protected virtual void OnBaseRendererChanged(object sender, EventArgs e)
+        protected override void OnBaseRendererChanged(object sender, EventArgs e)
         {
             // Can only generate change events if not suspended
             if (_suspendCount == 0)
             {
-                BaseRendererChanged?.Invoke(this, e);
+                base.OnBaseRendererChanged(this, e);
             }
         }
 
@@ -2869,35 +2783,24 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">An EventArgs containing event data.</param>
-        protected virtual void OnButtonSpecChanged(object sender, EventArgs e)
+        protected override void OnButtonSpecChanged(object sender, EventArgs e)
         {
             // Can only generate change events if not suspended
             if (_suspendCount == 0)
             {
-                ButtonSpecChanged?.Invoke(this, e);
+                base.OnButtonSpecChanged(this, e);
             }
         }
-        #endregion
-
-        #region Property Grid
-        // Note: Uncomment when `KryptonPalettePropertyGrid` is completed
-        //[KryptonPersist]
-        //[Category(@"Visuals")]
-        //[Description(@"Colors associated with the property grid control.")]
-        //[DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-        //public KryptonPalettePropertyGrid PropertyGrid { get; set; }
-
-        //public bool ShouldSerializePropertyGrid() => !PropertyGrid.IsDefault;
         #endregion
 
         #region Internal
         internal bool HasCircularReference()
         {
             // Use a dictionary as a set to check for existence
-            var paletteSet = new Dictionary<IPalette, bool>();
+            var paletteSet = new Dictionary<PaletteBase, bool>();
 
             // Start processing from ourself upwards
-            IPalette palette = this;
+            PaletteBase palette = this;
 
             // Keep searching until no more palettes found
             while (palette != null)
@@ -2914,7 +2817,7 @@ namespace Krypton.Toolkit
                     // Cast to correct type
 
                     // If this is a KryptonPalette instance
-                    if (palette is KryptonPalette owner)
+                    if (palette is KryptonCustomPaletteBase owner)
                     {
                         // Get the next palette up in hierarchy
                         palette = owner.BasePaletteMode switch
@@ -3594,7 +3497,7 @@ namespace Krypton.Toolkit
                                     if (propertyIsDefault != null && propertyIsDefault.PropertyType == typeof(bool))
                                     {
                                         // If the object 'IsDefault' then no need to reset it
-                                        if ((bool)propertyIsDefault.GetValue(childObj))
+                                        if ((bool)propertyIsDefault.GetValue(childObj)!)
                                         {
                                             childObj = null;
                                         }
@@ -5702,7 +5605,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void SetPalette(IPalette basePalette)
+        private void SetPalette(PaletteBase basePalette)
         {
             if (basePalette != _basePalette)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPropertyGrid.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPropertyGrid.cs
@@ -18,7 +18,7 @@ namespace Krypton.Toolkit
     public class KryptonPropertyGrid : PropertyGrid
     {
         #region Variables
-        private IPalette _palette;
+        private PaletteBase _palette;
 
         private readonly PaletteRedirect _paletteRedirect;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTableLayoutPanel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTableLayoutPanel.cs
@@ -167,7 +167,7 @@ namespace Krypton.Toolkit
         [Category(@"Visuals")]
         [Description(@"Custom palette applied to drawing.")]
         [DefaultValue(null)]
-        public IPalette Palette
+        public PaletteBase Palette
         {
             [DebuggerStepThrough]
             get => _backGroundPanel.Palette;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
@@ -19,14 +19,17 @@ namespace Krypton.Toolkit
     public class KryptonThemeComboBox : KryptonComboBox
     {
         #region Instance Fields
-        private readonly List<string> _supportedThemesList;
+        private readonly ICollection<string> _supportedThemesNames;
         private int _selectedIndex;
         #endregion
 
         #region Properties
 
+        /// <summary>
+        /// Helper, to return a new list of names
+        /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public List<string> SupportedThemesList => _supportedThemesList;
+        public List<string> SupportedThemesList => _supportedThemesNames.ToList();
 
         /// <summary>
         /// Gets and sets the ThemeSelectedIndex.
@@ -62,7 +65,7 @@ namespace Krypton.Toolkit
         {
             DropDownStyle = ComboBoxStyle.DropDownList;
 
-            _supportedThemesList = ThemeManager.PropagateSupportedThemeList();
+            _supportedThemesNames = ThemeManager.SupportedInternalThemeNames;
             _selectedIndex = 25;
         }
         #endregion
@@ -79,13 +82,15 @@ namespace Krypton.Toolkit
 
         #region Protected Overrides
 
+        /// <inheritdoc />
         protected override void OnCreateControl()
         {
             base.OnCreateControl();
-            Items.AddRange(ThemeManager.ReturnThemeArray());
+            Items.AddRange(_supportedThemesNames.ToArray());
             SelectedIndex = _selectedIndex;
         }
 
+        /// <inheritdoc />
         protected override void OnSelectedIndexChanged(EventArgs e)
         {
             ThemeManager.ApplyTheme(Text, Manager);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonWebBrowser.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonWebBrowser.cs
@@ -23,7 +23,7 @@ namespace Krypton.Toolkit
     public class KryptonWebBrowser : WebBrowser
     {
         #region Instance Fields
-        private IPalette _palette;
+        private PaletteBase _palette;
         private readonly PaletteMode _paletteMode = PaletteMode.Global;
         private KryptonContextMenu _kryptonContextMenu;
         private IRenderer _renderer;
@@ -199,7 +199,7 @@ namespace Krypton.Toolkit
 
         /// <summary>Sets the palette being used.</summary>
         /// <param name="palette">The chosen palette.</param>
-        private void SetPalette(IPalette palette)
+        private void SetPalette(PaletteBase palette)
         {
             if (palette != _palette)
             {
@@ -262,7 +262,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public IPalette GetResolvedPalette() => _palette;
+        public PaletteBase GetResolvedPalette() => _palette;
 
         #endregion Palette Controls
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonWrapLabel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonWrapLabel.cs
@@ -30,8 +30,8 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Instance Fields
-        private IPalette _localPalette;
-        private IPalette _palette;
+        private PaletteBase _localPalette;
+        private PaletteBase _palette;
         private PaletteMode _paletteMode;
         private readonly PaletteRedirect _redirector;
         private LabelStyle _labelStyle;
@@ -320,7 +320,7 @@ namespace Krypton.Toolkit
         [Category(@"Visuals")]
         [Description(@"Custom palette applied to drawing.")]
         [DefaultValue(null)]
-        public IPalette Palette
+        public PaletteBase Palette
         {
             [DebuggerStepThrough]
             get => _localPalette;
@@ -331,7 +331,7 @@ namespace Krypton.Toolkit
                 if (_localPalette != value)
                 {
                     // Remember the starting palette
-                    IPalette old = _localPalette;
+                    PaletteBase old = _localPalette;
 
                     // Use the provided palette value
                     SetPalette(value);
@@ -405,7 +405,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public IPalette GetResolvedPalette() => _palette;
+        public PaletteBase GetResolvedPalette() => _palette;
 
         /// <summary>
         /// Gets access to the current renderer.
@@ -775,7 +775,7 @@ namespace Krypton.Toolkit
 
         /// <summary>Sets the palette.</summary>
         /// <param name="palette">The palette.</param>
-        private void SetPalette(IPalette palette)
+        private void SetPalette(PaletteBase palette)
         {
             if (palette != _palette)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContainerControlBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContainerControlBase.cs
@@ -30,8 +30,8 @@ namespace Krypton.Toolkit
         private bool _refreshAll;
         private bool _paintTransparent;
         private bool _evalTransparent;
-        private IPalette _localPalette;
-        private IPalette _palette;
+        private PaletteBase _localPalette;
+        private PaletteBase _palette;
         private PaletteMode _paletteMode;
         private readonly SimpleCall _refreshCall;
         private readonly SimpleCall _layoutCall;
@@ -318,7 +318,7 @@ namespace Krypton.Toolkit
         [Category(@"Visuals")]
         [Description(@"Custom palette applied to drawing.")]
         [DefaultValue(null)]
-        public IPalette Palette
+        public PaletteBase Palette
         {
             [DebuggerStepThrough]
             get => _localPalette;
@@ -329,7 +329,7 @@ namespace Krypton.Toolkit
                 if (_localPalette != value)
                 {
                     // Remember the starting palette
-                    IPalette old = _localPalette;
+                    PaletteBase old = _localPalette;
 
                     // Use the provided palette value
                     SetPalette(value);
@@ -426,7 +426,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public IPalette GetResolvedPalette() => _palette;
+        public PaletteBase GetResolvedPalette() => _palette;
 
         /// <summary>
         /// Gets and sets the dirty palette counter.
@@ -1081,7 +1081,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void SetPalette(IPalette palette)
+        private void SetPalette(PaletteBase palette)
         {
             if (palette != _palette)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContextMenu.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContextMenu.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit
     {
         #region Instance Fields
         private readonly KryptonContextMenu _contextMenu;
-        private IPalette _palette;
+        private PaletteBase _palette;
         private readonly ContextMenuProvider _provider;
         private ViewDrawDocker _drawDocker;
         private readonly ViewLayoutStack _viewColumns;
@@ -70,7 +70,7 @@ namespace Krypton.Toolkit
         /// <param name="enabled">Enabled state of the context menu.</param>
         /// <param name="keyboardActivated">Was the context menu activate by a keyboard action.</param>
         public VisualContextMenu(KryptonContextMenu contextMenu,
-                                 IPalette palette,
+                                 PaletteBase palette,
                                  PaletteMode paletteMode,
                                  PaletteRedirect redirector,
                                  PaletteRedirectContextMenu redirectorImages,
@@ -468,7 +468,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void SetPalette(IPalette palette)
+        private void SetPalette(PaletteBase palette)
         {
             if (palette != _palette)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContextMenuDTP.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContextMenuDTP.cs
@@ -35,7 +35,7 @@ namespace Krypton.Toolkit
         /// <param name="keyboardActivated">Was the context menu activate by a keyboard action.</param>
         /// <param name="dropScreenRect">Screen rectangle of the drop down button.</param>
         public VisualContextMenuDTP(KryptonContextMenu contextMenu,
-                                    IPalette palette,
+                                    PaletteBase palette,
                                     PaletteMode paletteMode,
                                     PaletteRedirect redirector,
                                     PaletteRedirectContextMenu redirectorImages,

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualControlBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualControlBase.cs
@@ -31,8 +31,8 @@ namespace Krypton.Toolkit
         private bool _paintTransparent;
         private bool _evalTransparent;
         private bool _globalEvents;
-        private IPalette _localPalette;
-        private IPalette _palette;
+        private PaletteBase _localPalette;
+        private PaletteBase _palette;
         private PaletteMode _paletteMode;
         private readonly SimpleCall _refreshCall;
         private readonly SimpleCall _layoutCall;
@@ -325,7 +325,7 @@ namespace Krypton.Toolkit
         [Category(@"Visuals")]
         [Description(@"Custom palette applied to drawing.")]
         [DefaultValue(null)]
-        public IPalette Palette
+        public PaletteBase Palette
         {
             [DebuggerStepThrough]
             get => _localPalette;
@@ -336,7 +336,7 @@ namespace Krypton.Toolkit
                 if (_localPalette != value)
                 {
                     // Remember the starting palette
-                    IPalette old = _localPalette;
+                    PaletteBase old = _localPalette;
 
                     // Use the provided palette value
                     SetPalette(value);
@@ -433,7 +433,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public IPalette GetResolvedPalette() => _palette;
+        public PaletteBase GetResolvedPalette() => _palette;
 
         /// <summary>
         /// Gets and sets the dirty palette counter.
@@ -1170,7 +1170,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void SetPalette(IPalette palette)
+        private void SetPalette(PaletteBase palette)
         {
             if (palette != _palette)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
@@ -39,8 +39,8 @@ namespace Krypton.Toolkit
         private int _compositionHeight;
         private int _ignoreCount;
         private ViewBase _capturedElement;
-        private IPalette _localPalette;
-        private IPalette _palette;
+        private PaletteBase _localPalette;
+        private PaletteBase _palette;
         private PaletteMode _paletteMode;
         private readonly IntPtr _screenDC;
         private ShadowValues _shadowValues;
@@ -454,7 +454,7 @@ namespace Krypton.Toolkit
         [Category(@"Visuals")]
         [Description(@"Custom palette applied to drawing.")]
         [DefaultValue(null)]
-        public IPalette Palette
+        public PaletteBase Palette
         {
             [DebuggerStepThrough]
             get => _localPalette;
@@ -465,7 +465,7 @@ namespace Krypton.Toolkit
                 if (_localPalette != value)
                 {
                     // Remember the starting palette
-                    IPalette old = _localPalette;
+                    PaletteBase old = _localPalette;
 
                     // Use the provided palette value
                     SetPalette(value);
@@ -531,7 +531,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public IPalette GetResolvedPalette() => _palette;
+        public PaletteBase GetResolvedPalette() => _palette;
 
         /// <summary>
         /// Create a tool strip renderer appropriate for the current renderer/palette pair.
@@ -1881,7 +1881,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void SetPalette(IPalette palette)
+        private void SetPalette(PaletteBase palette)
         {
             if (palette != _palette)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPanel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPanel.cs
@@ -34,8 +34,8 @@ namespace Krypton.Toolkit
         private bool _evalTransparent;
         private bool _globalEvents;
         private Size _lastLayoutSize;
-        private IPalette _localPalette;
-        private IPalette _palette;
+        private PaletteBase _localPalette;
+        private PaletteBase _palette;
         private PaletteMode _paletteMode;
         private readonly SimpleCall _refreshCall;
         private KryptonContextMenu _kryptonContextMenu;
@@ -353,7 +353,7 @@ namespace Krypton.Toolkit
         [Category(@"Visuals")]
         [Description(@"Custom palette applied to drawing.")]
         [DefaultValue(null)]
-        public IPalette Palette
+        public PaletteBase Palette
         {
             [DebuggerStepThrough]
             get => _localPalette;
@@ -364,7 +364,7 @@ namespace Krypton.Toolkit
                 if (_localPalette != value)
                 {
                     // Remember the starting palette
-                    IPalette old = _localPalette;
+                    PaletteBase old = _localPalette;
 
                     // Use the provided palette value
                     SetPalette(value);
@@ -705,7 +705,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public IPalette GetResolvedPalette() => _palette;
+        public PaletteBase GetResolvedPalette() => _palette;
 
         #endregion
 
@@ -1061,7 +1061,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void SetPalette(IPalette palette)
+        private void SetPalette(PaletteBase palette)
         {
             if (palette != _palette)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPopup.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPopup.cs
@@ -79,8 +79,8 @@ namespace Krypton.Toolkit
             #endregion
 
             // We use double buffering to reduce drawing flicker
-            SetStyle(ControlStyles.OptimizedDoubleBuffer 
-                     | ControlStyles.AllPaintingInWmPaint 
+            SetStyle(ControlStyles.OptimizedDoubleBuffer
+                     | ControlStyles.AllPaintingInWmPaint
                      | ControlStyles.UserPaint, true);
 
             // We need to repaint entire control whenever resized
@@ -292,7 +292,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual IPalette GetResolvedPalette() => null;
+        public virtual PaletteBase GetResolvedPalette() => null;
 
         /// <summary>
         /// Gets access to the current renderer.

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonPaletteActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonPaletteActionList.cs
@@ -15,7 +15,7 @@ namespace Krypton.Toolkit
     internal class KryptonPaletteActionList : DesignerActionList
     {
         #region Instance Fields
-        private readonly KryptonPalette _palette;
+        private readonly KryptonCustomPaletteBase _palette;
         private readonly IComponentChangeService _service;
         #endregion
 
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit
             : base(owner.Component)
         {
             // Remember the panel instance
-            _palette = owner.Component as KryptonPalette;
+            _palette = owner.Component as KryptonCustomPaletteBase;
 
             // Cache service used to notify when a property has changed
             _service = (IComponentChangeService)GetService(typeof(IComponentChangeService));

--- a/Source/Krypton Components/Krypton.Toolkit/General/ContextMenuProvider.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/ContextMenuProvider.cs
@@ -88,7 +88,7 @@ namespace Krypton.Toolkit
         public ContextMenuProvider(KryptonContextMenu contextMenu,
                                    ViewContextMenuManager viewManager,
                                    ViewLayoutStack viewColumns,
-                                   IPalette palette,
+                                   PaletteBase palette,
                                    PaletteMode paletteMode,
                                    PaletteRedirect redirector,
                                    PaletteRedirectContextMenu redirectorImages,
@@ -132,7 +132,7 @@ namespace Krypton.Toolkit
         /// <param name="enabled">Enabled state of the context menu.</param>
         public ContextMenuProvider(ViewContextMenuManager viewManager,
                                    ViewLayoutStack viewColumns,
-                                   IPalette palette,
+                                   PaletteBase palette,
                                    PaletteMode paletteMode,
                                    PaletteContextMenuRedirect stateCommon,
                                    PaletteContextMenuItemState stateDisabled,
@@ -305,7 +305,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the custom palette.
         /// </summary>
-        public IPalette ProviderPalette { get; }
+        public PaletteBase ProviderPalette { get; }
 
         /// <summary>
         /// Gets access to the palette mode.

--- a/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
@@ -67,56 +67,56 @@ namespace Krypton.Toolkit
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <param name="state">State for which an image is needed.</param>
         /// <returns>Button image.</returns>
-        Image GetImage(IPalette palette, PaletteState state);
+        Image GetImage(PaletteBase palette, PaletteState state);
 
         /// <summary>
         /// Gets the button image transparent color.
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Color value.</returns>
-        Color GetImageTransparentColor(IPalette palette);
+        Color GetImageTransparentColor(PaletteBase palette);
 
         /// <summary>
         /// Gets the button short text.
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Short text string.</returns>
-        string GetShortText(IPalette palette);
+        string GetShortText(PaletteBase palette);
 
         /// <summary>
         /// Gets the button long text.
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Long text string.</returns>
-        string GetLongText(IPalette palette);
+        string GetLongText(PaletteBase palette);
 
         /// <summary>
         /// Gets the button tooltip title text.
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Tooltip title string.</returns>
-        string GetToolTipTitle(IPalette palette);
+        string GetToolTipTitle(PaletteBase palette);
 
         /// <summary>
         /// Gets and image color to remap to container foreground.
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Color value.</returns>
-        Color GetColorMap(IPalette palette);
+        Color GetColorMap(PaletteBase palette);
 
         /// <summary>
         /// Gets the button visibility.
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibility value.</returns>
-        bool GetVisible(IPalette palette);
+        bool GetVisible(PaletteBase palette);
 
         /// <summary>
         /// Gets the button enabled state.
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button enabled value.</returns>
-        ButtonEnabled GetEnabled(IPalette palette);
+        ButtonEnabled GetEnabled(PaletteBase palette);
 
         /// <summary>
         /// Sets the current view associated with the button spec.
@@ -141,28 +141,28 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button edge value.</returns>
-        RelativeEdgeAlign GetEdge(IPalette palette);
+        RelativeEdgeAlign GetEdge(PaletteBase palette);
 
         /// <summary>
         /// Gets the button style.
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button style value.</returns>
-        ButtonStyle GetStyle(IPalette palette);
+        ButtonStyle GetStyle(PaletteBase palette);
 
         /// <summary>
         /// Gets the button location value.
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button location.</returns>
-        HeaderLocation GetLocation(IPalette palette);
+        HeaderLocation GetLocation(PaletteBase palette);
 
         /// <summary>
         /// Gets the button orientation.
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Orientation value.</returns>
-        ButtonOrientation GetOrientation(IPalette palette);
+        ButtonOrientation GetOrientation(PaletteBase palette);
     }
     #endregion
 
@@ -292,7 +292,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the custom palette.
         /// </summary>
-        IPalette ProviderPalette { get; }
+        PaletteBase ProviderPalette { get; }
 
         /// <summary>
         /// Gets access to the palette mode.

--- a/Source/Krypton Components/Krypton.Toolkit/General/GlobalId.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/GlobalId.cs
@@ -12,10 +12,20 @@
 
 namespace Krypton.Toolkit
 {
+    public interface IGlobalId
+    {
+        #region Id
+        /// <summary>
+        /// Gets the unique identifier of the object.
+        /// </summary>
+        int Id { get; }
+        #endregion
+    }
+
     /// <summary>
     /// Contains a global identifier that is unique among objects.
     /// </summary>
-    public class GlobalId
+    public class GlobalId : IGlobalId
     {
         #region Instance Fields
 

--- a/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/HScrollSkin.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/HScrollSkin.cs
@@ -35,7 +35,7 @@ namespace Krypton.Toolkit
 
         private HScrollBar HSB;
 
-        private static IPalette _palette;
+        private static PaletteBase _palette;
         private readonly PaletteRedirect _paletteRedirect;
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/ScrollBarExtendedRenderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/ScrollBarExtendedRenderer.cs
@@ -54,7 +54,7 @@ namespace Krypton.Toolkit
         /// </summary>
         public static Color[] gripColours = new Color[2];
 
-        private static IPalette _palette;
+        private static PaletteBase _palette;
         private static PaletteRedirect _paletteRedirect;
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/ScrollBarKryptonRenderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/ScrollBarKryptonRenderer.cs
@@ -54,7 +54,7 @@ namespace Krypton.Toolkit
         /// </summary>
         public static Color[] gripColours = new Color[2];
 
-        private static IPalette _palette;
+        private static PaletteBase _palette;
         private static PaletteRedirect _paletteRedirect;
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/VScrollSkin.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/VScrollSkin.cs
@@ -35,7 +35,7 @@ namespace Krypton.Toolkit
         private VScrollBar VSB;
         private HScrollBar HSC;
 
-        private static IPalette _palette;
+        private static PaletteBase _palette;
         private readonly PaletteRedirect _paletteRedirect;
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Krypton.Toolkit 2022.csproj.DotSettings
+++ b/Source/Krypton Components/Krypton.Toolkit/Krypton.Toolkit 2022.csproj.DotSettings
@@ -1,2 +1,2 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp100</s:String></wpf:ResourceDictionary>
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">Latest</s:String></wpf:ResourceDictionary>

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBack/PaletteBackToPalette.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBack/PaletteBackToPalette.cs
@@ -18,7 +18,7 @@ namespace Krypton.Toolkit
     public class PaletteBackToPalette : IPaletteBack
     {
         #region Instance Fields
-        private readonly IPalette _palette;
+        private readonly PaletteBase _palette;
 
         #endregion
 
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Source for getting all values.</param>
         /// <param name="style">Style of values required.</param>
-        public PaletteBackToPalette(IPalette palette, PaletteBackStyle style)
+        public PaletteBackToPalette(PaletteBase palette, PaletteBackStyle style)
         {
             // Remember source palette
             _palette = palette;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBorder/PaletteBorderToPalette.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBorder/PaletteBorderToPalette.cs
@@ -18,7 +18,7 @@ namespace Krypton.Toolkit
     public class PaletteBorderToPalette : IPaletteBorder
     {
         #region Instance Fields
-        private readonly IPalette _palette;
+        private readonly PaletteBase _palette;
 
         #endregion
 
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Source for getting all values.</param>
         /// <param name="style">Style of values required.</param>
-        public PaletteBorderToPalette(IPalette palette,
+        public PaletteBorderToPalette(PaletteBase palette,
                                       PaletteBorderStyle style)
         {
             // Remember inheritance

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentToPalette.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentToPalette.cs
@@ -18,7 +18,7 @@ namespace Krypton.Toolkit
     public class PaletteContentToPalette : IPaletteContent
     {
         #region Instance Fields
-        private readonly IPalette _palette;
+        private readonly PaletteBase _palette;
 
         #endregion
 
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Source for getting all values.</param>
         /// <param name="style">Style of values required.</param>
-        public PaletteContentToPalette(IPalette palette, PaletteContentStyle style)
+        public PaletteContentToPalette(PaletteBase palette, PaletteContentStyle style)
         {
             // Remember source palette
             _palette = palette;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDefinitions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDefinitions.cs
@@ -20,7 +20,7 @@ namespace Krypton.Toolkit
 	/// <summary>
 	/// Exposes a palette for drawing.
 	/// </summary>
-	public interface IPalette
+	public interface IPalette1
 	{
 		#region Events
 		/// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDragDrop/PaletteDragDrop.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDragDrop/PaletteDragDrop.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit
                                    IPaletteDragDrop
     {
         #region Instance Fields
-        private IPalette _inherit;
+        private PaletteBase _inherit;
         private PaletteDragFeedback _feedback;
         private Color _solidBack;
         private Color _solidBorder;
@@ -36,7 +36,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="inherit">Source for inheriting values.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteDragDrop(IPalette inherit,
+        public PaletteDragDrop(PaletteBase inherit,
                                NeedPaintHandler needPaint)
         {
             // Remember inheritance
@@ -77,7 +77,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Sets the inheritance parent.
         /// </summary>
-        public void SetInherit(IPalette inherit)
+        public void SetInherit(PaletteBase inherit)
         {
             _inherit = inherit;
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirect.cs
@@ -15,38 +15,10 @@ namespace Krypton.Toolkit
     /// <summary>
     /// Redirects requests onto a dynamic instance of a IPalette.
     /// </summary>
-    public class PaletteRedirect : GlobalId,
-                                   IPalette
+    public class PaletteRedirect : PaletteBase, IGlobalId
     {
         #region Instance Fields
-        private IPalette _target;
-        #endregion
-
-        #region Events
-        /// <summary>
-        /// Occurs when a palette change requires a repaint.
-        /// </summary>
-        public event EventHandler<PaletteLayoutEventArgs> PalettePaint;
-
-        /// <summary>
-        /// Occurs when the AllowFormChrome setting changes.
-        /// </summary>
-        public event EventHandler AllowFormChromeChanged;
-
-        /// <summary>
-        /// Occurs when the BasePalette/BasePaletteMode setting changes.
-        /// </summary>
-        public event EventHandler BasePaletteChanged;
-
-        /// <summary>
-        /// Occurs when the BaseRenderer/BaseRendererMode setting changes.
-        /// </summary>
-        public event EventHandler BaseRendererChanged;
-
-        /// <summary>
-        /// Occurs when a button spec change occurs.
-        /// </summary>
-        public event EventHandler ButtonSpecChanged;
+        private PaletteBase _target;
         #endregion
 
         #region Identity
@@ -62,16 +34,20 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteRedirect class.
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
-        public PaletteRedirect(IPalette target) =>
+        public PaletteRedirect(PaletteBase target)
+        {
+            Id = CommonHelper.NextId;
             // Remember incoming target
             _target = target;
+        }
+
         #endregion
 
         #region Target
         /// <summary>
         /// Gets and sets the redirection target.
         /// </summary>
-        public virtual IPalette Target
+        public virtual PaletteBase Target
         {
             get => _target;
             set => _target = value;
@@ -83,7 +59,7 @@ namespace Krypton.Toolkit
         /// Gets a value indicating if KryptonForm instances should show custom chrome.
         /// </summary>
         /// <returns>InheritBool value.</returns>
-        public virtual InheritBool GetAllowFormChrome() => _target.GetAllowFormChrome();
+        public override InheritBool GetAllowFormChrome() => _target.GetAllowFormChrome();
 
         #endregion
 
@@ -92,7 +68,7 @@ namespace Krypton.Toolkit
         /// Gets the renderer to use for this palette.
         /// </summary>
         /// <returns>Renderer to use for drawing palette settings.</returns>
-        public virtual IRenderer GetRenderer() => _target.GetRenderer();
+        public override IRenderer GetRenderer() => _target.GetRenderer();
 
         #endregion
 
@@ -103,7 +79,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Background style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>InheritBool value.</returns>
-        public virtual InheritBool GetBackDraw(PaletteBackStyle style, PaletteState state) => _target.GetBackDraw(style, state);
+        public override InheritBool GetBackDraw(PaletteBackStyle style, PaletteState state) => _target.GetBackDraw(style, state);
 
         /// <summary>
         /// Gets the graphics drawing hint for the background.
@@ -111,7 +87,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Border style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>PaletteGraphicsHint value.</returns>
-        public virtual PaletteGraphicsHint GetBackGraphicsHint(PaletteBackStyle style, PaletteState state) => _target.GetBackGraphicsHint(style, state);
+        public override PaletteGraphicsHint GetBackGraphicsHint(PaletteBackStyle style, PaletteState state) => _target.GetBackGraphicsHint(style, state);
 
         /// <summary>
         /// Gets the first background color.
@@ -119,7 +95,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Background style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetBackColor1(PaletteBackStyle style, PaletteState state) => _target.GetBackColor1(style, state);
+        public override Color GetBackColor1(PaletteBackStyle style, PaletteState state) => _target.GetBackColor1(style, state);
 
         /// <summary>
         /// Gets the second back color.
@@ -127,7 +103,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Background style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetBackColor2(PaletteBackStyle style, PaletteState state) => _target.GetBackColor2(style, state);
+        public override Color GetBackColor2(PaletteBackStyle style, PaletteState state) => _target.GetBackColor2(style, state);
 
         /// <summary>
         /// Gets the color background drawing style.
@@ -135,7 +111,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Background style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color drawing style.</returns>
-        public virtual PaletteColorStyle GetBackColorStyle(PaletteBackStyle style, PaletteState state) => _target.GetBackColorStyle(style, state);
+        public override PaletteColorStyle GetBackColorStyle(PaletteBackStyle style, PaletteState state) => _target.GetBackColorStyle(style, state);
 
         /// <summary>
         /// Gets the color alignment.
@@ -143,7 +119,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Background style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color alignment style.</returns>
-        public virtual PaletteRectangleAlign GetBackColorAlign(PaletteBackStyle style, PaletteState state) => _target.GetBackColorAlign(style, state);
+        public override PaletteRectangleAlign GetBackColorAlign(PaletteBackStyle style, PaletteState state) => _target.GetBackColorAlign(style, state);
 
         /// <summary>
         /// Gets the color background angle.
@@ -151,7 +127,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Background style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Angle used for color drawing.</returns>
-        public virtual float GetBackColorAngle(PaletteBackStyle style, PaletteState state) => _target.GetBackColorAngle(style, state);
+        public override float GetBackColorAngle(PaletteBackStyle style, PaletteState state) => _target.GetBackColorAngle(style, state);
 
         /// <summary>
         /// Gets a background image.
@@ -159,7 +135,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Background style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Image instance.</returns>
-        public virtual Image GetBackImage(PaletteBackStyle style, PaletteState state) => _target.GetBackImage(style, state);
+        public override Image GetBackImage(PaletteBackStyle style, PaletteState state) => _target.GetBackImage(style, state);
 
         /// <summary>
         /// Gets the background image style.
@@ -167,7 +143,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Background style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Image style value.</returns>
-        public virtual PaletteImageStyle GetBackImageStyle(PaletteBackStyle style, PaletteState state) => _target.GetBackImageStyle(style, state);
+        public override PaletteImageStyle GetBackImageStyle(PaletteBackStyle style, PaletteState state) => _target.GetBackImageStyle(style, state);
 
         /// <summary>
         /// Gets the image alignment.
@@ -175,7 +151,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Background style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Image alignment style.</returns>
-        public virtual PaletteRectangleAlign GetBackImageAlign(PaletteBackStyle style, PaletteState state) => _target.GetBackImageAlign(style, state);
+        public override PaletteRectangleAlign GetBackImageAlign(PaletteBackStyle style, PaletteState state) => _target.GetBackImageAlign(style, state);
 
         #endregion
 
@@ -186,7 +162,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Border style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>InheritBool value.</returns>
-        public virtual InheritBool GetBorderDraw(PaletteBorderStyle style, PaletteState state) => _target.GetBorderDraw(style, state);
+        public override InheritBool GetBorderDraw(PaletteBorderStyle style, PaletteState state) => _target.GetBorderDraw(style, state);
 
         /// <summary>
         /// Gets a value indicating which borders to draw.
@@ -194,7 +170,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Border style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>PaletteDrawBorders value.</returns>
-        public virtual PaletteDrawBorders GetBorderDrawBorders(PaletteBorderStyle style, PaletteState state) => _target.GetBorderDrawBorders(style, state);
+        public override PaletteDrawBorders GetBorderDrawBorders(PaletteBorderStyle style, PaletteState state) => _target.GetBorderDrawBorders(style, state);
 
         /// <summary>
         /// Gets the graphics drawing hint for the border.
@@ -202,7 +178,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Border style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>PaletteGraphicsHint value.</returns>
-        public virtual PaletteGraphicsHint GetBorderGraphicsHint(PaletteBorderStyle style, PaletteState state) => _target.GetBorderGraphicsHint(style, state);
+        public override PaletteGraphicsHint GetBorderGraphicsHint(PaletteBorderStyle style, PaletteState state) => _target.GetBorderGraphicsHint(style, state);
 
         /// <summary>
         /// Gets the first border color.
@@ -210,7 +186,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Border style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetBorderColor1(PaletteBorderStyle style, PaletteState state) => _target.GetBorderColor1(style, state);
+        public override Color GetBorderColor1(PaletteBorderStyle style, PaletteState state) => _target.GetBorderColor1(style, state);
 
         /// <summary>
         /// Gets the second border color.
@@ -218,7 +194,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Border style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetBorderColor2(PaletteBorderStyle style, PaletteState state) => _target.GetBorderColor2(style, state);
+        public override Color GetBorderColor2(PaletteBorderStyle style, PaletteState state) => _target.GetBorderColor2(style, state);
 
         /// <summary>
         /// Gets the color border drawing style.
@@ -226,7 +202,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Border style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color drawing style.</returns>
-        public virtual PaletteColorStyle GetBorderColorStyle(PaletteBorderStyle style, PaletteState state) => _target.GetBorderColorStyle(style, state);
+        public override PaletteColorStyle GetBorderColorStyle(PaletteBorderStyle style, PaletteState state) => _target.GetBorderColorStyle(style, state);
 
         /// <summary>
         /// Gets the color border alignment.
@@ -234,7 +210,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Border style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color alignment style.</returns>
-        public virtual PaletteRectangleAlign GetBorderColorAlign(PaletteBorderStyle style, PaletteState state) => _target.GetBorderColorAlign(style, state);
+        public override PaletteRectangleAlign GetBorderColorAlign(PaletteBorderStyle style, PaletteState state) => _target.GetBorderColorAlign(style, state);
 
         /// <summary>
         /// Gets the color border angle.
@@ -242,7 +218,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Border style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Angle used for color drawing.</returns>
-        public virtual float GetBorderColorAngle(PaletteBorderStyle style, PaletteState state) => _target.GetBorderColorAngle(style, state);
+        public override float GetBorderColorAngle(PaletteBorderStyle style, PaletteState state) => _target.GetBorderColorAngle(style, state);
 
         /// <summary>
         /// Gets the border width.
@@ -250,7 +226,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Border style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Integer width.</returns>
-        public virtual int GetBorderWidth(PaletteBorderStyle style, PaletteState state) => _target.GetBorderWidth(style, state);
+        public override int GetBorderWidth(PaletteBorderStyle style, PaletteState state) => _target.GetBorderWidth(style, state);
 
         /// <summary>
         /// Gets the border corner rounding.
@@ -258,7 +234,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Border style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Float rounding.</returns>
-        public virtual float GetBorderRounding(PaletteBorderStyle style, PaletteState state) => _target.GetBorderRounding(style, state);
+        public override float GetBorderRounding(PaletteBorderStyle style, PaletteState state) => _target.GetBorderRounding(style, state);
 
         /// <summary>
         /// Gets a border image.
@@ -266,7 +242,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Border style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Image instance.</returns>
-        public virtual Image GetBorderImage(PaletteBorderStyle style, PaletteState state) => _target.GetBorderImage(style, state);
+        public override Image GetBorderImage(PaletteBorderStyle style, PaletteState state) => _target.GetBorderImage(style, state);
 
         /// <summary>
         /// Gets the border image style.
@@ -274,7 +250,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Border style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Image style value.</returns>
-        public virtual PaletteImageStyle GetBorderImageStyle(PaletteBorderStyle style, PaletteState state) => _target.GetBorderImageStyle(style, state);
+        public override PaletteImageStyle GetBorderImageStyle(PaletteBorderStyle style, PaletteState state) => _target.GetBorderImageStyle(style, state);
 
         /// <summary>
         /// Gets the image border alignment.
@@ -282,7 +258,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Border style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Image alignment style.</returns>
-        public virtual PaletteRectangleAlign GetBorderImageAlign(PaletteBorderStyle style, PaletteState state) => _target.GetBorderImageAlign(style, state);
+        public override PaletteRectangleAlign GetBorderImageAlign(PaletteBorderStyle style, PaletteState state) => _target.GetBorderImageAlign(style, state);
         #endregion
 
         #region Content
@@ -292,7 +268,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>InheritBool value.</returns>
-        public virtual InheritBool GetContentDraw(PaletteContentStyle style, PaletteState state) => _target.GetContentDraw(style, state);
+        public override InheritBool GetContentDraw(PaletteContentStyle style, PaletteState state) => _target.GetContentDraw(style, state);
 
         /// <summary>
         /// Gets a value indicating if content should be drawn with focus indication.
@@ -300,7 +276,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>InheritBool value.</returns>
-        public virtual InheritBool GetContentDrawFocus(PaletteContentStyle style, PaletteState state) => _target.GetContentDrawFocus(style, state);
+        public override InheritBool GetContentDrawFocus(PaletteContentStyle style, PaletteState state) => _target.GetContentDrawFocus(style, state);
 
         /// <summary>
         /// Gets the horizontal relative alignment of the image.
@@ -308,7 +284,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>RelativeAlignment value.</returns>
-        public virtual PaletteRelativeAlign GetContentImageH(PaletteContentStyle style, PaletteState state) => _target.GetContentImageH(style, state);
+        public override PaletteRelativeAlign GetContentImageH(PaletteContentStyle style, PaletteState state) => _target.GetContentImageH(style, state);
 
         /// <summary>
         /// Gets the vertical relative alignment of the image.
@@ -316,7 +292,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>RelativeAlignment value.</returns>
-        public virtual PaletteRelativeAlign GetContentImageV(PaletteContentStyle style, PaletteState state) => _target.GetContentImageV(style, state);
+        public override PaletteRelativeAlign GetContentImageV(PaletteContentStyle style, PaletteState state) => _target.GetContentImageV(style, state);
 
         /// <summary>
         /// Gets the effect applied to drawing of the image.
@@ -324,7 +300,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>PaletteImageEffect value.</returns>
-        public virtual PaletteImageEffect GetContentImageEffect(PaletteContentStyle style, PaletteState state) => _target.GetContentImageEffect(style, state);
+        public override PaletteImageEffect GetContentImageEffect(PaletteContentStyle style, PaletteState state) => _target.GetContentImageEffect(style, state);
 
         /// <summary>
         /// Gets the image color to remap into another color.
@@ -332,7 +308,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetContentImageColorMap(PaletteContentStyle style, PaletteState state) => _target.GetContentImageColorMap(style, state);
+        public override Color GetContentImageColorMap(PaletteContentStyle style, PaletteState state) => _target.GetContentImageColorMap(style, state);
 
         /// <summary>
         /// Gets the color to use in place of the image map color.
@@ -340,7 +316,10 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetContentImageColorTo(PaletteContentStyle style, PaletteState state) => _target.GetContentImageColorTo(style, state);
+        public override Color GetContentImageColorTo(PaletteContentStyle style, PaletteState state) => _target.GetContentImageColorTo(style, state);
+
+        /// <inheritdoc />
+        public override Color GetContentImageColorTransparent(PaletteContentStyle style, PaletteState state) => _target.GetContentImageColorTransparent(style, state);
 
         /// <summary>
         /// Gets the font for the short text.
@@ -348,7 +327,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public virtual Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextFont(style, state);
+        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextFont(style, state);
 
         /// <summary>
         /// Gets the font for the short text by generating a new font instance.
@@ -356,7 +335,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public virtual Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextNewFont(style, state);
+        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextNewFont(style, state);
 
         /// <summary>
         /// Gets the rendering hint for the short text.
@@ -364,7 +343,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>PaletteTextHint value.</returns>
-        public virtual PaletteTextHint GetContentShortTextHint(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextHint(style, state);
+        public override PaletteTextHint GetContentShortTextHint(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextHint(style, state);
 
         /// <summary>
         /// Gets the prefix drawing setting for short text.
@@ -372,7 +351,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>PaletteTextPrefix value.</returns>
-        public virtual PaletteTextHotkeyPrefix GetContentShortTextPrefix(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextPrefix(style, state);
+        public override PaletteTextHotkeyPrefix GetContentShortTextPrefix(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextPrefix(style, state);
 
         /// <summary>
         /// Gets the flag indicating if multiline text is allowed for short text.
@@ -380,7 +359,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>InheritBool value.</returns>
-        public virtual InheritBool GetContentShortTextMultiLine(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextMultiLine(style, state);
+        public override InheritBool GetContentShortTextMultiLine(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextMultiLine(style, state);
 
         /// <summary>
         /// Gets the text trimming to use for short text.
@@ -388,7 +367,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>PaletteTextTrim value.</returns>
-        public virtual PaletteTextTrim GetContentShortTextTrim(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextTrim(style, state);
+        public override PaletteTextTrim GetContentShortTextTrim(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextTrim(style, state);
 
         /// <summary>
         /// Gets the horizontal relative alignment of the short text.
@@ -396,7 +375,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>RelativeAlignment value.</returns>
-        public virtual PaletteRelativeAlign GetContentShortTextH(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextH(style, state);
+        public override PaletteRelativeAlign GetContentShortTextH(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextH(style, state);
 
         /// <summary>
         /// Gets the vertical relative alignment of the short text.
@@ -404,7 +383,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>RelativeAlignment value.</returns>
-        public virtual PaletteRelativeAlign GetContentShortTextV(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextV(style, state);
+        public override PaletteRelativeAlign GetContentShortTextV(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextV(style, state);
 
         /// <summary>
         /// Gets the horizontal relative alignment of multiline short text.
@@ -412,7 +391,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>RelativeAlignment value.</returns>
-        public virtual PaletteRelativeAlign GetContentShortTextMultiLineH(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextMultiLineH(style, state);
+        public override PaletteRelativeAlign GetContentShortTextMultiLineH(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextMultiLineH(style, state);
 
         /// <summary>
         /// Gets the first back color for the short text.
@@ -420,7 +399,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetContentShortTextColor1(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextColor1(style, state);
+        public override Color GetContentShortTextColor1(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextColor1(style, state);
 
         /// <summary>
         /// Gets the second back color for the short text.
@@ -428,7 +407,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetContentShortTextColor2(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextColor2(style, state);
+        public override Color GetContentShortTextColor2(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextColor2(style, state);
 
         /// <summary>
         /// Gets the color drawing style for the short text.
@@ -436,7 +415,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color drawing style.</returns>
-        public virtual PaletteColorStyle GetContentShortTextColorStyle(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextColorStyle(style, state);
+        public override PaletteColorStyle GetContentShortTextColorStyle(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextColorStyle(style, state);
 
         /// <summary>
         /// Gets the color alignment for the short text.
@@ -444,7 +423,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color alignment style.</returns>
-        public virtual PaletteRectangleAlign GetContentShortTextColorAlign(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextColorAlign(style, state);
+        public override PaletteRectangleAlign GetContentShortTextColorAlign(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextColorAlign(style, state);
 
         /// <summary>
         /// Gets the color background angle for the short text.
@@ -452,7 +431,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Angle used for color drawing.</returns>
-        public virtual float GetContentShortTextColorAngle(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextColorAngle(style, state);
+        public override float GetContentShortTextColorAngle(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextColorAngle(style, state);
 
         /// <summary>
         /// Gets a background image for the short text.
@@ -460,7 +439,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Image instance.</returns>
-        public virtual Image GetContentShortTextImage(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextImage(style, state);
+        public override Image GetContentShortTextImage(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextImage(style, state);
 
         /// <summary>
         /// Gets the background image style.
@@ -468,7 +447,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Image style value.</returns>
-        public virtual PaletteImageStyle GetContentShortTextImageStyle(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextImageStyle(style, state);
+        public override PaletteImageStyle GetContentShortTextImageStyle(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextImageStyle(style, state);
 
         /// <summary>
         /// Gets the image alignment for the short text.
@@ -476,7 +455,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Image alignment style.</returns>
-        public virtual PaletteRectangleAlign GetContentShortTextImageAlign(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextImageAlign(style, state);
+        public override PaletteRectangleAlign GetContentShortTextImageAlign(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextImageAlign(style, state);
 
         /// <summary>
         /// Gets the font for the long text.
@@ -484,7 +463,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public virtual Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextFont(style, state);
+        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextFont(style, state);
 
         /// <summary>
         /// Gets the font for the long text by generating a new font instance.
@@ -492,7 +471,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public virtual Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextNewFont(style, state);
+        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextNewFont(style, state);
 
         /// <summary>
         /// Gets the rendering hint for the long text.
@@ -500,7 +479,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>PaletteTextHint value.</returns>
-        public virtual PaletteTextHint GetContentLongTextHint(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextHint(style, state);
+        public override PaletteTextHint GetContentLongTextHint(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextHint(style, state);
 
         /// <summary>
         /// Gets the flag indicating if multiline text is allowed for long text.
@@ -508,7 +487,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>InheritBool value.</returns>
-        public virtual InheritBool GetContentLongTextMultiLine(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextMultiLine(style, state);
+        public override InheritBool GetContentLongTextMultiLine(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextMultiLine(style, state);
 
         /// <summary>
         /// Gets the text trimming to use for long text.
@@ -516,7 +495,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>PaletteTextTrim value.</returns>
-        public virtual PaletteTextTrim GetContentLongTextTrim(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextTrim(style, state);
+        public override PaletteTextTrim GetContentLongTextTrim(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextTrim(style, state);
 
         /// <summary>
         /// Gets the prefix drawing setting for long text.
@@ -524,7 +503,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>PaletteTextPrefix value.</returns>
-        public virtual PaletteTextHotkeyPrefix GetContentLongTextPrefix(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextPrefix(style, state);
+        public override PaletteTextHotkeyPrefix GetContentLongTextPrefix(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextPrefix(style, state);
 
         /// <summary>
         /// Gets the horizontal relative alignment of the long text.
@@ -532,7 +511,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>RelativeAlignment value.</returns>
-        public virtual PaletteRelativeAlign GetContentLongTextH(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextH(style, state);
+        public override PaletteRelativeAlign GetContentLongTextH(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextH(style, state);
 
         /// <summary>
         /// Gets the vertical relative alignment of the long text.
@@ -540,7 +519,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>RelativeAlignment value.</returns>
-        public virtual PaletteRelativeAlign GetContentLongTextV(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextV(style, state);
+        public override PaletteRelativeAlign GetContentLongTextV(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextV(style, state);
 
         /// <summary>
         /// Gets the horizontal relative alignment of multiline long text.
@@ -548,7 +527,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>RelativeAlignment value.</returns>
-        public virtual PaletteRelativeAlign GetContentLongTextMultiLineH(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextMultiLineH(style, state);
+        public override PaletteRelativeAlign GetContentLongTextMultiLineH(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextMultiLineH(style, state);
 
         /// <summary>
         /// Gets the first back color for the long text.
@@ -556,7 +535,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetContentLongTextColor1(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextColor1(style, state);
+        public override Color GetContentLongTextColor1(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextColor1(style, state);
 
         /// <summary>
         /// Gets the second back color for the long text.
@@ -564,7 +543,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetContentLongTextColor2(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextColor2(style, state);
+        public override Color GetContentLongTextColor2(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextColor2(style, state);
 
         /// <summary>
         /// Gets the color drawing style for the long text.
@@ -572,7 +551,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color drawing style.</returns>
-        public virtual PaletteColorStyle GetContentLongTextColorStyle(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextColorStyle(style, state);
+        public override PaletteColorStyle GetContentLongTextColorStyle(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextColorStyle(style, state);
 
         /// <summary>
         /// Gets the color alignment for the long text.
@@ -580,7 +559,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color alignment style.</returns>
-        public virtual PaletteRectangleAlign GetContentLongTextColorAlign(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextColorAlign(style, state);
+        public override PaletteRectangleAlign GetContentLongTextColorAlign(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextColorAlign(style, state);
 
         /// <summary>
         /// Gets the color background angle for the long text.
@@ -588,7 +567,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Angle used for color drawing.</returns>
-        public virtual float GetContentLongTextColorAngle(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextColorAngle(style, state);
+        public override float GetContentLongTextColorAngle(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextColorAngle(style, state);
 
         /// <summary>
         /// Gets a background image for the long text.
@@ -596,7 +575,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Image instance.</returns>
-        public virtual Image GetContentLongTextImage(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextImage(style, state);
+        public override Image GetContentLongTextImage(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextImage(style, state);
 
         /// <summary>
         /// Gets the background image style for the long text.
@@ -604,7 +583,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Image style value.</returns>
-        public virtual PaletteImageStyle GetContentLongTextImageStyle(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextImageStyle(style, state);
+        public override PaletteImageStyle GetContentLongTextImageStyle(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextImageStyle(style, state);
 
         /// <summary>
         /// Gets the image alignment for the long text.
@@ -612,7 +591,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Image alignment style.</returns>
-        public virtual PaletteRectangleAlign GetContentLongTextImageAlign(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextImageAlign(style, state);
+        public override PaletteRectangleAlign GetContentLongTextImageAlign(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextImageAlign(style, state);
 
         /// <summary>
         /// Gets the padding between the border and content drawing.
@@ -620,7 +599,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public virtual Padding GetContentPadding(PaletteContentStyle style, PaletteState state) => _target.GetContentPadding(style, state);
+        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state) => _target.GetContentPadding(style, state);
 
         /// <summary>
         /// Gets the padding between adjacent content items.
@@ -628,7 +607,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Integer value.</returns>
-        public virtual int GetContentAdjacentGap(PaletteContentStyle style, PaletteState state) => _target.GetContentAdjacentGap(style, state);
+        public override int GetContentAdjacentGap(PaletteContentStyle style, PaletteState state) => _target.GetContentAdjacentGap(style, state);
 
         #endregion
 
@@ -639,7 +618,7 @@ namespace Krypton.Toolkit
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public virtual int GetMetricInt(PaletteState state, PaletteMetricInt metric) => _target.GetMetricInt(state, metric);
+        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric) => _target.GetMetricInt(state, metric);
 
         /// <summary>
         /// Gets a boolean metric value.
@@ -647,7 +626,7 @@ namespace Krypton.Toolkit
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>InheritBool value.</returns>
-        public virtual InheritBool GetMetricBool(PaletteState state, PaletteMetricBool metric) => _target.GetMetricBool(state, metric);
+        public override InheritBool GetMetricBool(PaletteState state, PaletteMetricBool metric) => _target.GetMetricBool(state, metric);
 
         /// <summary>
         /// Gets a padding metric value.
@@ -655,7 +634,7 @@ namespace Krypton.Toolkit
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public virtual Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric) => _target.GetMetricPadding(state, metric);
+        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric) => _target.GetMetricPadding(state, metric);
 
         #endregion
 
@@ -665,7 +644,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="expanded">Is the node expanded</param>
         /// <returns>Appropriate image for drawing; otherwise null.</returns>
-        public virtual Image GetTreeViewImage(bool expanded) => _target.GetTreeViewImage(expanded);
+        public override Image GetTreeViewImage(bool expanded) => _target.GetTreeViewImage(expanded);
 
         /// <summary>
         /// Gets a check box image appropriate for the provided state.
@@ -675,7 +654,7 @@ namespace Krypton.Toolkit
         /// <param name="tracking">Is the check box being hot tracked.</param>
         /// <param name="pressed">Is the check box being pressed.</param>
         /// <returns>Appropriate image for drawing; otherwise null.</returns>
-        public virtual Image GetCheckBoxImage(bool enabled, CheckState checkState, bool tracking, bool pressed) => _target.GetCheckBoxImage(enabled, checkState, tracking, pressed);
+        public override Image GetCheckBoxImage(bool enabled, CheckState checkState, bool tracking, bool pressed) => _target.GetCheckBoxImage(enabled, checkState, tracking, pressed);
 
         /// <summary>
         /// Gets a check box image appropriate for the provided state.
@@ -685,31 +664,31 @@ namespace Krypton.Toolkit
         /// <param name="tracking">Is the radio button being hot tracked.</param>
         /// <param name="pressed">Is the radio button being pressed.</param>
         /// <returns>Appropriate image for drawing; otherwise null.</returns>
-        public virtual Image GetRadioButtonImage(bool enabled, bool checkState, bool tracking, bool pressed) => _target.GetRadioButtonImage(enabled, checkState, tracking, pressed);
+        public override Image GetRadioButtonImage(bool enabled, bool checkState, bool tracking, bool pressed) => _target.GetRadioButtonImage(enabled, checkState, tracking, pressed);
 
         /// <summary>
         /// Gets a drop down button image appropriate for the provided state.
         /// </summary>
         /// <param name="state">PaletteState for which image is required.</param>
-        public virtual Image GetDropDownButtonImage(PaletteState state) => _target.GetDropDownButtonImage(state);
+        public override Image GetDropDownButtonImage(PaletteState state) => _target.GetDropDownButtonImage(state);
 
         /// <summary>
         /// Gets a checked image appropriate for a context menu item.
         /// </summary>
         /// <returns>Appropriate image for drawing; otherwise null.</returns>
-        public virtual Image GetContextMenuCheckedImage() => _target.GetContextMenuCheckedImage();
+        public override Image GetContextMenuCheckedImage() => _target.GetContextMenuCheckedImage();
 
         /// <summary>
         /// Gets a indeterminate image appropriate for a context menu item.
         /// </summary>
         /// <returns>Appropriate image for drawing; otherwise null.</returns>
-        public virtual Image GetContextMenuIndeterminateImage() => _target.GetContextMenuIndeterminateImage();
+        public override Image GetContextMenuIndeterminateImage() => _target.GetContextMenuIndeterminateImage();
 
         /// <summary>
         /// Gets an image indicating a sub-menu on a context menu item.
         /// </summary>
         /// <returns>Appropriate image for drawing; otherwise null.</returns>
-        public virtual Image GetContextMenuSubMenuImage() => _target.GetContextMenuSubMenuImage();
+        public override Image GetContextMenuSubMenuImage() => _target.GetContextMenuSubMenuImage();
 
         /// <summary>
         /// Gets a check box image appropriate for the provided state.
@@ -717,7 +696,7 @@ namespace Krypton.Toolkit
         /// <param name="button">Enum of the button to fetch.</param>
         /// <param name="state">State of the button to fetch.</param>
         /// <returns>Appropriate image for drawing; otherwise null.</returns>
-        public virtual Image GetGalleryButtonImage(PaletteRibbonGalleryButton button, PaletteState state) => _target.GetGalleryButtonImage(button, state);
+        public override Image GetGalleryButtonImage(PaletteRibbonGalleryButton button, PaletteState state) => _target.GetGalleryButtonImage(button, state);
 
         #endregion
 
@@ -727,7 +706,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="style">Style of button spec.</param>
         /// <returns>Icon value.</returns>
-        public virtual Icon GetButtonSpecIcon(PaletteButtonSpecStyle style) => _target.GetButtonSpecIcon(style);
+        public override Icon GetButtonSpecIcon(PaletteButtonSpecStyle style) => _target.GetButtonSpecIcon(style);
 
         /// <summary>
         /// Gets the image to display for the button.
@@ -735,7 +714,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Style of button spec.</param>
         /// <param name="state">State for which image is required.</param>
         /// <returns>Image value.</returns>
-        public virtual Image GetButtonSpecImage(PaletteButtonSpecStyle style,
+        public override Image GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                 PaletteState state) =>
             _target.GetButtonSpecImage(style, state);
 
@@ -744,63 +723,66 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="style">Style of button spec.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetButtonSpecImageTransparentColor(PaletteButtonSpecStyle style) => _target.GetButtonSpecImageTransparentColor(style);
+        public override Color GetButtonSpecImageTransparentColor(PaletteButtonSpecStyle style) => _target.GetButtonSpecImageTransparentColor(style);
 
         /// <summary>
         /// Gets the short text to display for the button.
         /// </summary>
         /// <param name="style">Style of button spec.</param>
         /// <returns>String value.</returns>
-        public virtual string GetButtonSpecShortText(PaletteButtonSpecStyle style) => _target.GetButtonSpecShortText(style);
+        public override string GetButtonSpecShortText(PaletteButtonSpecStyle style) => _target.GetButtonSpecShortText(style);
 
         /// <summary>
         /// Gets the long text to display for the button.
         /// </summary>
         /// <param name="style">Style of button spec.</param>
         /// <returns>String value.</returns>
-        public virtual string GetButtonSpecLongText(PaletteButtonSpecStyle style) => _target.GetButtonSpecLongText(style);
+        public override string GetButtonSpecLongText(PaletteButtonSpecStyle style) => _target.GetButtonSpecLongText(style);
 
         /// <summary>
         /// Gets the tooltip title text to display for the button.
         /// </summary>
         /// <param name="style">Style of button spec.</param>
         /// <returns>String value.</returns>
-        public virtual string GetButtonSpecToolTipTitle(PaletteButtonSpecStyle style) => _target.GetButtonSpecToolTipTitle(style);
+        public override string GetButtonSpecToolTipTitle(PaletteButtonSpecStyle style) => _target.GetButtonSpecToolTipTitle(style);
 
         /// <summary>
         /// Gets the color to remap from the image to the container foreground.
         /// </summary>
         /// <param name="style">Style of button spec.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetButtonSpecColorMap(PaletteButtonSpecStyle style) => _target.GetButtonSpecColorMap(style);
+        public override Color GetButtonSpecColorMap(PaletteButtonSpecStyle style) => _target.GetButtonSpecColorMap(style);
+
+        /// <inheritdoc />
+        public override Color GetButtonSpecColorTransparent(PaletteButtonSpecStyle style) => _target.GetButtonSpecColorTransparent(style);
 
         /// <summary>
         /// Gets the button style used for drawing the button.
         /// </summary>
         /// <param name="style">Style of button spec.</param>
         /// <returns>ButtonStyle value.</returns>
-        public virtual PaletteButtonStyle GetButtonSpecStyle(PaletteButtonSpecStyle style) => _target.GetButtonSpecStyle(style);
+        public override PaletteButtonStyle GetButtonSpecStyle(PaletteButtonSpecStyle style) => _target.GetButtonSpecStyle(style);
 
         /// <summary>
         /// Get the location for the button.
         /// </summary>
         /// <param name="style">Style of button spec.</param>
         /// <returns>HeaderLocation value.</returns>
-        public virtual HeaderLocation GetButtonSpecLocation(PaletteButtonSpecStyle style) => _target.GetButtonSpecLocation(style);
+        public override HeaderLocation GetButtonSpecLocation(PaletteButtonSpecStyle style) => _target.GetButtonSpecLocation(style);
 
         /// <summary>
         /// Gets the edge to position the button against.
         /// </summary>
         /// <param name="style">Style of button spec.</param>
         /// <returns>PaletteRelativeEdgeAlign value.</returns>
-        public virtual PaletteRelativeEdgeAlign GetButtonSpecEdge(PaletteButtonSpecStyle style) => _target.GetButtonSpecEdge(style);
+        public override PaletteRelativeEdgeAlign GetButtonSpecEdge(PaletteButtonSpecStyle style) => _target.GetButtonSpecEdge(style);
 
         /// <summary>
         /// Gets the button orientation.
         /// </summary>
         /// <param name="style">Style of button spec.</param>
         /// <returns>PaletteButtonOrientation value.</returns>
-        public virtual PaletteButtonOrientation GetButtonSpecOrientation(PaletteButtonSpecStyle style) => _target.GetButtonSpecOrientation(style);
+        public override PaletteButtonOrientation GetButtonSpecOrientation(PaletteButtonSpecStyle style) => _target.GetButtonSpecOrientation(style);
 
         #endregion
 
@@ -809,140 +791,140 @@ namespace Krypton.Toolkit
         /// Gets the ribbon shape that should be used.
         /// </summary>
         /// <returns>Ribbon shape value.</returns>
-        public virtual PaletteRibbonShape GetRibbonShape() => _target.GetRibbonShape();
+        public override PaletteRibbonShape GetRibbonShape() => _target.GetRibbonShape();
 
         /// <summary>
         /// Gets the text alignment for the ribbon context text.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public virtual PaletteRelativeAlign GetRibbonContextTextAlign(PaletteState state) => _target.GetRibbonContextTextAlign(state);
+        public override PaletteRelativeAlign GetRibbonContextTextAlign(PaletteState state) => _target.GetRibbonContextTextAlign(state);
 
         /// <summary>
         /// Gets the font for the ribbon context text.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public virtual Font GetRibbonContextTextFont(PaletteState state) => _target.GetRibbonContextTextFont(state);
+        public override Font GetRibbonContextTextFont(PaletteState state) => _target.GetRibbonContextTextFont(state);
 
         /// <summary>
         /// Gets the color for the ribbon context text.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public virtual Color GetRibbonContextTextColor(PaletteState state) => _target.GetRibbonContextTextColor(state);
+        public override Color GetRibbonContextTextColor(PaletteState state) => _target.GetRibbonContextTextColor(state);
 
         /// <summary>
         /// Gets the dark disabled color used for ribbon glyphs.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetRibbonDisabledDark(PaletteState state) => _target.GetRibbonDisabledDark(state);
+        public override Color GetRibbonDisabledDark(PaletteState state) => _target.GetRibbonDisabledDark(state);
 
         /// <summary>
         /// Gets the light disabled color used for ribbon glyphs.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetRibbonDisabledLight(PaletteState state) => _target.GetRibbonDisabledLight(state);
+        public override Color GetRibbonDisabledLight(PaletteState state) => _target.GetRibbonDisabledLight(state);
 
         /// <summary>
         /// Gets the color for the drop arrow light.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetRibbonDropArrowLight(PaletteState state) => _target.GetRibbonDropArrowLight(state);
+        public override Color GetRibbonDropArrowLight(PaletteState state) => _target.GetRibbonDropArrowLight(state);
 
         /// <summary>
         /// Gets the color for the drop arrow dark.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetRibbonDropArrowDark(PaletteState state) => _target.GetRibbonDropArrowDark(state);
+        public override Color GetRibbonDropArrowDark(PaletteState state) => _target.GetRibbonDropArrowDark(state);
 
         /// <summary>
         /// Gets the color for the dialog launcher dark.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetRibbonGroupDialogDark(PaletteState state) => _target.GetRibbonGroupDialogDark(state);
+        public override Color GetRibbonGroupDialogDark(PaletteState state) => _target.GetRibbonGroupDialogDark(state);
 
         /// <summary>
         /// Gets the color for the dialog launcher light.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetRibbonGroupDialogLight(PaletteState state) => _target.GetRibbonGroupDialogLight(state);
+        public override Color GetRibbonGroupDialogLight(PaletteState state) => _target.GetRibbonGroupDialogLight(state);
 
         /// <summary>
         /// Gets the color for the group separator dark.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetRibbonGroupSeparatorDark(PaletteState state) => _target.GetRibbonGroupSeparatorDark(state);
+        public override Color GetRibbonGroupSeparatorDark(PaletteState state) => _target.GetRibbonGroupSeparatorDark(state);
 
         /// <summary>
         /// Gets the color for the group separator light.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetRibbonGroupSeparatorLight(PaletteState state) => _target.GetRibbonGroupSeparatorLight(state);
+        public override Color GetRibbonGroupSeparatorLight(PaletteState state) => _target.GetRibbonGroupSeparatorLight(state);
 
         /// <summary>
         /// Gets the color for the minimize bar dark.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetRibbonMinimizeBarDark(PaletteState state) => _target.GetRibbonMinimizeBarDark(state);
+        public override Color GetRibbonMinimizeBarDark(PaletteState state) => _target.GetRibbonMinimizeBarDark(state);
 
         /// <summary>
         /// Gets the color for the minimize bar light.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetRibbonMinimizeBarLight(PaletteState state) => _target.GetRibbonMinimizeBarLight(state);
+        public override Color GetRibbonMinimizeBarLight(PaletteState state) => _target.GetRibbonMinimizeBarLight(state);
 
         /// <summary>
         /// Gets the color for the tab separator.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetRibbonTabSeparatorColor(PaletteState state) => _target.GetRibbonTabSeparatorColor(state);
+        public override Color GetRibbonTabSeparatorColor(PaletteState state) => _target.GetRibbonTabSeparatorColor(state);
 
         /// <summary>
         /// Gets the color for the tab context separators.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetRibbonTabSeparatorContextColor(PaletteState state) => _target.GetRibbonTabSeparatorContextColor(state);
+        public override Color GetRibbonTabSeparatorContextColor(PaletteState state) => _target.GetRibbonTabSeparatorContextColor(state);
 
         /// <summary>
         /// Gets the font for the ribbon text.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public virtual Font GetRibbonTextFont(PaletteState state) => _target.GetRibbonTextFont(state);
+        public override Font GetRibbonTextFont(PaletteState state) => _target.GetRibbonTextFont(state);
 
         /// <summary>
         /// Gets the rendering hint for the ribbon font.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>PaletteTextHint value.</returns>
-        public virtual PaletteTextHint GetRibbonTextHint(PaletteState state) => _target.GetRibbonTextHint(state);
+        public override PaletteTextHint GetRibbonTextHint(PaletteState state) => _target.GetRibbonTextHint(state);
 
         /// <summary>
         /// Gets the color for the extra QAT button dark content color.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetRibbonQATButtonDark(PaletteState state) => _target.GetRibbonQATButtonDark(state);
+        public override Color GetRibbonQATButtonDark(PaletteState state) => _target.GetRibbonQATButtonDark(state);
 
         /// <summary>
         /// Gets the color for the extra QAT button light content color.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetRibbonQATButtonLight(PaletteState state) => _target.GetRibbonQATButtonLight(state);
+        public override Color GetRibbonQATButtonLight(PaletteState state) => _target.GetRibbonQATButtonLight(state);
 
         #endregion
 
@@ -953,7 +935,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Background style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>PaletteRibbonBackStyle value.</returns>
-        public virtual PaletteRibbonColorStyle GetRibbonBackColorStyle(PaletteRibbonBackStyle style, PaletteState state) => _target.GetRibbonBackColorStyle(style, state);
+        public override PaletteRibbonColorStyle GetRibbonBackColorStyle(PaletteRibbonBackStyle style, PaletteState state) => _target.GetRibbonBackColorStyle(style, state);
 
         /// <summary>
         /// Gets the first background color for the ribbon item.
@@ -961,7 +943,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Background style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetRibbonBackColor1(PaletteRibbonBackStyle style, PaletteState state) => _target.GetRibbonBackColor1(style, state);
+        public override Color GetRibbonBackColor1(PaletteRibbonBackStyle style, PaletteState state) => _target.GetRibbonBackColor1(style, state);
 
         /// <summary>
         /// Gets the second background color for the ribbon item.
@@ -969,7 +951,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Background style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetRibbonBackColor2(PaletteRibbonBackStyle style, PaletteState state) => _target.GetRibbonBackColor2(style, state);
+        public override Color GetRibbonBackColor2(PaletteRibbonBackStyle style, PaletteState state) => _target.GetRibbonBackColor2(style, state);
 
         /// <summary>
         /// Gets the third background color for the ribbon item.
@@ -977,7 +959,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Background style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetRibbonBackColor3(PaletteRibbonBackStyle style, PaletteState state) => _target.GetRibbonBackColor3(style, state);
+        public override Color GetRibbonBackColor3(PaletteRibbonBackStyle style, PaletteState state) => _target.GetRibbonBackColor3(style, state);
 
         /// <summary>
         /// Gets the fourth background color for the ribbon item.
@@ -985,7 +967,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Background style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetRibbonBackColor4(PaletteRibbonBackStyle style, PaletteState state) => _target.GetRibbonBackColor4(style, state);
+        public override Color GetRibbonBackColor4(PaletteRibbonBackStyle style, PaletteState state) => _target.GetRibbonBackColor4(style, state);
 
         /// <summary>
         /// Gets the fifth background color for the ribbon item.
@@ -993,7 +975,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Background style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetRibbonBackColor5(PaletteRibbonBackStyle style, PaletteState state) => _target.GetRibbonBackColor5(style, state);
+        public override Color GetRibbonBackColor5(PaletteRibbonBackStyle style, PaletteState state) => _target.GetRibbonBackColor5(style, state);
 
         #endregion
 
@@ -1004,7 +986,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Text style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetRibbonTextColor(PaletteRibbonTextStyle style, PaletteState state) => _target.GetRibbonTextColor(style, state);
+        public override Color GetRibbonTextColor(PaletteRibbonTextStyle style, PaletteState state) => _target.GetRibbonTextColor(style, state);
 
         #endregion
 
@@ -1015,7 +997,7 @@ namespace Krypton.Toolkit
         /// <param name="element">Element for which color is required.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetElementColor1(PaletteElement element, PaletteState state) => _target.GetElementColor1(element, state);
+        public override Color GetElementColor1(PaletteElement element, PaletteState state) => _target.GetElementColor1(element, state);
 
         /// <summary>
         /// Gets the second element color.
@@ -1023,7 +1005,7 @@ namespace Krypton.Toolkit
         /// <param name="element">Element for which color is required.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetElementColor2(PaletteElement element, PaletteState state) => _target.GetElementColor2(element, state);
+        public override Color GetElementColor2(PaletteElement element, PaletteState state) => _target.GetElementColor2(element, state);
 
         /// <summary>
         /// Gets the third element color.
@@ -1031,7 +1013,7 @@ namespace Krypton.Toolkit
         /// <param name="element">Element for which color is required.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetElementColor3(PaletteElement element, PaletteState state) => _target.GetElementColor3(element, state);
+        public override Color GetElementColor3(PaletteElement element, PaletteState state) => _target.GetElementColor3(element, state);
 
         /// <summary>
         /// Gets the fourth element color.
@@ -1039,7 +1021,7 @@ namespace Krypton.Toolkit
         /// <param name="element">Element for which color is required.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetElementColor4(PaletteElement element, PaletteState state) => _target.GetElementColor4(element, state);
+        public override Color GetElementColor4(PaletteElement element, PaletteState state) => _target.GetElementColor4(element, state);
 
         /// <summary>
         /// Gets the fifth element color.
@@ -1047,7 +1029,7 @@ namespace Krypton.Toolkit
         /// <param name="element">Element for which color is required.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetElementColor5(PaletteElement element, PaletteState state) => _target.GetElementColor5(element, state);
+        public override Color GetElementColor5(PaletteElement element, PaletteState state) => _target.GetElementColor5(element, state);
 
         #endregion
 
@@ -1056,108 +1038,70 @@ namespace Krypton.Toolkit
         /// Gets the feedback drawing method used.
         /// </summary>
         /// <returns>Feedback enumeration value.</returns>
-        public virtual PaletteDragFeedback GetDragDropFeedback() => _target.GetDragDropFeedback();
+        public override PaletteDragFeedback GetDragDropFeedback() => _target.GetDragDropFeedback();
 
         /// <summary>
         /// Gets the background color for a solid drag drop area.
         /// </summary>
         /// <returns>Color value.</returns>
-        public virtual Color GetDragDropSolidBack() => _target.GetDragDropSolidBack();
+        public override Color GetDragDropSolidBack() => _target.GetDragDropSolidBack();
 
         /// <summary>
         /// Gets the border color for a solid drag drop area.
         /// </summary>
         /// <returns>Color value.</returns>
-        public virtual Color GetDragDropSolidBorder() => _target.GetDragDropSolidBack();
+        public override Color GetDragDropSolidBorder() => _target.GetDragDropSolidBack();
 
         /// <summary>
         /// Gets the opacity of the solid area.
         /// </summary>
         /// <returns>Opacity ranging from 0 to 1.</returns>
-        public virtual float GetDragDropSolidOpacity() => _target.GetDragDropSolidOpacity();
+        public override float GetDragDropSolidOpacity() => _target.GetDragDropSolidOpacity();
 
         /// <summary>
         /// Gets the background color for the docking indicators area.
         /// </summary>
         /// <returns>Color value.</returns>
-        public virtual Color GetDragDropDockBack() => _target.GetDragDropDockBack();
+        public override Color GetDragDropDockBack() => _target.GetDragDropDockBack();
 
         /// <summary>
         /// Gets the border color for the docking indicators area.
         /// </summary>
         /// <returns>Color value.</returns>
-        public virtual Color GetDragDropDockBorder() => _target.GetDragDropDockBorder();
+        public override Color GetDragDropDockBorder() => _target.GetDragDropDockBorder();
 
         /// <summary>
         /// Gets the active color for docking indicators.
         /// </summary>
         /// <returns>Color value.</returns>
-        public virtual Color GetDragDropDockActive() => _target.GetDragDropDockActive();
+        public override Color GetDragDropDockActive() => _target.GetDragDropDockActive();
 
         /// <summary>
         /// Gets the inactive color for docking indicators.
         /// </summary>
         /// <returns>Color value.</returns>
-        public virtual Color GetDragDropDockInactive() => _target.GetDragDropDockInactive();
+        public override Color GetDragDropDockInactive() => _target.GetDragDropDockInactive();
 
         #endregion
 
         #region ColorTable
+
+        /// <inheritdoc />
+        protected override void DefineFonts()
+        {
+            throw new NotImplementedException();
+        }
+
         /// <summary>
         /// Gets access to the color table instance.
         /// </summary>
-        public virtual KryptonColorTable ColorTable => _target.ColorTable;
+        public override KryptonColorTable ColorTable => _target.ColorTable;
 
         #endregion
 
-        #region OnPalettePaint
-        /// <summary>
-        /// Raises the PalettePaint event.
-        /// </summary>
-        /// <param name="sender">Source of the event.</param>
-        /// <param name="e">An PaletteLayoutEventArgs containing event data.</param>
-        protected virtual void OnPalettePaint(object sender, PaletteLayoutEventArgs e) => PalettePaint?.Invoke(this, e);
-
-        #endregion
-
-        #region OnAllowFormChromeChanged
-        /// <summary>
-        /// Raises the AllowFormChromeChanged event.
-        /// </summary>
-        /// <param name="sender">Source of the event.</param>
-        /// <param name="e">An EventArgs containing event data.</param>
-        protected virtual void OnAllowFormChromeChanged(object sender, EventArgs e) => AllowFormChromeChanged?.Invoke(this, e);
-
-        #endregion
-
-        #region OnBasePaletteChanged
-        /// <summary>
-        /// Raises the BasePaletteChanged event.
-        /// </summary>
-        /// <param name="sender">Source of the event.</param>
-        /// <param name="e">An EventArgs containing event data.</param>
-        protected virtual void OnBasePaletteChanged(object sender, EventArgs e) => BasePaletteChanged?.Invoke(this, e);
-
-        #endregion
-
-        #region OnBaseRendererChanged
-        /// <summary>
-        /// Raises the BaseRendererChanged event.
-        /// </summary>
-        /// <param name="sender">Source of the event.</param>
-        /// <param name="e">An EventArgs containing event data.</param>
-        protected virtual void OnBaseRendererChanged(object sender, EventArgs e) => BaseRendererChanged?.Invoke(this, e);
-
-        #endregion
-
-        #region OnButtonSpecChanged
-        /// <summary>
-        /// Raises the ButtonSpecChanged event.
-        /// </summary>
-        /// <param name="sender">Source of the event.</param>
-        /// <param name="e">An EventArgs containing event data.</param>
-        protected virtual void OnButtonSpecChanged(object sender, EventArgs e) => ButtonSpecChanged?.Invoke(this, e);
-
-        #endregion
+        /// <inheritdoc />
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public int Id { get; }
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectBack.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectBack.cs
@@ -34,7 +34,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteRedirectBack class.
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
-        public PaletteRedirectBack(IPalette target)
+        public PaletteRedirectBack(PaletteBase target)
             : this(target, null, null, null, null, null, null, null, null, null)
         {
         }
@@ -45,7 +45,7 @@ namespace Krypton.Toolkit
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="disabled">Redirection for disabled state requests.</param>
         /// <param name="normal">Redirection for normal state requests.</param>
-        public PaletteRedirectBack(IPalette target,
+        public PaletteRedirectBack(PaletteBase target,
                                    IPaletteBack disabled,
                                    IPaletteBack normal)
             : this(target, disabled, normal, null, null, null, null, null, null, null)
@@ -65,7 +65,7 @@ namespace Krypton.Toolkit
         /// <param name="checkedTracking">Redirection for checked tracking state requests.</param>
         /// <param name="focusOverride">Redirection for focus override state requests.</param>
         /// <param name="normalDefaultOverride">Redirection for normal default override state requests.</param>
-        public PaletteRedirectBack(IPalette target,
+        public PaletteRedirectBack(PaletteBase target,
                                    IPaletteBack disabled,
                                    IPaletteBack normal,
                                    IPaletteBack pressed,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectBorder.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectBorder.cs
@@ -34,7 +34,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteRedirectBorder class.
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
-        public PaletteRedirectBorder(IPalette target)
+        public PaletteRedirectBorder(PaletteBase target)
             : this(target, null, null, null, null, null, null, null, null, null)
         {
         }
@@ -45,7 +45,7 @@ namespace Krypton.Toolkit
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="disabled">Redirection for disabled state requests.</param>
         /// <param name="normal">Redirection for normal state requests.</param>
-        public PaletteRedirectBorder(IPalette target,
+        public PaletteRedirectBorder(PaletteBase target,
                                      IPaletteBorder disabled,
                                      IPaletteBorder normal)
             : this(target, disabled, normal, null, null, null, null, null, null, null)
@@ -60,7 +60,7 @@ namespace Krypton.Toolkit
         /// <param name="normal">Redirection for normal state requests.</param>
         /// <param name="pressed">Redirection for pressed state requests.</param>
         /// <param name="tracking">Redirection for tracking state requests.</param>
-        public PaletteRedirectBorder(IPalette target,
+        public PaletteRedirectBorder(PaletteBase target,
                                      IPaletteBorder disabled,
                                      IPaletteBorder normal,
                                      IPaletteBorder pressed,
@@ -82,7 +82,7 @@ namespace Krypton.Toolkit
         /// <param name="checkedTracking">Redirection for checked tracking state requests.</param>
         /// <param name="focusOverride">Redirection for focus override state requests.</param>
         /// <param name="normalDefaultOverride">Redirection for normal default override state requests.</param>
-        public PaletteRedirectBorder(IPalette target,
+        public PaletteRedirectBorder(PaletteBase target,
                                      IPaletteBorder disabled,
                                      IPaletteBorder normal,
                                      IPaletteBorder pressed,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectBorderEdge.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectBorderEdge.cs
@@ -27,7 +27,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteRedirectBorderEdge class.
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
-        public PaletteRedirectBorderEdge(IPalette target)
+        public PaletteRedirectBorderEdge(PaletteBase target)
             : this(target, null, null)
         {
         }
@@ -38,7 +38,7 @@ namespace Krypton.Toolkit
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="disabled">Redirection for disabled state requests.</param>
         /// <param name="normal">Redirection for normal state requests.</param>
-        public PaletteRedirectBorderEdge(IPalette target,
+        public PaletteRedirectBorderEdge(PaletteBase target,
                                          PaletteBorderEdge disabled,
                                          PaletteBorderEdge normal)
             : base(target)

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectButtonSpec.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectButtonSpec.cs
@@ -27,7 +27,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="inherit">Redirection button spec requests.</param>
-        public PaletteRedirectButtonSpec(IPalette target, IPaletteButtonSpec inherit)
+        public PaletteRedirectButtonSpec(PaletteBase target, IPaletteButtonSpec inherit)
             : base(target) =>
             _inherit = inherit;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectContent.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectContent.cs
@@ -47,7 +47,7 @@ namespace Krypton.Toolkit
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="disabled">Redirection for disabled state requests.</param>
         /// <param name="normal">Redirection for normal state requests.</param>
-        public PaletteRedirectContent(IPalette target,
+        public PaletteRedirectContent(PaletteBase target,
                                       IPaletteContent disabled,
                                       IPaletteContent normal)
             : this(target, disabled, normal, null, null, null, null, null, null, null, null, null, null)
@@ -70,7 +70,7 @@ namespace Krypton.Toolkit
         /// <param name="linkVisitedOverride">Redirection for link visited override state requests.</param>
         /// <param name="linkNotVisitedOverride">Redirection for link not visited override state requests.</param>
         /// <param name="linkPressedOverride">Redirection for link pressed override state requests.</param>
-        public PaletteRedirectContent(IPalette target,
+        public PaletteRedirectContent(PaletteBase target,
                                       IPaletteContent disabled,
                                       IPaletteContent normal,
                                       IPaletteContent pressed,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectDouble.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectDouble.cs
@@ -42,7 +42,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteRedirectDouble class.
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
-        public PaletteRedirectDouble(IPalette target)
+        public PaletteRedirectDouble(PaletteBase target)
             : this(target, null, null, null, null, null, null, null, null, null)
         {
         }
@@ -53,7 +53,7 @@ namespace Krypton.Toolkit
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="disabled">Redirection for disabled state requests.</param>
         /// <param name="normal">Redirection for normal state requests.</param>
-        public PaletteRedirectDouble(IPalette target,
+        public PaletteRedirectDouble(PaletteBase target,
                                      IPaletteDouble disabled,
                                      IPaletteDouble normal)
             : this(target, disabled, normal, null, null, null, null, null, null, null)
@@ -68,7 +68,7 @@ namespace Krypton.Toolkit
         /// <param name="normal">Redirection for normal state requests.</param>
         /// <param name="pressed">Redirection for pressed state requests.</param>
         /// <param name="tracking">Redirection for tracking state requests.</param>
-        public PaletteRedirectDouble(IPalette target,
+        public PaletteRedirectDouble(PaletteBase target,
                                      IPaletteDouble disabled,
                                      IPaletteDouble normal,
                                      IPaletteDouble pressed,
@@ -90,7 +90,7 @@ namespace Krypton.Toolkit
         /// <param name="checkedTracking">Redirection for checked tracking state requests.</param>
         /// <param name="focusOverride">Redirection for focus override state requests.</param>
         /// <param name="normalDefaultOverride">Redirection for normal default override state requests.</param>
-        public PaletteRedirectDouble(IPalette target,
+        public PaletteRedirectDouble(PaletteBase target,
                                      IPaletteDouble disabled,
                                      IPaletteDouble normal,
                                      IPaletteDouble pressed,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectDoubleMetric.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectDoubleMetric.cs
@@ -29,7 +29,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteRedirectDoubleMetric class.
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
-        public PaletteRedirectDoubleMetric(IPalette target)
+        public PaletteRedirectDoubleMetric(PaletteBase target)
             : this(target, null, null, null, null)
         {
         }
@@ -42,7 +42,7 @@ namespace Krypton.Toolkit
         /// <param name="disableMetric">Redirection for disabled metric requests.</param>
         /// <param name="normal">Redirection for normal state requests.</param>
         /// <param name="normalMetric">Redirection for normal metric requests.</param>
-        public PaletteRedirectDoubleMetric(IPalette target,
+        public PaletteRedirectDoubleMetric(PaletteBase target,
                                            IPaletteDouble disabled, IPaletteMetric disableMetric,
                                            IPaletteDouble normal, IPaletteMetric normalMetric)
             : base(target, disabled, normal)

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectGrids.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectGrids.cs
@@ -27,7 +27,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="grid">Grid reference for directing palette requests.</param>
-        public PaletteRedirectGrids(IPalette target, KryptonPaletteGrid grid)
+        public PaletteRedirectGrids(PaletteBase target, KryptonPaletteGrid grid)
             : base(target)
         {
             Debug.Assert(grid != null);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectMetric.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectMetric.cs
@@ -27,7 +27,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteRedirectMetric class.
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
-        public PaletteRedirectMetric(IPalette target)
+        public PaletteRedirectMetric(PaletteBase target)
             : this(target, null, null)
         {
         }
@@ -38,7 +38,7 @@ namespace Krypton.Toolkit
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="disableMetric">Redirection for disabled metric requests.</param>
         /// <param name="normalMetric">Redirection for normal metric requests.</param>
-        public PaletteRedirectMetric(IPalette target,
+        public PaletteRedirectMetric(PaletteBase target,
                                      IPaletteMetric disableMetric,
                                      IPaletteMetric normalMetric)
             : base(target)

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectRibbonBack.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectRibbonBack.cs
@@ -31,7 +31,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteRedirectRibbonBack class.
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
-        public PaletteRedirectRibbonBack(IPalette target)
+        public PaletteRedirectRibbonBack(PaletteBase target)
             : this(target, null, null, null, null, null, null)
         {
         }
@@ -42,7 +42,7 @@ namespace Krypton.Toolkit
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="disabledBack">Redirection for back disabled state requests.</param>
         /// <param name="normalBack">Redirection for back normal state requests.</param>
-        public PaletteRedirectRibbonBack(IPalette target,
+        public PaletteRedirectRibbonBack(PaletteBase target,
                                          IPaletteRibbonBack disabledBack,
                                          IPaletteRibbonBack normalBack)
             : this(target, disabledBack, normalBack, null, null, null, null)
@@ -59,7 +59,7 @@ namespace Krypton.Toolkit
         /// <param name="trackingBack">Redirection for back tracking state requests.</param>
         /// <param name="selectedBack">Redirection for selected states requests.</param>
         /// <param name="focusOverrideBack">Redirection for back focus override state requests.</param>
-        public PaletteRedirectRibbonBack(IPalette target,
+        public PaletteRedirectRibbonBack(PaletteBase target,
                                          IPaletteRibbonBack disabledBack,
                                          IPaletteRibbonBack normalBack,
                                          IPaletteRibbonBack pressedBack,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectRibbonDouble.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectRibbonDouble.cs
@@ -37,7 +37,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteRedirectRibbonDouble class.
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
-        public PaletteRedirectRibbonDouble(IPalette target)
+        public PaletteRedirectRibbonDouble(PaletteBase target)
             : this(target, 
                    null, null, null, null, null, null,
                    null, null, null, null, null, null)
@@ -60,7 +60,7 @@ namespace Krypton.Toolkit
         /// <param name="trackingText">Redirection for text tracking state requests.</param>
         /// <param name="selectedText">Redirection for text selected states requests.</param>
         /// <param name="focusOverrideText">Redirection for text focus override state requests.</param>
-        public PaletteRedirectRibbonDouble(IPalette target,
+        public PaletteRedirectRibbonDouble(PaletteBase target,
                                            IPaletteRibbonBack disabledBack,
                                            IPaletteRibbonBack normalBack,
                                            IPaletteRibbonBack pressedBack,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectRibbonGeneral.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectRibbonGeneral.cs
@@ -29,7 +29,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteRedirectRibbonGeneral class.
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
-        public PaletteRedirectRibbonGeneral(IPalette target)
+        public PaletteRedirectRibbonGeneral(PaletteBase target)
             : this(target, null, null, null, null)
         {
         }
@@ -42,7 +42,7 @@ namespace Krypton.Toolkit
         /// <param name="normal">Redirection for normal state requests.</param>
         /// <param name="pressed">Redirection for pressed state requests.</param>
         /// <param name="tracking">Redirection for tracking state requests.</param>
-        public PaletteRedirectRibbonGeneral(IPalette target,
+        public PaletteRedirectRibbonGeneral(PaletteBase target,
                                             IPaletteRibbonGeneral disabled,
                                             IPaletteRibbonGeneral normal,
                                             IPaletteRibbonGeneral pressed,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectTriple.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectTriple.cs
@@ -42,7 +42,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteRedirectTriple class.
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
-        public PaletteRedirectTriple(IPalette target)
+        public PaletteRedirectTriple(PaletteBase target)
             : this(target, null, null, null, null, null, null, null, null, null)
         {
         }
@@ -53,7 +53,7 @@ namespace Krypton.Toolkit
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="disabled">Redirection for disabled state requests.</param>
         /// <param name="normal">Redirection for normal state requests.</param>
-        public PaletteRedirectTriple(IPalette target,
+        public PaletteRedirectTriple(PaletteBase target,
                                      IPaletteTriple disabled,
                                      IPaletteTriple normal)
             : this(target, disabled, normal, null, null, null, null, null, null, null)
@@ -67,7 +67,7 @@ namespace Krypton.Toolkit
         /// <param name="disabled">Redirection for disabled state requests.</param>
         /// <param name="normal">Redirection for normal state requests.</param>
         /// <param name="tracking">Redirection for tracking state requests.</param>
-        public PaletteRedirectTriple(IPalette target,
+        public PaletteRedirectTriple(PaletteBase target,
                                      IPaletteTriple disabled,
                                      IPaletteTriple normal,
                                      IPaletteTriple tracking)
@@ -85,7 +85,7 @@ namespace Krypton.Toolkit
         /// <param name="tracking">Redirection for tracking state requests.</param>
         /// <param name="selected">Redirection for all checked states.</param>
         /// <param name="focusOverride">Redirection for focus override state requests.</param>
-        public PaletteRedirectTriple(IPalette target,
+        public PaletteRedirectTriple(PaletteBase target,
                                      IPaletteTriple disabled,
                                      IPaletteTriple normal,
                                      IPaletteTriple pressed,
@@ -110,7 +110,7 @@ namespace Krypton.Toolkit
         /// <param name="checkedTracking">Redirection for checked tracking state requests.</param>
         /// <param name="focusOverride">Redirection for focus override state requests.</param>
         /// <param name="normalDefaultOverride">Redirection for normal default override state requests.</param>
-        public PaletteRedirectTriple(IPalette target,
+        public PaletteRedirectTriple(PaletteBase target,
                                      IPaletteTriple disabled,
                                      IPaletteTriple normal,
                                      IPaletteTriple pressed,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectTripleMetric.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectTripleMetric.cs
@@ -27,7 +27,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteRedirectTripleMetric class.
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
-        public PaletteRedirectTripleMetric(IPalette target)
+        public PaletteRedirectTripleMetric(PaletteBase target)
             : this(target, null, null, null, null)
         {
         }
@@ -40,7 +40,7 @@ namespace Krypton.Toolkit
         /// <param name="disableMetric">Redirection for disabled metric requests.</param>
         /// <param name="normal">Redirection for normal state requests.</param>
         /// <param name="normalMetric">Redirection for normal metric requests.</param>
-        public PaletteRedirectTripleMetric(IPalette target,
+        public PaletteRedirectTripleMetric(PaletteBase target,
                                            IPaletteTriple disabled, IPaletteMetric disableMetric,
                                            IPaletteTriple normal, IPaletteMetric normalMetric)
             : base(target, disabled, normal)

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTools/PaletteTools.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTools/PaletteTools.cs
@@ -14,48 +14,18 @@ namespace Krypton.Toolkit
 {
     public class PaletteTools
     {
-        #region Variables
-        private static readonly string[] _themeList = new string[] { "Custom",
-                                                            "Professional - System",
-                                                            "Professional - Office 2003",
-                                                            "Office 2007 - Black",
-                                                            "Office 2007 - Blue",
-                                                            "Office 2007 - Silver",
-                                                            "Office 2007 - White",
-                                                            "Office 2010 - Black",
-                                                            "Office 2010 - Blue",
-                                                            "Office 2010 - Silver",
-                                                            "Office 2010 - White",
-                                                            //"Office 2013",
-                                                            "Office 2013 - White",
-                                                            "Microsoft 365 - Black",
-                                                            "Microsoft 365 - Blue",
-                                                            "Microsoft 365 - Silver",
-                                                            "Microsoft 365 - White",
-                                                            "Sparkle - Blue",
-                                                            "Sparkle - Orange",
-                                                            "Sparkle - Purple" };
-        #endregion
-
         #region Properties
         /// <summary>Gets the theme list.</summary>
         /// <value>The theme list.</value>
-        public static string[] ThemeList => _themeList;
+        public static List<string> ThemeList1 => ThemeManager.SupportedInternalThemeNames.ToList();
 
-        #endregion
-
-        #region Constructor
-        public PaletteTools()
-        {
-
-        }
         #endregion
 
         #region Methods
         /// <summary>Links the type of the palette to the correct theme style.</summary>
         /// <param name="themeName">Name of the theme.</param>
         /// <returns></returns>
-        public PaletteModeManager LinkPaletteType(string themeName)
+        public PaletteModeManager LinkPaletteType1(string themeName)
         {
             PaletteModeManager paletteMode = new();
 
@@ -153,7 +123,7 @@ namespace Krypton.Toolkit
 
             if (!string.IsNullOrWhiteSpace(customThemePath))
             {
-                KryptonPalette palette = new();
+                KryptonCustomPaletteBase palette = new();
 
                 palette.Import(customThemePath);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTripleToPalette.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTripleToPalette.cs
@@ -31,7 +31,7 @@ namespace Krypton.Toolkit
         /// <param name="backStyle">Initial background style.</param>
         /// <param name="borderStyle">Initial border style.</param>
         /// <param name="contentStyle">Initial content style.</param>
-        public PaletteTripleToPalette(IPalette palette,
+        public PaletteTripleToPalette(PaletteBase palette,
                                       PaletteBackStyle backStyle,
                                       PaletteBorderStyle borderStyle,
                                       PaletteContentStyle contentStyle)

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Bases/PaletteMicrosoft365Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Bases/PaletteMicrosoft365Base.cs
@@ -16,7 +16,7 @@ namespace Krypton.Toolkit
     /// Provides a base for Microsoft 365 palettes.
     /// </summary>
     /// <seealso cref="PaletteBase" />
-    public abstract class PaletteMicrosoft365Base : PaletteBase
+    public abstract class PaletteMicrosoft365Base : PaletteBase 
     {
         #region Static Fields
         private static readonly Padding _contentPaddingGrid = new(2, 1, 2, 1);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkMode.cs
@@ -410,7 +410,7 @@ namespace Krypton.Toolkit
     /// Provides a base for Office 365 palettes.
     /// </summary>
     /// <seealso cref="PaletteBase" />
-    public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
+    public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase 
     {
         #region Static Fields
 
@@ -5177,7 +5177,7 @@ namespace Krypton.Toolkit
         /// <param name="colors">Source of </param>
         /// <param name="roundedEdges">Should have rounded edges.</param>
         /// <param name="palette">Associated palette instance.</param>
-        public KryptonColorTable365BlackDarkMode(Color[] colors, InheritBool roundedEdges, IPalette palette) : base(palette)
+        public KryptonColorTable365BlackDarkMode(Color[] colors, InheritBool roundedEdges, PaletteBase palette) : base(palette)
         {
             Debug.Assert(colors != null);
             _colors = colors;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueDarkMode.cs
@@ -404,7 +404,7 @@ namespace Krypton.Toolkit
     /// Provides a base for Office 365 palettes.
     /// </summary>
     /// <seealso cref="PaletteBase" />
-    public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
+    public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase 
     {
         #region Static Fields
 
@@ -5156,7 +5156,7 @@ namespace Krypton.Toolkit
         /// <param name="colors">Source of </param>
         /// <param name="roundedEdges">Should have rounded edges.</param>
         /// <param name="palette">Associated palette instance.</param>
-        public KryptonColorTable365BlueDarkMode(Color[] colors, InheritBool roundedEdges, IPalette palette) : base(palette)
+        public KryptonColorTable365BlueDarkMode(Color[] colors, InheritBool roundedEdges, PaletteBase palette) : base(palette)
         {
             Debug.Assert(colors != null);
             _colors = colors;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueLightMode.cs
@@ -410,7 +410,7 @@ namespace Krypton.Toolkit
     /// Provides a base for Office 365 palettes.
     /// </summary>
     /// <seealso cref="PaletteBase" />
-    public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
+    public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase 
     {
         #region Static Fields
 
@@ -5184,7 +5184,7 @@ namespace Krypton.Toolkit
         /// <param name="colors">Source of </param>
         /// <param name="roundedEdges">Should have rounded edges.</param>
         /// <param name="palette">Associated palette instance.</param>
-        public KryptonColorTable365BlueLightMode(Color[] colors, InheritBool roundedEdges, IPalette palette) : base(palette)
+        public KryptonColorTable365BlueLightMode(Color[] colors, InheritBool roundedEdges, PaletteBase palette) : base(palette)
         {
             Debug.Assert(colors != null);
             _colors = colors;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverDarkMode.cs
@@ -406,7 +406,7 @@ namespace Krypton.Toolkit
     /// Provides a base for Office 365 palettes.
     /// </summary>
     /// <seealso cref="PaletteBase" />
-    public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
+    public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase 
     {
         #region Static Fields
 
@@ -5141,7 +5141,7 @@ namespace Krypton.Toolkit
         /// <param name="colors">Source of </param>
         /// <param name="roundedEdges">Should have rounded edges.</param>
         /// <param name="palette">Associated palette instance.</param>
-        public KryptonColorTable365SilverDarkMode(Color[] colors, InheritBool roundedEdges, IPalette palette) : base(palette)
+        public KryptonColorTable365SilverDarkMode(Color[] colors, InheritBool roundedEdges, PaletteBase palette) : base(palette)
         {
             Debug.Assert(colors != null);
             _colors = colors;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverLightMode.cs
@@ -411,7 +411,7 @@ namespace Krypton.Toolkit
     /// Provides a base for Office 365 palettes.
     /// </summary>
     /// <seealso cref="PaletteBase" />
-    public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
+    public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase 
     {
         #region Static Fields
 
@@ -5176,7 +5176,7 @@ namespace Krypton.Toolkit
         /// <param name="colors">Source of </param>
         /// <param name="roundedEdges">Should have rounded edges.</param>
         /// <param name="palette">Associated palette instance.</param>
-        public KryptonColorTable365SilverLightMode(Color[] colors, InheritBool roundedEdges, IPalette palette) : base(palette)
+        public KryptonColorTable365SilverLightMode(Color[] colors, InheritBool roundedEdges, PaletteBase palette) : base(palette)
         {
             Debug.Assert(colors != null);
             _colors = colors;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Black.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Black.cs
@@ -423,7 +423,7 @@ namespace Krypton.Toolkit
     /// Provides a base for Office 365 palettes.
     /// </summary>
     /// <seealso cref="PaletteBase" />
-    public abstract class PaletteMicrosoft365BlackThemeBase : PaletteBase
+    public abstract class PaletteMicrosoft365BlackThemeBase : PaletteBase 
     {
         #region Static Fields
         private static readonly Padding _contentPaddingGrid = new(2, 1, 2, 1);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Bases/PaletteOffice2007Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Bases/PaletteOffice2007Base.cs
@@ -15,7 +15,7 @@ namespace Krypton.Toolkit
     /// <summary>
     /// Provides a professional appearance using colors/fonts generated from system settings.
     /// </summary>
-    public abstract class PaletteOffice2007Base : PaletteBase
+    public abstract class PaletteOffice2007Base : PaletteBase 
     {
         #region Static Fields
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlackDarkMode.cs
@@ -590,7 +590,7 @@ namespace Krypton.Toolkit
     /// <summary>
     /// Provides a professional appearance using colors/fonts generated from system settings.
     /// </summary>
-    public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
+    public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase 
     {
         #region Static Fields
 
@@ -6232,7 +6232,7 @@ namespace Krypton.Toolkit
         /// <param name="palette">Associated palette instance.</param>
         public KryptonColorTable2007BlackDarkMode(Color[] colors,
                                      InheritBool roundedEdges,
-                                     IPalette palette)
+                                     PaletteBase palette)
             : base(palette)
         {
             Debug.Assert(colors != null);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueDarkMode.cs
@@ -436,7 +436,7 @@ namespace Krypton.Toolkit
     /// <summary>
     /// Provides a professional appearance using colors/fonts generated from system settings.
     /// </summary>
-    public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
+    public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase 
     {
         #region Static Fields
 
@@ -5524,7 +5524,7 @@ namespace Krypton.Toolkit
         /// <param name="palette">Associated palette instance.</param>
         public KryptonColorTable2007BlueDarkMode(Color[] colors,
                                      InheritBool roundedEdges,
-                                     IPalette palette)
+                                     PaletteBase palette)
             : base(palette)
         {
             Debug.Assert(colors != null);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueLightMode.cs
@@ -437,7 +437,7 @@ namespace Krypton.Toolkit
     /// <summary>
     /// Provides a professional appearance using colors/fonts generated from system settings.
     /// </summary>
-    public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
+    public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase 
     {
         #region Static Fields
 
@@ -5991,7 +5991,7 @@ namespace Krypton.Toolkit
         /// <param name="palette">Associated palette instance.</param>
         public KryptonColorTable2007BlueLightMode(Color[] colours,
                                      InheritBool roundedEdges,
-                                     IPalette palette)
+                                     PaletteBase palette)
             : base(palette)
         {
             Debug.Assert(colours != null);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverDarkMode.cs
@@ -417,7 +417,7 @@ namespace Krypton.Toolkit
     /// <summary>
     /// Provides a professional appearance using colors/fonts generated from system settings.
     /// </summary>
-    public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
+    public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase 
     {
         #region Static Fields
 
@@ -5972,7 +5972,7 @@ namespace Krypton.Toolkit
         /// <param name="palette">Associated palette instance.</param>
         public KryptonColorTable2007SilverDarkMode(Color[] colors,
                                      InheritBool roundedEdges,
-                                     IPalette palette)
+                                     PaletteBase palette)
             : base(palette)
         {
             Debug.Assert(colors != null);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverLightMode.cs
@@ -422,7 +422,7 @@ namespace Krypton.Toolkit
     /// <summary>
     /// Provides a professional appearance using colors/fonts generated from system settings.
     /// </summary>
-    public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
+    public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase 
     {
         #region Static Fields
 
@@ -6030,7 +6030,7 @@ namespace Krypton.Toolkit
         /// <param name="palette">Associated palette instance.</param>
         public KryptonColorTable2007SilverLightMode(Color[] colors,
                                      InheritBool roundedEdges,
-                                     IPalette palette)
+                                     PaletteBase palette)
             : base(palette)
         {
             Debug.Assert(colors != null);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Bases/PaletteOffice2010Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Bases/PaletteOffice2010Base.cs
@@ -15,7 +15,7 @@ namespace Krypton.Toolkit
     /// <summary>
     /// Provides a base for Office 2010 palettes.
     /// </summary>
-    public abstract class PaletteOffice2010Base : PaletteBase
+    public abstract class PaletteOffice2010Base : PaletteBase 
     {
         #region Static Fields
         private static readonly Padding _contentPaddingGrid = new(2, 1, 2, 1);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlackDarkMode.cs
@@ -754,7 +754,7 @@ namespace Krypton.Toolkit
     /// <summary>
     /// Provides a base for Office 2010 palettes.
     /// </summary>
-    public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
+    public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase 
     {
         #region Static Fields
 
@@ -5567,7 +5567,7 @@ namespace Krypton.Toolkit
         /// <param name="palette">Associated palette instance.</param>
         public KryptonColorTable2010BlackDarkMode(Color[] colors,
                                      InheritBool roundedEdges,
-                                     IPalette palette)
+                                     PaletteBase palette)
             : base(palette)
         {
             Debug.Assert(colors != null);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueDarkMode.cs
@@ -408,7 +408,7 @@ namespace Krypton.Toolkit
     /// <summary>
     /// Provides a base for Office 2010 palettes.
     /// </summary>
-    public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
+    public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase 
     {
         #region Static Fields
 
@@ -5185,7 +5185,7 @@ namespace Krypton.Toolkit
         /// <param name="palette">Associated palette instance.</param>
         public KryptonColorTable2010BlueDarkMode(Color[] colors,
                                      InheritBool roundedEdges,
-                                     IPalette palette)
+                                     PaletteBase palette)
             : base(palette)
         {
             Debug.Assert(colors != null);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueLightMode.cs
@@ -412,7 +412,7 @@ namespace Krypton.Toolkit
     /// <summary>
     /// Provides a base for Office 2010 palettes.
     /// </summary>
-    public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
+    public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase 
     {
         #region Static Fields
 
@@ -5189,7 +5189,7 @@ namespace Krypton.Toolkit
         /// <param name="palette">Associated palette instance.</param>
         public KryptonColorTable2010BlueLightMode(Color[] colors,
                                      InheritBool roundedEdges,
-                                     IPalette palette)
+                                     PaletteBase palette)
             : base(palette)
         {
             Debug.Assert(colors != null);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverDarkMode.cs
@@ -405,7 +405,7 @@ namespace Krypton.Toolkit
     /// <summary>
     /// Provides a base for Office 2010 palettes.
     /// </summary>
-    public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
+    public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase 
     {
         #region Static Fields
 
@@ -5183,7 +5183,7 @@ namespace Krypton.Toolkit
         /// <param name="palette">Associated palette instance.</param>
         public KryptonColorTable2010SilverDarkMode(Color[] colors,
                                      InheritBool roundedEdges,
-                                     IPalette palette)
+                                     PaletteBase palette)
             : base(palette)
         {
             Debug.Assert(colors != null);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverLightMode.cs
@@ -416,7 +416,7 @@ namespace Krypton.Toolkit
     /// <summary>
     /// Provides a base for Office 2010 palettes.
     /// </summary>
-    public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
+    public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase 
     {
         #region Static Fields
 
@@ -5224,7 +5224,7 @@ namespace Krypton.Toolkit
         /// <param name="palette">Associated palette instance.</param>
         public KryptonColorTable2010SilverLightMode(Color[] colors,
                                      InheritBool roundedEdges,
-                                     IPalette palette)
+                                     PaletteBase palette)
             : base(palette)
         {
             Debug.Assert(colors != null);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Bases/PaletteOffice2013Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Bases/PaletteOffice2013Base.cs
@@ -15,7 +15,7 @@ namespace Krypton.Toolkit
     /// <summary>
     /// Provides a base for Office 2013 palettes.
     /// </summary>
-    public abstract class PaletteOffice2013Base : PaletteBase
+    public abstract class PaletteOffice2013Base : PaletteBase 
     {
         #region Static Fields
         private static readonly Padding _contentPaddingGrid = new(2, 1, 2, 1);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013White.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013White.cs
@@ -391,7 +391,7 @@ namespace Krypton.Toolkit
     /// <summary>
     /// Gets the single instance of the ### palette.
     /// </summary>
-    public abstract class PaletteOffice2013WhiteBase : PaletteBase
+    public abstract class PaletteOffice2013WhiteBase : PaletteBase 
     {
         #region Static Fields
         private static readonly Padding _contentPaddingGrid = new(2, 1, 2, 1);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/PaletteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/PaletteBase.cs
@@ -16,7 +16,7 @@ namespace Krypton.Toolkit
     /// Provides base class implementation for palettes.
     /// </summary>
     [ToolboxItem(false)]
-    public abstract class PaletteBase : Component, IPalette
+    public abstract class PaletteBase : Component
     {
         #region Instance Fields
         private BasePaletteType _basePaletteType;
@@ -55,7 +55,7 @@ namespace Krypton.Toolkit
 
         #region Identity
         /// <summary>Initializes a new instance of the <see cref="PaletteBase" /> class.</summary>
-        protected PaletteBase()
+        protected PaletteBase ()
         {
             // We need to notice when system color settings change
             SystemEvents.UserPreferenceChanged += OnUserPreferenceChanged;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/PaletteVisualStudioBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/PaletteVisualStudioBase.cs
@@ -16,7 +16,7 @@ namespace Krypton.Toolkit
     /// Provides a base for Visual Studio 2020 palettes.
     /// </summary>
     /// <seealso cref="PaletteBase" />
-    public abstract class PaletteVisualStudioBase : PaletteBase
+    public abstract class PaletteVisualStudioBase : PaletteBase 
     {
         #region Static Fields
         private static readonly Padding _contentPaddingGrid = new(2, 1, 2, 1);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Professional/PaletteProfessionalSystem.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Professional/PaletteProfessionalSystem.cs
@@ -15,7 +15,7 @@ namespace Krypton.Toolkit
     /// <summary>
     /// Provides a professional appearance using colors/fonts generated from system settings.
     /// </summary>
-    public class PaletteProfessionalSystem : PaletteBase
+    public class PaletteProfessionalSystem : PaletteBase 
     {
         #region Static Fields
         private static readonly Padding _contentPaddingGrid = new(2, 1, 2, 1);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/Base/PaletteSparkleBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/Base/PaletteSparkleBase.cs
@@ -15,7 +15,7 @@ namespace Krypton.Toolkit
     /// <summary>
     /// Provides a fixed blue variation on the sparkle appearance.
     /// </summary>
-    public class PaletteSparkleBase : PaletteBase
+    public class PaletteSparkleBase : PaletteBase 
     {
         #region Static Fields
         private static readonly Padding _contentPaddingGrid = new(2, 1, 2, 1);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/Extra Themes/PaletteSparkleBlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/Extra Themes/PaletteSparkleBlueDarkMode.cs
@@ -339,7 +339,7 @@ namespace Krypton.Toolkit
     /// <summary>
     /// Provides a fixed blue variation on the sparkle appearance.
     /// </summary>
-    public abstract class PaletteSparkleBlueDarkModeBase : PaletteBase
+    public abstract class PaletteSparkleBlueDarkModeBase : PaletteBase 
     {
         #region Static Fields
         private static readonly Padding _contentPaddingGrid = new(2, 1, 2, 1);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonInternalKCT.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonInternalKCT.cs
@@ -27,7 +27,7 @@ namespace Krypton.Toolkit
         /// <param name="baseKCT">Initial base KCT to inherit values from.</param>
         /// <param name="palette">Reference to associated palette.</param>
         public KryptonInternalKCT(KryptonColorTable baseKCT,
-                                  IPalette palette)
+                                  PaletteBase palette)
             : base(palette)
         {
             Debug.Assert(baseKCT != null);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteTMS.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteTMS.cs
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit
         /// <param name="palette">Associated palettte instance.</param>
         /// <param name="baseKCT">Initial base KCT to inherit values from.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public KryptonPaletteTMS(IPalette palette,
+        public KryptonPaletteTMS(PaletteBase palette,
                                    KryptonColorTable baseKCT,
                                    NeedPaintHandler needPaint)
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTable.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTable.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit
     {
         #region Instance Fields
 
-        private IPalette _palette;
+        private PaletteBase _palette;
         #endregion
 
         #region Identity
@@ -27,7 +27,7 @@ namespace Krypton.Toolkit
         /// Creates a new instance of the KryptonColorTable class.
         /// </summary>
         /// <param name="palette">Reference to associated palette.</param>
-        public KryptonColorTable(IPalette palette) => Palette = palette;
+        public KryptonColorTable(PaletteBase palette) => Palette = palette;
 
         #endregion
 
@@ -35,7 +35,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the associated palette instance.
         /// </summary>
-        public IPalette Palette { get; }
+        public PaletteBase Palette { get; }
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTable2007.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTable2007.cs
@@ -55,7 +55,7 @@ namespace Krypton.Toolkit
         /// <param name="palette">Associated palette instance.</param>
         public KryptonColorTable2007(Color[] colors,
                                      InheritBool roundedEdges,
-                                     IPalette palette)
+                                     PaletteBase palette)
             : base(palette)
         {
             Debug.Assert(colors != null);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTable2010.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTable2010.cs
@@ -55,7 +55,7 @@ namespace Krypton.Toolkit
         /// <param name="palette">Associated palette instance.</param>
         public KryptonColorTable2010(Color[] colors,
                                      InheritBool roundedEdges,
-                                     IPalette palette)
+                                     PaletteBase palette)
             : base(palette)
         {
             Debug.Assert(colors != null);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTable2013.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTable2013.cs
@@ -57,7 +57,7 @@ namespace Krypton.Toolkit
         /// <param name="palette">Associated palette instance.</param>
         public KryptonColorTable2013(Color[] colors,
                                      InheritBool roundedEdges,
-                                     IPalette palette)
+                                     PaletteBase palette)
             : base(palette)
         {
             Debug.Assert(colors != null);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTable365.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTable365.cs
@@ -55,7 +55,7 @@ namespace Krypton.Toolkit
         /// <param name="colors">Source of </param>
         /// <param name="roundedEdges">Should have rounded edges.</param>
         /// <param name="palette">Associated palette instance.</param>
-        public KryptonColorTable365(Color[] colors, InheritBool roundedEdges, IPalette palette) : base(palette)
+        public KryptonColorTable365(Color[] colors, InheritBool roundedEdges, PaletteBase palette) : base(palette)
         {
             Debug.Assert(colors != null);
             _colors = colors;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTableOffice365.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTableOffice365.cs
@@ -58,7 +58,7 @@ namespace Krypton.Toolkit
         /// <param name="palette">Associated palette instance.</param>
         public KryptonColorTableOffice365(Color[] colors,
                                      InheritBool roundedEdges,
-                                     IPalette palette)
+                                     PaletteBase palette)
             : base(palette)
         {
             Debug.Assert(colors != null);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTableSparkle.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTableSparkle.cs
@@ -53,7 +53,7 @@ namespace Krypton.Toolkit
         public KryptonColorTableSparkle(Color[] colors,
                                         Color[] sparkleColors,
                                         InheritBool roundedEdges,
-                                        IPalette palette)
+                                        PaletteBase palette)
             : base(palette)
         {
             Debug.Assert(colors != null);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTableVisualStudio2019.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTableVisualStudio2019.cs
@@ -56,7 +56,7 @@ namespace Krypton.Toolkit
         /// <param name="colors">Source of </param>
         /// <param name="roundedEdges">Should have rounded edges.</param>
         /// <param name="palette">Associated palette instance.</param>
-        public KryptonColorTableVisualStudio2020(Color[] colors, InheritBool roundedEdges, IPalette palette) : base(palette)
+        public KryptonColorTableVisualStudio2020(Color[] colors, InheritBool roundedEdges, PaletteBase palette) : base(palette)
         {
             Debug.Assert(colors != null);
             _colors = colors;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonProfessionalCustomKCT.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonProfessionalCustomKCT.cs
@@ -29,7 +29,7 @@ namespace Krypton.Toolkit
         public KryptonProfessionalCustomKCT(Color[] headerColors,
                                             Color[] colorTableColors,
                                             bool useSystemColors,
-                                            IPalette palette)
+                                            PaletteBase palette)
             : base(headerColors, useSystemColors, palette) =>
             _colors = colorTableColors;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonProfessionalKCT.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonProfessionalKCT.cs
@@ -27,7 +27,7 @@ namespace Krypton.Toolkit
         /// <param name="palette">Reference to associated palette.</param>
         public KryptonProfessionalKCT(Color[] colors, 
                                       bool useSystemColors,
-                                      IPalette palette)
+                                      PaletteBase palette)
             : base(palette)
         {
             Debug.Assert(colors != null);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectBreadCrumb.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectBreadCrumb.cs
@@ -26,7 +26,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteRedirectBreadCrumb class.
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
-        public PaletteRedirectBreadCrumb(IPalette target)
+        public PaletteRedirectBreadCrumb(PaletteBase target)
             : base(target)
         {
             Left = false;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectCheckBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectCheckBox.cs
@@ -36,7 +36,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="images">Reference to source of check box images.</param>
-        public PaletteRedirectCheckBox(IPalette target,
+        public PaletteRedirectCheckBox(PaletteBase target,
                                        CheckBoxImages images)
             : base(target)
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectCommon.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectCommon.cs
@@ -29,7 +29,7 @@ namespace Krypton.Toolkit
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="disabled">Redirection for disabled state requests.</param>
         /// <param name="others">Redirection for all other state requests.</param>
-        public PaletteRedirectCommon(IPalette target,
+        public PaletteRedirectCommon(PaletteBase target,
                                      IPaletteTriple disabled,
                                      IPaletteTriple others)
             : base(target)

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectContextMenu.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectContextMenu.cs
@@ -27,7 +27,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="images">Reference to source of context menu images.</param>
-        public PaletteRedirectContextMenu(IPalette target,
+        public PaletteRedirectContextMenu(PaletteBase target,
                                           ContextMenuImages images)
             : base(target)
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectDropDownButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectDropDownButton.cs
@@ -36,7 +36,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="images">Reference to source of drop down button images.</param>
-        public PaletteRedirectDropDownButton(IPalette target,
+        public PaletteRedirectDropDownButton(PaletteBase target,
                                              DropDownButtonImages images)
             : base(target)
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectRadioButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectRadioButton.cs
@@ -36,7 +36,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="images">Reference to source of radio button images.</param>
-        public PaletteRedirectRadioButton(IPalette target,
+        public PaletteRedirectRadioButton(PaletteBase target,
                                           RadioButtonImages images)
             : base(target)
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectTreeView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectTreeView.cs
@@ -40,7 +40,7 @@ namespace Krypton.Toolkit
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="plusMinusImages">Reference to source of tree view images.</param>
         /// <param name="checkboxImages">Reference to source of check box images.</param>
-        public PaletteRedirectTreeView(IPalette target,
+        public PaletteRedirectTreeView(PaletteBase target,
                                        TreeViewImages plusMinusImages,
                                        CheckBoxImages checkboxImages)
             : base(target)

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderBase.cs
@@ -144,7 +144,7 @@ namespace Krypton.Toolkit
         /// Gets a renderer for drawing the toolstrips.
         /// </summary>
         /// <param name="colorPalette">Color palette to use when rendering toolstrip.</param>
-        public abstract ToolStripRenderer RenderToolStrip(IPalette colorPalette);
+        public abstract ToolStripRenderer RenderToolStrip(PaletteBase colorPalette);
         #endregion
 
         #region RenderStandardBorder
@@ -552,7 +552,7 @@ namespace Krypton.Toolkit
         /// <param name="tracking">Should check box be Displayed as hot tracking.</param>
         /// <param name="pressed">Should check box be Displayed as pressed.</param>
         public abstract Size GetCheckBoxPreferredSize(ViewLayoutContext context,
-                                                      IPalette palette,
+                                                      PaletteBase palette,
                                                       bool enabled,
                                                       CheckState checkState,
                                                       bool tracking,
@@ -570,7 +570,7 @@ namespace Krypton.Toolkit
         /// <param name="pressed">Should check box be Displayed as pressed.</param>
         public abstract void DrawCheckBox(RenderContext context,
                                           Rectangle displayRect,
-                                          IPalette palette,
+                                          PaletteBase palette,
                                           bool enabled,
                                           CheckState checkState,
                                           bool tracking,
@@ -586,7 +586,7 @@ namespace Krypton.Toolkit
         /// <param name="tracking">Should check box be Displayed as hot tracking.</param>
         /// <param name="pressed">Should check box be Displayed as pressed.</param>
         public abstract Size GetRadioButtonPreferredSize(ViewLayoutContext context,
-                                                         IPalette palette,
+                                                         PaletteBase palette,
                                                          bool enabled,
                                                          bool checkState,
                                                          bool tracking,
@@ -603,7 +603,7 @@ namespace Krypton.Toolkit
         /// <param name="pressed">Should radio button be Displayed as pressed.</param>
         public abstract void DrawRadioButton(RenderContext context,
                                              Rectangle displayRect,
-                                             IPalette palette,
+                                             PaletteBase palette,
                                              bool enabled,
                                              bool checkState,
                                              bool tracking,
@@ -617,7 +617,7 @@ namespace Krypton.Toolkit
         /// <param name="state">State for which image size is needed.</param>
         /// <param name="orientation">How to orientate the image.</param>
         public abstract Size GetDropDownButtonPreferredSize(ViewLayoutContext context,
-                                                            IPalette palette,
+                                                            PaletteBase palette,
                                                             PaletteState state,
                                                             VisualOrientation orientation);
 
@@ -631,7 +631,7 @@ namespace Krypton.Toolkit
         /// <param name="orientation">How to orientate the image.</param>
         public abstract void DrawDropDownButton(RenderContext context,
                                                 Rectangle displayRect,
-                                                IPalette palette,
+                                                PaletteBase palette,
                                                 PaletteState state,
                                                 VisualOrientation orientation);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderDefinitions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderDefinitions.cs
@@ -72,7 +72,7 @@ namespace Krypton.Toolkit
         /// Gets a renderer for drawing the toolstrips.
         /// </summary>
         /// <param name="colorPalette">Color palette to use when rendering toolstrip.</param>
-        ToolStripRenderer RenderToolStrip(IPalette colorPalette);
+        ToolStripRenderer RenderToolStrip(PaletteBase colorPalette);
     }
     #endregion
 
@@ -515,7 +515,7 @@ namespace Krypton.Toolkit
         /// <param name="tracking">Should check box be Displayed as hot tracking.</param>
         /// <param name="pressed">Should check box be Displayed as pressed.</param>
         Size GetCheckBoxPreferredSize(ViewLayoutContext context,
-                                      IPalette palette,
+                                      PaletteBase palette,
                                       bool enabled,
                                       CheckState checkState,
                                       bool tracking,
@@ -533,7 +533,7 @@ namespace Krypton.Toolkit
         /// <param name="pressed">Should check box be Displayed as pressed.</param>
         void DrawCheckBox(RenderContext context,
                           Rectangle displayRect,
-                          IPalette palette,
+                          PaletteBase palette,
                           bool enabled,
                           CheckState checkState,
                           bool tracking,
@@ -549,7 +549,7 @@ namespace Krypton.Toolkit
         /// <param name="tracking">Should check box be Displayed as hot tracking.</param>
         /// <param name="pressed">Should check box be Displayed as pressed.</param>
         Size GetRadioButtonPreferredSize(ViewLayoutContext context,
-                                         IPalette palette,
+                                         PaletteBase palette,
                                          bool enabled,
                                          bool checkState,
                                          bool tracking,
@@ -567,7 +567,7 @@ namespace Krypton.Toolkit
         /// <param name="pressed">Should radio button be Displayed as pressed.</param>
         void DrawRadioButton(RenderContext context,
                              Rectangle displayRect,
-                             IPalette palette,
+                             PaletteBase palette,
                              bool enabled,
                              bool checkState,
                              bool tracking,
@@ -581,7 +581,7 @@ namespace Krypton.Toolkit
         /// <param name="state">State for which image size is needed.</param>
         /// <param name="orientation">How to orientate the image.</param>
         Size GetDropDownButtonPreferredSize(ViewLayoutContext context,
-                                            IPalette palette,
+                                            PaletteBase palette,
                                             PaletteState state,
                                             VisualOrientation orientation);
 
@@ -595,7 +595,7 @@ namespace Krypton.Toolkit
         /// <param name="orientation">How to orientate the image.</param>
         void DrawDropDownButton(RenderContext context,
                                 Rectangle displayRect,
-                                IPalette palette,
+                                PaletteBase palette,
                                 PaletteState state,
                                 VisualOrientation orientation);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderMicrosoft365.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderMicrosoft365.cs
@@ -61,7 +61,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="colourPalette">The colour palette.</param>
         /// <returns></returns>
-        public override ToolStripRenderer RenderToolStrip(IPalette colourPalette)
+        public override ToolStripRenderer RenderToolStrip(PaletteBase colourPalette)
         {
             Debug.Assert(colourPalette != null);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderOffice2007.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderOffice2007.cs
@@ -88,7 +88,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="colorPalette">Color palette to use when rendering toolstrip.</param>
         /// <exception cref="ArgumentNullException"></exception>
-        public override ToolStripRenderer RenderToolStrip(IPalette colorPalette)
+        public override ToolStripRenderer RenderToolStrip(PaletteBase colorPalette)
         {
             Debug.Assert(colorPalette != null);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderOffice2010.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderOffice2010.cs
@@ -88,7 +88,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="colorPalette">Color palette to use when rendering toolstrip.</param>
         /// <exception cref="ArgumentNullException"></exception>
-        public override ToolStripRenderer RenderToolStrip(IPalette colorPalette)
+        public override ToolStripRenderer RenderToolStrip(PaletteBase colorPalette)
         {
             Debug.Assert(colorPalette != null);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderOffice2013.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderOffice2013.cs
@@ -81,7 +81,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="colorPalette">Color palette to use when rendering toolstrip.</param>
         /// <exception cref="ArgumentNullException"></exception>
-        public override ToolStripRenderer RenderToolStrip(IPalette colorPalette)
+        public override ToolStripRenderer RenderToolStrip(PaletteBase colorPalette)
         {
             Debug.Assert(colorPalette != null);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderSparkle.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderSparkle.cs
@@ -290,7 +290,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="colorPalette">Color palette to use when rendering toolstrip.</param>
         /// <exception cref="ArgumentNullException"></exception>
-        public override ToolStripRenderer RenderToolStrip(IPalette colorPalette)
+        public override ToolStripRenderer RenderToolStrip(PaletteBase colorPalette)
         {
             Debug.Assert(colorPalette != null);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
@@ -375,7 +375,7 @@ namespace Krypton.Toolkit
         /// Gets a renderer for drawing the toolstrips.
         /// </summary>
         /// <param name="colorPalette">Color palette to use when rendering toolstrip.</param>
-        public override ToolStripRenderer RenderToolStrip(IPalette colorPalette)
+        public override ToolStripRenderer RenderToolStrip(PaletteBase colorPalette)
         {
             Debug.Assert(colorPalette != null);
 
@@ -2352,7 +2352,7 @@ namespace Krypton.Toolkit
         /// <param name="pressed">Should check box be Displayed as pressed.</param>
         /// <exception cref="ArgumentNullException"></exception>
         public override Size GetCheckBoxPreferredSize(ViewLayoutContext context,
-                                                      IPalette palette,
+                                                      PaletteBase palette,
                                                       bool enabled,
                                                       CheckState checkState,
                                                       bool tracking,
@@ -2403,7 +2403,7 @@ namespace Krypton.Toolkit
         /// <exception cref="ArgumentNullException"></exception>
         public override void DrawCheckBox(RenderContext context,
                                           Rectangle displayRect,
-                                          IPalette palette,
+                                          PaletteBase palette,
                                           bool enabled,
                                           CheckState checkState,
                                           bool tracking,
@@ -2458,7 +2458,7 @@ namespace Krypton.Toolkit
         /// <param name="tracking">Should check box be Displayed as hot tracking.</param>
         /// <param name="pressed">Should check box be Displayed as pressed.</param>
         public override Size GetRadioButtonPreferredSize(ViewLayoutContext context,
-                                                         IPalette palette,
+                                                         PaletteBase palette,
                                                          bool enabled,
                                                          bool checkState,
                                                          bool tracking,
@@ -2494,7 +2494,7 @@ namespace Krypton.Toolkit
         /// <exception cref="ArgumentNullException"></exception>
         public override void DrawRadioButton(RenderContext context,
                                              Rectangle displayRect,
-                                             IPalette palette,
+                                             PaletteBase palette,
                                              bool enabled,
                                              bool checkState,
                                              bool tracking,
@@ -2547,7 +2547,7 @@ namespace Krypton.Toolkit
         /// <param name="state">State for which image size is needed.</param>
         /// <param name="orientation">How to orientate the image.</param>
         public override Size GetDropDownButtonPreferredSize(ViewLayoutContext context,
-                                                            IPalette palette,
+                                                            PaletteBase palette,
                                                             PaletteState state,
                                                             VisualOrientation orientation)
         {
@@ -2582,7 +2582,7 @@ namespace Krypton.Toolkit
         /// <exception cref="ArgumentNullException"></exception>
         public override void DrawDropDownButton(RenderContext context,
                                                 Rectangle displayRect,
-                                                IPalette palette,
+                                                PaletteBase palette,
                                                 PaletteState state,
                                                 VisualOrientation orientation)
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/ThemeManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/ThemeManager.cs
@@ -10,6 +10,8 @@
  */
 #endregion
 
+using Krypton.Toolkit.Utilities;
+
 namespace Krypton.Toolkit
 {
     /// <summary>
@@ -21,100 +23,56 @@ namespace Krypton.Toolkit
         /// <summary>
         /// The supported themes
         /// </summary>
-        private static readonly string[] _supportedThemes =
-        {
-            "Professional - System",
+        /// TODO: this should use the list from Z:\GitHub\Krypton-Suite\Standard-Toolkit\Source\Krypton Components\Krypton.Toolkit\Converters\PaletteModeConverter.cs
+        private static readonly BiDictionary<string, PaletteModeManager> _supportedThemes = new(new Dictionary<string, PaletteModeManager>
+            {
+                { @"Professional - System", PaletteModeManager.ProfessionalSystem },
+                { @"Professional - Office 2003", PaletteModeManager.ProfessionalOffice2003 },
+                { @"Office 2007 - Blue", PaletteModeManager.Office2007Blue },
+                { @"Office 2007 - Blue (Dark Mode)", PaletteModeManager.Office2007BlueDarkMode },
+                { @"Office 2007 - Blue (Light Mode)", PaletteModeManager.Office2007BlueLightMode },
+                { @"Office 2007 - Silver", PaletteModeManager.Office2007Silver },
+                { @"Office 2007 - Silver (Dark Mode)", PaletteModeManager.Office2007SilverDarkMode },
+                { @"Office 2007 - Silver (Light Mode)", PaletteModeManager.Office2007SilverLightMode },
+                { @"Office 2007 - White", PaletteModeManager.Office2007White },
+                { @"Office 2007 - Black", PaletteModeManager.Office2007Black },
+                { @"Office 2007 - Black (Dark Mode)", PaletteModeManager.Office2007BlackDarkMode },
+                { @"Office 2007 - Dark Gray", PaletteModeManager.Office2007DarkGray },
+                { @"Office 2010 - Blue", PaletteModeManager.Office2010Blue },
+                { @"Office 2010 - Blue (Dark Mode)", PaletteModeManager.Office2010BlueDarkMode },
+                { @"Office 2010 - Blue (Light Mode)", PaletteModeManager.Office2010BlueLightMode },
+                { @"Office 2010 - Silver", PaletteModeManager.Office2010Silver },
+                { @"Office 2010 - Silver (Dark Mode)", PaletteModeManager.Office2010SilverDarkMode },
+                { @"Office 2010 - Silver (Light Mode)", PaletteModeManager.Office2010SilverLightMode },
+                { @"Office 2010 - White", PaletteModeManager.Office2010White },
+                { @"Office 2010 - Black", PaletteModeManager.Office2010Black },
+                { @"Office 2010 - Black (Dark Mode)", PaletteModeManager.Office2010BlackDarkMode },
+                { @"Office 2010 - Dark Gray", PaletteModeManager.Office2010DarkGray },
+                { @"Office 2013 - Dark Gray", PaletteModeManager.Office2013DarkGray },
+                //{ @"Office 2013", PaletteModeManager.Office2013 },
+                { @"Office 2013 - White", PaletteModeManager.Office2013White },
+                { @"Sparkle - Blue", PaletteModeManager.SparkleBlue },
+                { @"Sparkle - Blue (Dark Mode)", PaletteModeManager.SparkleBlueDarkMode },
+                { @"Sparkle - Blue (Light Mode)", PaletteModeManager.SparkleBlueLightMode },
+                { @"Sparkle - Orange", PaletteModeManager.SparkleOrange },
+                { @"Sparkle - Orange (Dark Mode)", PaletteModeManager.SparkleOrangeDarkMode },
+                { @"Sparkle - Orange (Light Mode)", PaletteModeManager.SparkleOrangeLightMode },
+                { @"Sparkle - Purple", PaletteModeManager.SparklePurple },
+                { @"Sparkle - Purple (Dark Mode)", PaletteModeManager.SparklePurpleDarkMode },
+                { @"Sparkle - Purple (Light Mode)", PaletteModeManager.SparklePurpleLightMode },
+                { @"Office 365 - Blue", PaletteModeManager.Microsoft365Blue },
+                { @"Office 365 - Blue (Dark Mode)", PaletteModeManager.Microsoft365BlueDarkMode },
+                { @"Office 365 - Blue (Light Mode)", PaletteModeManager.Microsoft365BlueLightMode },
+                { @"Office 365 - Silver", PaletteModeManager.Microsoft365Silver },
+                { @"Office 365 - Silver (Dark Mode)", PaletteModeManager.Microsoft365SilverDarkMode },
+                { @"Office 365 - Silver (Light Mode)", PaletteModeManager.Microsoft365SilverLightMode },
+                { @"Office 365 - White", PaletteModeManager.Microsoft365White },
+                { @"Office 365 - Black", PaletteModeManager.Microsoft365Black },
+                { @"Office 365 - Black (Dark Mode)", PaletteModeManager.Microsoft365BlackDarkMode },
+                { @"Office 365 - Dark Gray", PaletteModeManager.Microsoft365DarkGray },
+                { @"Custom", PaletteModeManager.Custom }
+            });
 
-            "Professional - Office 2003",
-
-            "Office 2007 - Black",
-
-            "Office 2007 - Black (Dark Mode)",
-
-            //"Office 2007 - Black (Light Mode)",
-
-            "Office 2007 - Blue",
-
-            "Office 2007 - Blue (Dark Mode)",
-
-            "Office 2007 - Blue (Light Mode)",
-
-            "Office 2007 - Dark Gray",
-
-            "Office 2007 - Silver",
-
-            "Office 2007 - Silver (Dark Mode)",
-
-            "Office 2007 - Silver (Light Mode)",
-
-            "Office 2010 - Black",
-
-            "Office 2010 - Black (Dark Mode)",
-
-            //"Office 2010 - Black (Light Mode)",
-
-            "Office 2010 - Blue",
-
-            "Office 2010 - Blue (Dark Mode)",
-
-            "Office 2010 - Blue (Light Mode)",
-
-            "Office 2010 - Dark Gray",
-
-            "Office 2010 - Silver",
-
-            "Office 2010 - Silver (Dark Mode)",
-
-            "Office 2010 - Silver (Light Mode)",
-
-            "Office 2010 - White",
-
-            "Office 2013 - White",
-
-            "Office 2013 - Dark Gray",
-
-            "Microsoft 365 - Black",
-
-            "Microsoft 365 - Black (Dark Mode)",
-
-            //"Microsoft 365 - Black (Light Mode)",
-
-            "Microsoft 365 - Blue",
-
-            "Microsoft 365 - Blue (Dark Mode)",
-
-            "Microsoft 365 - Blue (Light Mode)",
-
-            "Microsoft 365 - Dark Gray",
-
-            "Microsoft 365 - Silver",
-
-            "Microsoft 365 - Silver (Dark Mode)",
-
-            "Microsoft 365 - Silver (Light Mode)",
-
-            "Microsoft 365 - White",
-
-            "Sparkle - Blue",
-
-            "Sparkle - Blue (Dark Mode)",
-
-            "Sparkle - Blue (Light Mode)",
-
-            "Sparkle - Orange",
-
-            "Sparkle - Orange (Dark Mode)",
-
-            "Sparkle - Orange (Light Mode)",
-
-            "Sparkle - Purple",
-
-            "Sparkle - Purple (Dark Mode)",
-
-            "Sparkle - Purple (Light Mode)",
-
-            "Custom"
-        };
         #endregion
 
         #region Instance Fields
@@ -128,7 +86,7 @@ namespace Krypton.Toolkit
         /// <value>
         /// The supported theme array.
         /// </value>
-        public static string[] SupportedThemeArray => _supportedThemes;
+        public static ICollection<string> SupportedInternalThemeNames => _supportedThemes.GetAllFirsts();
 
         #endregion
 
@@ -265,147 +223,7 @@ namespace Krypton.Toolkit
         /// <param name="manager">The manager.</param>
         public static void ApplyTheme(string themeName, KryptonManager manager)
         {
-            switch (themeName)
-            {
-                case @"Custom":
-                    ApplyTheme(PaletteModeManager.Custom, manager);
-                    break;
-                case @"Professional - System":
-                    ApplyTheme(PaletteModeManager.ProfessionalSystem, manager);
-                    break;
-                case @"Professional - Office 2003":
-                    ApplyTheme(PaletteModeManager.ProfessionalOffice2003, manager);
-                    break;
-                case @"Office 2007 - Blue":
-                    ApplyTheme(PaletteModeManager.Office2007Blue, manager);
-                    break;
-                case @"Office 2007 - Blue (Dark Mode)":
-                    ApplyTheme(PaletteModeManager.Office2007BlueDarkMode, manager);
-                    break;
-                case @"Office 2007 - Blue (Light Mode)":
-                    ApplyTheme(PaletteModeManager.Office2007BlueLightMode, manager);
-                    break;
-                case @"Office 2007 - Silver":
-                    ApplyTheme(PaletteModeManager.Office2007Silver, manager);
-                    break;
-                case @"Office 2007 - Silver (Dark Mode)":
-                    ApplyTheme(PaletteModeManager.Office2007SilverDarkMode, manager);
-                    break;
-                case @"Office 2007 - Silver (Light Mode)":
-                    ApplyTheme(PaletteModeManager.Office2007SilverLightMode, manager);
-                    break;
-                case @"Office 2007 - White":
-                    ApplyTheme(PaletteModeManager.Office2007White, manager);
-                    break;
-                case @"Office 2007 - Black":
-                    ApplyTheme(PaletteModeManager.Office2007Black, manager);
-                    break;
-                case @"Office 2007 - Black (Dark Mode)":
-                    ApplyTheme(PaletteModeManager.Office2007BlackDarkMode, manager);
-                    break;
-                case @"Office 2007 - Dark Gray":
-                    ApplyTheme(PaletteModeManager.Office2007DarkGray, manager);
-                    break;
-                case @"Office 2010 - Blue":
-                    ApplyTheme(PaletteModeManager.Office2010Blue, manager);
-                    break;
-                case @"Office 2010 - Blue (Dark Mode)":
-                    ApplyTheme(PaletteModeManager.Office2010BlueDarkMode, manager);
-                    break;
-                case @"Office 2010 - Blue (Light Mode)":
-                    ApplyTheme(PaletteModeManager.Office2010BlueLightMode, manager);
-                    break;
-                case @"Office 2010 - Silver":
-                    ApplyTheme(PaletteModeManager.Office2010Silver, manager);
-                    break;
-                case @"Office 2010 - Silver (Dark Mode)":
-                    ApplyTheme(PaletteModeManager.Office2010SilverDarkMode, manager);
-                    break;
-                case @"Office 2010 - Silver (Light Mode)":
-                    ApplyTheme(PaletteModeManager.Office2010SilverLightMode, manager);
-                    break;
-                case @"Office 2010 - White":
-                    ApplyTheme(PaletteModeManager.Office2010White, manager);
-                    break;
-                case @"Office 2010 - Black":
-                    ApplyTheme(PaletteModeManager.Office2010Black, manager);
-                    break;
-                case @"Office 2010 - Black (Dark Mode)":
-                    ApplyTheme(PaletteModeManager.Office2010BlackDarkMode, manager);
-                    break;
-                case @"Office 2010 - Dark Gray":
-                    ApplyTheme(PaletteModeManager.Office2010DarkGray, manager);
-                    break;
-                case @"Office 2013 - Dark Gray":
-                    ApplyTheme(PaletteModeManager.Office2013DarkGray, manager);
-                    break;
-                /*case @"Office 2013":
-                    ApplyTheme(PaletteModeManager.Office2013, manager);
-                    break;*/
-                case @"Office 2013 - White":
-                    ApplyTheme(PaletteModeManager.Office2013White, manager);
-                    break;
-                case @"Sparkle - Blue":
-                    ApplyTheme(PaletteModeManager.SparkleBlue, manager);
-                    break;
-                case @"Sparkle - Blue (Dark Mode)":
-                    ApplyTheme(PaletteModeManager.SparkleBlueDarkMode, manager);
-                    break;
-                case @"Sparkle - Blue (Light Mode)":
-                    ApplyTheme(PaletteModeManager.SparkleBlueLightMode, manager);
-                    break;
-                case @"Sparkle - Orange":
-                    ApplyTheme(PaletteModeManager.SparkleOrange, manager);
-                    break;
-                case @"Sparkle - Orange (Dark Mode)":
-                    ApplyTheme(PaletteModeManager.SparkleOrangeDarkMode, manager);
-                    break;
-                case @"Sparkle - Orange (Light Mode)":
-                    ApplyTheme(PaletteModeManager.SparkleOrangeLightMode, manager);
-                    break;
-                case @"Sparkle - Purple":
-                    ApplyTheme(PaletteModeManager.SparklePurple, manager);
-                    break;
-                case @"Sparkle - Purple (Dark Mode)":
-                    ApplyTheme(PaletteModeManager.SparklePurpleDarkMode, manager);
-                    break;
-                case @"Sparkle - Purple (Light Mode)":
-                    ApplyTheme(PaletteModeManager.SparklePurpleLightMode, manager);
-                    break;
-                case @"Microsoft 365 - Blue":
-                    ApplyTheme(PaletteModeManager.Microsoft365Blue, manager);
-                    break;
-                case @"Microsoft 365 - Blue (Dark Mode)":
-                    ApplyTheme(PaletteModeManager.Microsoft365BlueDarkMode, manager);
-                    break;
-                case @"Microsoft 365 - Blue (Light Mode)":
-                    ApplyTheme(PaletteModeManager.Microsoft365BlueLightMode, manager);
-                    break;
-                case @"Microsoft 365 - Silver":
-                    ApplyTheme(PaletteModeManager.Microsoft365Silver, manager);
-                    break;
-                case @"Microsoft 365 - Silver (Dark Mode)":
-                    ApplyTheme(PaletteModeManager.Microsoft365SilverDarkMode, manager);
-                    break;
-                case @"Microsoft 365 - Silver (Light Mode)":
-                    ApplyTheme(PaletteModeManager.Microsoft365SilverLightMode, manager);
-                    break;
-                case @"Microsoft 365 - White":
-                    ApplyTheme(PaletteModeManager.Microsoft365White, manager);
-                    break;
-                case @"Microsoft 365 - Black":
-                    ApplyTheme(PaletteModeManager.Microsoft365Black, manager);
-                    break;
-                case @"Microsoft 365 - Black (Dark Mode)":
-                    ApplyTheme(PaletteModeManager.Microsoft365BlackDarkMode, manager);
-                    break;
-                case @"Microsoft 365 - Dark Gray":
-                    ApplyTheme(PaletteModeManager.Microsoft365DarkGray, manager);
-                    break;
-                default:
-                    throw new ArgumentNullException(nameof(themeName));
-            }
-
+            ApplyTheme(_supportedThemes.GetByFirst(themeName), manager);
         }
 
         /// <summary>
@@ -437,49 +255,7 @@ namespace Krypton.Toolkit
         {
             var paletteMode = manager?.GlobalPaletteMode ?? paletteModeManager;
 
-            return paletteMode switch
-            {
-                PaletteModeManager.Custom => "Custom",
-                PaletteModeManager.ProfessionalSystem => "Professional - System",
-                PaletteModeManager.ProfessionalOffice2003 => "Professional - Office 2003",
-                PaletteModeManager.Office2007Blue => "Office 2007 - Blue",
-                PaletteModeManager.Office2007BlueDarkMode => "Office 2007 - Blue (Dark Mode)",
-                PaletteModeManager.Office2007BlueLightMode => "Office 2007 - Blue (Light Mode)",
-                PaletteModeManager.Office2007Silver => "Office 2007 - Silver",
-                PaletteModeManager.Office2007SilverDarkMode => "Office 2007 - Silver (Dark Mode)",
-                PaletteModeManager.Office2007SilverLightMode => "Office 2007 - Silver (Light Mode)",
-                PaletteModeManager.Office2007White => "Office 2007 - White",
-                PaletteModeManager.Office2007Black => "Office 2007 - Black",
-                PaletteModeManager.Office2007BlackDarkMode => "Office 2007 - Black (Dark Mode)",
-                PaletteModeManager.Office2007DarkGray => "Office 2007 - Dark Gray",
-                PaletteModeManager.Office2010Blue => "Office 2010 - Blue",
-                PaletteModeManager.Office2010BlueDarkMode => "Office 2010 - Blue (Dark Mode)",
-                PaletteModeManager.Office2010BlueLightMode => "Office 2010 - Blue (Light Mode)",
-                PaletteModeManager.Office2010Silver => "Office 2010 - Silver",
-                PaletteModeManager.Office2010SilverDarkMode => "Office 2010 - Silver (Dark Mode)",
-                PaletteModeManager.Office2010SilverLightMode => "Office 2010 - Silver (Light Mode)",
-                PaletteModeManager.Office2010White => "Office 2010 - White",
-                PaletteModeManager.Office2010Black => "Office 2010 - Black",
-                PaletteModeManager.Office2010BlackDarkMode => "Office 2010 - Black (Dark Mode)",
-                PaletteModeManager.Office2010DarkGray => "Office 2010 - Dark Gray",
-                PaletteModeManager.Office2013DarkGray => "Office 2013 - Dark Gray",
-                //PaletteModeManager.Office2013 => "Office 2013",
-                PaletteModeManager.Office2013White => "Office 2013 - White",
-                PaletteModeManager.SparkleBlue => "Sparkle - Blue",
-                PaletteModeManager.SparkleOrange => "Sparkle - Orange",
-                PaletteModeManager.SparklePurple => "Sparkle - Purple",
-                PaletteModeManager.Microsoft365Blue => "Microsoft 365 - Blue",
-                PaletteModeManager.Microsoft365BlueDarkMode => "Microsoft 365 - Blue (Dark Mode)",
-                PaletteModeManager.Microsoft365BlueLightMode => "Microsoft 365 - Blue (Light Mode)",
-                PaletteModeManager.Microsoft365Silver => "Microsoft 365 - Silver",
-                PaletteModeManager.Microsoft365SilverDarkMode => "Microsoft 365 - Silver (Dark Mode)",
-                PaletteModeManager.Microsoft365SilverLightMode => "Microsoft 365 - Silver (Light Mode)",
-                PaletteModeManager.Microsoft365White => "Microsoft 365 - White",
-                PaletteModeManager.Microsoft365Black => "Microsoft 365 - Black",
-                PaletteModeManager.Microsoft365BlackDarkMode => "Microsoft 365 - Black (Dark Mode)",
-                PaletteModeManager.Microsoft365DarkGray => "Microsoft 365 - Dark Gray",
-                _ => null
-            };
+            return _supportedThemes.GetBySecond(paletteMode);
         }
 
         /// <summary>
@@ -489,14 +265,14 @@ namespace Krypton.Toolkit
         /// <param name="manager">The manager.</param>
         /// <param name="themeFile">A custom theme file.</param>
         /// <param name="silent">if set to <c>true</c> [silent].</param>
-        public static void LoadCustomTheme(KryptonPalette palette, KryptonManager manager, string themeFile = "", bool silent = false)
+        public static void LoadCustomTheme(KryptonCustomPaletteBase palette, KryptonManager manager, string themeFile = "", bool silent = false)
         {
             try
             {
                 //throw new ApplicationException(@"Currently not implemented correctly");
 
                 // Declare new instances
-                palette = new KryptonPalette();
+                palette = new KryptonCustomPaletteBase();
 
                 manager = new KryptonManager();
 
@@ -586,7 +362,7 @@ namespace Krypton.Toolkit
         {
             try
             {
-                foreach (var theme in SupportedThemeArray)
+                foreach (var theme in SupportedInternalThemeNames)
                 {
                     if (!excludes.Any(t => theme.IndexOf(t, StringComparison.InvariantCultureIgnoreCase) > -1))
                     {
@@ -649,30 +425,6 @@ namespace Krypton.Toolkit
         /// <param name="themeName">Name of the theme.</param>
         /// <returns>The <see cref="PaletteModeManager"/> equivalent.</returns>
         public static PaletteModeManager ApplyThemeManagerMode(string themeName) => (PaletteModeManager)Enum.Parse(typeof(PaletteModeManager), themeName);
-
-        /// <summary>Returns the theme array.</summary>
-        /// <returns>
-        ///   <br />
-        /// </returns>
-        public static string[] ReturnThemeArray() => _supportedThemes;
-
-        /// <summary>
-        /// 
-        /// </summary>
-        public static List<string> PropagateSupportedThemeList()
-        {
-            try
-            {
-                return ReturnThemeArray().ToList();
-            }
-            catch (Exception e)
-            {
-                ExceptionHandler.CaptureException(e);
-            }
-
-            return new List<string>();
-        }
-
         #endregion
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Tooling/DebugTools.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Tooling/DebugTools.cs
@@ -20,12 +20,12 @@ namespace Krypton.Toolkit
             if (lineNumber > 0)
             {
                 KryptonMessageBox.Show($"If you are seeing this message, please submit a new bug report at: https://github.com/Krypton-Suite/Standard-Toolkit/issues/new/choose.\n\nAdditional details:-\nMethod Signature: {methodSignature}\nClass Name: {className}\nLine Number: {lineNumber}", 
-                    "Not Implemented", KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.Information);
+                    "Not Implemented", KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.SystemError);
             }
             else
             {
                 KryptonMessageBox.Show($"If you are seeing this message, please submit a new bug report at: https://github.com/Krypton-Suite/Standard-Toolkit/issues/new/choose.\n\nAdditional details:-\nMethod Signature: {methodSignature}\nClass Name: {className}", 
-                    "Not Implemented", KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.Information);
+                    "Not Implemented", KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.SystemError);
             }
         }
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Utilities/BiDictionary.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Utilities/BiDictionary.cs
@@ -1,0 +1,68 @@
+﻿#region BSD License
+/*
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2022 - 2023. All rights reserved. 
+ *  
+ */
+#endregion
+
+namespace Krypton.Toolkit.Utilities
+{
+    /// <summary>
+    /// Taken and then modified from
+    /// https://stackoverflow.com/questions/255341/getting-multiple-keys-of-specified-value-of-a-generic-dictionary/255638#255638
+    /// </summary>
+    /// <typeparam name="TFirst"></typeparam>
+    /// <typeparam name="TSecond"></typeparam>
+    internal class BiDictionary<TFirst, TSecond>
+    {
+        private static readonly IList<TFirst> _emptyFirstList = Array.Empty<TFirst>();
+        private static readonly IList<TSecond> _emptySecondList = Array.Empty<TSecond>();
+
+        private readonly IDictionary<TFirst, TSecond> _firstToSecond = new Dictionary<TFirst, TSecond>();
+        private readonly IDictionary<TSecond, TFirst> _secondToFirst = new Dictionary<TSecond, TFirst>();
+
+
+        public BiDictionary(IDictionary<TFirst, TSecond> dictionary)
+        {
+            if (dictionary == null)
+            {
+                throw new ArgumentNullException(nameof(dictionary));
+            }
+
+            foreach (KeyValuePair<TFirst, TSecond> keyValuePair in dictionary)
+            {
+                this.Add(keyValuePair.Key, keyValuePair.Value);
+            }
+        }
+
+        public void Add(TFirst first, TSecond second)
+        {
+            _firstToSecond.Add(first, second);
+            _secondToFirst.Add(second, first);
+        }
+
+        // Note potential ambiguity using indexers (e.g. mapping from int to int)
+        // Hence the methods as well...
+        public TSecond this[TFirst first] => GetByFirst(first);
+
+        public TFirst this[TSecond second] => GetBySecond(second);
+
+        public TSecond GetByFirst(TFirst first)
+        {
+            _firstToSecond.TryGetValue(first, out var second);
+            return second;
+        }
+
+        public TFirst GetBySecond(TSecond second)
+        {
+            _secondToFirst.TryGetValue(second, out var first);
+            return first;
+        }
+
+        public ICollection<TFirst> GetAllFirsts()
+        {
+            return _firstToSecond.Keys;
+        }
+    }
+}

--- a/Source/Krypton Components/Krypton.Toolkit/Utilities/PaletteImageScaler.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Utilities/PaletteImageScaler.cs
@@ -35,7 +35,7 @@ namespace Krypton.Toolkit
         /// <param name="factorDpiX">multiplier from dpi of 96 X</param>
         /// <param name="factorDpiY">multiplier from dpi of 96 Y</param>
         /// <param name="pal">KryptonPalette</param>
-        public static void ScalePalette(float factorDpiX, float factorDpiY, KryptonPalette pal)
+        public static void ScalePalette(float factorDpiX, float factorDpiY, KryptonCustomPaletteBase pal)
         {
             if (pal == null 
                 //|| pal.HasAlreadyBeenScaled

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawButton.cs
@@ -234,7 +234,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the drop down capability of the button.
         /// </summary>
-        public IPalette DropDownPalette
+        public PaletteBase DropDownPalette
         {
             get => _drawDropDownButton.Palette;
             set => _drawDropDownButton.Palette = value;

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawCheckBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawCheckBox.cs
@@ -18,7 +18,7 @@ namespace Krypton.Toolkit
     public class ViewDrawCheckBox : ViewLeaf
     {
         #region Instance Fields
-        private readonly IPalette _palette;
+        private readonly PaletteBase _palette;
         private bool _tracking;
 
         #endregion
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the ViewDrawCheckBox class.
         /// </summary>
         /// <param name="palette">Palette for source of drawing values.</param>
-        public ViewDrawCheckBox(IPalette palette)
+        public ViewDrawCheckBox(PaletteBase palette)
         {
             Debug.Assert(palette != null);
             _palette = palette;

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawDropDownButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawDropDownButton.cs
@@ -41,7 +41,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the palette to use.
         /// </summary>
-        public IPalette Palette { get; set; }
+        public PaletteBase Palette { get; set; }
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawRadioButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawRadioButton.cs
@@ -18,7 +18,7 @@ namespace Krypton.Toolkit
     public class ViewDrawRadioButton : ViewLeaf
     {
         #region Instance Fields
-        private readonly IPalette _palette;
+        private readonly PaletteBase _palette;
 
         #endregion
 
@@ -27,7 +27,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the ViewDrawRadioButton class.
         /// </summary>
         /// <param name="palette">Palette for source of drawing values.</param>
-        public ViewDrawRadioButton(IPalette palette)
+        public ViewDrawRadioButton(PaletteBase palette)
         {
             Debug.Assert(palette != null);
             _palette = palette;

--- a/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutMenuItemSelect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutMenuItemSelect.cs
@@ -68,7 +68,7 @@ namespace Krypton.Toolkit
             _imageIndexEnd = Math.Min(_imageIndexEnd, _imageCount - 1);
             _imageIndexCount = Math.Max(0, _imageIndexEnd - _imageIndexStart + 1);
 
-            IPalette palette = provider.ProviderPalette ?? KryptonManager.GetPaletteForMode(provider.ProviderPaletteMode);
+            PaletteBase palette = provider.ProviderPalette ?? KryptonManager.GetPaletteForMode(provider.ProviderPaletteMode);
 
             // Create triple that can be used by the draw button
             _triple = new PaletteTripleToPalette(palette,


### PR DESCRIPTION
- Remove `IPalette` and use `PaletteBase` instead
- Fix fallout in abstract class useage
- Rename `KryptonPalette` to `KryptonCustomPaletteBase` to reflect usage
- Start to sort out code in `ThemeManager`
- Some spelling mistake fixes

#https://github.com/Krypton-Suite/Standard-Toolkit/issues/827

![image](https://user-images.githubusercontent.com/2418812/209334936-264b69b9-2b87-4ae0-94f5-8ce679b53f4a.png)
