### PR TITLE
* Replaced `LinkAreaStart` & `LinkAreaEnd` with just `ContentLinkArea`

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -37,8 +37,7 @@
     - `ContentAreaType` - Defines content area type of a `KryptonMessageBox`, default is normal
     - `LinkLabelCommand` - Specifies a `KryptonCommand` if using the `MessageBoxContentAreaType.LinkLabel` type.
     - `LinkLaunchArgument` - Specifies the `ProcessStartInfo` if a `LinkLabelCommand` has not been defined.
-    - `LinkAreaStart` - Specifies the start of a link if using the `MessageBoxContentAreaType.LinkLabel` type.
-    - `LinkAreaEnd` - Specifies the end of a link if using the `MessageBoxContentAreaType.LinkLabel` type.
+    - `ContentLinkArea` - Specifies the area of a link, if using the `MessageBoxContentAreaType.LinkLabel` type.
 * Added `KryptonLanguageManager` to the `KryptonManager` action list
 * Resolved [#1008](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1008), Krypton Save/Open file dialogs are not accessible from the toolbox
 * Implemented [#1007](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1007), A way to alter all of the strings in the toolkit to language specific strings

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMessageBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMessageBox.cs
@@ -35,21 +35,19 @@ namespace Krypton.Toolkit
         /// <param name="contentAreaType">Specifies the <see cref="T:MessageBoxContentAreaType"/>.</param>
         /// <param name="linkAreaCommand">Specifies a <see cref="T:KryptonCommand"/> if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
         /// <param name="linkLaunchArgument">Specifies the <see cref="ProcessStartInfo"/> if a <paramref name="linkAreaCommand"> has not been defined.</paramref></param>
-        /// <param name="linkAreaStart">Specifies the start of a link if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
-        /// <param name="linkAreaEnd">Specifies the end of a link if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
+        /// <param name="contentLinkArea">Specifies the area within the <see cref="KryptonLinkWrapLabel"/> to be regarded as a link. See <see cref="LinkArea"/>.</param>
         /// <param name="messageTextAlignment">Specifies how the message text should be aligned. See <see cref="System.Drawing.ContentAlignment"/> for supported values.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
         public static DialogResult Show(string text, string caption, bool? showCtrlCopy = null,
-                                         MessageBoxContentAreaType? contentAreaType = null,
-                                         KryptonCommand? linkAreaCommand = null,
-                                         ProcessStartInfo? linkLaunchArgument = null,
-                                         int? linkAreaStart = null,
-                                         int? linkAreaEnd = null,
-                                         ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft) =>
+                                        MessageBoxContentAreaType? contentAreaType = null,
+                                        KryptonCommand? linkAreaCommand = null,
+                                        ProcessStartInfo? linkLaunchArgument = null,
+                                        LinkArea? contentLinkArea = null,
+                                        ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft) =>
             ShowCore(null, text, caption, KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.None,
-                         KryptonMessageBoxDefaultButton.Button4, 0, null, showCtrlCopy,
-                         null, null, @"", null, null, @"",
-                         contentAreaType, linkAreaCommand, linkLaunchArgument, linkAreaStart, linkAreaEnd, messageTextAlignment);
+                     KryptonMessageBoxDefaultButton.Button4, 0, null, showCtrlCopy,
+                     null, null, @"", null, null, @"",
+                     contentAreaType, linkAreaCommand, linkLaunchArgument, contentLinkArea, messageTextAlignment);
 
         /// <summary>
         /// Displays a message box in front+center of the application and with the specified text, caption and buttons.
@@ -59,22 +57,21 @@ namespace Krypton.Toolkit
         /// <param name="contentAreaType">Specifies the <see cref="T:MessageBoxContentAreaType"/>.</param>
         /// <param name="linkAreaCommand">Specifies a <see cref="T:KryptonCommand"/> if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
         /// <param name="linkLaunchArgument">Specifies the <see cref="ProcessStartInfo"/> if a <paramref name="linkAreaCommand"> has not been defined.</paramref></param>
-        /// <param name="linkAreaStart">Specifies the start of a link if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
-        /// <param name="linkAreaEnd">Specifies the end of a link if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
+        /// <param name="contentLinkArea">Specifies the area within the <see cref="KryptonLinkWrapLabel"/> to be regarded as a link. See <see cref="LinkArea"/>.</param>
         /// <param name="messageTextAlignment">Specifies how the message text should be aligned. See <see cref="System.Drawing.ContentAlignment"/> for supported values.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
         public static DialogResult Show(string text, bool? showCtrlCopy = null,
-                                          MessageBoxContentAreaType? contentAreaType = null,
-                                          KryptonCommand? linkAreaCommand = null,
-                                          ProcessStartInfo? linkLaunchArgument = null,
-                                          int? linkAreaStart = null,
-                                          int? linkAreaEnd = null,
-                                          ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft) =>
+                                        MessageBoxContentAreaType? contentAreaType = null,
+                                        KryptonCommand? linkAreaCommand = null,
+                                        ProcessStartInfo? linkLaunchArgument = null,
+                                        LinkArea? contentLinkArea = null,
+                                        ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft) =>
             ShowCore(null, text, @"", KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.None,
-                         KryptonMessageBoxDefaultButton.Button4, 0,
-                         null, showCtrlCopy, false, null, @"", null, null, @"",
-                         contentAreaType, linkAreaCommand, linkLaunchArgument,
-                         linkAreaStart, linkAreaEnd, messageTextAlignment);
+                     KryptonMessageBoxDefaultButton.Button4, 0,
+                     null, showCtrlCopy, false, null, @"",
+                     null, null, @"",
+                     contentAreaType, linkAreaCommand, linkLaunchArgument,
+                     contentLinkArea, messageTextAlignment);
 
         /// <summary>
         /// Displays a message box in front+center of the specified object and with the specified text, caption, buttons, icon, default button, and options.
@@ -85,22 +82,20 @@ namespace Krypton.Toolkit
         /// <param name="contentAreaType">Specifies the <see cref="T:MessageBoxContentAreaType"/>.</param>
         /// <param name="linkAreaCommand">Specifies a <see cref="T:KryptonCommand"/> if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
         /// <param name="linkLaunchArgument">Specifies the <see cref="ProcessStartInfo"/> if a <paramref name="linkAreaCommand"> has not been defined.</paramref></param>
-        /// <param name="linkAreaStart">Specifies the start of a link if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
-        /// <param name="linkAreaEnd">Specifies the end of a link if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
+        /// <param name="contentLinkArea">Specifies the area within the <see cref="KryptonLinkWrapLabel"/> to be regarded as a link. See <see cref="LinkArea"/>.</param>
         /// <param name="messageTextAlignment">Specifies how the message text should be aligned. See <see cref="System.Drawing.ContentAlignment"/> for supported values.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
         public static DialogResult Show(IWin32Window? owner, string text, bool? showCtrlCopy = null,
-                                         MessageBoxContentAreaType? contentAreaType = null,
-                                         KryptonCommand? linkAreaCommand = null,
-                                         ProcessStartInfo? linkLaunchArgument = null,
-                                         int? linkAreaStart = null,
-                                         int? linkAreaEnd = null,
-                                         ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft) =>
+                                        MessageBoxContentAreaType? contentAreaType = null,
+                                        KryptonCommand? linkAreaCommand = null,
+                                        ProcessStartInfo? linkLaunchArgument = null,
+                                        LinkArea? contentLinkArea = null,
+                                        ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft) =>
             ShowCore(owner, text, @"", KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.None,
                      KryptonMessageBoxDefaultButton.Button4, 0, null, showCtrlCopy,
                      false, null, @"", null,
                      null, @"",
-                     contentAreaType, linkAreaCommand, linkLaunchArgument, linkAreaStart, linkAreaEnd, messageTextAlignment);
+                     contentAreaType, linkAreaCommand, linkLaunchArgument, contentLinkArea, messageTextAlignment);
 
         /// <summary>
         /// Displays a message box in front+center of the specified object and with the specified text, caption, buttons, icon, default button, and options.
@@ -112,22 +107,20 @@ namespace Krypton.Toolkit
         /// <param name="contentAreaType">Specifies the <see cref="T:MessageBoxContentAreaType"/>.</param>
         /// <param name="linkAreaCommand">Specifies a <see cref="T:KryptonCommand"/> if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
         /// <param name="linkLaunchArgument">Specifies the <see cref="ProcessStartInfo"/> if a <paramref name="linkAreaCommand"> has not been defined.</paramref></param>
