### PR TITLE
- Rename `KryptonPalette` to `KryptonCustomPaletteBase` to make it obvious what it is

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -5,6 +5,7 @@
 =======
 
 ## 2023-11-xx - Build 2311 - November 2023
+* Complete [#827](https://github.com/Krypton-Suite/Standard-Toolkit/issues/827),Expose IPalette / PaletteBase as a public interface in KryptonManager
 * Fixed the display of the initial selected theme in the "ThemeSelection ComboBox"
 * Resolved [#876](https://github.com/Krypton-Suite/Standard-Toolkit/issues/876), `Office 365 - Black` does not display text correctly
 * Resolved [#874](https://github.com/Krypton-Suite/Standard-Toolkit/issues/874), 80.xx Canary Nuget text is incorrrect

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
@@ -2704,7 +2704,7 @@ namespace Krypton.Toolkit
 
         protected override void DefineFonts()
         {
-            throw new NotImplementedException();
+            // This class has no font fields
         }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
@@ -48,6 +48,13 @@ namespace Krypton.Toolkit
 
         private bool ShouldSerializeThemeSelectedIndex() => _selectedIndex != 25;
 
+        /// <summary>
+        /// Gets and sets the ThemeSelectedIndex.
+        /// </summary>
+        [Category(@"Visuals")]
+        [Description(@"Custom Theme to use when `Custom` is selected")]
+        [DefaultValue(null)]
+        public KryptonCustomPaletteBase KryptonCustomPalette { get; set; }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public KryptonManager Manager
@@ -98,6 +105,12 @@ namespace Krypton.Toolkit
             ThemeSelectedIndex = SelectedIndex;
 
             base.OnSelectedIndexChanged(e);
+            if ((ThemeManager.GetThemeManagerMode(Text) == PaletteMode.Custom)
+                && (KryptonCustomPalette != null)
+               )
+            {
+                Manager.GlobalPalette = KryptonCustomPalette;
+            }
         }
 
         #endregion


### PR DESCRIPTION
- Rename `KryptonPalette` to `KryptonCustomPaletteBase` to make it obvious what it is
- Add designer code to allow the `KryptonThemeComboBox` to add a `KryptonCustomPalette`

#827

![image](https://user-images.githubusercontent.com/2418812/213860199-2424a788-d81c-4488-aaac-f08481cb8932.png)

