### PR TITLE
- Extend #1015 to include Tooltips for other "Krypton Menu item" types (i.e. not just text!)

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,7 +3,8 @@
 =======
 
 ## 2023-11-xx - Build 2311 - November 2023
-* Implemented [#1015](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1057), Show a tooltips on a `KryptonContextMenuItem`
+* Implemented [#1069](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1069), Include Tooltips for other "Krypton Menu item" types (i.e. not just text!)
+* Implemented [#1015](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1015), Show a tooltips on a `KryptonContextMenuItem`
 * Implemented [#1057](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1057), Move `DefineFonts` etc up to `PaletteBase`
 * Implemented [#981](https://github.com/Krypton-Suite/Standard-Toolkit/issues/981), "ReadMe.md" landing page could do with a "Table of contents" at the beginning
 * New `KryptonLanguageManager.Strings` is now `KryptonLanguageManager.GeneralToolkitStrings`

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuCheckBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuCheckBox.cs
@@ -149,8 +149,12 @@ namespace Krypton.Toolkit
                                               object parent,
                                               ViewLayoutStack columns,
                                               bool standardStyle,
-                                              bool imageColumn) =>
-            new ViewDrawMenuCheckBox(provider, this);
+                                              bool imageColumn)
+        {
+            SetProvider(provider);
+
+            return new ViewDrawMenuCheckBox(provider, this);
+        }
 
         /// <summary>
         /// Gets and sets if clicking the check box automatically closes the context menu.
@@ -247,6 +251,7 @@ namespace Krypton.Toolkit
         [Category(@"Appearance")]
         [Description(@"Check box image color to make transparent.")]
         [Localizable(true)]
+        [DisallowNull]
         public Color ImageTransparentColor
         {
             get => _imageTransparentColor;
@@ -261,7 +266,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private bool ShouldSerializeImageTransparentColor() => (_imageTransparentColor == null) || !_imageTransparentColor.Equals(Color.Empty);
+        private bool ShouldSerializeImageTransparentColor() => !_imageTransparentColor.Equals(Color.Empty);
 
         /// <summary>
         /// Gets and sets the check box label style.

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuCheckButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuCheckButton.cs
@@ -144,8 +144,11 @@ namespace Krypton.Toolkit
                                               object parent,
                                               ViewLayoutStack columns,
                                               bool standardStyle,
-                                              bool imageColumn) =>
-            new ViewDrawMenuCheckButton(provider, this);
+                                              bool imageColumn)
+        {
+            SetProvider(provider);
+            return new ViewDrawMenuCheckButton(provider, this);
+        }
 
         /// <summary>
         /// Gets and sets if clicking the check box automatically closes the context menu.

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuColorColumns.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuColorColumns.cs
@@ -161,8 +161,11 @@ namespace Krypton.Toolkit
                                               object parent,
                                               ViewLayoutStack columns,
                                               bool standardStyle,
-                                              bool imageColumn) =>
-            new ViewDrawMenuColorColumns(provider, this);
+                                              bool imageColumn)
+        {
+            SetProvider(provider);
+            return new ViewDrawMenuColorColumns(provider, this);
+        }
 
         /// <summary>
         /// Gets and sets if clicking a color entry automatically closes the context menu.
@@ -212,7 +215,7 @@ namespace Krypton.Toolkit
         [KryptonPersist]
         [Category(@"Appearance")]
         [Description(@"Color that has been selected by the user.")]