-        /// <param name="linkAreaStart">Specifies the start of a link if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
-        /// <param name="linkAreaEnd">Specifies the end of a link if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
+        /// <param name="contentLinkArea">Specifies the area within the <see cref="KryptonLinkWrapLabel"/> to be regarded as a link. See <see cref="LinkArea"/>.</param>
         /// <param name="messageTextAlignment">Specifies how the message text should be aligned. See <see cref="System.Drawing.ContentAlignment"/> for supported values.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
         public static DialogResult Show(IWin32Window? owner, string text, string caption, bool? showCtrlCopy = null,
-                                          MessageBoxContentAreaType? contentAreaType = null,
-                                          KryptonCommand? linkAreaCommand = null,
-                                          ProcessStartInfo? linkLaunchArgument = null,
-                                          int? linkAreaStart = null,
-                                          int? linkAreaEnd = null,
-                                          ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft) =>
+                                        MessageBoxContentAreaType? contentAreaType = null,
+                                        KryptonCommand? linkAreaCommand = null,
+                                        ProcessStartInfo? linkLaunchArgument = null,
+                                        LinkArea? contentLinkArea = null,
+                                        ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft) =>
             ShowCore(owner, text, caption, KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.None,
                      KryptonMessageBoxDefaultButton.Button4, 0, null, showCtrlCopy,
                      false, null, @"", null,
                      null, @"",
-                     contentAreaType, linkAreaCommand, linkLaunchArgument, linkAreaStart, linkAreaEnd, messageTextAlignment);
+                     contentAreaType, linkAreaCommand, linkLaunchArgument, contentLinkArea, messageTextAlignment);
 
         /// <summary>
         /// Displays a message box in front+center of the application and with the specified text, caption and buttons.
@@ -139,25 +132,23 @@ namespace Krypton.Toolkit
         /// <param name="contentAreaType">Specifies the <see cref="T:MessageBoxContentAreaType"/>.</param>
         /// <param name="linkAreaCommand">Specifies a <see cref="T:KryptonCommand"/> if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
         /// <param name="linkLaunchArgument">Specifies the <see cref="ProcessStartInfo"/> if a <paramref name="linkAreaCommand"> has not been defined.</paramref></param>
-        /// <param name="linkAreaStart">Specifies the start of a link if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
-        /// <param name="linkAreaEnd">Specifies the end of a link if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
+        /// <param name="contentLinkArea">Specifies the area within the <see cref="KryptonLinkWrapLabel"/> to be regarded as a link. See <see cref="LinkArea"/>.</param>
         /// <param name="messageTextAlignment">Specifies how the message text should be aligned. See <see cref="System.Drawing.ContentAlignment"/> for supported values.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
         public static DialogResult Show(string text, string caption, KryptonMessageBoxButtons buttons,
-                                         bool? showCtrlCopy = null,
-                                         MessageBoxContentAreaType? contentAreaType = null,
-                                         KryptonCommand? linkAreaCommand = null,
-                                         ProcessStartInfo? linkLaunchArgument = null,
-                                         int? linkAreaStart = null,
-                                         int? linkAreaEnd = null,
-                                         ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft) =>
+                                        bool? showCtrlCopy = null,
+                                        MessageBoxContentAreaType? contentAreaType = null,
+                                        KryptonCommand? linkAreaCommand = null,
+                                        ProcessStartInfo? linkLaunchArgument = null,
+                                        LinkArea? contentLinkArea = null,
+                                        ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft) =>
                                        ShowCore(null, text, caption, buttons, KryptonMessageBoxIcon.None,
-                                           KryptonMessageBoxDefaultButton.Button1, 0,
-                                           new HelpInfo(@"", 0, null), showCtrlCopy,
-                                           null, null, @"",
-                                           null, null, @"",
-                                           contentAreaType, linkAreaCommand, linkLaunchArgument,
-                                           linkAreaStart, linkAreaEnd, messageTextAlignment);
+                                                KryptonMessageBoxDefaultButton.Button1, 0,
+                                                new HelpInfo(@"", 0, null), showCtrlCopy,
+                                                null, null, @"",
+                                                null, null, @"",
+                                                contentAreaType, linkAreaCommand, linkLaunchArgument,
+                                                contentLinkArea, messageTextAlignment);
 
         /// <summary>
         /// Displays a message box in front+center of the application and with the specified text, caption, buttons, icon, default button, and options.
@@ -179,8 +170,7 @@ namespace Krypton.Toolkit
         /// <param name="contentAreaType">Specifies the <see cref="T:MessageBoxContentAreaType"/>.</param>
         /// <param name="linkAreaCommand">Specifies a <see cref="T:KryptonCommand"/> if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
         /// <param name="linkLaunchArgument">Specifies the <see cref="ProcessStartInfo"/> if a <paramref name="linkAreaCommand"> has not been defined.</paramref></param>
-        /// <param name="linkAreaStart">Specifies the start of a link if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
-        /// <param name="linkAreaEnd">Specifies the end of a link if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
+        /// <param name="contentLinkArea">Specifies the area within the <see cref="KryptonLinkWrapLabel"/> to be regarded as a link. See <see cref="LinkArea"/>.</param>
         /// <param name="messageTextAlignment">Specifies how the message text should be aligned. See <see cref="System.Drawing.ContentAlignment"/> for supported values.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
         public static DialogResult Show(string text, string caption, KryptonMessageBoxButtons buttons,
@@ -192,16 +182,16 @@ namespace Krypton.Toolkit
                                          ProcessStartInfo? linkLaunchArgument = null, Image? applicationImage = null,
                                          string? applicationPath = @"",
                                          MessageBoxContentAreaType? contentAreaType = null,
-                                         KryptonCommand? linkAreaCommand = null, int? linkAreaStart = null,
-                                         int? linkAreaEnd = null,
+                                         KryptonCommand? linkAreaCommand = null,
+                                         LinkArea? contentLinkArea = null,
                                          ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft)
             =>
                 ShowCore(null, text, caption, buttons, icon, defaultButton, options,
-                             displayHelpButton ? new HelpInfo() : null, showCtrlCopy,
-                             showHelpButton, showActionButton,
-                             actionButtonText, actionButtonCommand, applicationImage, applicationPath,
-                             contentAreaType, linkAreaCommand, linkLaunchArgument,
-                             linkAreaStart, linkAreaEnd, messageTextAlignment);
+                         displayHelpButton ? new HelpInfo() : null, showCtrlCopy,
+                         showHelpButton, showActionButton,
+                         actionButtonText, actionButtonCommand, applicationImage, applicationPath,
+                         contentAreaType, linkAreaCommand, linkLaunchArgument,
+                         contentLinkArea, messageTextAlignment);
 
 
         /// <summary>
@@ -225,31 +215,29 @@ namespace Krypton.Toolkit
         /// <param name="contentAreaType">Specifies the <see cref="T:MessageBoxContentAreaType"/>.</param>
         /// <param name="linkAreaCommand">Specifies a <see cref="T:KryptonCommand"/> if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
         /// <param name="linkLaunchArgument">Specifies the <see cref="ProcessStartInfo"/> if a <paramref name="linkAreaCommand"> has not been defined.</paramref></param>
-        /// <param name="linkAreaStart">Specifies the start of a link if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
-        /// <param name="linkAreaEnd">Specifies the end of a link if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
+        /// <param name="contentLinkArea">Specifies the area within the <see cref="KryptonLinkWrapLabel"/> to be regarded as a link. See <see cref="LinkArea"/>.</param>
         /// <param name="messageTextAlignment">Specifies how the message text should be aligned. See <see cref="System.Drawing.ContentAlignment"/> for supported values.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
         public static DialogResult Show(IWin32Window? owner, string text, string caption,
-                                         KryptonMessageBoxButtons buttons, KryptonMessageBoxIcon icon,
-                                         KryptonMessageBoxDefaultButton defaultButton = KryptonMessageBoxDefaultButton.Button4,
-                                         MessageBoxOptions options = 0, bool displayHelpButton = false,
-                                         bool? showCtrlCopy = null, bool? showHelpButton = null,
-                                         bool? showActionButton = null, string? actionButtonText = @"",
-                                         KryptonCommand? actionButtonCommand = null, Image? applicationImage = null,
-                                         string? applicationPath = @"",
-                                         MessageBoxContentAreaType? contentAreaType = null,
-                                         KryptonCommand? linkAreaCommand = null,
-                                         ProcessStartInfo? linkLaunchArgument = null,
-                                         int? linkAreaStart = null,
-                                         int? linkAreaEnd = null,
-                                         ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft)
+                                        KryptonMessageBoxButtons buttons, KryptonMessageBoxIcon icon,
+                                        KryptonMessageBoxDefaultButton defaultButton = KryptonMessageBoxDefaultButton.Button4,
+                                        MessageBoxOptions options = 0, bool displayHelpButton = false,
+                                        bool? showCtrlCopy = null, bool? showHelpButton = null,
+                                        bool? showActionButton = null, string? actionButtonText = @"",
+                                        KryptonCommand? actionButtonCommand = null, Image? applicationImage = null,
+                                        string? applicationPath = @"",
+                                        MessageBoxContentAreaType? contentAreaType = null,
+                                        KryptonCommand? linkAreaCommand = null,
+                                        ProcessStartInfo? linkLaunchArgument = null,
+                                        LinkArea? contentLinkArea = null,
+                                        ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft)
             =>
                 ShowCore(owner, text, caption, buttons, icon, defaultButton, options,
-                             displayHelpButton ? new HelpInfo() : null, showCtrlCopy,
-                             showHelpButton, showActionButton, actionButtonText,
-                             actionButtonCommand, applicationImage, applicationPath,
-                             contentAreaType, linkAreaCommand, linkLaunchArgument,
-                             linkAreaStart, linkAreaEnd, messageTextAlignment);
+                         displayHelpButton ? new HelpInfo() : null, showCtrlCopy,
+                         showHelpButton, showActionButton, actionButtonText,
+                         actionButtonCommand, applicationImage, applicationPath,
+                         contentAreaType, linkAreaCommand, linkLaunchArgument,
+                         contentLinkArea, messageTextAlignment);
 
         /// <param name="text">The text to display in the message box.</param>
         /// <param name="caption" >The text to display in the title bar of the message box. default="string.Empty"</param>
