### PR TITLE
* `KryptonButton` split option

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2023-11-xx - Build 2311 - November 2023
+* New `ShowSplitOption` for `KryptonButton`, allows a krypton/context menu to be shown
 * Implemented [#1023](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1023), Please remove "sealed" from `KryptonWrapLabel` and `KryptonLinkWrapLabel`
 * Added ability to embed links into the `KryptonMessageBox` content. The new options are:-
     - `ContentAreaType` - Defines content area type of a `KryptonMessageBox`, default is normal

--- a/Source/Krypton Components/Krypton.Navigator/Page/KryptonPage.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Page/KryptonPage.cs
@@ -1459,7 +1459,11 @@ namespace Krypton.Navigator
         /// <param name="e">An EventArgs containing the event data.</param>
         protected override void OnTabStopChanged(EventArgs e)
         {
-            TabStopChanged.Invoke(this, e);
+            // https://github.com/Krypton-Suite/Standard-Toolkit/issues/1023#issuecomment-1588810368
+            if (TabStopChanged != null)
+            {
+                TabStopChanged.Invoke(this, e);
+            }
         }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Navigator/Page/KryptonPageCollection.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Page/KryptonPageCollection.cs
@@ -20,7 +20,7 @@ namespace Krypton.Navigator
     /// <summary>
     /// Specialise the generic collection event args with specific type.
     /// </summary>
-    public class KryptonPageEventArgs : TypedCollectionEventArgs<KryptonPage> 
+    public class KryptonPageEventArgs : TypedCollectionEventArgs<KryptonPage>
     {
         #region Public
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Base/PaletteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Base/PaletteBase.cs
@@ -42,7 +42,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Occurs when a palette change requires a repaint.
         /// </summary>
-        public event EventHandler<PaletteLayoutEventArgs> PalettePaint;
+        public event EventHandler<PaletteLayoutEventArgs>? PalettePaint;
 
         /// <summary>
         /// Occurs when the AllowFormChrome setting changes.
@@ -1356,12 +1356,20 @@ namespace Krypton.Toolkit
         #endregion
 
         #region OnPalettePaint
+
         /// <summary>
         /// Raises the PalettePaint event.
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">An PaletteLayoutEventArgs containing event data.</param>
-        protected virtual void OnPalettePaint(object sender, PaletteLayoutEventArgs e) => PalettePaint(this, e);
+        protected virtual void OnPalettePaint(object sender, PaletteLayoutEventArgs e)
+        {
+            // https://github.com/Krypton-Suite/Standard-Toolkit/issues/1023#issuecomment-1588810368
+            if (PalettePaint != null)
+            {
+                PalettePaint(this, e);
+            }
+        }
 
         #endregion
 

--- a/Source/Krypton Components/TestForm/Form1.Designer.cs
+++ b/Source/Krypton Components/TestForm/Form1.Designer.cs
@@ -41,6 +41,11 @@
             this.kryptonLanguageManager1 = new Krypton.Toolkit.KryptonLanguageManager();
             this.kryptonCustomPaletteBase1 = new Krypton.Toolkit.KryptonCustomPaletteBase(this.components);
             this.kcmdMessageboxTest = new Krypton.Toolkit.KryptonCommand();
+            this.kryptonContextMenu1 = new Krypton.Toolkit.KryptonContextMenu();
+            this.kryptonContextMenuItems1 = new Krypton.Toolkit.KryptonContextMenuItems();
+            this.kryptonContextMenuItem1 = new Krypton.Toolkit.KryptonContextMenuItem();
+            this.kryptonContextMenuItem2 = new Krypton.Toolkit.KryptonContextMenuItem();
+            this.kryptonContextMenuItem3 = new Krypton.Toolkit.KryptonContextMenuItem();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).BeginInit();
             this.kryptonPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonThemeComboBox1)).BeginInit();
@@ -96,8 +101,10 @@
             // 
             // kryptonButton1
             // 
+            this.kryptonButton1.KryptonContextMenu = this.kryptonContextMenu1;
             this.kryptonButton1.Location = new System.Drawing.Point(55, 231);
             this.kryptonButton1.Name = "kryptonButton1";
+            this.kryptonButton1.ShowSplitOption = true;
             this.kryptonButton1.Size = new System.Drawing.Size(90, 25);
             this.kryptonButton1.TabIndex = 5;
             this.kryptonButton1.Click += new System.EventHandler(this.kryptonButton1_Click);
@@ -169,6 +176,30 @@
             this.kcmdMessageboxTest.Text = "kryptonCommand1";
             this.kcmdMessageboxTest.Execute += new System.EventHandler(this.kcmdMessageboxTest_Execute);
             // 
+            // kryptonContextMenu1
+            // 
+            this.kryptonContextMenu1.Items.AddRange(new Krypton.Toolkit.KryptonContextMenuItemBase[] {
+            this.kryptonContextMenuItems1});
+            // 
+            // kryptonContextMenuItems1
+            // 
+            this.kryptonContextMenuItems1.Items.AddRange(new Krypton.Toolkit.KryptonContextMenuItemBase[] {
+            this.kryptonContextMenuItem1,
+            this.kryptonContextMenuItem2,
+            this.kryptonContextMenuItem3});
+            // 
+            // kryptonContextMenuItem1
+            // 
+            this.kryptonContextMenuItem1.Text = "Menu Item";
+            // 
+            // kryptonContextMenuItem2
+            // 
+            this.kryptonContextMenuItem2.Text = "Menu Item";
+            // 
+            // kryptonContextMenuItem3
+            // 
+            this.kryptonContextMenuItem3.Text = "Menu Item";
+            // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -202,5 +233,10 @@
         private Krypton.Toolkit.KryptonCustomPaletteBase kryptonCustomPaletteBase1;
         private Krypton.Toolkit.KryptonCommand kcmdMessageboxTest;
         private Krypton.Toolkit.KryptonButton kbtnTestMessagebox;
+        private Krypton.Toolkit.KryptonContextMenu kryptonContextMenu1;
+        private Krypton.Toolkit.KryptonContextMenuItems kryptonContextMenuItems1;
+        private Krypton.Toolkit.KryptonContextMenuItem kryptonContextMenuItem1;
+        private Krypton.Toolkit.KryptonContextMenuItem kryptonContextMenuItem2;
+        private Krypton.Toolkit.KryptonContextMenuItem kryptonContextMenuItem3;
     }
 }

--- a/Source/Krypton Components/TestForm/Form1.resx
+++ b/Source/Krypton Components/TestForm/Form1.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="kryptonContextMenu1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>745, 17</value>
+  </metadata>
   <metadata name="kryptonManager1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>


### PR DESCRIPTION
* New `ShowSplitOption` for `KryptonButton`, allows a krypton/context menu to be shown

![ButtonSplitOption](https://github.com/Krypton-Suite/Standard-Toolkit/assets/949607/876c8ea3-dd14-474e-873e-6a0cee2b15fb)

![image](https://github.com/Krypton-Suite/Standard-Toolkit/assets/949607/c1c5bf62-085c-4f95-ac7c-f19002e3b255)