-        [DefaultValue(typeof(Color), "")]
+        [DefaultValue(typeof(Color), "Empty")]
         public Color SelectedColor
         {
             get => _selectedColor;

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuHeading.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuHeading.cs
@@ -30,6 +30,12 @@ namespace Krypton.Toolkit
         private readonly PaletteRedirectTriple? _redirectHeading;
         #endregion
 
+        /// <summary>
+        /// Occurs when the <see cref="KryptonContextMenuItem"/> wants to display a tooltip.
+        /// </summary>
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        private new event EventHandler<ToolTipNeededEventArgs>? ToolTipNeeded = null;
         #region Identity
         /// <summary>
         /// Initialize a new instance of the KryptonContextMenuHeading class.
@@ -104,8 +110,23 @@ namespace Krypton.Toolkit
                                               object parent,
                                               ViewLayoutStack columns,
                                               bool standardStyle,
-                                              bool imageColumn) =>
-            new ViewDrawMenuHeading(this, provider.ProviderStateCommon.Heading);
+                                              bool imageColumn)
+        {
+            // SetProvider(provider); ,_ no tooltips for headers, as there is no provider
+            return new ViewDrawMenuHeading(this, provider.ProviderStateCommon.Heading);
+        }
+
+        /// <summary>
+        /// Remove access to the ToolTipValues content.
+        /// </summary>
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        private new ToolTipValues ToolTipValues
+        {
+            get => base.ToolTipValues;
+            set => base.ToolTipValues = value;
+        }
+        private bool ShouldSerializeToolTipValues() => false;
 
         /// <summary>
         /// Gets and sets the heading menu item text.

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuImageSelect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuImageSelect.cs
@@ -129,8 +129,11 @@ namespace Krypton.Toolkit
                                               object parent,
                                               ViewLayoutStack columns,
                                               bool standardStyle,
-                                              bool imageColumn) =>
-            new ViewLayoutMenuItemSelect(this, provider);
+                                              bool imageColumn)
+        {
+            SetProvider(provider);
+            return new ViewLayoutMenuItemSelect(this, provider);
+        }
 
         /// <summary>
         /// Gets and sets padding around the image selection area.

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuItem.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuItem.cs
@@ -63,13 +63,6 @@ namespace Krypton.Toolkit
         [Category(@"Property Changed")]
         [Description(@"Occurs when the check state property changes.")]
         public event EventHandler? CheckStateChanged;
-
-        /// <summary>
-        /// Occurs when the <see cref="KryptonContextMenuItem"/> wants to display a tooltip.
-        /// </summary>
-        [Description(@"Occurs when the KryptonContextMenuItem wants to display a tooltip.")]
-        [Category(@"Behavior")]
-        public event EventHandler<ToolTipNeededEventArgs>? ToolTipNeeded;
         #endregion
 
         #region Identity
@@ -702,12 +695,6 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="e">An EventArgs that contains the event data.</param>
         protected virtual void OnCheckStateChanged(EventArgs e) => CheckStateChanged?.Invoke(this, e);
-
-        /// <summary>
-        /// Raises the ToolTipNeeded event.
-        /// </summary>
-        /// <param name="e"></param>
-        protected virtual void OnToolTipNeeded(ToolTipNeededEventArgs e) => ToolTipNeeded?.Invoke(this, e);
         #endregion
 
         #region Internal

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuItemBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuItemBase.cs
@@ -22,7 +22,8 @@ namespace Krypton.Toolkit
 
         private bool _visible;
         private ToolTipValues _toolTipValues = new ToolTipValues(null);
-
+        private VisualPopupToolTip? _visualPopupToolTip;
+        private IContextMenuProvider _provider;
         #endregion
 
         #region Events
@@ -32,13 +33,26 @@ namespace Krypton.Toolkit
         [Category(@"Property Changed")]
         [Description(@"Occurs when the value of property has changed.")]
         public event PropertyChangedEventHandler? PropertyChanged;
+
+        /// <summary>
+        /// Occurs when the <see cref="KryptonContextMenuItem"/> wants to display a tooltip.
+        /// </summary>
+        [Description(@"Occurs when the KryptonContextMenuItem wants to display a tooltip.")]
+        [Category(@"Behavior")]
+        public event EventHandler<ToolTipNeededEventArgs>? ToolTipNeeded;
         #endregion
 
         #region Identity
         /// <summary>
         /// Initialize a new instance of the KryptonContextMenuItem class.
         /// </summary>