@@ -270,28 +258,27 @@ namespace Krypton.Toolkit
         /// <param name="contentAreaType">Specifies the <see cref="T:MessageBoxContentAreaType"/>.</param>
         /// <param name="linkAreaCommand">Specifies a <see cref="T:KryptonCommand"/> if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
         /// <param name="linkLaunchArgument">Specifies the <see cref="ProcessStartInfo"/> if a <paramref name="linkAreaCommand"> has not been defined.</paramref></param>
-        /// <param name="linkAreaStart">Specifies the start of a link if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
-        /// <param name="linkAreaEnd">Specifies the end of a link if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
+        /// <param name="contentLinkArea">Specifies the area within the <see cref="KryptonLinkWrapLabel"/> to be regarded as a link. See <see cref="LinkArea"/>.</param>
         /// <param name="messageTextAlignment">Specifies how the message text should be aligned. See <see cref="System.Drawing.ContentAlignment"/> for supported values.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
         public static DialogResult Show(string text, string caption, KryptonMessageBoxButtons buttons,
-                                         KryptonMessageBoxIcon icon, KryptonMessageBoxDefaultButton defaultButton,
-                                         MessageBoxOptions options, string? helpFilePath,
-                                         HelpNavigator navigator, object? param, bool? showCtrlCopy = null,
-                                         bool? showHelpButton = null, bool? showActionButton = null,
-                                         string? actionButtonText = @"", KryptonCommand? actionButtonCommand = null,
-                                         Image? applicationImage = null, string? applicationPath = @"",
-                                         MessageBoxContentAreaType? contentAreaType = null,
-                                         KryptonCommand? linkAreaCommand = null,
-                                         ProcessStartInfo? linkLaunchArgument = null, int? linkAreaStart = null,
-                                         int? linkAreaEnd = null,
-                                         ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft)
+                                        KryptonMessageBoxIcon icon, KryptonMessageBoxDefaultButton defaultButton,
+                                        MessageBoxOptions options, string? helpFilePath,
+                                        HelpNavigator navigator, object? param, bool? showCtrlCopy = null,
+                                        bool? showHelpButton = null, bool? showActionButton = null,
+                                        string? actionButtonText = @"", KryptonCommand? actionButtonCommand = null,
+                                        Image? applicationImage = null, string? applicationPath = @"",
+                                        MessageBoxContentAreaType? contentAreaType = null,
+                                        KryptonCommand? linkAreaCommand = null,
+                                        ProcessStartInfo? linkLaunchArgument = null,
+                                        LinkArea? contentLinkArea = null,
+                                        ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft)
             => ShowCore(null, text, caption, buttons, icon, defaultButton, options,
-                            new HelpInfo(helpFilePath, navigator, param), showCtrlCopy,
-                            showHelpButton, showActionButton, actionButtonText,
-                            actionButtonCommand, applicationImage, applicationPath,
-                            contentAreaType, linkAreaCommand, linkLaunchArgument,
-                            linkAreaStart, linkAreaEnd, messageTextAlignment);
+                        new HelpInfo(helpFilePath, navigator, param), showCtrlCopy,
+                        showHelpButton, showActionButton, actionButtonText,
+                        actionButtonCommand, applicationImage, applicationPath,
+                        contentAreaType, linkAreaCommand, linkLaunchArgument,
+                        contentLinkArea, messageTextAlignment);
 
         /// <summary>
         /// Displays a message box with the specified text, caption, buttons, icon, default button, options, and Help button, using the specified Help file, HelpNavigator, and Help topic.
@@ -316,30 +303,33 @@ namespace Krypton.Toolkit
         /// <param name="contentAreaType">Specifies the <see cref="T:MessageBoxContentAreaType"/>.</param>
         /// <param name="linkAreaCommand">Specifies a <see cref="T:KryptonCommand"/> if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
         /// <param name="linkLaunchArgument">Specifies the <see cref="ProcessStartInfo"/> if a <paramref name="linkAreaCommand"> has not been defined.</paramref></param>
-        /// <param name="linkAreaStart">Specifies the start of a link if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
-        /// <param name="linkAreaEnd">Specifies the end of a link if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
+        /// <param name="contentLinkArea">Specifies the area within the <see cref="KryptonLinkWrapLabel"/> to be regarded as a link. See <see cref="LinkArea"/>.</param>
         /// <param name="messageTextAlignment">Specifies how the message text should be aligned. See <see cref="System.Drawing.ContentAlignment"/> for supported values.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
-        public static DialogResult Show(IWin32Window? owner, string text, string caption, KryptonMessageBoxButtons buttons,
-                                          KryptonMessageBoxIcon icon, KryptonMessageBoxDefaultButton defaultButton,
-                                          MessageBoxOptions options, string? helpFilePath, HelpNavigator navigator,
-                                          object? param, bool? showCtrlCopy = null,
-                                          bool? showHelpButton = null,
-                                          bool? showActionButton = null,
-                                          string? actionButtonText = @"",
-                                          KryptonCommand? actionButtonCommand = null, Image? applicationImage = null,
-                                          string? applicationPath = @"",
-                                          MessageBoxContentAreaType? contentAreaType = null,
-                                          KryptonCommand? linkAreaCommand = null,
-                                          ProcessStartInfo? linkLaunchArgument = null,
-                                          int? linkAreaStart = 0, int? linkAreaEnd = 255,
-                                          ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft)
+        public static DialogResult Show(IWin32Window? owner, string text, string caption,
+                                        KryptonMessageBoxButtons buttons,
+                                        KryptonMessageBoxIcon icon,
+                                        KryptonMessageBoxDefaultButton defaultButton,
+                                        MessageBoxOptions options,
+                                        string? helpFilePath, HelpNavigator navigator,
+                                        object? param, bool? showCtrlCopy = null,
+                                        bool? showHelpButton = null,
+                                        bool? showActionButton = null,
+                                        string? actionButtonText = @"",
+                                        KryptonCommand? actionButtonCommand = null,
+                                        Image? applicationImage = null,
+                                        string? applicationPath = @"",
+                                        MessageBoxContentAreaType? contentAreaType = null,
+                                        KryptonCommand? linkAreaCommand = null,
+                                        ProcessStartInfo? linkLaunchArgument = null,
+                                        LinkArea? contentLinkArea = null,
+                                        ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft)
             => ShowCore(owner, text, caption, buttons, icon, defaultButton, options,
-                            new HelpInfo(helpFilePath, navigator, param), showCtrlCopy,
-                            showHelpButton, showActionButton, actionButtonText,
-                            actionButtonCommand, applicationImage, applicationPath,
-                            contentAreaType, linkAreaCommand, linkLaunchArgument,
-                            linkAreaStart, linkAreaEnd, messageTextAlignment);
+                        new HelpInfo(helpFilePath, navigator, param),
+                        showCtrlCopy, showHelpButton, showActionButton,
+                        actionButtonText, actionButtonCommand, applicationImage,
+                        applicationPath, contentAreaType, linkAreaCommand,
+                        linkLaunchArgument, contentLinkArea, messageTextAlignment);
 
         #endregion
 
@@ -365,8 +355,7 @@ namespace Krypton.Toolkit
         /// <param name="contentAreaType">Specifies the <see cref="T:MessageBoxContentAreaType"/>.</param>
         /// <param name="linkLabelCommand">Specifies a <see cref="T:KryptonCommand"/> if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
         /// <param name="linkLaunchArgument">Specifies the <see cref="ProcessStartInfo"/> if a <paramref name="linkLabelCommand"> has not been defined.</paramref></param>
