### PR TITLE
- Remove code that disallowed setting of the DataGridView Border

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2023-11-xx - Build 2311 - November 2023
+* Resolved [#991](https://github.com/Krypton-Suite/Standard-Toolkit/pull/991),  Remove code that disallowed setting of the DataGridView Border
 * Implemented [#267](https://github.com/Krypton-Suite/Standard-Toolkit/issues/267), "Open / Save File Dialog" are in the Main Forms elements - Where is Kryptons' Standard themed equivalent.
 * New `KryptonThemeSelector`, to allow switching between themes easily
 * Resolved [#986](https://github.com/Krypton-Suite/Standard-Toolkit/issues/986), `ViewBuilderOutlookBase` - Stream cannot be null to initialize a bitmap (thanks to [Angelo](https://github.com/AngeloCresta))

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -233,17 +233,18 @@ namespace Krypton.Toolkit
             set => base.BackgroundColor = value;
         }
 
-        /// <summary>
-        /// Gets or sets the border style for the DataGridView.
-        /// </summary>
-        [Browsable(false)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public new BorderStyle BorderStyle
-        {
-            get => base.BorderStyle;
-            set { /* Do nothing, we do not allow a border style change! */ }
-        }
+        ///// <summary>
+        ///// Gets or sets the border style for the DataGridView.
+        ///// </summary>
+        //[Browsable(false)]
+        //[EditorBrowsable(EditorBrowsableState.Never)]
+        //[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        // Disable as part of https://github.com/Krypton-Suite/Standard-Toolkit/issues/989
+        //public new BorderStyle BorderStyle
+        //{
+        //    get => base.BorderStyle;
+        //    set { /* Do nothing, we do not allow a border style change! */ }
+        //}
 
         /// <summary>
         /// Gets the cell border style for the DataGridView.

--- a/Source/Krypton Components/Krypton.Toolkit/ShellDialogs/FileDialogWrapper.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ShellDialogs/FileDialogWrapper.cs
@@ -86,7 +86,12 @@ namespace Krypton.Toolkit
             //actioned = handled;
             if (e.message == PI.WM_.INITDIALOG)
             {
+                #if NET462
+                using var g  = _commonDialogHandler._wrapperForm.CreateGraphics();
+                _scaleFactor = g.DpiX / 96.0f;
+                #else
                 _scaleFactor = _commonDialogHandler._wrapperForm.DeviceDpi / 96.0f;
+                #endif
                 _commonDialogHandler._wrapperForm.Resize += FormResize;
                 _commonDialogHandler._wrapperForm.MinimumSize = new SizeF(440 *_scaleFactor, 345 * _scaleFactor).ToSize();
             }


### PR DESCRIPTION
- Also fix build break for .net462 of the `FileDialogWrapper`

#989

![image](https://user-images.githubusercontent.com/2418812/230571971-9484e52d-30b3-481b-b406-4bec1cc97411.png)