-        protected KryptonContextMenuItemBase() => _visible = true;
+        protected KryptonContextMenuItemBase()
+        {
+            _visible = true;
+            ToolTipManager = new ToolTipManager(_toolTipValues);
+            ToolTipManager.ShowToolTip += OnShowToolTip;
+            ToolTipManager.CancelToolTip += OnCancelToolTip;
+        }
 
         #endregion
 
@@ -73,11 +87,23 @@ namespace Krypton.Toolkit
         /// <param name="standardStyle">Draw items with standard or alternate style.</param>
         /// <param name="imageColumn">Draw an image background for the item images.</param>
         /// <returns>ViewBase that is the root of the view hierarchy being added.</returns>
+        /// <remarks>Make sure to call `SetProvider(provider);`
+        /// </remarks>
         public abstract ViewBase GenerateView(IContextMenuProvider provider,
-                                              object parent,
-                                              ViewLayoutStack columns,
-                                              bool standardStyle,
-                                              bool imageColumn);
+            object parent,
+            ViewLayoutStack columns,
+            bool standardStyle,
+            bool imageColumn);
+
+        internal void SetProvider([DisallowNull] IContextMenuProvider provider)
+        {
+            Debug.Assert(provider.ProviderRedirector != null);
+            _provider = provider;
+            for (var idx = 0; idx < ItemChildCount; ++idx)
+            {
+                this[idx]?.SetProvider(provider);
+            }
+        }
 
         /// <summary>
         /// Gets and sets user-defined data associated with the object.