-        /// <param name="linkAreaStart">Specifies the start of a link if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
-        /// <param name="linkAreaEnd">Specifies the end of a link if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
+        /// <param name="contentLinkArea">Specifies the area within the <see cref="KryptonLinkWrapLabel"/> to be regarded as a link. See <see cref="LinkArea"/>.</param>
         /// <param name="messageTextAlignment">Specifies how the message text should be aligned. See <see cref="System.Drawing.ContentAlignment"/> for supported values.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
         private static DialogResult ShowCore(IWin32Window? owner,
@@ -383,7 +372,7 @@ namespace Krypton.Toolkit
                                              MessageBoxContentAreaType? contentAreaType,
                                              KryptonCommand? linkLabelCommand,
                                              ProcessStartInfo? linkLaunchArgument,
-                                             int? linkAreaStart, int? linkAreaEnd,
+                                             LinkArea? contentLinkArea,
                                              ContentAlignment? messageTextAlignment)
         {
             caption = string.IsNullOrEmpty(caption) ? @" " : caption;
@@ -396,7 +385,7 @@ namespace Krypton.Toolkit
                                                       showActionButton, actionButtonText,
                                                       actionButtonCommand, applicationImage, applicationPath,
                                                       contentAreaType, linkLabelCommand,
-                                                      linkLaunchArgument, linkAreaStart, linkAreaEnd, messageTextAlignment);
+                                                      linkLaunchArgument, contentLinkArea, messageTextAlignment);
 
             kmb.StartPosition = showOwner == null ? FormStartPosition.CenterScreen : FormStartPosition.CenterParent;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMessageBoxForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMessageBoxForm.cs
@@ -48,7 +48,6 @@ namespace Krypton.Toolkit
         // For the LinkLabel option
         private readonly MessageBoxContentAreaType? _contentAreaType;
         private readonly KryptonCommand? _linkLabelCommand;
-        private readonly int _linkAreaStart, _linkAreaEnd;
         private readonly ProcessStartInfo? _linkLaunchArgument;
         private readonly ContentAlignment? _messageTextAlignment;
         private readonly LinkArea _contentLinkArea;
@@ -65,21 +64,21 @@ namespace Krypton.Toolkit
 
 
         internal KryptonMessageBoxForm(IWin32Window? showOwner, string text, string caption,
-                                               KryptonMessageBoxButtons buttons,
-                                               KryptonMessageBoxIcon icon,
-                                               KryptonMessageBoxDefaultButton defaultButton,
-                                               MessageBoxOptions options,
-                                               HelpInfo? helpInfo, bool? showCtrlCopy,
-                                               bool? showHelpButton,
-                                               bool? showActionButton, string? actionButtonText,
-                                               KryptonCommand? actionButtonCommand,
-                                               Image? applicationImage,
-                                               string? applicationPath,
-                                               MessageBoxContentAreaType? contentAreaType,
-                                               KryptonCommand? linkLabelCommand,
-                                               ProcessStartInfo? linkLaunchArgument,
-                                               LinkArea? contentLinkArea,
-                                               ContentAlignment? messageTextAlignment)
+                                       KryptonMessageBoxButtons buttons,
+                                       KryptonMessageBoxIcon icon,
+                                       KryptonMessageBoxDefaultButton defaultButton,
+                                       MessageBoxOptions options,
+                                       HelpInfo? helpInfo, bool? showCtrlCopy,
+                                       bool? showHelpButton,
+                                       bool? showActionButton, string? actionButtonText,
+                                       KryptonCommand? actionButtonCommand,
+                                       Image? applicationImage,
+                                       string? applicationPath,
+                                       MessageBoxContentAreaType? contentAreaType,
+                                       KryptonCommand? linkLabelCommand,
+                                       ProcessStartInfo? linkLaunchArgument,
+                                       LinkArea? contentLinkArea,
+                                       ContentAlignment? messageTextAlignment)
         {
             // Store incoming values
             _text = text;
@@ -809,8 +808,6 @@ namespace Krypton.Toolkit
                     _linkLabelMessageText.Visible = true;
 
                     _messageText.Visible = false;
-
-                    _linkLabelMessageText.LinkArea = new LinkArea(_linkAreaStart, _linkAreaEnd);
                     break;
             }
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMessageBoxForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMessageBoxForm.cs
@@ -51,6 +51,7 @@ namespace Krypton.Toolkit
         private readonly int _linkAreaStart, _linkAreaEnd;
         private readonly ProcessStartInfo? _linkLaunchArgument;
         private readonly ContentAlignment? _messageTextAlignment;
+        private readonly LinkArea _contentLinkArea;
 
         #endregion
 
@@ -77,7 +78,7 @@ namespace Krypton.Toolkit
                                                MessageBoxContentAreaType? contentAreaType,
                                                KryptonCommand? linkLabelCommand,
                                                ProcessStartInfo? linkLaunchArgument,
-                                               int? linkAreaStart, int? linkAreaEnd,
+                                               LinkArea? contentLinkArea,
                                                ContentAlignment? messageTextAlignment)
         {
             // Store incoming values
@@ -97,8 +98,7 @@ namespace Krypton.Toolkit
             _applicationPath = applicationPath ?? string.Empty;
             _contentAreaType = contentAreaType ?? MessageBoxContentAreaType.Normal;
             _linkLabelCommand = linkLabelCommand ?? new KryptonCommand();
-            _linkAreaStart = linkAreaStart ?? 0;
-            _linkAreaEnd = linkAreaEnd ?? text.Length;
+            _contentLinkArea = contentLinkArea ?? new LinkArea(0, text.Length);
             _linkLaunchArgument = linkLaunchArgument ?? new ProcessStartInfo();
             _messageTextAlignment = messageTextAlignment ?? ContentAlignment.MiddleLeft;
 
@@ -116,6 +116,7 @@ namespace Krypton.Toolkit
             UpdateTextExtra(showCtrlCopy);
             UpdateContentAreaType(contentAreaType);
             UpdateContentAreaTextAlignment(contentAreaType, messageTextAlignment);
+            UpdateContentLinkArea(contentLinkArea);
 
             SetupActionButtonUI(_showActionButton);
 
@@ -829,6 +830,14 @@ namespace Krypton.Toolkit
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(contentAreaType), contentAreaType, null);
+            }
+        }
+
+        private void UpdateContentLinkArea(LinkArea? contentLinkArea)
+        {
+            if (contentLinkArea != null)
+            {
+                _linkLabelMessageText.LinkArea = (LinkArea)contentLinkArea;
             }
         }
 

--- a/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
@@ -1872,4 +1872,5 @@ namespace Krypton.Toolkit
     }
 
     #endregion
+
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Tooling/DebugTools.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Tooling/DebugTools.cs
@@ -24,7 +24,7 @@ namespace Krypton.Toolkit
             if (lineNumber > 0)
             {
                 KryptonMessageBox.Show($"If you are seeing this message, please submit a new bug report here.\n\nAdditional details:-\nMethod Signature: {methodSignature}\nClass Name: {className}\nLine Number: {lineNumber}",
-                    "Not Implemented", KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.Error, contentAreaType: MessageBoxContentAreaType.LinkLabel, actionButtonCommand: linkCommand, linkAreaStart: 64, linkAreaEnd: 67);
+                    "Not Implemented", KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.Error, contentAreaType: MessageBoxContentAreaType.LinkLabel, actionButtonCommand: linkCommand, contentLinkArea: new LinkArea(64, 67));
             }
             else
             {

--- a/Source/Krypton Components/TestForm/Form5.Designer.cs
+++ b/Source/Krypton Components/TestForm/Form5.Designer.cs
@@ -31,6 +31,7 @@
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Form5));
             this.kryptonPanel1 = new Krypton.Toolkit.KryptonPanel();
+            this.kryptonThemeComboBox1 = new Krypton.Toolkit.KryptonThemeComboBox();
             this.ktrkProgressValues = new Krypton.Toolkit.KryptonTrackBar();
             this.kbtnKMBTest = new Krypton.Toolkit.KryptonButton();
             this.kryptonLabel1 = new Krypton.Toolkit.KryptonLabel();
@@ -73,8 +74,40 @@
             this.toolStripStatusLabel1 = new System.Windows.Forms.ToolStripStatusLabel();
             this.kryptonProgressBarToolStripItem1 = new Krypton.Toolkit.KryptonProgressBarToolStripItem();
             this.toolStripProgressBar1 = new System.Windows.Forms.ToolStripProgressBar();
