### PR TITLE
- Implement the changes necessary to colour the PropertyGrid controls correctly

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2023-11-xx - Build 2311 - November 2023
+* Implemented [#894](https://github.com/Krypton-Suite/Standard-Toolkit/issues/894), `KryptonPropertyGrid` needs to have full Krypton support
 * Resolved [#999](https://github.com/Krypton-Suite/Standard-Toolkit/issues/999), Incorrect project file names while building
 * Part resolved [#66](https://github.com/Krypton-Suite/Standard-Toolkit/issues/66), to allow ribbon designer in vs 17.5x and .net48 project types.
 * Resolved [#838](https://github.com/Krypton-Suite/Standard-Toolkit/issues/838),

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContent.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContent.cs
@@ -81,7 +81,7 @@ namespace Krypton.Toolkit
         /// <param name="inherit">Source for inheriting defaulted values.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
         public PaletteContent(IPaletteContent inherit,
-                              NeedPaintHandler needPaint)
+                              NeedPaintHandler? needPaint)
         {
             Debug.Assert(inherit != null);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentImage.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentImage.cs
@@ -51,7 +51,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Instance Fields
-        private InternalStorage _storage;
+        private InternalStorage? _storage;
         #endregion
 
         #region Events
@@ -68,7 +68,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteContentImage class.
         /// </summary>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteContentImage(NeedPaintHandler needPaint) =>
+        public PaletteContentImage(NeedPaintHandler? needPaint) =>
             // Store the provided paint notification delegate
             NeedPaint = needPaint;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentText.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentText.cs
@@ -99,7 +99,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteContentText class.
         /// </summary>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteContentText(NeedPaintHandler needPaint) =>
+        public PaletteContentText(NeedPaintHandler? needPaint) =>
             // Store the provided paint notification delegate
             NeedPaint = needPaint;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Enumerations/PaletteEnumerations.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Enumerations/PaletteEnumerations.cs
@@ -285,14 +285,4 @@ namespace Krypton.Toolkit
 
     #endregion
 
-    #region Enumeration: KryptonPropertyGridColors
-
-    internal enum KryptonPropertyGridColors
-    {
-        HelpBackColor = 1,
-        HelpForeColor = 2,
-        LineColor = 3,
-        CategoryForeColor = 4
-    }
-    #endregion
-    }
+}

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlackDarkMode.cs
@@ -6642,42 +6642,6 @@ namespace Krypton.Toolkit
 
         #endregion
 
-        #region Property Grid
-
-        /// <summary>
-        /// Gets the color of the property grid help back.
-        /// </summary>
-        /// <value>
-        /// The color of the property grid help back.
-        /// </value>
-        public override Color PropertyGridHelpBackColor => _propertyGridColors[(int)KryptonPropertyGridColors.HelpBackColor];
-
-        /// <summary>
-        /// Gets the color of the property grid help fore.
-        /// </summary>
-        /// <value>
-        /// The color of the property grid help fore.
-        /// </value>
-        public override Color PropertyGridHelpForeColor => _propertyGridColors[(int)KryptonPropertyGridColors.HelpForeColor];
-
-        /// <summary>
-        /// Gets the color of the property grid category fore.
-        /// </summary>
-        /// <value>
-        /// The color of the property grid category fore.
-        /// </value>
-        public override Color PropertyGridCategoryForeColor => _propertyGridColors[(int)KryptonPropertyGridColors.CategoryForeColor];
-
-        /// <summary>
-        /// Gets the color of the property grid line.
-        /// </summary>
-        /// <value>
-        /// The color of the property grid line.
-        /// </value>
-        public override Color PropertyGridLineColor => _propertyGridColors[(int)KryptonPropertyGridColors.LineColor];
-
-        #endregion
-
         #region Separator
         #region SeparatorLight
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTable.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTable.cs
@@ -55,26 +55,6 @@ namespace Krypton.Toolkit
 
         #endregion
 
-        #region Property Grid
-
-        /// <summary>Gets the color of the property grid help back.</summary>
-        /// <value>The color of the property grid help back.</value>
-        public virtual Color PropertyGridHelpBackColor => _palette.ColorTable.MenuStripGradientBegin;
-
-        /// <summary>Gets the color of the property grid help fore.</summary>
-        /// <value>The color of the property grid help fore.</value>
-        public virtual Color PropertyGridHelpForeColor => _palette.ColorTable.StatusStripText;
-
-        /// <summary>Gets the color of the property grid line.</summary>
-        /// <value>The color of the property grid line.</value>
-        public virtual Color PropertyGridLineColor => _palette.ColorTable.ToolStripGradientMiddle;
-
-        /// <summary>Gets the color of the property grid category fore.</summary>
-        /// <value>The color of the property grid category fore.</value>
-        public virtual Color PropertyGridCategoryForeColor => _palette.ColorTable.StatusStripText;
-
-        #endregion
-
         #region MenuStripText
         /// <summary>
         /// Gets the text color used on the menu strip.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteInputControlTripleStates.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteInputControlTripleStates.cs
@@ -25,7 +25,7 @@ namespace Krypton.Toolkit
         /// <param name="inherit">Source for inheriting values.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
         public PaletteInputControlTripleStates(IPaletteTriple inherit,
-                                               NeedPaintHandler needPaint)
+                                               NeedPaintHandler? needPaint)
         {
             Debug.Assert(inherit != null);
 


### PR DESCRIPTION
- Implement the changes necessary to colour the PropertyGrid controls correctly
- Use existing palette colours

#894

![image](https://user-images.githubusercontent.com/2418812/232193407-77f2b1a3-5f4b-441f-abc5-26738a048182.png)
