### PR TITLE
* #1117 + Tidy up

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -5,7 +5,8 @@
 ## 2024-11-xx - Build 2411 - November 2024
 * New `KryptonLanguageManager` is now integrated into `KryptonManager` as `ToolkitStrings`
 * Implemented [#1091](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1091), Krypton File Dialogs Missing Buttons
-    - Use `KryptonAboutToolkit.Show(<arguments>);` to invoke
+* Implemented [#1009](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1009), Powered by Krypton Toolkit button
+    - Use `KryptonAboutToolkit.Show();` to invoke
 * Removed support for .NET 7, in accordance with its official release cadence
 * Support for .NET 9
 * Version bump `80.xx.xx.xx` -> `90.xx.xx.xx`
@@ -13,6 +14,7 @@
 =======
 
 ## 2023-11-14 - Build 2311 - November 2023
+* Implemented [#1117](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1117),  Is it possible to have the KForm back colour as the KPanel colour
 * Resolved [#1153](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1153), Whilst investigating #1152 found that "Start drag" in certain application causes an exception.
 * Resolved [#1152](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1152), Unable to resize control dragged from Navigator via KryptonDockingManager.FloatingWindowAdding event.
 * Resolved [#1146](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1146), Krypton.Navigator throws exception in Initialise when attempting to EndInit().

--- a/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavFormClose.cs
+++ b/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavFormClose.cs
@@ -15,7 +15,7 @@ namespace Krypton.Navigator
 
         private bool _enabled = true;
 
-        private KryptonNavigator _navigator;
+        private readonly KryptonNavigator _navigator;
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavFormMaximize.cs
+++ b/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavFormMaximize.cs
@@ -13,7 +13,7 @@ namespace Krypton.Navigator
     {
         #region Instance Fields
 
-        private KryptonNavigator _navigator;
+        private readonly KryptonNavigator _navigator;
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecCollection.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecCollection.cs
@@ -210,7 +210,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="index">Object index.</param>
         /// <returns>Object at specified index.</returns>
-        object IList.this[int index]
+        object? IList.this[int index]
         {
             get => _specs[index];
 
@@ -300,7 +300,7 @@ namespace Krypton.Toolkit
         /// <returns>T at specified index.</returns>
         public T? this[string uniqueName]
         {
-            get 
+            get
             {
                 // First priority is the UniqueName
                 foreach (T bs in this.Where(bs => bs.UniqueName == uniqueName))

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecManagerBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecManagerBase.cs
@@ -446,11 +446,10 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="align">Edge of buttons caller is interested in searching.</param>
         /// <returns>ViewDrawButton reference; otherwise false.</returns>
-        public virtual ViewDrawButton? GetFirstVisibleViewButton(PaletteRelativeEdgeAlign align) => (from specView in _specLookup.Values
-                                                                                                     where specView.ViewCenter.Visible && specView.ViewButton.Enabled
-                                                                                                     where specView.ButtonSpec.Edge == align
-                                                                                                     select specView.ViewButton
-                    )
+        public virtual ViewDrawButton? GetFirstVisibleViewButton(PaletteRelativeEdgeAlign align) => (_specLookup.Values
+                .Where(specView => specView.ViewButton != null && specView.ViewCenter.Visible && specView.ViewButton.Enabled)
+                .Where(specView => specView.ButtonSpec.Edge == align)
+                .Select(specView => specView.ViewButton))
                 .FirstOrDefault();
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecRemapByContentBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecRemapByContentBase.cs
@@ -32,7 +32,7 @@ namespace Krypton.Toolkit
             : base(target)
         {
             Debug.Assert(buttonSpec != null);
-            _buttonSpec = buttonSpec;
+            _buttonSpec = buttonSpec!;
         }
         #endregion
 
@@ -80,7 +80,7 @@ namespace Krypton.Toolkit
             Color mapColor = OverrideImageColor(state);
 
             // If mapping occurring then return the target remap color
-            if ((mapColor != Color.Empty)  && (PaletteContent != null))
+            if ((mapColor != Color.Empty) && (PaletteContent != null))
             {
                 PaletteState getState = PaletteState;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckSet.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckSet.cs
@@ -43,7 +43,7 @@ namespace Krypton.Toolkit
             public KryptonCheckButtonCollection([DisallowNull] KryptonCheckSet owner)
             {
                 Debug.Assert(owner != null);
-                _owner = owner;
+                _owner = owner!;
             }
             #endregion
 
@@ -426,7 +426,7 @@ namespace Krypton.Toolkit
             }
 
             // If the incoming button is already checked
-                if (checkButton.Checked)
+            if (checkButton.Checked)
             {
                 // If we already have a button checked
                 if (_checkedButton != null)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckedListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckedListBox.cs
@@ -119,7 +119,7 @@ namespace Krypton.Toolkit
             /// </summary>
             /// <param name="index">Item index.</param>
             /// <returns>Item at specified index.</returns>
-            public object this[int index]
+            public object? this[int index]
             {
                 get
                 {
@@ -132,13 +132,13 @@ namespace Krypton.Toolkit
             #endregion
 
             #region Private
-            int IList.Add(object value) => throw new NotSupportedException(@"Read Only Collection");
+            int IList.Add(object? value) => throw new NotSupportedException(@"Read Only Collection");
 
             void IList.Clear() => throw new NotSupportedException(@"Read Only Collection");
 
-            void IList.Insert(int index, object value) => throw new NotSupportedException(@"Read Only Collection");
+            void IList.Insert(int index, object? value) => throw new NotSupportedException(@"Read Only Collection");
 
-            void IList.Remove(object value) => throw new NotSupportedException(@"Read Only Collection");
+            void IList.Remove(object? value) => throw new NotSupportedException(@"Read Only Collection");
 
             void IList.RemoveAt(int index) => throw new NotSupportedException(@"Read Only Collection");
 
@@ -291,9 +291,9 @@ namespace Krypton.Toolkit
 
             void IList.Clear() => throw new NotSupportedException(@"Read Only Collection");
 
-            void IList.Insert(int index, object value) => throw new NotSupportedException(@"Read Only Collection");
+            void IList.Insert(int index, object? value) => throw new NotSupportedException(@"Read Only Collection");
 
-            void IList.Remove(object value) => throw new NotSupportedException(@"Read Only Collection");
+            void IList.Remove(object? value) => throw new NotSupportedException(@"Read Only Collection");
 
             void IList.RemoveAt(int index) => throw new NotSupportedException(@"Read Only Collection");
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonColorDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonColorDialog.cs
@@ -6,13 +6,17 @@
  */
 #endregion
 
+// Note: Only used for this class
+using Timer = System.Windows.Forms.Timer;
+
 namespace Krypton.Toolkit
 {
     /// <summary>
     /// Represents a common dialog box that displays colours
     /// that are currently installed on the system.
     /// </summary>
-    [ToolboxBitmap(typeof(ColorDialog), "ToolboxBitmaps.KryptonColorDialog.png"),
+    [ToolboxItem(true),
+     ToolboxBitmap(typeof(ColorDialog), "ToolboxBitmaps.KryptonColorDialog.png"),
      Description("Displays a Kryptonised version of the standard Colour dialog, which displays colours that are currently installed on the system.")]
     public class KryptonColorDialog : ColorDialog
     {
@@ -25,7 +29,7 @@ namespace Krypton.Toolkit
         private CommonDialogHandler.Attributes _redEdit;
         private CommonDialogHandler.Attributes _greenEdit;
         private CommonDialogHandler.Attributes _blueEdit;
-        private System.Windows.Forms.Timer _alphaUpdateTimer;
+        private readonly Timer _alphaUpdateTimer;
         #endregion
 
         /// <summary>
@@ -126,8 +130,8 @@ namespace Krypton.Toolkit
         public bool ShowAlphaSlider
         {
             get => _showAlphaSlider;
-            set 
-            { 
+            set
+            {
                 _showAlphaSlider = value;
                 if (value)
                 {
@@ -164,7 +168,7 @@ namespace Krypton.Toolkit
         private void Timer1OnTick(object sender, EventArgs e)
         {
             var text = new StringBuilder(6);
-            if ( PI.GetWindowText(_redEdit.hWnd, text, 4) <= 0)
+            if (PI.GetWindowText(_redEdit.hWnd, text, 4) <= 0)
             {
                 // Probably Closing, or in transition
                 return;
@@ -210,7 +214,7 @@ namespace Krypton.Toolkit
         protected override IntPtr HookProc(IntPtr hWnd, int msg, IntPtr wparam, IntPtr lparam)
         {
             var (handled, retValue) = _commonDialogHandler.HookProc(hWnd, msg, wparam, lparam);
-            if (msg == PI.WM_.INITDIALOG )
+            if (msg == PI.WM_.INITDIALOG)
             {
                 if (!FullOpen)
                 {
@@ -254,7 +258,7 @@ namespace Krypton.Toolkit
                             var lpPoint = new PI.POINT(rcClient.left, rcClient.top);
                             PI.ScreenToClient(hWnd, ref lpPoint);
                             _alphaPanel.Location = new Point(lpPoint.X, lpPoint.Y);
-                            _alphaPanel.Size = new Size((rcClient.right - rcClient.left)/2, rcClient.bottom - rcClient.top);
+                            _alphaPanel.Size = new Size((rcClient.right - rcClient.left) / 2, rcClient.bottom - rcClient.top);
                         }
 
                         _commonDialogHandler._wrapperForm.Controls[0].Controls.Add(_alphaPanel);
@@ -263,15 +267,15 @@ namespace Krypton.Toolkit
                         _greenEdit = _commonDialogHandler.Controls.First(ctl => ctl.DlgCtrlId == 0x000002C3);
                         _blueEdit = _commonDialogHandler.Controls.First(ctl => ctl.DlgCtrlId == 0x000002C4);
                         // Add a slider
-                        _alphaSlider.Location = _redEdit.ClientLocation with { X = _redEdit.ClientLocation.X + _redEdit.Size.Width+4 };
+                        _alphaSlider.Location = _redEdit.ClientLocation with { X = _redEdit.ClientLocation.X + _redEdit.Size.Width + 4 };
                         //_commonDialogHandler._wrapperForm.ClientSize
-                        _alphaSlider.Size = new Size(_commonDialogHandler._wrapperForm.ClientSize.Width- _alphaSlider.Location.X+4, _blueEdit.ClientLocation.Y - _redEdit.ClientLocation.Y + _blueEdit.Size.Height);
+                        _alphaSlider.Size = new Size(_commonDialogHandler._wrapperForm.ClientSize.Width - _alphaSlider.Location.X + 4, _blueEdit.ClientLocation.Y - _redEdit.ClientLocation.Y + _blueEdit.Size.Height);
                         _commonDialogHandler._wrapperForm.Controls[0].Controls.Add(_alphaSlider);
                         // Find the Add button 
                         var btnAdd = _commonDialogHandler.Controls.First(static ctl => ctl.DlgCtrlId == 0x00002C8);
                         btnAdd.Button.Parent.Width -= 16;
 
-                        _alphaLabel.Location = Point.Add(_blueEdit.ClientLocation, new Size(_blueEdit.Size.Width+2, _blueEdit.Size.Height) );
+                        _alphaLabel.Location = Point.Add(_blueEdit.ClientLocation, new Size(_blueEdit.Size.Width + 2, _blueEdit.Size.Height));
                         _commonDialogHandler._wrapperForm.Controls[0].Controls.Add(_alphaLabel);
                         _alphaUpdateTimer.Enabled = true;
                     }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -1373,10 +1373,9 @@ namespace Krypton.Toolkit
         }
 
         /// <summary>
-        /// Gets and sets the text associated associated with the control.
+        /// Gets and sets the text associated with the control.
         /// </summary>
-        [AllowNull]
-        public override string Text
+        public override string? Text
         {
             get => _comboBox.Text;
             set => _comboBox.Text = value;
@@ -1388,7 +1387,7 @@ namespace Krypton.Toolkit
         [Bindable(true)]
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public object SelectedItem
+        public object? SelectedItem
         {
             get => _comboBox.SelectedItem;
             set => _comboBox.SelectedItem = value;
@@ -1399,7 +1398,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public string SelectedText
+        public string? SelectedText
         {
             get => _comboBox.SelectedText;
             set => _comboBox.SelectedText = value;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
@@ -3576,10 +3576,10 @@ namespace Krypton.Toolkit
                                 // Grab the property object
                                 var childObj = prop.GetValue(obj, null);
 
-                                // Should be test if the object contains only default values?
+                                // Test if the object contains only default values?
                                 if (ignoreDefaults)
                                 {
-                                    PropertyDescriptor propertyIsDefault = TypeDescriptor.GetProperties(childObj)[nameof(IsDefault)];
+                                    PropertyDescriptor? propertyIsDefault = TypeDescriptor.GetProperties(childObj)[nameof(IsDefault)];
 
                                     // All compound objects are expected to have an 'IsDefault' returning a boolean
                                     if (propertyIsDefault != null && propertyIsDefault.PropertyType == typeof(bool))
@@ -3757,7 +3757,7 @@ namespace Krypton.Toolkit
                                     // Grab the property object
                                     var childObj = prop.GetValue(obj, null);
 
-                                    PropertyDescriptor propertyIsDefault = TypeDescriptor.GetProperties(childObj)[nameof(IsDefault)];
+                                    PropertyDescriptor? propertyIsDefault = TypeDescriptor.GetProperties(childObj)[nameof(IsDefault)];
 
                                     // All compound objects are expected to have an 'IsDefault' returning a boolean
                                     if (propertyIsDefault != null && propertyIsDefault.PropertyType == typeof(bool))

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -1209,50 +1209,67 @@ namespace Krypton.Toolkit
                         {
                             // If this is a column header cell
                             case { RowIndex: -1, ColumnIndex: >= 0 }:
-                            {
-                                // If this column needs a sort glyph drawn
-                                if (Columns[e.ColumnIndex].HeaderCell.SortGlyphDirection != SortOrder.None)
                                 {
-                                    // Draw the sort glyph and update the remainder cell bounds left over
-                                    tempCellBounds = Renderer.RenderGlyph.DrawGridSortGlyph(renderContext, Columns[e.ColumnIndex].HeaderCell.SortGlyphDirection, tempCellBounds, paletteContent, state, rtl);
-                                }
-
-                                // If this column supports icons, see if it has any.
-                                if (Columns[e.ColumnIndex] is IIconCell iconColumn)
-                                {
-                                    foreach (IconSpec spec in iconColumn.IconSpecs)
+                                    // If this column needs a sort glyph drawn
+                                    if (Columns[e.ColumnIndex].HeaderCell.SortGlyphDirection != SortOrder.None)
                                     {
-                                        if (spec.Icon == null)
-                                        {
-                                            continue;
-                                        }
-                                        // Draw icon and update the remainder cell bounds left over
-                                        var iconWidth = spec.Icon.Width + 5;
-                                        var width = tempCellBounds.Width - iconWidth;
-                                        var iconBounds = new Rectangle(
-                                            tempCellBounds.X + (spec.Alignment == IconSpec.IconAlignment.Left
-                                                ? 5
-                                                : width), tempCellBounds.Y + 3, spec.Icon.Width, spec.Icon.Height);
-                                        renderContext.Graphics.DrawImage(spec.Icon, iconBounds);
-                                        tempCellBounds = tempCellBounds with { X = tempCellBounds.X +
-                                            (spec.Alignment == IconSpec.IconAlignment.Left ? iconWidth : 0), Width = width };
+                                        // Draw the sort glyph and update the remainder cell bounds left over
+                                        tempCellBounds = Renderer.RenderGlyph.DrawGridSortGlyph(renderContext, Columns[e.ColumnIndex].HeaderCell.SortGlyphDirection, tempCellBounds, paletteContent, state, rtl);
                                     }
-                                }
 
-                                break;
-                            }
+                                    // If this column supports icons, see if it has any.
+                                    if (Columns[e.ColumnIndex] is IIconCell iconColumn)
+                                    {
+                                        foreach (IconSpec spec in iconColumn.IconSpecs)
+                                        {
+                                            if (spec.Icon == null)
+                                            {
+                                                continue;
+                                            }
+                                            // Draw icon and update the remainder cell bounds left over
+                                            var iconWidth = spec.Icon.Width + 5;
+                                            var width = tempCellBounds.Width - iconWidth;
+                                            var iconBounds = new Rectangle(
+                                                tempCellBounds.X + (spec.Alignment == IconSpec.IconAlignment.Left
+                                                    ? 5
+                                                    : width), tempCellBounds.Y + 3, spec.Icon.Width, spec.Icon.Height);
+                                            renderContext.Graphics.DrawImage(spec.Icon, iconBounds);
+                                            tempCellBounds = tempCellBounds with
+                                            {
+                                                X = tempCellBounds.X +
+                                                (spec.Alignment == IconSpec.IconAlignment.Left ? iconWidth : 0),
+                                                Width = width
+                                            };
+                                        }
+                                    }
+
+                                    break;
+                                }
                             // If this is a row header cell
                             case { RowIndex: >= 0, ColumnIndex: -1 }:
-                            {
-                                // By default there is no glyph needed for the row
-                                var glyph = GridRowGlyph.None;
-
-                                // Find the correct glyph that should be drawn
-                                if (CurrentCellAddress.Y == e.RowIndex)
                                 {
-                                    if (VirtualMode)
+                                    // By default there is no glyph needed for the row
+                                    var glyph = GridRowGlyph.None;
+
+                                    // Find the correct glyph that should be drawn
+                                    if (CurrentCellAddress.Y == e.RowIndex)
                                     {
-                                        if (IsCurrentRowDirty && ShowEditingIcon)
+                                        if (VirtualMode)
+                                        {
+                                            if (IsCurrentRowDirty && ShowEditingIcon)
+                                            {
+                                                glyph = GridRowGlyph.Pencil;
+                                            }
+                                            else if (NewRowIndex == e.RowIndex)
+                                            {
+                                                glyph = GridRowGlyph.ArrowStar;
+                                            }
+                                            else
+                                            {
+                                                glyph = GridRowGlyph.Arrow;
+                                            }
+                                        }
+                                        else if (IsCurrentCellDirty && ShowEditingIcon)
                                         {
                                             glyph = GridRowGlyph.Pencil;
                                         }
@@ -1265,98 +1282,89 @@ namespace Krypton.Toolkit
                                             glyph = GridRowGlyph.Arrow;
                                         }
                                     }
-                                    else if (IsCurrentCellDirty && ShowEditingIcon)
-                                    {
-                                        glyph = GridRowGlyph.Pencil;
-                                    }
                                     else if (NewRowIndex == e.RowIndex)
                                     {
-                                        glyph = GridRowGlyph.ArrowStar;
+                                        glyph = GridRowGlyph.Star;
                                     }
-                                    else
+
+                                    // Do we need to draw an image?
+                                    if (glyph != GridRowGlyph.None)
                                     {
-                                        glyph = GridRowGlyph.Arrow;
+                                        // Draw the row glyph and update the remainder cell bounds left over
+                                        tempCellBounds = Renderer.RenderGlyph.DrawGridRowGlyph(renderContext, glyph, tempCellBounds, paletteContent, state, rtl);
                                     }
-                                }
-                                else if (NewRowIndex == e.RowIndex)
-                                {
-                                    glyph = GridRowGlyph.Star;
-                                }
 
-                                // Do we need to draw an image?
-                                if (glyph != GridRowGlyph.None)
-                                {
-                                    // Draw the row glyph and update the remainder cell bounds left over
-                                    tempCellBounds = Renderer.RenderGlyph.DrawGridRowGlyph(renderContext, glyph, tempCellBounds, paletteContent, state, rtl);
-                                }
-
-                                // Is there an error icon associated with the row that needs showing
-                                if (ShowRowErrors && !string.IsNullOrEmpty(Rows[e.RowIndex].ErrorText))
-                                {
-                                    // Draw error icon and update the remainder cell bounds left over
-                                    Rectangle beforeCellBounds = tempCellBounds;
-                                    tempCellBounds = Renderer.RenderGlyph.DrawGridErrorGlyph(renderContext, tempCellBounds, state, rtl);
+                                    // Is there an error icon associated with the row that needs showing
+                                    if (ShowRowErrors && !string.IsNullOrEmpty(Rows[e.RowIndex].ErrorText))
+                                    {
+                                        // Draw error icon and update the remainder cell bounds left over
+                                        Rectangle beforeCellBounds = tempCellBounds;
+                                        tempCellBounds = Renderer.RenderGlyph.DrawGridErrorGlyph(renderContext, tempCellBounds, state, rtl);
 
                                         // Calculate the icon rectangle
                                         var iconBounds = new Rectangle(tempCellBounds.Right + 1, tempCellBounds.Top,
                                         beforeCellBounds.Width - tempCellBounds.Width, tempCellBounds.Height);
 
-                                    // Cache the icon area
-                                    if (_rowCache.ContainsKey(e.RowIndex))
-                                    {
-                                        _rowCache[e.RowIndex] = iconBounds;
+                                        // Cache the icon area
+                                        if (_rowCache.ContainsKey(e.RowIndex))
+                                        {
+                                            _rowCache[e.RowIndex] = iconBounds;
+                                        }
+                                        else
+                                        {
+                                            _rowCache.Add(e.RowIndex, iconBounds);
+                                        }
                                     }
                                     else
                                     {
-                                        _rowCache.Add(e.RowIndex, iconBounds);
+                                        // Remove any cache entry
+                                        if (_rowCache.ContainsKey(e.RowIndex))
+                                        {
+                                            _rowCache.Remove(e.RowIndex);
+                                        }
                                     }
-                                }
-                                else
-                                {
-                                    // Remove any cache entry
-                                    if (_rowCache.ContainsKey(e.RowIndex))
-                                    {
-                                        _rowCache.Remove(e.RowIndex);
-                                    }
-                                }
 
-                                break;
-                            }
+                                    break;
+                                }
                             // Is this a data cell
                             case { RowIndex: >= 0, ColumnIndex: >= 0 }:
-                            {
-                                // If this cell supports icons, see if it has any.
-                                if (Rows[e.RowIndex].Cells[e.ColumnIndex] is IIconCell iconColumn)
                                 {
-                                    foreach (IconSpec spec in iconColumn.IconSpecs)
+                                    // If this cell supports icons, see if it has any.
+                                    if (Rows[e.RowIndex].Cells[e.ColumnIndex] is IIconCell iconColumn)
                                     {
-                                        if (spec.Icon == null)
+                                        foreach (IconSpec spec in iconColumn.IconSpecs)
                                         {
-                                            continue;
+                                            if (spec.Icon == null)
+                                            {
+                                                continue;
+                                            }
+
+                                            // Draw icon and update the remainder cell bounds left over
+                                            var iconWidth = spec.Icon.Width + 5;
+                                            var width = tempCellBounds.Width - iconWidth;
+                                            var iconBounds = new Rectangle(
+                                                tempCellBounds.X + (spec.Alignment == IconSpec.IconAlignment.Left
+                                                    ? 5
+                                                    : width), tempCellBounds.Y + 3, spec.Icon.Width, spec.Icon.Height);
+                                            renderContext.Graphics.DrawImage(spec.Icon, iconBounds);
+                                            tempCellBounds = tempCellBounds with
+                                            {
+                                                X = tempCellBounds.X +
+                                                (spec.Alignment == IconSpec.IconAlignment.Left ? iconWidth : 0),
+                                                Width = width
+                                            };
                                         }
-
-                                        // Draw icon and update the remainder cell bounds left over
-                                        var iconWidth = spec.Icon.Width + 5;
-                                        var width = tempCellBounds.Width - iconWidth;
-                                        var iconBounds = new Rectangle(
-                                            tempCellBounds.X + (spec.Alignment == IconSpec.IconAlignment.Left
-                                                ? 5
-                                                : width), tempCellBounds.Y + 3, spec.Icon.Width, spec.Icon.Height);
-                                        renderContext.Graphics.DrawImage(spec.Icon, iconBounds);
-                                        tempCellBounds = tempCellBounds with { X = tempCellBounds.X +
-                                            (spec.Alignment == IconSpec.IconAlignment.Left ? iconWidth : 0), Width = width };
                                     }
-                                }
 
-                                // Is there an error icon associated with the cell that needs showing
-                                if (ShowCellErrors && !string.IsNullOrEmpty(Rows[e.RowIndex].Cells[e.ColumnIndex].ErrorText))
-                                {
-                                    // Draw error icon and update the remainder cell bounds left over
-                                    tempCellBounds = Renderer.RenderGlyph.DrawGridErrorGlyph(renderContext, tempCellBounds, state, rtl);
-                                }
+                                    // Is there an error icon associated with the cell that needs showing
+                                    if (ShowCellErrors && !string.IsNullOrEmpty(Rows[e.RowIndex].Cells[e.ColumnIndex].ErrorText))
+                                    {
+                                        // Draw error icon and update the remainder cell bounds left over
+                                        tempCellBounds = Renderer.RenderGlyph.DrawGridErrorGlyph(renderContext, tempCellBounds, state, rtl);
+                                    }
 
-                                break;
-                            }
+                                    break;
+                                }
                         }
 
                         if (((e.PaintParts & DataGridViewPaintParts.ContentForeground) == DataGridViewPaintParts.ContentForeground) ||
@@ -2395,7 +2403,7 @@ namespace Krypton.Toolkit
 
             try
             {
-                return (string)_miGTTT!.Invoke(cell, new object[] { row });
+                return _miGTTT!.Invoke(cell, new object[] { row }) as string ?? string.Empty;
             }
             catch
             {
@@ -2416,7 +2424,7 @@ namespace Krypton.Toolkit
 
             try
             {
-                return (string)_miGET!.Invoke(cell, new object[] { row });
+                return _miGET!.Invoke(cell, new object[] { row }) as string ?? string.Empty;
             }
             catch
             {
@@ -2478,7 +2486,7 @@ namespace Krypton.Toolkit
                                                                            BindingFlags.GetField);
             }
 
-            return (string)_miATT!.Invoke(this, new object[] { false, string.Empty, -1, -1 });
+            return _miATT!.Invoke(this, new object[] { false, string.Empty, -1, -1 }) as string ?? string.Empty;
         }
 
         private string TruncateToolTipText(string toolTipText)
@@ -2609,7 +2617,7 @@ namespace Krypton.Toolkit
         private void OnContextMenuStripOpening(object sender, CancelEventArgs e)
         {
             // Get the actual strip instance
-            ContextMenuStrip cms = base.ContextMenuStrip;
+            ContextMenuStrip? cms = base.ContextMenuStrip;
 
             // Make sure it has the correct renderer
             cms.Renderer = CreateToolStripRenderer();

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxCell.cs
@@ -284,8 +284,8 @@ namespace Krypton.Toolkit
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public override void DetachEditingControl()
         {
-            DataGridView dataGridView = DataGridView;
-            switch (dataGridView.EditingControl)
+            DataGridView? dataGridView = DataGridView;
+            switch (dataGridView?.EditingControl)
             {
                 case null:
                     throw new InvalidOperationException(@"Cell is detached or its grid has no editing control.");
@@ -466,8 +466,8 @@ namespace Krypton.Toolkit
         }
 
         private bool OwnsEditingComboBox(int rowIndex) =>
-            rowIndex != -1 
-            && DataGridView is { EditingControl: KryptonDataGridViewComboBoxEditingControl control } 
+            rowIndex != -1
+            && DataGridView is { EditingControl: KryptonDataGridViewComboBoxEditingControl control }
             && (rowIndex == ((IDataGridViewEditingControl)control).EditingControlRowIndex);
 
         private static bool PartPainted(DataGridViewPaintParts paintParts, DataGridViewPaintParts paintPart) => (paintParts & paintPart) != 0;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewCustomEditingControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewCustomEditingControl.cs
@@ -51,10 +51,10 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Property which represents the current formatted value of the editing control
         /// </summary>
-        public virtual object EditingControlFormattedValue
+        public virtual object? EditingControlFormattedValue
         {
             get => GetEditingControlFormattedValue(DataGridViewDataErrorContexts.Formatting);
-            set => Text = (string)value;
+            set => Text = value as string;
         }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDateTimePickerCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDateTimePickerCell.cs
@@ -73,7 +73,7 @@ namespace Krypton.Toolkit
             _maxDate = DateTime.MaxValue;
             _minDate = DateTime.MinValue;
             _format = DateTimePickerFormat.Long;
-            _calendarDimensions = new Size(1,1);
+            _calendarDimensions = new Size(1, 1);
             _calendarTodayText = "Today:";
             _calendarFirstDayOfWeek = Day.Default;
             _calendarShowToday = true;
@@ -396,7 +396,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        
+
         /// <summary>
         /// The CalendarShowTodayCircle property replicates the one from the KryptonDateTimePicker control
         /// </summary>
@@ -462,7 +462,7 @@ namespace Krypton.Toolkit
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public override void DetachEditingControl()
         {
-            DataGridView dataGridView = DataGridView;
+            DataGridView? dataGridView = DataGridView;
             if (dataGridView?.EditingControl == null)
             {
                 throw new InvalidOperationException("Cell is detached or its grid has no editing control.");
@@ -537,10 +537,10 @@ namespace Krypton.Toolkit
         /// <param name="formattedValueTypeConverter">A TypeConverter associated with the formatted value type that provides custom conversion from the value type, or null if no such custom conversion is needed.</param>
         /// <param name="context">A bitwise combination of DataGridViewDataErrorContexts values describing the context in which the formatted value is needed.</param>
         /// <returns></returns>
-        protected override object GetFormattedValue(object value, int rowIndex, 
+        protected override object GetFormattedValue(object value, int rowIndex,
             ref DataGridViewCellStyle cellStyle,
-            TypeConverter valueTypeConverter, 
-            TypeConverter formattedValueTypeConverter, 
+            TypeConverter valueTypeConverter,
+            TypeConverter formattedValueTypeConverter,
             DataGridViewDataErrorContexts context)
         {
             if ((value == null) || (value == DBNull.Value))
@@ -567,9 +567,9 @@ namespace Krypton.Toolkit
         /// <param name="formattedValueTypeConverter">A TypeConverter for the display value type, or null to use the default converter.</param>
         /// <param name="valueTypeConverter">A TypeConverter for the cell value type, or null to use the default converter.</param>
         /// <returns></returns>
-        public override object ParseFormattedValue(object formattedValue, 
-            DataGridViewCellStyle cellStyle, 
-            TypeConverter formattedValueTypeConverter, 
+        public override object ParseFormattedValue(object formattedValue,
+            DataGridViewCellStyle cellStyle,
+            TypeConverter formattedValueTypeConverter,
             TypeConverter valueTypeConverter)
         {
             if (formattedValue == null)
@@ -746,7 +746,7 @@ namespace Krypton.Toolkit
         }
 
         private bool OwnsEditingDateTimePicker(int rowIndex) =>
-            rowIndex != -1 && DataGridView is { EditingControl: KryptonDataGridViewDateTimePickerEditingControl control } 
+            rowIndex != -1 && DataGridView is { EditingControl: KryptonDataGridViewDateTimePickerEditingControl control }
                            && (rowIndex == ((IDataGridViewEditingControl)control).EditingControlRowIndex);
 
         private static bool PartPainted(DataGridViewPaintParts paintParts, DataGridViewPaintParts paintPart) => (paintParts & paintPart) != 0;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDateTimePickerEditingControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDateTimePickerEditingControl.cs
@@ -55,11 +55,11 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Property which represents the current formatted value of the editing control
         /// </summary>
-        public virtual object EditingControlFormattedValue
+        public virtual object? EditingControlFormattedValue
         {
             get => GetEditingControlFormattedValue(DataGridViewDataErrorContexts.Formatting);
 
-            set 
+            set
             {
                 if ((value == null) || (value == DBNull.Value))
                 {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownCell.cs
@@ -70,7 +70,7 @@ namespace Krypton.Toolkit
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public override void DetachEditingControl()
         {
-            DataGridView dataGridView = DataGridView;
+            DataGridView? dataGridView = DataGridView;
             if (dataGridView?.EditingControl == null)
             {
                 throw new InvalidOperationException(@"Cell is detached or its grid has no editing control.");
@@ -230,7 +230,7 @@ namespace Krypton.Toolkit
         }
 
         private bool OwnsEditingDomainUpDown(int rowIndex) =>
-            rowIndex != -1 && DataGridView is { EditingControl: KryptonDataGridViewDomainUpDownEditingControl control } 
+            rowIndex != -1 && DataGridView is { EditingControl: KryptonDataGridViewDomainUpDownEditingControl control }
                            && (rowIndex == ((IDataGridViewEditingControl)control).EditingControlRowIndex);
 
         private static bool PartPainted(DataGridViewPaintParts paintParts, DataGridViewPaintParts paintPart) => (paintParts & paintPart) != 0;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownEditingControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownEditingControl.cs
@@ -51,10 +51,10 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Property which represents the current formatted value of the editing control
         /// </summary>
-        public virtual object EditingControlFormattedValue
+        public virtual object? EditingControlFormattedValue
         {
             get => GetEditingControlFormattedValue(DataGridViewDataErrorContexts.Formatting);
-            set => Text = (string)value;
+            set => Text = value as string;
         }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewLinkCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewLinkCell.cs
@@ -115,7 +115,7 @@ namespace Krypton.Toolkit
         {
             try
             {
-                var kDGV = (KryptonDataGridView)DataGridView;
+                var kDGV = DataGridView as KryptonDataGridView;
 
                 // Ensure the view classes are created and hooked up
                 CreateViewAndPalettes(kDGV);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewMaskedTextBoxCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewMaskedTextBoxCell.cs
@@ -424,7 +424,7 @@ namespace Krypton.Toolkit
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public override void DetachEditingControl()
         {
-            DataGridView dataGridView = DataGridView;
+            DataGridView? dataGridView = DataGridView;
             if (dataGridView?.EditingControl == null)
             {
                 throw new InvalidOperationException("Cell is detached or its grid has no editing control.");
@@ -591,8 +591,8 @@ namespace Krypton.Toolkit
         }
 
         private bool OwnsEditingMaskedTextBox(int rowIndex) =>
-            rowIndex != -1 
-            && DataGridView is { EditingControl: KryptonDataGridViewMaskedTextBoxEditingControl control } 
+            rowIndex != -1
+            && DataGridView is { EditingControl: KryptonDataGridViewMaskedTextBoxEditingControl control }
             && (rowIndex == ((IDataGridViewEditingControl)control).EditingControlRowIndex);
 
         private static bool PartPainted(DataGridViewPaintParts paintParts, DataGridViewPaintParts paintPart) => (paintParts & paintPart) != 0;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewMaskedTextBoxEditingControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewMaskedTextBoxEditingControl.cs
@@ -51,10 +51,10 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Property which represents the current formatted value of the editing control
         /// </summary>
-        public virtual object EditingControlFormattedValue
+        public virtual object? EditingControlFormattedValue
         {
             get => GetEditingControlFormattedValue(DataGridViewDataErrorContexts.Formatting);
-            set => Text = (string)value;
+            set => Text = value as string;
         }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewNumericUpDownEditingControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewNumericUpDownEditingControl.cs
@@ -51,10 +51,10 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Property which represents the current formatted value of the editing control
         /// </summary>
-        public virtual object EditingControlFormattedValue
+        public virtual object? EditingControlFormattedValue
         {
             get => GetEditingControlFormattedValue(DataGridViewDataErrorContexts.Formatting);
-            set => Text = (string)value;
+            set => Text = value as string;
         }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxCell.cs
@@ -119,7 +119,7 @@ namespace Krypton.Toolkit
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public override void DetachEditingControl()
         {
-            DataGridView dataGridView = DataGridView;
+            DataGridView? dataGridView = DataGridView;
             if (dataGridView?.EditingControl == null)
             {
                 throw new InvalidOperationException("Cell is detached or its grid has no editing control.");

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxEditingControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxEditingControl.cs
@@ -51,10 +51,10 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Property which represents the current formatted value of the editing control
         /// </summary>
-        public virtual object EditingControlFormattedValue
+        public virtual object? EditingControlFormattedValue
         {
             get => GetEditingControlFormattedValue(DataGridViewDataErrorContexts.Formatting);
-            set => Text = (string)value;
+            set => Text = value as string;
         }
 
         /// <summary>
@@ -193,7 +193,7 @@ namespace Krypton.Toolkit
             base.OnTextChanged(e);
 
             //if (Focused)
-                NotifyDataGridViewOfValueChange();
+            NotifyDataGridViewOfValueChange();
         }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonFontDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonFontDialog.cs
@@ -16,7 +16,8 @@ namespace Krypton.Toolkit
     /// Represents a common dialog box that displays a list of fonts
     /// that are currently installed on the system.
     /// </summary>
-    [ToolboxBitmap(typeof(FontDialog), "ToolboxBitmaps.KryptonFontDialog.png"),
+    [ToolboxItem(true),
+     ToolboxBitmap(typeof(FontDialog), "ToolboxBitmaps.KryptonFontDialog.png"),
      Description("Displays a Kryptonised version of the standard Font dialog, that prompts the user to choose a font from those installed on the local computer.")]
     public class KryptonFontDialog : FontDialog
     {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -200,7 +200,7 @@ namespace Krypton.Toolkit
             _useDropShadow = false;
 #pragma warning restore CS0618
 
-            //_integratedToolBarValues = new IntegratedToolBarValues();
+            BackStyle = PaletteBackStyle.PanelClient;
         }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonHeader.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonHeader.cs
@@ -532,7 +532,7 @@ namespace Krypton.Toolkit
             if (!IsDisposed)
             {
                 // Do not show tooltips when the form we are in does not have focus
-                Form topForm = FindForm();
+                Form? topForm = FindForm();
                 if (topForm is { ContainsFocus: false })
                 {
                     return;
@@ -547,7 +547,7 @@ namespace Krypton.Toolkit
                     var shadow = true;
 
                     // Find the button spec associated with the tooltip request
-                    ButtonSpec buttonSpec = _buttonManager.ButtonSpecFromView(e.Target);
+                    ButtonSpec? buttonSpec = _buttonManager.ButtonSpecFromView(e.Target);
 
                     // If the tooltip is for a button spec
                     if (buttonSpec != null)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPrintDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPrintDialog.cs
@@ -30,6 +30,7 @@ namespace Krypton.Toolkit
     /// This may go into the extended toolkit as a "Full replacement" if it is deemed necessary.
     /// </remarks>
     [DefaultProperty(nameof(Document))]
+    [ToolboxItem(true)]
     [ToolboxBitmap(typeof(PrintDialog), "ToolboxBitmaps.KryptonPrintDialog.png")]
     [Description(nameof(PrintDialog))]
     [Designer("System.Windows.Forms.Design.PrintDialogDesigner")]

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
@@ -28,6 +28,8 @@ namespace Krypton.Toolkit
         private const int DEFAULT_COMPOSITION_HEIGHT = 30;
         private static readonly bool _themedApp;
         private readonly PaletteDoubleRedirect _stateCommon;
+        private readonly PaletteContentInheritRedirect ItemShortcutTextRedirect;
+        private readonly PaletteContentJustShortText ItemShortcutText;
 
         #endregion
 
@@ -36,7 +38,6 @@ namespace Krypton.Toolkit
         private bool _windowActive;
         private bool _trackingMouse;
         private bool _applyCustomChrome;
-        private bool _closeBoxVisible;
         private bool _allowComposition;
         private bool _insideUpdateComposition;
         private bool _captured;
@@ -52,7 +53,7 @@ namespace Krypton.Toolkit
         private ShadowManager _shadowManager;
         private BlurValues _blurValues;
         private BlurManager _blurManager;
-        private object _lockObject = new object();
+        private object? _lockObject = new object();
         #endregion
 
         #region Events
@@ -106,6 +107,8 @@ namespace Krypton.Toolkit
         {
             InitializeComponent();
 
+            base.DoubleBuffered = true;
+
             // Automatically redraw whenever the size of the window changes
             SetStyle(ControlStyles.ResizeRedraw, true);
 
@@ -125,13 +128,17 @@ namespace Krypton.Toolkit
 
             // Default the composition height
             _compositionHeight = DEFAULT_COMPOSITION_HEIGHT;
-            _closeBoxVisible = true;
+
+            CloseBox = true;
 
             // Create constant target for resolving palette delegates
             Redirector = CreateRedirector();
 
             _stateCommon = new PaletteDoubleRedirect(Redirector, PaletteBackStyle.ButtonCustom1,
                 PaletteBorderStyle.ButtonCustom1, NeedPaintDelegate);
+
+            ItemShortcutTextRedirect = new PaletteContentInheritRedirect(Redirector, PaletteContentStyle.LabelNormalPanel);
+            ItemShortcutText = new PaletteContentJustShortText(ItemShortcutTextRedirect, NeedPaintDelegate);
 
             // Hook into global static events
             KryptonManager.GlobalPaletteChanged += OnGlobalPaletteChanged;
@@ -186,7 +193,105 @@ namespace Krypton.Toolkit
 
         #region Public
 
-        // Note: What does this do?
+        /// <inheritdoc />
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        protected override bool DoubleBuffered
+        {
+            get => true;
+            set
+            {
+                // Do Nothing
+            }
+        }
+
+        /// <inheritdoc />
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public override Color BackColor
+        {
+            get
+            {
+                Color rawBackColor = _stateCommon.Back.GetBackColor1(Enabled ? PaletteState.Disabled : PaletteState.Normal);
+                return !rawBackColor.IsEmpty ? rawBackColor : Control.DefaultBackColor;
+            }
+            set
+            {
+                //Do Nothing;
+            }
+        }
+
+        /// <inheritdoc />
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [AmbientValue(null)]
+        public override Font Font
+        {
+            get => ItemShortcutText.GetContentShortTextFont(Enabled ? PaletteState.Disabled : PaletteState.Normal);
+            set
+            {
+                //Do Nothing;
+            }
+        }
+
+        /// <inheritdoc />
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public override Color ForeColor
+        {
+            get => ItemShortcutText.GetContentShortTextColor1(Enabled ? PaletteState.Disabled : PaletteState.Normal);
+            set
+            {
+                //Do Nothing;
+            }
+        }
+
+        /// <inheritdoc />
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [DefaultValue(null)]
+        public override Image? BackgroundImage
+        {
+            get => _stateCommon.Back.GetBackImage(Enabled ? PaletteState.Disabled : PaletteState.Normal);
+            set
+            {
+                //Do Nothing;
+            }
+        }
+        /// <inheritdoc />
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [DefaultValue(ImageLayout.Tile)]
+        public override ImageLayout BackgroundImageLayout
+        {
+            get
+            {
+                return _stateCommon.Back.GetBackImageStyle(Enabled ? PaletteState.Disabled : PaletteState.Normal) switch
+                {
+                    PaletteImageStyle.TopMiddle => ImageLayout.Center,
+                    PaletteImageStyle.CenterLeft => ImageLayout.Center,
+                    PaletteImageStyle.CenterMiddle => ImageLayout.Center,
+                    PaletteImageStyle.CenterRight => ImageLayout.Center,
+                    PaletteImageStyle.Stretch => ImageLayout.Stretch,
+                    PaletteImageStyle.Tile => ImageLayout.Tile,
+                    _ => ImageLayout.None
+                };
+            }
+            set
+            {
+                //Do Nothing;
+            }
+        }
+
+        /// <summary>Sets the default panel backcolor source i.e. PanelClient.</summary>
+        [DefaultValue(typeof(PaletteBackStyle), @"PaletteBackStyle.PanelClient")]
+        [Description(@"Sets the default panel backcolor source i.e. PanelClient.")]
         public PaletteBackStyle BackStyle
         {
             get => _stateCommon.BackStyle;
@@ -325,12 +430,7 @@ namespace Krypton.Toolkit
         [Category("Window Style")]
         [DefaultValue(true)]
         [Description("Form Close Button Visiblity: This will also Hide the System Menu `Close` and disable the `Alt+F4` action")]
-        public bool CloseBox
-        {
-            [DebuggerStepThrough]
-            get => _closeBoxVisible;
-            set => _closeBoxVisible = value;
-        }
+        public bool CloseBox { [DebuggerStepThrough] get; set; }
 
         /// <summary>
         /// Gets a value indicating if composition is being applied.
@@ -629,6 +729,7 @@ namespace Krypton.Toolkit
         [Category(@"Window Style")]
         [DefaultValue(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Obsolete(@"Please use a ButtonSpec, as this gives greater flexibility!", true)]
         [Description(@"Please use a ButtonSpec, as this gives greater flexibility!")]
         public new bool HelpButton
         {
@@ -1105,6 +1206,13 @@ namespace Krypton.Toolkit
                     InvalidateNonClient();
                 }
             }
+
+            // Force repaint of Background etc.
+            OnBackColorChanged(EventArgs.Empty);
+            OnBackgroundImageChanged(EventArgs.Empty);
+            OnBackgroundImageLayoutChanged(EventArgs.Empty);
+            OnFontChanged(EventArgs.Empty);
+            OnForeColorChanged(EventArgs.Empty);
         }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/General/CommonHelper.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/CommonHelper.cs
@@ -123,7 +123,7 @@ namespace Krypton.Toolkit
         } = new Padding(-1);
 
         /// <summary>
-        /// Check a short cut menu for a matching short and invoke that item if found.
+        /// Check a short-cut menu for a matching short and invoke that item if found.
         /// </summary>
         /// <param name="cms">ContextMenuStrip instance to check.</param>
         /// <param name="msg">Windows message that generated check.</param>
@@ -1602,6 +1602,14 @@ namespace Krypton.Toolkit
         /// <returns></returns>
         public static Bitmap ScaleImageForSizedDisplay(Image src, float trgtWidth, float trgtHeight)
         {
+            if (trgtWidth <= 0 || trgtHeight <= 0)
+            {
+                // For some reason, in the designer it can send a rect that has a negative size element,
+                // therefore the targets will also be negative
+                return new Bitmap(0, 0);
+            }
+
+
             var newImage = new Bitmap((int)trgtWidth, (int)trgtHeight);
             using Graphics gr = Graphics.FromImage(newImage);
             gr.Clear(Color.Transparent);

--- a/Source/Krypton Components/Krypton.Toolkit/General/KryptonAboutToolkitData.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/KryptonAboutToolkitData.cs
@@ -9,6 +9,7 @@
 
 namespace Krypton.Toolkit
 {
+    /// <summary>Contains the information used for creating a new <see cref="KryptonAboutToolkitForm"/>.</summary>
     public struct KryptonAboutToolkitData
     {
         #region Static Fields
@@ -133,9 +134,60 @@ namespace Krypton.Toolkit
 
         #region Identity
 
+        /// <summary>Initializes a new instance of the <see cref="KryptonAboutToolkitData" /> struct.</summary>
         public KryptonAboutToolkitData()
         {
+            ShowDiscordButton = true;
 
+            ShowDeveloperInformationButton = true;
+
+            ShowVersionInformationButton = true;
+
+            ShowThemeOptions = true;
+
+            ShowSystemInformationButton = true;
+
+            ToolkitType = ToolkitType.Stable;
+
+            HeaderText = DEFAULT_HEADER_TEXT;
+
+            CurrentThemeText = DEFAULT_CURRENT_THEME_TEXT;
+
+            GeneralInformationLearnMoreText = DEFAULT_GENERAL_INFORMATION_LEARN_MORE_TEXT;
+
+            GeneralInformationLicenseText = DEFAULT_GENERAL_INFORMATION_LICENSE_TEXT;
+
+            GeneralInformationWelcomeText = DEFAULT_GENERAL_INFORMATION_WELCOME_TEXT;
+
+            DiscordText = DEFAULT_JOIN_DISCORD_SERVER;
+
+            RepositoryInformationText = DEFAULT_VIEW_REPOSITORIES;
+
+            DownloadDocumentationText = DEFAULT_DOWNLOAD_DOCUMENTATION;
+
+            DownloadDemosText = DEFAULT_DOWNLOAD_DEMOS;
+
+            FileNameColumnHeaderText = DEFAULT_FILE_NAME_COLUMN_HEADER_TEXT;
+
+            VersionColumnHeaderText = DEFAULT_VERSION_COLUMN_HEADER_TEXT;
+
+            ToolBarGeneralInformationText = DEFAULT_TOOL_BAR_GENERAL_INFORMATION_TEXT;
+
+            ToolBarDiscordText = DEFAULT_TOOL_BAR_DISCORD_TEXT;
+
+            ToolBarDeveloperInformationText = DEFAULT_TOOL_BAR_DEVELOPER_INFORMATION_TEXT;
+
+            ToolBarVersionInformationText = DEFAULT_TOOL_BAR_VERSION_INFORMATION_TEXT;
+
+            LearnMoreLinkArea = new LinkArea(133, 143);
+
+            DiscordLinkArea = new LinkArea(0, 4);
+
+            RepositoryInformationLinkArea = new LinkArea(0, 4);
+
+            DownloadDemosLinkArea = new LinkArea(0, 9);
+
+            DocumentationLinkArea = new LinkArea(0, 9);
         }
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/General/ModalWaitDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/ModalWaitDialog.cs
@@ -27,7 +27,7 @@ namespace Krypton.Toolkit
 
         #region Instance Fields
 
-        private bool _showProgressBar;
+        private readonly bool _showProgressBar;
         private bool _startTimestamped;
         private DateTime _startTimestamp;
         private DateTime _spinTimestamp;

--- a/Source/Krypton Components/Krypton.Toolkit/General/TypedCollection.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/TypedCollection.cs
@@ -293,7 +293,7 @@ namespace Krypton.Toolkit
             // Not allow to add the same item more than once
             if (_list.Contains(item))
             {
-                throw new ArgumentOutOfRangeException(nameof(item), @"Item already in collection");
+                throw new ArgumentOutOfRangeException(nameof(item), @"Item is already in collection");
             }
 
             // Generate before insert event

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentJustShortText.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentJustShortText.cs
@@ -13,7 +13,7 @@
 namespace Krypton.Toolkit
 {
     /// <summary>
-    /// Implement storage but remove accesss to the non short text properties.
+    /// Implement storage but remove access to the non short text properties.
     /// </summary>
     public class PaletteContentJustShortText : PaletteContentJustText
     {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDefinitions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDefinitions.cs
@@ -2951,7 +2951,7 @@ namespace Krypton.Toolkit
 
     #region Enum PaletteImageStyle
     /// <summary>
-    /// Specifies the an image is aligned.
+    /// Specifies how an image is aligned.
     /// </summary>
     [TypeConverter(typeof(PaletteImageStyleConverter))]
     public enum PaletteImageStyle

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectDouble.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectDouble.cs
@@ -22,11 +22,11 @@ namespace Krypton.Toolkit
         private IPaletteDouble? _normal;
         private IPaletteDouble? _pressed;
         private IPaletteDouble? _tracking;
-        private IPaletteDouble _checkedNormal;
-        private IPaletteDouble _checkedPressed;
-        private IPaletteDouble _checkedTracking;
-        private IPaletteDouble _focusOverride;
-        private IPaletteDouble _normalDefaultOverride;
+        private IPaletteDouble? _checkedNormal;
+        private IPaletteDouble? _checkedPressed;
+        private IPaletteDouble? _checkedTracking;
+        private IPaletteDouble? _focusOverride;
+        private IPaletteDouble? _normalDefaultOverride;
         #endregion
 
         #region Identity
@@ -95,11 +95,11 @@ namespace Krypton.Toolkit
                                      IPaletteDouble? normal,
                                      IPaletteDouble? pressed,
                                      IPaletteDouble? tracking,
-                                     IPaletteDouble checkedNormal,
-                                     IPaletteDouble checkedPressed,
-                                     IPaletteDouble checkedTracking,
-                                     IPaletteDouble focusOverride,
-                                     IPaletteDouble normalDefaultOverride)
+                                     IPaletteDouble? checkedNormal,
+                                     IPaletteDouble? checkedPressed,
+                                     IPaletteDouble? checkedTracking,
+                                     IPaletteDouble? focusOverride,
+                                     IPaletteDouble? normalDefaultOverride)
             : base(target)
         {
             // Remember state specific inheritance
@@ -176,9 +176,11 @@ namespace Krypton.Toolkit
         /// <returns>InheritBool value.</returns>
         public override InheritBool GetBackDraw(PaletteBackStyle style, PaletteState state)
         {
-            IPaletteDouble inherit = GetInherit(state);
+            IPaletteDouble? inherit = GetInherit(state);
 
-            return inherit != null ? inherit.PaletteBack.GetBackDraw(state) : Target.GetBackDraw(style, state);
+            return inherit != null
+                ? inherit.PaletteBack.GetBackDraw(state)
+                : Target.GetBackDraw(style, state);
         }
 
         /// <summary>
@@ -189,9 +191,11 @@ namespace Krypton.Toolkit
         /// <returns>PaletteGraphicsHint value.</returns>
         public override PaletteGraphicsHint GetBackGraphicsHint(PaletteBackStyle style, PaletteState state)
         {
-            IPaletteDouble inherit = GetInherit(state);
+            IPaletteDouble? inherit = GetInherit(state);
 
-            return inherit != null ? inherit.PaletteBack.GetBackGraphicsHint(state) : Target.GetBackGraphicsHint(style, state);
+            return inherit != null
+                ? inherit.PaletteBack.GetBackGraphicsHint(state)
+                : Target.GetBackGraphicsHint(style, state);
         }
 
         /// <summary>
@@ -202,9 +206,11 @@ namespace Krypton.Toolkit
         /// <returns>Color value.</returns>
         public override Color GetBackColor1(PaletteBackStyle style, PaletteState state)
         {
-            IPaletteDouble inherit = GetInherit(state);
+            IPaletteDouble? inherit = GetInherit(state);
 
-            return inherit != null ? inherit.PaletteBack.GetBackColor1(state) : Target.GetBackColor1(style, state);
+            return inherit != null
+                ? inherit.PaletteBack.GetBackColor1(state)
+                : Target.GetBackColor1(style, state);
         }
 
         /// <summary>
@@ -215,9 +221,11 @@ namespace Krypton.Toolkit
         /// <returns>Color value.</returns>
         public override Color GetBackColor2(PaletteBackStyle style, PaletteState state)
         {
-            IPaletteDouble inherit = GetInherit(state);
+            IPaletteDouble? inherit = GetInherit(state);
 
-            return inherit != null ? inherit.PaletteBack.GetBackColor2(state) : Target.GetBackColor2(style, state);
+            return inherit != null
+                ? inherit.PaletteBack.GetBackColor2(state)
+                : Target.GetBackColor2(style, state);
         }
 
         /// <summary>
@@ -228,9 +236,11 @@ namespace Krypton.Toolkit
         /// <returns>Color drawing style.</returns>
         public override PaletteColorStyle GetBackColorStyle(PaletteBackStyle style, PaletteState state)
         {
-            IPaletteDouble inherit = GetInherit(state);
+            IPaletteDouble? inherit = GetInherit(state);
 
-            return inherit != null ? inherit.PaletteBack.GetBackColorStyle(state) : Target.GetBackColorStyle(style, state);
+            return inherit != null
+                ? inherit.PaletteBack.GetBackColorStyle(state)
+                : Target.GetBackColorStyle(style, state);
         }
 
         /// <summary>
@@ -241,9 +251,11 @@ namespace Krypton.Toolkit
         /// <returns>Color alignment style.</returns>
         public override PaletteRectangleAlign GetBackColorAlign(PaletteBackStyle style, PaletteState state)
         {
-            IPaletteDouble inherit = GetInherit(state);
+            IPaletteDouble? inherit = GetInherit(state);
 
-            return inherit != null ? inherit.PaletteBack.GetBackColorAlign(state) : Target.GetBackColorAlign(style, state);
+            return inherit != null
+                ? inherit.PaletteBack.GetBackColorAlign(state)
+                : Target.GetBackColorAlign(style, state);
         }
 
         /// <summary>
@@ -254,9 +266,11 @@ namespace Krypton.Toolkit
         /// <returns>Angle used for color drawing.</returns>
         public override float GetBackColorAngle(PaletteBackStyle style, PaletteState state)
         {
-            IPaletteDouble inherit = GetInherit(state);
+            IPaletteDouble? inherit = GetInherit(state);
 
-            return inherit != null ? inherit.PaletteBack.GetBackColorAngle(state) : Target.GetBackColorAngle(style, state);
+            return inherit != null
+                ? inherit.PaletteBack.GetBackColorAngle(state)
+                : Target.GetBackColorAngle(style, state);
         }
 
         /// <summary>
@@ -267,9 +281,11 @@ namespace Krypton.Toolkit
         /// <returns>Image instance.</returns>
         public override Image? GetBackImage(PaletteBackStyle style, PaletteState state)
         {
-            IPaletteDouble inherit = GetInherit(state);
+            IPaletteDouble? inherit = GetInherit(state);
 
-            return inherit != null ? inherit.PaletteBack.GetBackImage(state) : Target.GetBackImage(style, state);
+            return inherit != null
+                ? inherit.PaletteBack.GetBackImage(state)
+                : Target.GetBackImage(style, state);
         }
 
         /// <summary>
@@ -280,9 +296,11 @@ namespace Krypton.Toolkit
         /// <returns>Image style value.</returns>
         public override PaletteImageStyle GetBackImageStyle(PaletteBackStyle style, PaletteState state)
         {
-            IPaletteDouble inherit = GetInherit(state);
+            IPaletteDouble? inherit = GetInherit(state);
 
-            return inherit != null ? inherit.PaletteBack.GetBackImageStyle(state) : Target.GetBackImageStyle(style, state);
+            return inherit != null
+                ? inherit.PaletteBack.GetBackImageStyle(state)
+                : Target.GetBackImageStyle(style, state);
         }
 
         /// <summary>
@@ -293,9 +311,11 @@ namespace Krypton.Toolkit
         /// <returns>Image alignment style.</returns>
         public override PaletteRectangleAlign GetBackImageAlign(PaletteBackStyle style, PaletteState state)
         {
-            IPaletteDouble inherit = GetInherit(state);
+            IPaletteDouble? inherit = GetInherit(state);
 
-            return inherit != null ? inherit.PaletteBack.GetBackImageAlign(state) : Target.GetBackImageAlign(style, state);
+            return inherit != null
+                ? inherit.PaletteBack.GetBackImageAlign(state)
+                : Target.GetBackImageAlign(style, state);
         }
         #endregion
 
@@ -308,9 +328,11 @@ namespace Krypton.Toolkit
         /// <returns>InheritBool value.</returns>
         public override InheritBool GetBorderDraw(PaletteBorderStyle style, PaletteState state)
         {
-            IPaletteDouble inherit = GetInherit(state);
+            IPaletteDouble? inherit = GetInherit(state);
 
-            return inherit != null ? inherit.PaletteBorder.GetBorderDraw(state) : Target.GetBorderDraw(style, state);
+            return inherit != null
+                ? inherit.PaletteBorder.GetBorderDraw(state)
+                : Target.GetBorderDraw(style, state);
         }
 
         /// <summary>
@@ -321,7 +343,7 @@ namespace Krypton.Toolkit
         /// <returns>PaletteDrawBorders value.</returns>
         public override PaletteDrawBorders GetBorderDrawBorders(PaletteBorderStyle style, PaletteState state)
         {
-            IPaletteDouble inherit = GetInherit(state);
+            IPaletteDouble? inherit = GetInherit(state);
 
             return inherit != null ? inherit.PaletteBorder.GetBorderDrawBorders(state) : Target.GetBorderDrawBorders(style, state);
         }
@@ -334,7 +356,7 @@ namespace Krypton.Toolkit
         /// <returns>PaletteGraphicsHint value.</returns>
         public override PaletteGraphicsHint GetBorderGraphicsHint(PaletteBorderStyle style, PaletteState state)
         {
-            IPaletteDouble inherit = GetInherit(state);
+            IPaletteDouble? inherit = GetInherit(state);
 
             return inherit != null ? inherit.PaletteBorder.GetBorderGraphicsHint(state) : Target.GetBorderGraphicsHint(style, state);
         }
@@ -347,7 +369,7 @@ namespace Krypton.Toolkit
         /// <returns>Color value.</returns>
         public override Color GetBorderColor1(PaletteBorderStyle style, PaletteState state)
         {
-            IPaletteDouble inherit = GetInherit(state);
+            IPaletteDouble? inherit = GetInherit(state);
 
             return inherit != null ? inherit.PaletteBorder.GetBorderColor1(state) : Target.GetBorderColor1(style, state);
         }
@@ -360,7 +382,7 @@ namespace Krypton.Toolkit
         /// <returns>Color value.</returns>
         public override Color GetBorderColor2(PaletteBorderStyle style, PaletteState state)
         {
-            IPaletteDouble inherit = GetInherit(state);
+            IPaletteDouble? inherit = GetInherit(state);
 
             return inherit != null ? inherit.PaletteBorder.GetBorderColor2(state) : Target.GetBorderColor2(style, state);
         }
@@ -373,7 +395,7 @@ namespace Krypton.Toolkit
         /// <returns>Color drawing style.</returns>
         public override PaletteColorStyle GetBorderColorStyle(PaletteBorderStyle style, PaletteState state)
         {
-            IPaletteDouble inherit = GetInherit(state);
+            IPaletteDouble? inherit = GetInherit(state);
 
             return inherit != null ? inherit.PaletteBorder.GetBorderColorStyle(state) : Target.GetBorderColorStyle(style, state);
         }
@@ -386,7 +408,7 @@ namespace Krypton.Toolkit
         /// <returns>Color alignment style.</returns>
         public override PaletteRectangleAlign GetBorderColorAlign(PaletteBorderStyle style, PaletteState state)
         {
-            IPaletteDouble inherit = GetInherit(state);
+            IPaletteDouble? inherit = GetInherit(state);
 
             return inherit != null ? inherit.PaletteBorder.GetBorderColorAlign(state) : Target.GetBorderColorAlign(style, state);
         }
@@ -399,7 +421,7 @@ namespace Krypton.Toolkit
         /// <returns>Angle used for color drawing.</returns>
         public override float GetBorderColorAngle(PaletteBorderStyle style, PaletteState state)
         {
-            IPaletteDouble inherit = GetInherit(state);
+            IPaletteDouble? inherit = GetInherit(state);
 
             return inherit != null ? inherit.PaletteBorder.GetBorderColorAngle(state) : Target.GetBorderColorAngle(style, state);
         }
@@ -412,7 +434,7 @@ namespace Krypton.Toolkit
         /// <returns>Integer width.</returns>
         public override int GetBorderWidth(PaletteBorderStyle style, PaletteState state)
         {
-            IPaletteDouble inherit = GetInherit(state);
+            IPaletteDouble? inherit = GetInherit(state);
 
             return inherit != null ? inherit.PaletteBorder.GetBorderWidth(state) : Target.GetBorderWidth(style, state);
         }
@@ -425,7 +447,7 @@ namespace Krypton.Toolkit
         /// <returns>Float rounding.</returns>
         public override float GetBorderRounding(PaletteBorderStyle style, PaletteState state)
         {
-            IPaletteDouble inherit = GetInherit(state);
+            IPaletteDouble? inherit = GetInherit(state);
 
             return inherit != null ? inherit.PaletteBorder.GetBorderRounding(state) : Target.GetBorderRounding(style, state);
         }
@@ -438,7 +460,7 @@ namespace Krypton.Toolkit
         /// <returns>Image instance.</returns>
         public override Image? GetBorderImage(PaletteBorderStyle style, PaletteState state)
         {
-            IPaletteDouble inherit = GetInherit(state);
+            IPaletteDouble? inherit = GetInherit(state);
 
             return inherit != null ? inherit.PaletteBorder.GetBorderImage(state) : Target.GetBorderImage(style, state);
         }
@@ -451,7 +473,7 @@ namespace Krypton.Toolkit
         /// <returns>Image style value.</returns>
         public override PaletteImageStyle GetBorderImageStyle(PaletteBorderStyle style, PaletteState state)
         {
-            IPaletteDouble inherit = GetInherit(state);
+            IPaletteDouble? inherit = GetInherit(state);
 
             return inherit != null ? inherit.PaletteBorder.GetBorderImageStyle(state) : Target.GetBorderImageStyle(style, state);
         }
@@ -464,7 +486,7 @@ namespace Krypton.Toolkit
         /// <returns>Image alignment style.</returns>
         public override PaletteRectangleAlign GetBorderImageAlign(PaletteBorderStyle style, PaletteState state)
         {
-            IPaletteDouble inherit = GetInherit(state);
+            IPaletteDouble? inherit = GetInherit(state);
 
             return inherit != null ? inherit.PaletteBorder.GetBorderImageAlign(state) : Target.GetBorderImageAlign(style, state);
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectTriple.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectTriple.cs
@@ -27,9 +27,9 @@ namespace Krypton.Toolkit
         private IPaletteTriple? _checkedTracking;
         private IPaletteTriple? _focusOverride;
         private IPaletteTriple? _normalDefaultOverride;
-        private IPaletteTriple? _contextNormal;
-        private IPaletteTriple? _contextPressed;
-        private IPaletteTriple? _contextTracking;
+        private readonly IPaletteTriple? _contextNormal;
+        private readonly IPaletteTriple? _contextPressed;
+        private readonly IPaletteTriple? _contextTracking;
         #endregion
 
         #region Identity

--- a/Source/Krypton Components/Krypton.Toolkit/Utilities/GlobalToolkitUtilities.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Utilities/GlobalToolkitUtilities.cs
@@ -52,6 +52,20 @@ namespace Krypton.Toolkit
             }
         }
 
+        /// <summary>Launches a chosen process.</summary>
+        /// <param name="startInfo">The <see cref="ProcessStartInfo"/> object in which to start.</param>
+        public static void LaunchProcess(ProcessStartInfo startInfo)
+        {
+            try
+            {
+                Process.Start(startInfo);
+            }
+            catch (Exception e)
+            {
+                ExceptionHandler.CaptureException(e);
+            }
+        }
+
         /// <summary>Gets the file list.</summary>
         /// <param name="directory">The directory.</param>
         /// <param name="fileType">Type of the file.</param>

--- a/Source/Krypton Components/Krypton.Toolkit/Values/ColorButtonValues.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/ColorButtonValues.cs
@@ -20,7 +20,7 @@ namespace Krypton.Toolkit
     {
         #region Static Fields
 
-        private string _defaultText = KryptonManager.Strings.GlobalColorStrings.Color;
+        private readonly string _defaultText = KryptonManager.Strings.GlobalColorStrings.Color;
         private static readonly string _defaultExtraText = string.Empty;
         private static readonly Image _defaultImage = GenericImageResources.ButtonColorImageSmall;
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Values/IntegratedToolBarButtonValues.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/IntegratedToolBarButtonValues.cs
@@ -63,7 +63,7 @@ namespace Krypton.Toolkit
 
         private bool _showQuickPrintButton;
 
-        private KryptonIntegratedToolBarManager _toolBarManager = new();
+        private readonly KryptonIntegratedToolBarManager _toolBarManager = new KryptonIntegratedToolBarManager();
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Workspace/Controls Workspace/KryptonWorkspace.cs
+++ b/Source/Krypton Components/Krypton.Workspace/Controls Workspace/KryptonWorkspace.cs
@@ -10,7 +10,6 @@
  */
 #endregion
 
-using System.Linq;
 // ReSharper disable MemberCanBeProtected.Global
 
 namespace Krypton.Workspace
@@ -424,8 +423,8 @@ namespace Krypton.Workspace
         /// <summary>
         /// Gets and sets the active page.
         /// </summary>
-        [Browsable(true), 
-         Description(@"Gets and sets the active page."), 
+        [Browsable(true),
+         Description(@"Gets and sets the active page."),
          DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public KryptonPage? ActivePage { get; set; }
 
@@ -1246,7 +1245,7 @@ namespace Krypton.Workspace
                         StarSize itemSize = item.WorkspaceStarSize;
 
                         // Should the new width be applied?
-                        if ((itemSize.StarWidth.UsingStar && applyStar) 
+                        if ((itemSize.StarWidth.UsingStar && applyStar)
                             || (!itemSize.StarWidth.UsingStar && applyFixed)
                             )
                         {
@@ -1258,7 +1257,7 @@ namespace Krypton.Workspace
                         }
 
                         // Should the new height be applied?
-                        if ((itemSize.StarHeight.UsingStar && applyStar) 
+                        if ((itemSize.StarHeight.UsingStar && applyStar)
                             || (!itemSize.StarHeight.UsingStar && applyFixed)
                             )
                         {
@@ -1661,7 +1660,7 @@ namespace Krypton.Workspace
             var visibleCells = 0;
             var numPages = 0;
 
-            if (MaximizedCell is { AllowDroppingPages: true } )
+            if (MaximizedCell is { AllowDroppingPages: true })
             {
                 // Generate targets for maximized cell only
                 visibleCells = CellVisibleCount;
@@ -2510,7 +2509,7 @@ namespace Krypton.Workspace
                 // Remove all view separators no longer needed
                 for (var i = _drawPanel.Count - 1; i >= 0; i--)
                 {
-                    if ( _drawPanel[i] is ViewDrawWorkspaceSeparator separator)
+                    if (_drawPanel[i] is ViewDrawWorkspaceSeparator separator)
                     {
                         if (!separators.Contains(separator))
                         {
@@ -2530,7 +2529,7 @@ namespace Krypton.Workspace
 
                         // If the control has the expected interface
                         if (c is IWorkspaceItem { DisposeOnRemove: true })
-                            // Does the item want to be disposed on removal?
+                        // Does the item want to be disposed on removal?
                         {
                             c.Dispose();
                         }
@@ -2580,8 +2579,8 @@ namespace Krypton.Workspace
                 }
 
                 // If we have a maximized cell then ensure it has focus and not some other cell
-                if (MaximizedCell is { ContainsFocus: false } 
-                    && ContainsFocus )
+                if (MaximizedCell is { ContainsFocus: false }
+                    && ContainsFocus)
                 {
                     MaximizedCell.Select();
                 }
@@ -3203,7 +3202,7 @@ namespace Krypton.Workspace
                 if (workspaceItem != null)
                 {
                     // If no separator is associated with workspace, then create one now
-                    if ( !_workspaceToSeparator.TryGetValue(workspaceItem, out ViewDrawWorkspaceSeparator viewSeparator))
+                    if (!_workspaceToSeparator.TryGetValue(workspaceItem, out var viewSeparator))
                     {
                         // Create a view for the separator area
                         viewSeparator = new ViewDrawWorkspaceSeparator(this, workspaceItem, seq.Orientation)
@@ -3401,14 +3400,14 @@ namespace Krypton.Workspace
                             }
                             break;
                         case KryptonWorkspaceSequence child:
-                        {
-                            // Search inside the sequence for the first leaf in the specified direction
-                            KryptonWorkspaceCell? ret = RecursiveFindCellInSequence(child, forwards, onlyVisible);
-                            if (ret != null)
                             {
-                                return ret;
+                                // Search inside the sequence for the first leaf in the specified direction
+                                KryptonWorkspaceCell? ret = RecursiveFindCellInSequence(child, forwards, onlyVisible);
+                                if (ret != null)
+                                {
+                                    return ret;
+                                }
                             }
-                        }
                             break;
                     }
                 }
@@ -3471,14 +3470,14 @@ namespace Krypton.Workspace
                         }
                         break;
                     case KryptonWorkspaceSequence child:
-                    {
-                        // Search inside the sequence 
-                        KryptonWorkspaceCell? ret = RecursiveFindCellInSequence(child, forwards, onlyVisible);
-                        if (ret != null)
                         {
-                            return ret;
+                            // Search inside the sequence 
+                            KryptonWorkspaceCell? ret = RecursiveFindCellInSequence(child, forwards, onlyVisible);
+                            if (ret != null)
+                            {
+                                return ret;
+                            }
                         }
-                    }
                         break;
                 }
             }

--- a/Source/Krypton Components/Krypton.Workspace/Global/GlobalDeclarations.cs
+++ b/Source/Krypton Components/Krypton.Workspace/Global/GlobalDeclarations.cs
@@ -24,6 +24,7 @@ global using System.Threading;
 global using System.Windows.Forms;
 global using System.Windows.Forms.Design;
 global using System.Xml;
+global using System.Linq;
 
 global using Krypton.Navigator;
 global using Krypton.Toolkit;

--- a/Source/Krypton Components/Krypton.Workspace/Workspace/KryptonWorkspaceCellDesigner.cs
+++ b/Source/Krypton Components/Krypton.Workspace/Workspace/KryptonWorkspaceCellDesigner.cs
@@ -31,14 +31,14 @@ namespace Krypton.Workspace
         protected override void OnComponentRemoving(object sender, ComponentEventArgs e)
         {
             // If our control is being removed
-            if (e.Component == Navigator)
+            if (Equals(e.Component, Navigator))
             {
                 // If this workspace cell is inside a parent
                 var cell = (KryptonWorkspaceCell)Navigator;
                 // Cell an only be inside a workspace sequence
-                var sequence = (KryptonWorkspaceSequence)cell.WorkspaceParent;
+                var sequence = cell.WorkspaceParent as KryptonWorkspaceSequence;
                 // Remove the cell from the parent
-                sequence?.Children.Remove(cell);
+                sequence?.Children?.Remove(cell);
             }
 
             base.OnComponentRemoving(sender, e);

--- a/Source/Krypton Components/Krypton.Workspace/Workspace/KryptonWorkspaceSequenceDesigner.cs
+++ b/Source/Krypton Components/Krypton.Workspace/Workspace/KryptonWorkspaceSequenceDesigner.cs
@@ -94,14 +94,14 @@ namespace Krypton.Workspace
         private void OnComponentRemoving(object sender, ComponentEventArgs e)
         {
             // If our sequence is being removed
-            if (e.Component == _sequence)
+            if (Equals(e.Component, _sequence))
             {
                 // Need access to host in order to delete a component
-                var host = (IDesignerHost)GetService(typeof(IDesignerHost));
+                var host = GetService(typeof(IDesignerHost)) as IDesignerHost;
 
                 // Climb the workspace item tree to get the top most sequence
                 KryptonWorkspace? workspace = null;
-                IWorkspaceItem workspaceItem = _sequence;
+                IWorkspaceItem? workspaceItem = _sequence;
                 while (workspaceItem?.WorkspaceParent != null)
                 {
                     workspaceItem = workspaceItem.WorkspaceParent;

--- a/Source/Krypton Components/TestForm/Form1.cs
+++ b/Source/Krypton Components/TestForm/Form1.cs
@@ -135,7 +135,9 @@ namespace TestForm
 
         private void kryptonButton5_Click(object sender, EventArgs e)
         {
-            KryptonAboutToolkit.Show();
+            KryptonAboutToolkitData data = new KryptonAboutToolkitData();
+
+            KryptonAboutToolkit.Show(data);
         }
 
         private void Form1_Load(object sender, EventArgs e)


### PR DESCRIPTION
_Original PR:_

- Make the KryptonForm colors represents the controlled values from the `StateCommon`
- Remove Confusing Designer elements that try to override the `StateCommon-Back` settings
- A Few more tinkerings with the `nullables`
- Check `readonly` values

#1117

Plus sort out merge madness :) & enable KColor, Print etc dialogs on toolbox + extras

![image](https://github.com/Krypton-Suite/Standard-Toolkit/assets/949607/7c522283-510c-4937-a81a-db1a3ede1ba9)

Note PR #1167 can be discarded