+            this.buttonSpecAny1 = new Krypton.Toolkit.ButtonSpecAny();
+            this.kryptonCommand1 = new Krypton.Toolkit.KryptonCommand();
+            this.buttonSpecAny2 = new Krypton.Toolkit.ButtonSpecAny();
+            this.kryptonCommand2 = new Krypton.Toolkit.KryptonCommand();
+            this.buttonSpecAny3 = new Krypton.Toolkit.ButtonSpecAny();
+            this.kryptonCommand3 = new Krypton.Toolkit.KryptonCommand();
+            this.buttonSpecAny4 = new Krypton.Toolkit.ButtonSpecAny();
+            this.kryptonCommand4 = new Krypton.Toolkit.KryptonCommand();
+            this.buttonSpecAny5 = new Krypton.Toolkit.ButtonSpecAny();
+            this.kryptonCommand5 = new Krypton.Toolkit.KryptonCommand();
+            this.buttonSpecAny6 = new Krypton.Toolkit.ButtonSpecAny();
+            this.kryptonCommand6 = new Krypton.Toolkit.KryptonCommand();
+            this.buttonSpecAny7 = new Krypton.Toolkit.ButtonSpecAny();
+            this.kryptonCommand7 = new Krypton.Toolkit.KryptonCommand();
+            this.buttonSpecAny8 = new Krypton.Toolkit.ButtonSpecAny();
+            this.kryptonCommand8 = new Krypton.Toolkit.KryptonCommand();
+            this.buttonSpecAny9 = new Krypton.Toolkit.ButtonSpecAny();
+            this.kryptonCommand9 = new Krypton.Toolkit.KryptonCommand();
+            this.buttonSpecAny10 = new Krypton.Toolkit.ButtonSpecAny();
+            this.kryptonCommand10 = new Krypton.Toolkit.KryptonCommand();
+            this.buttonSpecAny11 = new Krypton.Toolkit.ButtonSpecAny();
+            this.kryptonCommand11 = new Krypton.Toolkit.KryptonCommand();
+            this.buttonSpecAny12 = new Krypton.Toolkit.ButtonSpecAny();
+            this.kryptonCommand12 = new Krypton.Toolkit.KryptonCommand();
+            this.buttonSpecAny13 = new Krypton.Toolkit.ButtonSpecAny();
+            this.kryptonCommand13 = new Krypton.Toolkit.KryptonCommand();
+            this.buttonSpecAny14 = new Krypton.Toolkit.ButtonSpecAny();
+            this.kryptonCommand14 = new Krypton.Toolkit.KryptonCommand();
+            this.buttonSpecAny15 = new Krypton.Toolkit.ButtonSpecAny();
+            this.kryptonCommand15 = new Krypton.Toolkit.KryptonCommand();
+            this.kryptonRichTextBox1 = new Krypton.Toolkit.KryptonRichTextBox();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).BeginInit();
             this.kryptonPanel1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonThemeComboBox1)).BeginInit();
             this.menuStrip1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel2)).BeginInit();
             this.kryptonPanel2.SuspendLayout();
@@ -83,6 +116,8 @@
             // 
             // kryptonPanel1
             // 
+            this.kryptonPanel1.Controls.Add(this.kryptonRichTextBox1);
+            this.kryptonPanel1.Controls.Add(this.kryptonThemeComboBox1);
             this.kryptonPanel1.Controls.Add(this.ktrkProgressValues);
             this.kryptonPanel1.Controls.Add(this.kbtnKMBTest);
             this.kryptonPanel1.Controls.Add(this.kryptonLabel1);
@@ -91,8 +126,18 @@
             this.kryptonPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonPanel1.Location = new System.Drawing.Point(0, 0);
             this.kryptonPanel1.Name = "kryptonPanel1";
-            this.kryptonPanel1.Size = new System.Drawing.Size(800, 376);
+            this.kryptonPanel1.Size = new System.Drawing.Size(800, 372);
             this.kryptonPanel1.TabIndex = 0;
+            // 
+            // kryptonThemeComboBox1
+            // 
+            this.kryptonThemeComboBox1.DropDownWidth = 201;
+            this.kryptonThemeComboBox1.IntegralHeight = false;
+            this.kryptonThemeComboBox1.Location = new System.Drawing.Point(13, 135);
+            this.kryptonThemeComboBox1.Name = "kryptonThemeComboBox1";
+            this.kryptonThemeComboBox1.Size = new System.Drawing.Size(201, 21);
+            this.kryptonThemeComboBox1.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
+            this.kryptonThemeComboBox1.TabIndex = 12;
             // 
             // ktrkProgressValues
             // 
@@ -392,7 +437,7 @@
             this.kryptonPanel2.Controls.Add(this.kryptonLabel2);
             this.kryptonPanel2.Controls.Add(this.kryptonButton1);
             this.kryptonPanel2.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.kryptonPanel2.Location = new System.Drawing.Point(0, 376);
+            this.kryptonPanel2.Location = new System.Drawing.Point(0, 372);
             this.kryptonPanel2.Name = "kryptonPanel2";
             this.kryptonPanel2.PanelBackStyle = Krypton.Toolkit.PaletteBackStyle.PanelAlternate;
             this.kryptonPanel2.Size = new System.Drawing.Size(800, 50);
@@ -414,10 +459,10 @@
             this.toolStripStatusLabel1,
             this.kryptonProgressBarToolStripItem1,
             this.toolStripProgressBar1});
-            this.statusStrip1.Location = new System.Drawing.Point(0, 426);
+            this.statusStrip1.Location = new System.Drawing.Point(0, 422);
             this.statusStrip1.Name = "statusStrip1";
             this.statusStrip1.RenderMode = System.Windows.Forms.ToolStripRenderMode.ManagerRenderMode;
-            this.statusStrip1.Size = new System.Drawing.Size(800, 24);
+            this.statusStrip1.Size = new System.Drawing.Size(800, 28);
             this.statusStrip1.TabIndex = 2;
             this.statusStrip1.Text = "statusStrip1";
             // 
@@ -430,7 +475,7 @@
             // kryptonProgressBarToolStripItem1
             // 
             this.kryptonProgressBarToolStripItem1.Name = "kryptonProgressBarToolStripItem1";
-            this.kryptonProgressBarToolStripItem1.Size = new System.Drawing.Size(100, 22);
+            this.kryptonProgressBarToolStripItem1.Size = new System.Drawing.Size(100, 26);
             this.kryptonProgressBarToolStripItem1.StateCommon.Back.Color1 = System.Drawing.Color.Green;
             this.kryptonProgressBarToolStripItem1.StateDisabled.Back.ColorStyle = Krypton.Toolkit.PaletteColorStyle.OneNote;
             this.kryptonProgressBarToolStripItem1.StateNormal.Back.ColorStyle = Krypton.Toolkit.PaletteColorStyle.OneNote;
@@ -443,10 +488,211 @@
             this.toolStripProgressBar1.Name = "toolStripProgressBar1";
             this.toolStripProgressBar1.Size = new System.Drawing.Size(100, 22);
             // 