@@ -102,7 +128,7 @@ namespace Krypton.Toolkit
         {
             get => _visible;
 
-            set 
+            set
             {
                 if (_visible != value)
                 {
@@ -113,7 +139,7 @@ namespace Krypton.Toolkit
         }
 
         /// <summary>
-        /// Gets access to the button content.
+        /// Gets access to the ToolTipValues content.
         /// </summary>
         [KryptonPersist]
         [Category(@"Behavior")]
@@ -142,6 +168,85 @@ namespace Krypton.Toolkit
         /// <param name="e">A PropertyChangedEventArgs containing the event data.</param>
         protected virtual void OnPropertyChanged(PropertyChangedEventArgs e) => PropertyChanged?.Invoke(this, e);
 
+        /// <summary>
+        /// Raises the ToolTipNeeded event.
+        /// </summary>
+        /// <param name="e"></param>
+        protected virtual void OnToolTipNeeded(ToolTipNeededEventArgs e) => ToolTipNeeded?.Invoke(this, e);
+        #endregion
+
+        #region Internal
+        /// <summary>
+        /// Gets access to the ToolTipManager used for displaying tool tips.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        internal ToolTipManager ToolTipManager { get; }
+
+        internal void OnShowToolTip(object sender, ToolTipEventArgs e)
+        {
+            //if (!IsDisposed)
+            {
+                // Do not show tooltips when the form we are in does not have focus
+                //Form? topForm = FindForm();
+                //if (topForm is { ContainsFocus: false })
+                //{
+                //    return;
+                //}
+
+                // Never show tooltips are design time
+                //if (!DesignMode)
+                if (_toolTipValues.EnableToolTips)
+                {
+                    // Remove any currently showing tooltip
+                    _visualPopupToolTip?.Dispose();
+
+                    // See if there is a tooltip to display for the new selection.
+                    var args = new ToolTipNeededEventArgs(0, this)
+                    {
+                        Heading = _toolTipValues.Heading,
+                        Description = _toolTipValues.Description,
+                        Icon = _toolTipValues.Image
+                    };
+                    OnToolTipNeeded(args);
+                    if (args.IsEmpty)
+                    {
+                        return;
+                    }
+
+                    _toolTipValues.Heading = args.Heading;
+                    _toolTipValues.Description = args.Description;
+                    _toolTipValues.Image = args.Icon;
+
+                    // Create the actual tooltip popup object
+                    var renderer = _provider.ProviderRedirector.Target?.GetRenderer();
+                    _visualPopupToolTip = new VisualPopupToolTip(_provider.ProviderRedirector,
+                        _toolTipValues,
+                        renderer,
+                        PaletteBackStyle.ControlToolTip,
+                        PaletteBorderStyle.ControlToolTip,
+                        CommonHelper.ContentStyleFromLabelStyle(_toolTipValues.ToolTipStyle),
+                        _toolTipValues.ToolTipShadow);
+
+                    _visualPopupToolTip.Disposed += OnVisualPopupToolTipDisposed;
+                    _visualPopupToolTip.ShowRelativeTo(e.Target, e.ControlMousePosition);
+                }
+            }
+        }
+
+        internal void OnCancelToolTip(object sender, EventArgs e) =>
+            // Remove any currently showing tooltip
+            _visualPopupToolTip?.Dispose();
+
+        internal void OnVisualPopupToolTipDisposed(object sender, EventArgs e)
+        {
+            // Unhook events from the specific instance that generated event
+            var popupToolTip = (VisualPopupToolTip)sender;
+            popupToolTip.Disposed -= OnVisualPopupToolTipDisposed;
+
+            // Not showing a popup page any more
+            _visualPopupToolTip = null;
+        }
         #endregion
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuItems.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuItems.cs
@@ -109,6 +109,7 @@ namespace Krypton.Toolkit
                                               bool standardStyle,
                                               bool imageColumn)
         {
+            SetProvider(provider);
             // Add child items into columns of display views
             var itemsColumns = new ViewLayoutStack(true);
             Items.GenerateView(provider, this, this, itemsColumns, StandardStyle, ImageColumn);

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuLinkLabel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuLinkLabel.cs
@@ -141,8 +141,11 @@ namespace Krypton.Toolkit
                                               object parent,
                                               ViewLayoutStack columns,
                                               bool standardStyle,
-                                              bool imageColumn) =>
-            new ViewDrawMenuLinkLabel(provider, this);
+                                              bool imageColumn)
+        {
+            SetProvider(provider);
+            return new ViewDrawMenuLinkLabel(provider, this);
+        }
 
         /// <summary>
         /// Gets and sets the link label style.

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuMonthCalendar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuMonthCalendar.cs
@@ -208,8 +208,11 @@ namespace Krypton.Toolkit
                                               object parent,
                                               ViewLayoutStack columns,
                                               bool standardStyle,
-                                              bool imageColumn) =>
-            new ViewDrawMenuMonthCalendar(provider, this);
+                                              bool imageColumn)
+        {
+            SetProvider(provider);
+            return new ViewDrawMenuMonthCalendar(provider, this);
+        }
 
         /// <summary>
         /// Gets and sets if selecting a day automatically closes the context menu.

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuRadioButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuRadioButton.cs
@@ -33,7 +33,7 @@ namespace Krypton.Toolkit
         private Image? _image;
         private Color _imageTransparentColor;
         private readonly PaletteContentInheritRedirect _stateCommonRedirect;
-        private KryptonCommand _command;
+        private KryptonCommand? _command;
         private LabelStyle _style;
         #endregion
 
@@ -138,8 +138,11 @@ namespace Krypton.Toolkit
                                               object parent,
                                               ViewLayoutStack columns,
                                               bool standardStyle,
