### PR TITLE
* `KryptonLanguageManager.Strings` 

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2023-11-xx - Build 2311 - November 2023
+* New `KryptonLanguageManager.Strings` is now `KryptonLanguageManager.GeneralToolkitStrings`
 * New `ShowSplitOption` for `KryptonButton`, allows a krypton/context menu to be shown
 * Implemented [#1023](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1023), Please remove "sealed" from `KryptonWrapLabel` and `KryptonLinkWrapLabel`
 * Added ability to embed links into the `KryptonMessageBox` content. The new options are:-

--- a/Source/Krypton Components/Krypton.Navigator/Page/KryptonPage.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Page/KryptonPage.cs
@@ -1472,7 +1472,10 @@ namespace Krypton.Navigator
         /// <param name="propertyName">Name of the appearance property that has changed.</param>
         protected virtual void OnAppearancePropertyChanged(string propertyName)
         {
-            AppearancePropertyChanged.Invoke(this, new(propertyName));
+            if (AppearancePropertyChanged != null)
+            {
+                AppearancePropertyChanged.Invoke(this, new(propertyName));
+            }
         }
 
         /// <summary>
@@ -1481,7 +1484,10 @@ namespace Krypton.Navigator
         /// <param name="changed">Set of flags that have changed.</param>
         protected virtual void OnFlagsChanged(KryptonPageFlags changed)
         {
-            FlagsChanged.Invoke(this, new(changed));
+            if (FlagsChanged != null)
+            {
+                FlagsChanged.Invoke(this, new(changed));
+            }
         }
 
         /// <summary>
@@ -1490,7 +1496,10 @@ namespace Krypton.Navigator
         /// <param name="e">An EventArgs containing the event data.</param>
         protected virtual void OnAutoHiddenSlideSizeChanged(EventArgs e)
         {
-            AutoHiddenSlideSizeChanged.Invoke(this, e);
+            if (AutoHiddenSlideSizeChanged != null)
+            {
+                AutoHiddenSlideSizeChanged.Invoke(this, e);
+            }
         }
 
         /// <summary>
@@ -1499,7 +1508,10 @@ namespace Krypton.Navigator
         /// <param name="e">An EventArgs containing the event data.</param>
         protected virtual void OnLoad(EventArgs e)
         {
-            Load.Invoke(this, e);
+            if (Load != null)
+            {
+                Load.Invoke(this, e);
+            }
         }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonButton.cs
@@ -775,37 +775,37 @@ namespace Krypton.Toolkit
             {
                 if (DialogResult == DialogResult.Abort)
                 {
-                    Text = KryptonLanguageManager.Strings.Abort;
+                    Text = KryptonLanguageManager.GeneralToolkitStrings.Abort;
                 }
 
                 if (DialogResult == DialogResult.Cancel)
                 {
-                    Text = KryptonLanguageManager.Strings.Cancel;
+                    Text = KryptonLanguageManager.GeneralToolkitStrings.Cancel;
                 }
 
                 if (DialogResult == DialogResult.OK)
                 {
-                    Text = KryptonLanguageManager.Strings.OK;
+                    Text = KryptonLanguageManager.GeneralToolkitStrings.OK;
                 }
 
                 if (DialogResult == DialogResult.Yes)
                 {
-                    Text = KryptonLanguageManager.Strings.Yes;
+                    Text = KryptonLanguageManager.GeneralToolkitStrings.Yes;
                 }
 
                 if (DialogResult == DialogResult.No)
                 {
-                    Text = KryptonLanguageManager.Strings.No;
+                    Text = KryptonLanguageManager.GeneralToolkitStrings.No;
                 }
 
                 if (DialogResult == DialogResult.Retry)
                 {
-                    Text = KryptonLanguageManager.Strings.Retry;
+                    Text = KryptonLanguageManager.GeneralToolkitStrings.Retry;
                 }
 
                 if (DialogResult == DialogResult.Ignore)
                 {
-                    Text = KryptonLanguageManager.Strings.Ignore;
+                    Text = KryptonLanguageManager.GeneralToolkitStrings.Ignore;
                 }
             }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLanguageManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLanguageManager.cs
@@ -59,12 +59,12 @@ namespace Krypton.Toolkit
         [MergableProperty(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         [Localizable(true)]
-        public GeneralStrings GeneralStrings => Strings;
+        public GeneralStrings GeneralStrings => GeneralToolkitStrings;
 
-        private bool ShouldSerializeGeneralStrings() => !Strings.IsDefault;
+        private bool ShouldSerializeGeneralStrings() => !GeneralToolkitStrings.IsDefault;
 
         /// <summary>Resets the general strings.</summary>
-        public void ResetGeneralStrings() => Strings.Reset();
+        public void ResetGeneralStrings() => GeneralToolkitStrings.ResetValues();
 
         /// <summary>Gets the data grid view style strings.</summary>
         /// <value>The data grid view style strings.</value>
@@ -401,7 +401,7 @@ namespace Krypton.Toolkit
 
         /// <summary>Gets the strings.</summary>
         /// <value>The strings.</value>
-        public static GeneralStrings Strings { get; } = new();
+        public static GeneralStrings GeneralToolkitStrings { get; } = new();
 
         /// <summary>Gets the grid view style strings.</summary>
         /// <value>The grid view style strings.</value>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonInputBoxForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonInputBoxForm.cs
@@ -133,8 +133,8 @@ namespace Krypton.Toolkit
 
         private void UpdateButtons()
         {
-            _buttonOk.Text = KryptonLanguageManager.Strings.OK;
-            _buttonCancel.Text = KryptonLanguageManager.Strings.Cancel;
+            _buttonOk.Text = KryptonLanguageManager.GeneralToolkitStrings.OK;
+            _buttonCancel.Text = KryptonLanguageManager.GeneralToolkitStrings.Cancel;
         }
 
         private void Response_KeyDown(object sender, KeyEventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMessageBoxForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMessageBoxForm.cs
@@ -361,14 +361,14 @@ namespace Krypton.Toolkit
             switch (_buttons)
             {
                 case KryptonMessageBoxButtons.OK:
-                    _button1.Text = KryptonLanguageManager.Strings.OK;
+                    _button1.Text = KryptonLanguageManager.GeneralToolkitStrings.OK;
                     _button1.DialogResult = DialogResult.OK;
                     _button1.Visible = true;
                     _button1.Enabled = true;
                     break;
                 case KryptonMessageBoxButtons.OKCancel:
-                    _button1.Text = KryptonLanguageManager.Strings.OK;
-                    _button2.Text = KryptonLanguageManager.Strings.Cancel;
+                    _button1.Text = KryptonLanguageManager.GeneralToolkitStrings.OK;
+                    _button2.Text = KryptonLanguageManager.GeneralToolkitStrings.Cancel;
                     _button1.DialogResult = DialogResult.OK;
                     _button2.DialogResult = DialogResult.Cancel;
                     _button1.Visible = true;
@@ -377,8 +377,8 @@ namespace Krypton.Toolkit
                     _button2.Enabled = true;
                     break;
                 case KryptonMessageBoxButtons.YesNo:
-                    _button1.Text = KryptonLanguageManager.Strings.Yes;
-                    _button2.Text = KryptonLanguageManager.Strings.No;
+                    _button1.Text = KryptonLanguageManager.GeneralToolkitStrings.Yes;
+                    _button2.Text = KryptonLanguageManager.GeneralToolkitStrings.No;
                     _button1.DialogResult = DialogResult.Yes;
                     _button2.DialogResult = DialogResult.No;
                     _button1.Visible = true;
@@ -388,9 +388,9 @@ namespace Krypton.Toolkit
                     ControlBox = false;
                     break;
                 case KryptonMessageBoxButtons.YesNoCancel:
-                    _button1.Text = KryptonLanguageManager.Strings.Yes;
-                    _button2.Text = KryptonLanguageManager.Strings.No;
-                    _button3.Text = KryptonLanguageManager.Strings.Cancel;
+                    _button1.Text = KryptonLanguageManager.GeneralToolkitStrings.Yes;
+                    _button2.Text = KryptonLanguageManager.GeneralToolkitStrings.No;
+                    _button3.Text = KryptonLanguageManager.GeneralToolkitStrings.Cancel;
                     _button1.DialogResult = DialogResult.Yes;
                     _button2.DialogResult = DialogResult.No;
                     _button3.DialogResult = DialogResult.Cancel;
@@ -402,8 +402,8 @@ namespace Krypton.Toolkit
                     _button3.Enabled = true;
                     break;
                 case KryptonMessageBoxButtons.RetryCancel:
-                    _button1.Text = KryptonLanguageManager.Strings.Retry;
-                    _button2.Text = KryptonLanguageManager.Strings.Cancel;
+                    _button1.Text = KryptonLanguageManager.GeneralToolkitStrings.Retry;
+                    _button2.Text = KryptonLanguageManager.GeneralToolkitStrings.Cancel;
                     _button1.DialogResult = DialogResult.Retry;
                     _button2.DialogResult = DialogResult.Cancel;
                     _button1.Visible = true;
@@ -412,9 +412,9 @@ namespace Krypton.Toolkit
                     _button2.Enabled = true;
                     break;
                 case KryptonMessageBoxButtons.AbortRetryIgnore:
-                    _button1.Text = KryptonLanguageManager.Strings.Abort;
-                    _button2.Text = KryptonLanguageManager.Strings.Retry;
-                    _button3.Text = KryptonLanguageManager.Strings.Ignore;
+                    _button1.Text = KryptonLanguageManager.GeneralToolkitStrings.Abort;
+                    _button2.Text = KryptonLanguageManager.GeneralToolkitStrings.Retry;
+                    _button3.Text = KryptonLanguageManager.GeneralToolkitStrings.Ignore;
                     _button1.DialogResult = DialogResult.Abort;
                     _button2.DialogResult = DialogResult.Retry;
                     _button3.DialogResult = DialogResult.Ignore;
@@ -427,9 +427,9 @@ namespace Krypton.Toolkit
                     ControlBox = false;
                     break;
                 case KryptonMessageBoxButtons.CancelTryContinue:
-                    _button1.Text = KryptonLanguageManager.Strings.Cancel;
-                    _button2.Text = KryptonLanguageManager.Strings.TryAgain;
-                    _button3.Text = KryptonLanguageManager.Strings.Continue;
+                    _button1.Text = KryptonLanguageManager.GeneralToolkitStrings.Cancel;
+                    _button2.Text = KryptonLanguageManager.GeneralToolkitStrings.TryAgain;
+                    _button3.Text = KryptonLanguageManager.GeneralToolkitStrings.Continue;
                     _button1.DialogResult = DialogResult.Cancel;
 #if NET6_0_OR_GREATER
                     _button2.DialogResult = DialogResult.TryAgain;
@@ -513,7 +513,7 @@ namespace Krypton.Toolkit
             {
                 helpButton.Visible = true;
                 helpButton.Enabled = true;
-                helpButton.Text = KryptonLanguageManager.Strings.Help;
+                helpButton.Text = KryptonLanguageManager.GeneralToolkitStrings.Help;
                 helpButton.KeyPress += (_, _) => LaunchHelp();
                 helpButton.Click += (_, _) => LaunchHelp();
             }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMultilineStringEditorForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMultilineStringEditorForm.cs
@@ -36,13 +36,13 @@ namespace Krypton.Toolkit
 
         /// <summary>Gets the contents of the text field.</summary>
         /// <value>The contents of the text field.</value>
-        [Category(@"Data"), 
-         DefaultValue(null), 
+        [Category(@"Data"),
+         DefaultValue(null),
          Description(@"The contents of the text field.")]
-        public string[]? Contents 
-        { 
-            get => _contents; 
-            private set => _contents = value; 
+        public string[]? Contents
+        {
+            get => _contents;
+            private set => _contents = value;
         }
 
         #endregion
@@ -62,7 +62,7 @@ namespace Krypton.Toolkit
         {
             InitializeComponent();
 
-            SetupVariables(contents,  collection, useRichTextBox, headerText, windowTitle);
+            SetupVariables(contents, collection, useRichTextBox, headerText, windowTitle);
 
             SetupControlsText();
 
@@ -75,25 +75,25 @@ namespace Krypton.Toolkit
 
         private void SetupControlsText()
         {
-            kbtnCancel.Text = KryptonLanguageManager.Strings.Cancel;
+            kbtnCancel.Text = KryptonLanguageManager.GeneralToolkitStrings.Cancel;
 
-            kbtnOk.Text = KryptonLanguageManager.Strings.OK;
+            kbtnOk.Text = KryptonLanguageManager.GeneralToolkitStrings.OK;
 
-            kcRichTextBoxCopy.Text = KryptonLanguageManager.Strings.Copy;
+            kcRichTextBoxCopy.Text = KryptonLanguageManager.GeneralToolkitStrings.Copy;
 
-            kcRichTextBoxCut.Text = KryptonLanguageManager.Strings.Cut;
+            kcRichTextBoxCut.Text = KryptonLanguageManager.GeneralToolkitStrings.Cut;
 
-            kcRichTextBoxPaste.Text = KryptonLanguageManager.Strings.Paste;
+            kcRichTextBoxPaste.Text = KryptonLanguageManager.GeneralToolkitStrings.Paste;
 
-            kcRichTextBoxSelectAll.Text = KryptonLanguageManager.Strings.SelectAll;
+            kcRichTextBoxSelectAll.Text = KryptonLanguageManager.GeneralToolkitStrings.SelectAll;
 
-            kcTextBoxCopy.Text = KryptonLanguageManager.Strings.Copy;
+            kcTextBoxCopy.Text = KryptonLanguageManager.GeneralToolkitStrings.Copy;
 
-            kcTextBoxCut.Text = KryptonLanguageManager.Strings.Cut;
+            kcTextBoxCut.Text = KryptonLanguageManager.GeneralToolkitStrings.Cut;
 
-            kcTextBoxPaste.Text = KryptonLanguageManager.Strings.Paste;
+            kcTextBoxPaste.Text = KryptonLanguageManager.GeneralToolkitStrings.Paste;
 
-            kcTextBoxSelectAll.Text = KryptonLanguageManager.Strings.SelectAll;
+            kcTextBoxSelectAll.Text = KryptonLanguageManager.GeneralToolkitStrings.SelectAll;
         }
 
         private void SetupVariables(string[]? contents, StringCollection? collection, bool? useRichTextBox, string? headerText, string? windowTitle)
@@ -224,7 +224,7 @@ namespace Krypton.Toolkit
 
             IWin32Window? showOwner = owner ?? FromHandle(PI.GetActiveWindow());
 
-            using KryptonMultilineStringEditorForm kmse = new(input, null, useRichTextBox, headerText,  windowTitle);
+            using KryptonMultilineStringEditorForm kmse = new(input, null, useRichTextBox, headerText, windowTitle);
 
             kmse.StartPosition = showOwner == null ? FormStartPosition.CenterParent : FormStartPosition.CenterScreen;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualTaskDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualTaskDialog.cs
@@ -411,7 +411,7 @@ namespace Krypton.Toolkit
                 }
 
                 firstButton = _buttonOK;
-                _buttonOK.Text = KryptonLanguageManager.Strings.OK;
+                _buttonOK.Text = KryptonLanguageManager.GeneralToolkitStrings.OK;
                 _buttonOK.Visible = true;
             }
             else
@@ -428,7 +428,7 @@ namespace Krypton.Toolkit
 
                 firstButton ??= _buttonYes;
 
-                _buttonYes.Text = KryptonLanguageManager.Strings.Yes;
+                _buttonYes.Text = KryptonLanguageManager.GeneralToolkitStrings.Yes;
                 _buttonYes.Visible = true;
             }
             else
@@ -445,7 +445,7 @@ namespace Krypton.Toolkit
 
                 firstButton ??= _buttonNo;
 
-                _buttonNo.Text = KryptonLanguageManager.Strings.No;
+                _buttonNo.Text = KryptonLanguageManager.GeneralToolkitStrings.No;
                 _buttonNo.Visible = true;
             }
             else
@@ -462,7 +462,7 @@ namespace Krypton.Toolkit
 
                 firstButton ??= _buttonCancel;
 
-                _buttonCancel.Text = KryptonLanguageManager.Strings.Cancel;
+                _buttonCancel.Text = KryptonLanguageManager.GeneralToolkitStrings.Cancel;
                 _buttonCancel.Visible = true;
             }
             else
@@ -479,7 +479,7 @@ namespace Krypton.Toolkit
 
                 firstButton ??= _buttonRetry;
 
-                _buttonRetry.Text = KryptonLanguageManager.Strings.Retry;
+                _buttonRetry.Text = KryptonLanguageManager.GeneralToolkitStrings.Retry;
                 _buttonRetry.Visible = true;
             }
             else
@@ -496,7 +496,7 @@ namespace Krypton.Toolkit
 
                 firstButton ??= _buttonClose;
 
-                _buttonClose.Text = KryptonLanguageManager.Strings.Close;
+                _buttonClose.Text = KryptonLanguageManager.GeneralToolkitStrings.Close;
                 _buttonClose.Visible = true;
             }
             else

--- a/Source/Krypton Components/Krypton.Toolkit/Translations/General/GeneralStrings.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Translations/General/GeneralStrings.cs
@@ -48,6 +48,7 @@ namespace Krypton.Toolkit
         private const string DEFAULT_YES_TO_ALL = @"Yes &to All"; // Accelerator key - T
         private const string DEFAULT_NO_TO_ALL = @"No t&o All"; // Accelerator key - O
         private const string DEFAULT_OK_TO_ALL = @"O&k to All"; // Accelerator key - K
+        private const string DEFAULT_RESET = @"&Reset"; // Accelerator key - R
 
         // Note: The following may not be needed...
         /*private const string DEFAULT_MORE_DETAILS = "M&ore Details...";
@@ -60,7 +61,7 @@ namespace Krypton.Toolkit
         /// <summary>Initializes a new instance of the <see cref="GeneralStrings" /> class.</summary>
         public GeneralStrings()
         {
-            Reset();
+            ResetValues();
         }
 
         /// <summary>
@@ -106,7 +107,8 @@ namespace Krypton.Toolkit
                                  ClearClipboard.Equals(DEFAULT_CLEAR_CLIPBOARD) &&
                                  YesToAll.Equals(DEFAULT_YES_TO_ALL) &&
                                  NoToAll.Equals(DEFAULT_NO_TO_ALL) &&
-                                 OkToAll.Equals(DEFAULT_OK_TO_ALL);
+                                 OkToAll.Equals(DEFAULT_OK_TO_ALL) &&
+                                 Reset.Equals(DEFAULT_RESET);
         // Note: The following may not be needed...
         /*MoreDetails.Equals(DEFAULT_MORE_DETAILS) &&
         LessDetails.Equals(DEFAULT_LESS_DETAILS);*/
@@ -114,7 +116,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Reset all strings to default values.
         /// </summary>
-        public void Reset()
+        public void ResetValues()
         {
             OK = DEFAULT_OK;
             Cancel = DEFAULT_CANCEL;
@@ -149,6 +151,7 @@ namespace Krypton.Toolkit
             YesToAll = DEFAULT_YES_TO_ALL;
             NoToAll = DEFAULT_NO_TO_ALL;
             OkToAll = DEFAULT_OK_TO_ALL;
+            Reset = DEFAULT_RESET;
 
             // Note: The following may not be needed...
             /*MoreDetails = DEFAULT_MORE_DETAILS;
@@ -413,6 +416,13 @@ namespace Krypton.Toolkit
         [Description(@"Ok to All string used for custom situations.")]
         [DefaultValue(DEFAULT_OK_TO_ALL)]
         public string OkToAll { get; set; }
+
+        /// <summary>Gets or sets the reset string used for custom situations.</summary>
+        [Localizable(true)]
+        [Category(@"Visuals")]
+        [Description(@"Reset string used for custom situations.")]
+        [DefaultValue(DEFAULT_RESET)]
+        public string Reset { get; set; }
 
         // Note: The following may not be needed...
 

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawToday.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawToday.cs
@@ -91,7 +91,7 @@ namespace Krypton.Toolkit
         /// Gets the content short text.
         /// </summary>
         /// <returns>String value.</returns>
-        public string GetShortText() => KryptonLanguageManager.Strings.Today + " " + _calendar.TodayDate.ToString(_calendar.TodayFormat);
+        public string GetShortText() => KryptonLanguageManager.GeneralToolkitStrings.Today + " " + _calendar.TodayDate.ToString(_calendar.TodayFormat);
 
         /// <summary>
         /// Gets the content long text.


### PR DESCRIPTION
* New `KryptonLanguageManager.Strings` is now `KryptonLanguageManager.GeneralToolkitStrings`

![image](https://github.com/Krypton-Suite/Standard-Toolkit/assets/949607/5e64cdb5-7d22-4711-b3ee-7da98644d467)