+            // buttonSpecAny1
+            // 
+            this.buttonSpecAny1.Enabled = Krypton.Toolkit.ButtonEnabled.True;
+            this.buttonSpecAny1.KryptonCommand = this.kryptonCommand1;
+            this.buttonSpecAny1.UniqueName = "f605d0a8865e404f8bfe158508b3a4de";
+            // 
+            // kryptonCommand1
+            // 
+            this.kryptonCommand1.AssignedButtonSpec = this.buttonSpecAny1;
+            this.kryptonCommand1.CommandType = Krypton.Toolkit.KryptonCommandType.IntegratedToolBarNewCommand;
+            this.kryptonCommand1.ImageSmall = ((System.Drawing.Image)(resources.GetObject("kryptonCommand1.ImageSmall")));
+            // 
+            // buttonSpecAny2
+            // 
+            this.buttonSpecAny2.Enabled = Krypton.Toolkit.ButtonEnabled.True;
+            this.buttonSpecAny2.KryptonCommand = this.kryptonCommand2;
+            this.buttonSpecAny2.UniqueName = "1ff2817dc9fc40da882c6b5f99e326fd";
+            // 
+            // kryptonCommand2
+            // 
+            this.kryptonCommand2.AssignedButtonSpec = this.buttonSpecAny2;
+            this.kryptonCommand2.CommandType = Krypton.Toolkit.KryptonCommandType.IntegratedToolBarOpenCommand;
+            this.kryptonCommand2.ImageSmall = ((System.Drawing.Image)(resources.GetObject("kryptonCommand2.ImageSmall")));
+            // 
+            // buttonSpecAny3
+            // 
+            this.buttonSpecAny3.Enabled = Krypton.Toolkit.ButtonEnabled.True;
+            this.buttonSpecAny3.KryptonCommand = this.kryptonCommand3;
+            this.buttonSpecAny3.UniqueName = "c2ee7f9823c9495393353da22e5e33b4";
+            // 
+            // kryptonCommand3
+            // 
+            this.kryptonCommand3.AssignedButtonSpec = this.buttonSpecAny3;
+            this.kryptonCommand3.CommandType = Krypton.Toolkit.KryptonCommandType.IntegratedToolBarSaveCommand;
+            this.kryptonCommand3.ImageSmall = ((System.Drawing.Image)(resources.GetObject("kryptonCommand3.ImageSmall")));
+            // 
+            // buttonSpecAny4
+            // 
+            this.buttonSpecAny4.Enabled = Krypton.Toolkit.ButtonEnabled.True;
+            this.buttonSpecAny4.KryptonCommand = this.kryptonCommand4;
+            this.buttonSpecAny4.UniqueName = "c524f280d6f04baaafd5e8e9495fd09d";
+            // 
+            // kryptonCommand4
+            // 
+            this.kryptonCommand4.AssignedButtonSpec = this.buttonSpecAny4;
+            this.kryptonCommand4.CommandType = Krypton.Toolkit.KryptonCommandType.IntegratedToolBarSaveAllCommand;
+            this.kryptonCommand4.ImageSmall = ((System.Drawing.Image)(resources.GetObject("kryptonCommand4.ImageSmall")));
+            // 
+            // buttonSpecAny5
+            // 
+            this.buttonSpecAny5.Enabled = Krypton.Toolkit.ButtonEnabled.True;
+            this.buttonSpecAny5.KryptonCommand = this.kryptonCommand5;
+            this.buttonSpecAny5.UniqueName = "8ef2facb6eda4780b0646c9101a41a55";
+            // 
+            // kryptonCommand5
+            // 
+            this.kryptonCommand5.AssignedButtonSpec = this.buttonSpecAny5;
+            this.kryptonCommand5.CommandType = Krypton.Toolkit.KryptonCommandType.IntegratedToolBarSaveAsCommand;
+            this.kryptonCommand5.ImageSmall = ((System.Drawing.Image)(resources.GetObject("kryptonCommand5.ImageSmall")));
+            // 
+            // buttonSpecAny6
+            // 
+            this.buttonSpecAny6.Enabled = Krypton.Toolkit.ButtonEnabled.True;
+            this.buttonSpecAny6.KryptonCommand = this.kryptonCommand6;
+            this.buttonSpecAny6.UniqueName = "21524c805767427193d30d8593526f93";
+            // 
+            // kryptonCommand6
+            // 
+            this.kryptonCommand6.AssignedButtonSpec = this.buttonSpecAny6;
+            this.kryptonCommand6.CommandType = Krypton.Toolkit.KryptonCommandType.IntegratedToolBarCutCommand;
+            this.kryptonCommand6.ImageSmall = ((System.Drawing.Image)(resources.GetObject("kryptonCommand6.ImageSmall")));
+            // 
+            // buttonSpecAny7
+            // 
+            this.buttonSpecAny7.Enabled = Krypton.Toolkit.ButtonEnabled.True;
+            this.buttonSpecAny7.KryptonCommand = this.kryptonCommand7;
+            this.buttonSpecAny7.UniqueName = "88f66da3c04f4b47a620df157cef2e70";
+            // 
+            // kryptonCommand7
+            // 
+            this.kryptonCommand7.AssignedButtonSpec = this.buttonSpecAny7;
+            this.kryptonCommand7.CommandType = Krypton.Toolkit.KryptonCommandType.IntegratedToolBarCopyCommand;
+            this.kryptonCommand7.ImageSmall = ((System.Drawing.Image)(resources.GetObject("kryptonCommand7.ImageSmall")));
+            // 
+            // buttonSpecAny8
+            // 
+            this.buttonSpecAny8.Enabled = Krypton.Toolkit.ButtonEnabled.True;
+            this.buttonSpecAny8.KryptonCommand = this.kryptonCommand8;
+            this.buttonSpecAny8.UniqueName = "0b34a05f7f864d05aba8e89529d152e0";
+            // 
+            // kryptonCommand8
+            // 
+            this.kryptonCommand8.AssignedButtonSpec = this.buttonSpecAny8;
+            this.kryptonCommand8.CommandType = Krypton.Toolkit.KryptonCommandType.IntegratedToolBarPasteCommand;
+            this.kryptonCommand8.ImageSmall = ((System.Drawing.Image)(resources.GetObject("kryptonCommand8.ImageSmall")));
+            // 
+            // buttonSpecAny9
+            // 
+            this.buttonSpecAny9.Enabled = Krypton.Toolkit.ButtonEnabled.True;
+            this.buttonSpecAny9.KryptonCommand = this.kryptonCommand9;
+            this.buttonSpecAny9.UniqueName = "9694cb140466450db01fa4319a373fe7";
+            // 
+            // kryptonCommand9
+            // 
+            this.kryptonCommand9.AssignedButtonSpec = this.buttonSpecAny9;
+            this.kryptonCommand9.CommandType = Krypton.Toolkit.KryptonCommandType.IntegratedToolBarUndoCommand;
+            this.kryptonCommand9.ImageSmall = ((System.Drawing.Image)(resources.GetObject("kryptonCommand9.ImageSmall")));
+            // 
+            // buttonSpecAny10
+            // 
+            this.buttonSpecAny10.Enabled = Krypton.Toolkit.ButtonEnabled.True;
+            this.buttonSpecAny10.KryptonCommand = this.kryptonCommand10;
+            this.buttonSpecAny10.UniqueName = "6642cbcd7389428dba083557733d1033";
+            // 
+            // kryptonCommand10
+            // 
+            this.kryptonCommand10.AssignedButtonSpec = this.buttonSpecAny10;
+            this.kryptonCommand10.CommandType = Krypton.Toolkit.KryptonCommandType.IntegratedToolBarRedoCommand;
+            this.kryptonCommand10.ImageSmall = ((System.Drawing.Image)(resources.GetObject("kryptonCommand10.ImageSmall")));
+            // 
+            // buttonSpecAny11
+            // 
+            this.buttonSpecAny11.Enabled = Krypton.Toolkit.ButtonEnabled.True;
+            this.buttonSpecAny11.KryptonCommand = this.kryptonCommand11;
+            this.buttonSpecAny11.UniqueName = "74db3c2b6178400c8ec6ed14a0a394c0";
+            // 
+            // kryptonCommand11
+            // 
+            this.kryptonCommand11.AssignedButtonSpec = this.buttonSpecAny11;
+            this.kryptonCommand11.CommandType = Krypton.Toolkit.KryptonCommandType.IntegratedToolBarPageSetupCommand;
+            this.kryptonCommand11.ImageSmall = ((System.Drawing.Image)(resources.GetObject("kryptonCommand11.ImageSmall")));
+            // 
+            // buttonSpecAny12
+            // 
+            this.buttonSpecAny12.Enabled = Krypton.Toolkit.ButtonEnabled.True;
+            this.buttonSpecAny12.KryptonCommand = this.kryptonCommand12;
+            this.buttonSpecAny12.UniqueName = "50ac1cab058249d4a3dd90ff75c757e0";
+            // 
+            // kryptonCommand12
+            // 
+            this.kryptonCommand12.AssignedButtonSpec = this.buttonSpecAny12;
+            this.kryptonCommand12.CommandType = Krypton.Toolkit.KryptonCommandType.IntegratedToolBarPrintPreviewCommand;
+            this.kryptonCommand12.ImageSmall = ((System.Drawing.Image)(resources.GetObject("kryptonCommand12.ImageSmall")));
+            // 
+            // buttonSpecAny13
+            // 
+            this.buttonSpecAny13.Enabled = Krypton.Toolkit.ButtonEnabled.True;
+            this.buttonSpecAny13.KryptonCommand = this.kryptonCommand13;
+            this.buttonSpecAny13.UniqueName = "546c7b4153cf4bf49e900f02acbddf57";
+            // 
+            // kryptonCommand13
+            // 
+            this.kryptonCommand13.AssignedButtonSpec = this.buttonSpecAny13;
+            this.kryptonCommand13.CommandType = Krypton.Toolkit.KryptonCommandType.IntegratedToolBarPrintCommand;
+            this.kryptonCommand13.ImageSmall = ((System.Drawing.Image)(resources.GetObject("kryptonCommand13.ImageSmall")));
+            // 
+            // buttonSpecAny14
+            // 
+            this.buttonSpecAny14.Enabled = Krypton.Toolkit.ButtonEnabled.True;
+            this.buttonSpecAny14.KryptonCommand = this.kryptonCommand14;
+            this.buttonSpecAny14.UniqueName = "7156d4510a29499cb0eb26ea230e36b9";
+            // 
+            // kryptonCommand14
+            // 
+            this.kryptonCommand14.AssignedButtonSpec = this.buttonSpecAny14;
+            this.kryptonCommand14.CommandType = Krypton.Toolkit.KryptonCommandType.IntegratedToolBarQuickPrintCommand;
+            this.kryptonCommand14.ImageSmall = ((System.Drawing.Image)(resources.GetObject("kryptonCommand14.ImageSmall")));
+            // 
+            // buttonSpecAny15
+            // 
+            this.buttonSpecAny15.Enabled = Krypton.Toolkit.ButtonEnabled.True;
+            this.buttonSpecAny15.KryptonCommand = this.kryptonCommand15;
+            this.buttonSpecAny15.UniqueName = "21201fe41a0d4bbb91c1fc22053d1724";
+            // 
+            // kryptonCommand15
+            // 
+            this.kryptonCommand15.AssignedButtonSpec = this.buttonSpecAny15;
+            // 
+            // kryptonRichTextBox1
+            // 
+            this.kryptonRichTextBox1.Location = new System.Drawing.Point(13, 162);
+            this.kryptonRichTextBox1.Name = "kryptonRichTextBox1";
+            this.kryptonRichTextBox1.Size = new System.Drawing.Size(388, 96);
+            this.kryptonRichTextBox1.TabIndex = 13;
+            this.kryptonRichTextBox1.Text = "kryptonRichTextBox1";
+            // 
             // Form5
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ButtonSpecs.Add(this.buttonSpecAny1);
+            this.ButtonSpecs.Add(this.buttonSpecAny2);
+            this.ButtonSpecs.Add(this.buttonSpecAny3);
+            this.ButtonSpecs.Add(this.buttonSpecAny4);
+            this.ButtonSpecs.Add(this.buttonSpecAny5);
+            this.ButtonSpecs.Add(this.buttonSpecAny6);
+            this.ButtonSpecs.Add(this.buttonSpecAny7);
+            this.ButtonSpecs.Add(this.buttonSpecAny8);
+            this.ButtonSpecs.Add(this.buttonSpecAny9);
+            this.ButtonSpecs.Add(this.buttonSpecAny10);
+            this.ButtonSpecs.Add(this.buttonSpecAny11);
+            this.ButtonSpecs.Add(this.buttonSpecAny12);
+            this.ButtonSpecs.Add(this.buttonSpecAny13);
+            this.ButtonSpecs.Add(this.buttonSpecAny14);
+            this.ButtonSpecs.Add(this.buttonSpecAny15);
             this.ClientSize = new System.Drawing.Size(800, 450);
             this.Controls.Add(this.kryptonPanel1);
             this.Controls.Add(this.kryptonPanel2);