-                                              bool imageColumn) =>
-            new ViewDrawMenuRadioButton(provider, this);
+                                              bool imageColumn)
+        {
+            SetProvider(provider);
+            return new ViewDrawMenuRadioButton(provider, this);
+        }
 
         /// <summary>
         /// Gets and sets if clicking the radio button automatically closes the context menu.

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuSeparator.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuSeparator.cs
@@ -90,6 +90,7 @@ namespace Krypton.Toolkit
                                               bool standardStyle,
                                               bool imageColumn)
         {
+            SetProvider(provider);
             if (Horizontal && (parent is KryptonContextMenuItemCollection))
             {
                 // Create a stack of horizontal items inside the item

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -3117,8 +3117,8 @@ namespace Krypton.Toolkit
 
         private void ShowToolTip(ToolTipNeededEventArgs e, Point location)
         {
-            _toolTipSpec.ToolTipTitle = e.Title;
-            _toolTipSpec.ToolTipBody = e.Body;
+            _toolTipSpec.ToolTipTitle = e.Heading;
+            _toolTipSpec.ToolTipBody = e.Description;
             _toolTipSpec.ToolTipImage = e.Icon;
             VisualPopupToolTip tip = GetToolTip();
             // Needed to make Krypton update the tooltip data with the data of the spec.

--- a/Source/Krypton Components/Krypton.Toolkit/EventArgs/ToolTipNeededEventArgs.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/EventArgs/ToolTipNeededEventArgs.cs
@@ -16,28 +16,32 @@
 namespace Krypton.Toolkit
 {
     /// <summary>
-    /// Event arguments for the ToolTipNeeded event raised by a KryptonComboBox when it
-    /// needs to render a tooltip.
+    /// Event arguments for the ToolTipNeeded event raised by
+    /// - KryptonComboBox
+    /// -  MenuItemBase
+    /// when they needs to render a tooltip. Allowing App, to change various details of the tip.
+    /// To cancel, then set `Heading`, `Description` and `Icon` to null(empty)
     /// </summary>
     public class ToolTipNeededEventArgs : EventArgs
     {
         /// <summary>
         /// The title of the tooltip.
         /// </summary>
-        public string Title { get; set; }
+        public string Heading { get; set; }
         /// <summary>
         /// The body of the tooltip.
         /// </summary>
-        public string Body { get; set; }
+        public string Description { get; set; }
+
         /// <summary>
         /// The icon of the tooltip.
         /// </summary>
-        public Image Icon { get; set; }
+        public Image? Icon { get; set; }
 
         /// <summary>
         /// Gets whether the instance is empty.
         /// </summary>
-        public bool IsEmpty => string.IsNullOrEmpty(Title) && string.IsNullOrEmpty(Body) && Icon == null;
+        public bool IsEmpty => string.IsNullOrEmpty(Heading) && string.IsNullOrEmpty(Description) && Icon == null;
 
         /// <summary>
         /// Initializes a new instance of the ToolTipNeededEventArgs class.

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuCheckBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuCheckBox.cs
@@ -91,6 +91,8 @@ namespace Krypton.Toolkit
             mcbc.Click += OnClick;
             _innerDocker.MouseController = mcbc;
             _innerDocker.KeyController = mcbc;
+            // Create the manager for handling tooltips
+            _innerDocker.MouseController = new ToolTipController(KryptonContextMenuCheckBox.ToolTipManager, this, mcbc);
 
             // Add docker as the composite content
             Add(_outerDocker);

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuCheckButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuCheckButton.cs
@@ -86,8 +86,10 @@ namespace Krypton.Toolkit
             var mcbc = new MenuCheckButtonController(provider.ProviderViewManager, _innerDocker,
                 this, provider.ProviderNeedPaintDelegate);
             mcbc.Click += OnClick;
-            _innerDocker.MouseController = mcbc;
+            //_innerDocker.MouseController = mcbc;
             _innerDocker.KeyController = mcbc;
+            // Create the manager for handling tooltips
+            _innerDocker.MouseController = new ToolTipController(KryptonContextMenuCheckButton.ToolTipManager, this, mcbc);
 
             // Add docker as the composite content
             Add(_outerDocker);

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuColorBlock.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuColorBlock.cs
@@ -54,8 +54,10 @@ namespace Krypton.Toolkit
             var mcbc = new MenuColorBlockController(provider.ProviderViewManager, this, this,
                 provider.ProviderNeedPaintDelegate);
             mcbc.Click += OnClick;
-            MouseController = mcbc;
+            //MouseController = mcbc;
             KeyController = mcbc;
+            // Create the manager for handling tooltips
+            MouseController = new ToolTipController(KryptonContextMenuColorColumns.ToolTipManager, this, mcbc);
         }
 
         /// <summary>
@@ -215,7 +217,7 @@ namespace Krypton.Toolkit
             var inside = Color.Empty;
 
             // Is this element selected?
-            var selected = (KryptonContextMenuColorColumns.SelectedColor != null) && KryptonContextMenuColorColumns.SelectedColor.Equals(Color);
+            var selected = (KryptonContextMenuColorColumns.SelectedColor != Color.Empty) && KryptonContextMenuColorColumns.SelectedColor.Equals(Color);
 
             switch (ElementState)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuImageSelectItem.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuImageSelectItem.cs
@@ -54,9 +54,12 @@ namespace Krypton.Toolkit
             // Need controller to handle tracking/pressing etc
             _controller = new MenuImageSelectController(viewManager, this, layout, needPaint);
             _controller.Click += OnItemClick;
-            MouseController = _controller;
+            //MouseController = _controller;
             SourceController = _controller;
             KeyController = _controller;
+            // Create the manager for handling tooltips
+            MouseController = new ToolTipController(imageSelect.ToolTipManager, this, _controller);
+
         }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuLinkLabel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuLinkLabel.cs
@@ -76,8 +76,10 @@ namespace Krypton.Toolkit
             var mllc = new MenuLinkLabelController(provider.ProviderViewManager, _drawContent, this,
                 provider.ProviderNeedPaintDelegate);
             mllc.Click += OnClick;
-            _drawContent.MouseController = mllc;
+            //_drawContent.MouseController = mllc;
             _drawContent.KeyController = mllc;
+            // Create the manager for handling tooltips
+            _drawContent.MouseController = new ToolTipController(KryptonContextMenuLinkLabel.ToolTipManager, this, mllc);
 
             // Add docker as the composite content
             Add(_outerDocker);

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuRadioButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuRadioButton.cs
@@ -88,8 +88,10 @@ namespace Krypton.Toolkit
             var mrbc = new MenuRadioButtonController(provider.ProviderViewManager, _innerDocker,
                 this, provider.ProviderNeedPaintDelegate);
             mrbc.Click += OnClick;
-            _innerDocker.MouseController = mrbc;
+            //_innerDocker.MouseController = mrbc;
             _innerDocker.KeyController = mrbc;
+            // Create the manager for handling tooltips
+            _innerDocker.MouseController = new ToolTipController(KryptonContextMenuRadioButton.ToolTipManager, this, mrbc);
 
             // We need to be notified whenever the checked state changes
             KryptonContextMenuRadioButton.CheckedChanged += OnCheckedChanged;

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuSeparator.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuSeparator.cs
@@ -23,7 +23,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="separator">Reference to owning separator entry.</param>
         /// <param name="palette">Palette for obtaining drawing values.</param>
-        public ViewDrawMenuSeparator(KryptonContextMenuSeparator separator,
+        public ViewDrawMenuSeparator([DisallowNull] KryptonContextMenuSeparator separator,
                                      PaletteDoubleRedirect? palette)
             : base(separator.StateNormal.Back, separator.StateNormal.Border)
         {
@@ -43,7 +43,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the ViewDrawMenuSeparator class.
         /// </summary>
         /// <param name="state">State specific source of palette values.</param>
-        public ViewDrawMenuSeparator(PaletteDouble? state)
+        public ViewDrawMenuSeparator([DisallowNull] PaletteDouble state)
             : base(state.Back, state.Border)
         {
             // We need to be big enough to contain 1 pixel square spacer


### PR DESCRIPTION
#1069

![image](https://github.com/Krypton-Suite/Standard-Toolkit/assets/2418812/d991ee3b-f2fa-4717-8895-ee43d2391646)