@@ -456,6 +702,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).EndInit();
             this.kryptonPanel1.ResumeLayout(false);
             this.kryptonPanel1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonThemeComboBox1)).EndInit();
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel2)).EndInit();
@@ -513,5 +760,37 @@
         private Krypton.Toolkit.KryptonProgressBarToolStripItem kryptonProgressBarToolStripItem1;
         private Krypton.Toolkit.KryptonTrackBar ktrkProgressValues;
         private System.Windows.Forms.ToolStripProgressBar toolStripProgressBar1;
+        private Krypton.Toolkit.ButtonSpecAny buttonSpecAny1;
+        private Krypton.Toolkit.ButtonSpecAny buttonSpecAny2;
+        private Krypton.Toolkit.ButtonSpecAny buttonSpecAny3;
+        private Krypton.Toolkit.ButtonSpecAny buttonSpecAny4;
+        private Krypton.Toolkit.ButtonSpecAny buttonSpecAny5;
+        private Krypton.Toolkit.ButtonSpecAny buttonSpecAny6;
+        private Krypton.Toolkit.ButtonSpecAny buttonSpecAny7;
+        private Krypton.Toolkit.ButtonSpecAny buttonSpecAny8;
+        private Krypton.Toolkit.ButtonSpecAny buttonSpecAny9;
+        private Krypton.Toolkit.ButtonSpecAny buttonSpecAny10;
+        private Krypton.Toolkit.ButtonSpecAny buttonSpecAny11;
+        private Krypton.Toolkit.ButtonSpecAny buttonSpecAny12;
+        private Krypton.Toolkit.ButtonSpecAny buttonSpecAny13;
+        private Krypton.Toolkit.ButtonSpecAny buttonSpecAny14;
+        private Krypton.Toolkit.ButtonSpecAny buttonSpecAny15;
+        private Krypton.Toolkit.KryptonCommand kryptonCommand1;
+        private Krypton.Toolkit.KryptonCommand kryptonCommand2;
+        private Krypton.Toolkit.KryptonCommand kryptonCommand3;
+        private Krypton.Toolkit.KryptonCommand kryptonCommand4;
+        private Krypton.Toolkit.KryptonCommand kryptonCommand5;
+        private Krypton.Toolkit.KryptonCommand kryptonCommand6;
+        private Krypton.Toolkit.KryptonCommand kryptonCommand7;
+        private Krypton.Toolkit.KryptonCommand kryptonCommand8;
+        private Krypton.Toolkit.KryptonCommand kryptonCommand9;
+        private Krypton.Toolkit.KryptonCommand kryptonCommand10;
+        private Krypton.Toolkit.KryptonCommand kryptonCommand11;
+        private Krypton.Toolkit.KryptonCommand kryptonCommand12;
+        private Krypton.Toolkit.KryptonCommand kryptonCommand13;
+        private Krypton.Toolkit.KryptonCommand kryptonCommand14;
+        private Krypton.Toolkit.KryptonCommand kryptonCommand15;
+        private Krypton.Toolkit.KryptonThemeComboBox kryptonThemeComboBox1;
+        private Krypton.Toolkit.KryptonRichTextBox kryptonRichTextBox1;
     }
 }

--- a/Source/Krypton Components/TestForm/Form5.resx
+++ b/Source/Krypton Components/TestForm/Form5.resx
@@ -244,4 +244,179 @@
   <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>280, 17</value>
   </metadata>
+  <metadata name="kryptonCommand1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>395, 17</value>
+  </metadata>
+  <data name="kryptonCommand1.ImageSmall" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wAAADsABataJCQAAAE1JREFUOE/tzMEJACAIhWFndgLnEp3NeOChoLRDx37wpH70LGaOatw98nQfjk5h
+        JyJhZmekAxAQVd0jHTBPvqxVwNwHPoBK4Hby5UVEA+6HCGkonwOPAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <metadata name="kryptonCommand2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>553, 17</value>
+  </metadata>
+  <data name="kryptonCommand2.ImageSmall" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wAAADsABataJCQAAAL5JREFUOE9jGBrg1cmp/18daoLj15dW/YdKEQavz879//HW1v/IAGQIVJqB4cWN
+        /f9fHW5FsQEZf7i64v//f/+gWiEAJA7VDnQekPPj9TWoFHEAwwBSAU4Dvj8/i9c76Pjl2QX/4Qb8/fmZ
+        JM1gfLQLYcDXhwexK8KDX55dBDXg35//b070YVWEDz+/vhdiwI+Xl7EqIISfP7gKMeD9hXlYFeDDL4/2
+        QGICmyQx+MX5pZQZ8PzGAURaIB8wMAAACMNXsIST1ZEAAAAASUVORK5CYII=
+</value>
+  </data>
+  <metadata name="kryptonCommand3.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>711, 17</value>
+  </metadata>
+  <data name="kryptonCommand3.ImageSmall" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wAAADsABataJCQAAAE9JREFUOE9joArojFz9nxwM1Y4wgFgwagAeA05tuQlVghuA1OA0gFQM1U5lAwgB
+        ZLVQ7TQyAJ0PA8hqodqpYMCOBSdRJIjBID1Q7ZQABgYAthJxq+ZC3aYAAAAASUVORK5CYII=
+</value>
+  </data>
+  <metadata name="kryptonCommand4.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>869, 17</value>
+  </metadata>
+  <data name="kryptonCommand4.ImageSmall" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wAAADsABataJCQAAAHhJREFUOE9j6Ixc/Z8UzIAOsAqSAmAGINtCDAZrBgEYB0WQFIBuAIgmBeM0gBCA
+        qRvOBpzafgOqFBNcOXr/f1f0GvwGEIspNwAGYBxkSVwAWQ1YMwjAOMiSyIqRAbIasGZkgCyJrBgZIKuB
+        akOA1b0HURTgx6v/AwD43jDuwHbn4AAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <metadata name="kryptonCommand5.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 54</value>
+  </metadata>
+  <data name="kryptonCommand5.ImageSmall" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wAAADsABataJCQAAAS9JREFUOE/VkLtLw1AchfP3iaOLi4OLi7MiolWwovhARHAQn1iqVISKotYKrdbW
+        ivigDkq01dvbZEsgJGuO+V1voyG2FnHxwIHccL7vwlX+JJOdCfymEv8UtJp/LnAcB483ZVGJty6wbRtv
+        jKN3IY32yB5iqbsPSV2QjZfkNBzLslDlNTy9MPTMnaBtKImOsYOgoFHPdu4FPLCcxfDauS+JeN8/Cgr7
+        D+AeTGO6lUoStcLCb0D9GtM0oWkaxmMXPkyNeuey2kTgui4MwxDwbOIyAE/E82AVjpX+VGNBHaYuJq99
+        eHq7APbKsT6YFluJhwUEFkvP6J45Fo9HkvndK+i6js2RU38rcUU5XC36P6kkGN3IiVu7po6EhFdr2Ipm
+        AjuJfx+C+5YyyN2qTYaK8g7vkoRkuDBwzQAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <metadata name="kryptonCommand6.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>175, 54</value>
+  </metadata>
+  <data name="kryptonCommand6.ImageSmall" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wAAADsABataJCQAAAStJREFUOE+tkE1LhGAUhf2Xfaz6B5FZiLkRhqmFQqRTiwEN1xEuahaW0UbQRFoI
+        BRZCv+TGud3ehpy0oAMXznuec18/tH9VXdeUJAnJsScwdOTYV5qmZBgGFUXRK5VlyQwdifqqqop0XSfb
+        tqltW1WERwaGjsSr5XkeF13XVUV4ZGAS/aymacg0TV6I45gHHhmY1IaVZRkvLQ8ywb9TFEVqOQzDvy13
+        XUeO46gL4JEJHlcQBLxoWZb6+77vD18wSyraPFrQ+vSKtg5OadfYozzPeeCRgaGDrqx9yL98oJ2zO8of
+        W57t2S1Nzm9UaRKlnH1ydLEjWNPWptf0/PqmAnhkchzlXHh6+SrAf79giPMn7M/v+SkY+JOlVxzjrOOL
+        kjYOFzzwEiut5pr2Dl4gR+e0C5jNAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <metadata name="kryptonCommand7.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>333, 54</value>
+  </metadata>
+  <data name="kryptonCommand7.ImageSmall" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wAAADsABataJCQAAAH5JREFUOE+9j8ENwCAMA5mv4/CmQ3UQvlmHyhWRIDiAqqon+eNGVxM+IcZYWHLO
+        pZ7MwbEFXUppT8IEoH5eo4LjvJ4o6FmGVSgZrEc3PE0PdYGu8AQi0kvYIbBigK5NJ9hZ0DIILExsf7Al
+        8OgENq14ucBDBR7/CFapp28J4Qav4wj4Xtqk0wAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <metadata name="kryptonCommand8.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>491, 54</value>
+  </metadata>
+  <data name="kryptonCommand8.ImageSmall" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wAAADsABataJCQAAAJpJREFUOE/NkNENgCAMRJ2ZCYgTMABhEAI/frOILlFzSpVgUYk/XnJR2rsncWjJ
+        GENKKXLOUR71CQA8rbXPgDlZWqZxC/KXazMQOeTxfghDBkhldp09xMPLolIzVy7eOld3SQE4r58llWHs
+        pH8RY3x/AxRK4ay1phDCCZHKMHYSAALEe79DpDLcApTuBpT6EWBO7hvgTgi1rWgFZkIMgpHdNjEAAAAA
+        SUVORK5CYII=
+</value>
+  </data>
+  <metadata name="kryptonCommand9.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>649, 54</value>
+  </metadata>
+  <data name="kryptonCommand9.ImageSmall" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wAAADsABataJCQAAAPtJREFUOE9jGFxg76kb//0bN//3qt34P7xt6/8LN+7/h0oRBkfP3/of1LQFrNm3
+        ftP/g2dvEa/51OU7/0NbtoI1g/D6g5eJ1wxyJsi5MM3YMMjwzEl7/vetPoHprXPX7hE0ABmDvDd361lU
+        Q0D+hwUeCK89gOkFUADXLzgMV7Pj+DVUNSAFINNBkj5AeuvRq1jDoXvlcbCa/Gl7MeVBgQfSDFIAMmwP
+        0FCoFBzcvv8ILA9yMVSINAAzIAQYsFAh0gDMC5VzD5JmwP4zN+GBCPLeSWDagUoRBiBNMBzZvu3/rhPX
+        SbMdlJAKp+/7P3vzmf/3Hj4mz+/YAQMDAG2s9OeMOx+7AAAAAElFTkSuQmCC
+</value>
+  </data>
+  <metadata name="kryptonCommand10.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>807, 54</value>
+  </metadata>
+  <data name="kryptonCommand10.ImageSmall" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wAAADsABataJCQAAAPxJREFUOE/Nk7kKAkEQRPf7RDHWf1Ex0sBABCMRxEQEEQ80FfFiPRA08QI/ZfTN
+        TnvsjEYGFgzb3VVT23Tvev+J5f6i0rWJMqkXSXVV+FQHmwf/hkp/rWKZnhaZktOAY+gnCs2FJqJ3g2LL
+        /2iAzlBPjDenx+XR+vgmkIvU4YnRGzpAtj7VRLmzstzFgBieGL0mBcn8UBO7w9UymG2D7ojhidFrUhAe
+        3DegQ2/SAN86eMXHDmQGrNGUnIBHZ81AthDP9tV0e3aaMAt4dNYWQL4x1ySrKrWXyr9/kdR5kssK0ekL
+        LrAmEYYPddeaLfBG/oVELhgsT3Lp6IfwvBvJGxnXlhkjRgAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <metadata name="kryptonCommand11.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>979, 54</value>
+  </metadata>
+  <data name="kryptonCommand11.ImageSmall" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wAAADsABataJCQAAALxJREFUOE+NjzEOhCAQRTmzHQXcgVDQ0cgd7GlVek/D5rMOC6yAL5mgM39egC3L
+        Ekd1HEdkIxDqgZmUciyZCa7rikKIvmQmACTZ9/1fMhO0da/9QLPHHRlDgvM8o7U2hhDSP6B5W2mRQAOs
+        65oEOMG2bVlQ0hXQDbz3VeC1gEBPa52DONuivlIqVjdwzlVL+O6RMySgt5fDNzW8wagolwUEBsaYKlxS
+        9pF7FJQ8Ce7RF7K1xTnvPictJhj7AF/pIOqLp03fAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <metadata name="kryptonCommand12.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 91</value>
+  </metadata>
+  <data name="kryptonCommand12.ImageSmall" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wAAADsABataJCQAAAUNJREFUOE+NkrHrgkAUx39/s0igOEjZYBE4OodNKiFODbY1tEcgjlLppG4Owovv
+        486StH5fOM733vc+5929PylFUejbOJ1OJKzjgmlKqGma9h3yC3C9Xr9DfgGgy+VCuq6PQ94BXddRXddU
+        liXd73eeEcMjh1j2kgS0bUu3243iOKbVakWqqvKMGHnUJwHYGTs6jsOm7XZLh8OBZ8TIoz4JaJqG9vs9
+        74pLEyUWYuRRF6mhAMBZ5/M57yjSA3mex3URDgXA4/Gg2WxGx+Nx1IQ86iIc6v0PdrvdqAn5xWIxDcBT
+        +b7PZ03TdGCUd2BZFmVZ9gkBAK+Q5zltNpv+FZIk6V9BDtM0Py6ZAe99EEUR2bbNC5bLJYVhSOv1uoeg
+        I8/n8wsiAZDsxKIo+k6sqorNruv2EMMwhoD/DHiDIODvJEnoCQbH9r3fctFUAAAAAElFTkSuQmCC
+</value>
+  </data>
+  <metadata name="kryptonCommand13.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>181, 91</value>
+  </metadata>
+  <data name="kryptonCommand13.ImageSmall" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wAAADsABataJCQAAAHBJREFUOE/dkcEKwCAMQ/vNIj35RR486fd1dDQyGLUbeBh7EDwkTaHSdlJKspLF
+        fDTk8dGCWqvknKep70rI6ExrTQjDMJ+APDNLuDHSHwquR4Q84OOQ5xF771JKeVWg0pkxxv3nogKL+Wwp
+        WMliBtEBAprXlPZiTgwAAAAASUVORK5CYII=
+</value>
+  </data>
+  <metadata name="kryptonCommand14.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>345, 91</value>
+  </metadata>
+  <data name="kryptonCommand14.ImageSmall" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
+        wAAADsABataJCQAAAUtJREFUOE+tUE1Lw1AQzM8V6kFjKKRESDyI3mxFET8KhdaGoJZio0FBsPgB3ooX
+        SVBBhRhQIeJ9zG7z0iZtjYIDw763szPZPOk3aF6eYr5VxVR9hSvdY2kUsiyDqOs6DxntGhuzXIj6bMhC
+        VVUQwjBE4+JkxLh0bOLxzecz6bFtABEQBAHU/a2Uec7awPvXJ2pX/WDSY9sAIsD3fRR2V7HZtXH78oDp
+        6Nx7vse520sCC40KJMuyoCgK/zcFiDdwXRelg+3IWMGd/4TX8INXpyARwBsIswgYxt71GQ/OmGscUmrt
+        JGYi6ckXszQMgwOXj5opkyD1+SvjzILlcpmH2jddLB7WMWuuc6U79VkfZxwmbeI4DjzPYxNVulOf9NyA
+        PKYeUXAShE6bUC0Wi5A6nQ40TftTAJE8tm33H3IYeQHx2GT8S8BPjMdiSNI3Q8UfWjSJy+QAAAAASUVO
+        RK5CYII=
+</value>
+  </data>
+  <metadata name="kryptonCommand15.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>509, 91</value>
+  </metadata>
 </root>


### PR DESCRIPTION
* Replaced `LinkAreaStart` & `LinkAreaEnd` with just `ContentLinkArea`

![image](https://github.com/Krypton-Suite/Standard-Toolkit/assets/949607/ecaa0bb4-e8e5-4cbf-85c8-cfcc29e28a99)
