### PR TITLE
* `KryptonComboBox` 

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,8 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
+* New adjusting the size of a `KryptonComboBox` also changes the `DropDownWidth`
+    - Note: The `DropDownWidth` can still be set independently from the `Size` property
 * New `KryptonLanguageManager` is now integrated into `KryptonManager` as `ToolkitStrings`
 * Implemented [#1091](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1091), Krypton File Dialogs Missing Buttons
 * Implemented [#1009](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1009), Powered by Krypton Toolkit button
@@ -60,6 +62,8 @@
 * Added `KryptonLanguageManager` to the `KryptonManager` action list
 * Resolved [#1008](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1008), Krypton Save/Open file dialogs are not accessible from the toolbox
 * Implemented [#1007](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1007), A way to alter all of the strings in the toolkit to language specific strings
+* Implemented [#1006](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1006), Make converter strings localisable
+    - **Note:** Components that use these strings may need to be 'refreshed' once changes have been made
 * Implemented [#602](https://github.com/Krypton-Suite/Standard-Toolkit/issues/602), ToolStrip embedded into the non client area
 * Implemented [#894](https://github.com/Krypton-Suite/Standard-Toolkit/issues/894), `KryptonPropertyGrid` needs to have full Krypton support
 * Resolved [#999](https://github.com/Krypton-Suite/Standard-Toolkit/issues/999), Incorrect project file names while building

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -2150,6 +2150,20 @@ namespace Krypton.Toolkit
             // element that thinks it has the focus is informed it does not
             OnMouseLeave(EventArgs.Empty);
 
+        /// <summary>Gets or sets the height and width of the control.</summary>
+        [DefaultValue(typeof(Size), "121, 21")]
+        public new Size Size
+        {
+            get => base.Size;
+
+            set
+            {
+                base.Size = value;
+
+                UpdateDropDownWidth(value);
+            }
+        }
+
         #endregion
 
         #region Protected
@@ -3145,6 +3159,8 @@ namespace Krypton.Toolkit
 
             StateCommon.ComboBox.Border.Rounding = _cornerRoundingRadius;
         }
+
+        private void UpdateDropDownWidth(Size value) => DropDownWidth = value.Width;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonAboutToolkitForm.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonAboutToolkitForm.Designer.cs
@@ -62,6 +62,7 @@
             this.tsbtnDeveloperInformation = new System.Windows.Forms.ToolStripButton();
             this.tssVersions = new System.Windows.Forms.ToolStripSeparator();
             this.tsbtnVersions = new System.Windows.Forms.ToolStripButton();
+            this.klblBuiltOn = new Krypton.Toolkit.KryptonLabel();
             ((System.ComponentModel.ISupportInitialize)(this.kpnlButtons)).BeginInit();
             this.kpnlButtons.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
@@ -220,13 +221,15 @@
             this.tlpGeneralInformation.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tlpGeneralInformation.Controls.Add(this.pbxLogo, 0, 0);
             this.tlpGeneralInformation.Controls.Add(this.klwlblGeneralInformation, 1, 0);
-            this.tlpGeneralInformation.Controls.Add(this.klblCurrentTheme, 1, 1);
-            this.tlpGeneralInformation.Controls.Add(this.ktcmbCurrentTheme, 1, 2);
+            this.tlpGeneralInformation.Controls.Add(this.klblCurrentTheme, 1, 2);
+            this.tlpGeneralInformation.Controls.Add(this.ktcmbCurrentTheme, 1, 3);
+            this.tlpGeneralInformation.Controls.Add(this.klblBuiltOn, 1, 1);
             this.tlpGeneralInformation.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tlpGeneralInformation.Location = new System.Drawing.Point(0, 0);
             this.tlpGeneralInformation.Name = "tlpGeneralInformation";
             this.tlpGeneralInformation.RowCount = 3;
             this.tlpGeneralInformation.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tlpGeneralInformation.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpGeneralInformation.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpGeneralInformation.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpGeneralInformation.Size = new System.Drawing.Size(774, 325);
@@ -239,7 +242,7 @@
             this.pbxLogo.Margin = new System.Windows.Forms.Padding(5);
             this.pbxLogo.Name = "pbxLogo";
             this.pbxLogo.Padding = new System.Windows.Forms.Padding(4, 4, 0, 0);
-            this.pbxLogo.Size = new System.Drawing.Size(64, 254);
+            this.pbxLogo.Size = new System.Drawing.Size(64, 224);
             this.pbxLogo.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
             this.pbxLogo.TabIndex = 0;
             this.pbxLogo.TabStop = false;
@@ -254,7 +257,7 @@
             this.klwlblGeneralInformation.Location = new System.Drawing.Point(79, 5);
             this.klwlblGeneralInformation.Margin = new System.Windows.Forms.Padding(5);
             this.klwlblGeneralInformation.Name = "klwlblGeneralInformation";
-            this.klwlblGeneralInformation.Size = new System.Drawing.Size(690, 254);
+            this.klwlblGeneralInformation.Size = new System.Drawing.Size(690, 224);
             this.klwlblGeneralInformation.Text = "Some of the components used in this application are part of the Krypton Standard " +
     "Toolkit.\r\n\r\nLicense: BSD-3-Clause\r\n\r\nTo learn more, click here.";
             this.klwlblGeneralInformation.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -275,7 +278,7 @@
             // ktcmbCurrentTheme
             // 
             this.ktcmbCurrentTheme.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.ktcmbCurrentTheme.DropDownWidth = 623;
+            this.ktcmbCurrentTheme.DropDownWidth = 690;
             this.ktcmbCurrentTheme.IntegralHeight = false;
             this.ktcmbCurrentTheme.Location = new System.Drawing.Point(79, 299);
             this.ktcmbCurrentTheme.Margin = new System.Windows.Forms.Padding(5);
@@ -492,6 +495,17 @@
             this.tsbtnVersions.Text = "Version Information";
             this.tsbtnVersions.Click += new System.EventHandler(this.tsbtnVersions_Click);
             // 
+            // klblBuiltOn
+            // 
+            this.klblBuiltOn.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.klblBuiltOn.LabelStyle = Krypton.Toolkit.LabelStyle.BoldControl;
+            this.klblBuiltOn.Location = new System.Drawing.Point(79, 239);
+            this.klblBuiltOn.Margin = new System.Windows.Forms.Padding(5);
+            this.klblBuiltOn.Name = "klblBuiltOn";
+            this.klblBuiltOn.Size = new System.Drawing.Size(690, 20);
+            this.klblBuiltOn.TabIndex = 4;
+            this.klblBuiltOn.Values.Text = "Built On: {0}";
+            // 
             // KryptonAboutToolkitForm
             // 
             this.AcceptButton = this.kbtnOk;
@@ -581,5 +595,6 @@
         private ToolStripButton tsbtnVersions;
         private DataGridViewTextBoxColumn clmnFileName;
         private DataGridViewTextBoxColumn clmnVersion;
+        private KryptonLabel klblBuiltOn;
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonAboutToolkitForm.resx
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonAboutToolkitForm.resx
@@ -117,19 +117,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="clmnFileName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="clmnVersion.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <metadata name="tsControls.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
-  </metadata>
-  <metadata name="clmnFileName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="clmnVersion.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="clmnFileName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="clmnVersion.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
   </metadata>
 </root>

--- a/Source/Krypton Components/Krypton.Toolkit/General/KryptonAboutToolkitData.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/KryptonAboutToolkitData.cs
@@ -14,6 +14,8 @@ namespace Krypton.Toolkit
     {
         #region Static Fields
 
+        private const string DEFAULT_BUILT_ON_TEXT = @"Built On";
+
         private const string DEFAULT_CURRENT_THEME_TEXT = @"Current Theme";
 
         private const string DEFAULT_HEADER_TEXT = @"About";

--- a/Source/Krypton Components/Krypton.Toolkit/Utilities/GlobalToolkitUtilities.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Utilities/GlobalToolkitUtilities.cs
@@ -54,7 +54,7 @@ namespace Krypton.Toolkit
 
         /// <summary>Launches a chosen process.</summary>
         /// <param name="startInfo">The <see cref="ProcessStartInfo"/> object in which to start.</param>
-        public static void LaunchProcess(ProcessStartInfo startInfo)
+        public static Process? LaunchProcess(ProcessStartInfo startInfo)
         {
             try
             {
@@ -64,6 +64,8 @@ namespace Krypton.Toolkit
             {
                 ExceptionHandler.CaptureException(e);
             }
+
+            return null;
         }
 
         /// <summary>Gets the file list.</summary>

--- a/Source/Krypton Components/TestForm/Form1.Designer.cs
+++ b/Source/Krypton Components/TestForm/Form1.Designer.cs
@@ -76,14 +76,17 @@
             this.kryptonIntegratedToolbarPrintCommand1 = new Krypton.Toolkit.KryptonIntegratedToolbarPrintCommand();
             this.kryptonManager1 = new Krypton.Toolkit.KryptonManager(this.components);
             this.kryptonCheckSet1 = new Krypton.Toolkit.KryptonCheckSet(this.components);
+            this.kryptonComboBox1 = new Krypton.Toolkit.KryptonComboBox();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).BeginInit();
             this.kryptonPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonThemeComboBox1)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonCheckSet1)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonComboBox1)).BeginInit();
             this.SuspendLayout();
             // 
             // kryptonPanel1
             // 
+            this.kryptonPanel1.Controls.Add(this.kryptonComboBox1);
             this.kryptonPanel1.Controls.Add(this.kcbtnSizableToolWindow);
             this.kryptonPanel1.Controls.Add(this.kcbtnFixedToolWindow);
             this.kryptonPanel1.Controls.Add(this.kcbtnSizable);
@@ -312,13 +315,13 @@
             // kryptonThemeComboBox1
             // 
             this.kryptonThemeComboBox1.DisplayMember = "Key";
-            this.kryptonThemeComboBox1.DropDownWidth = 121;
+            this.kryptonThemeComboBox1.DropDownWidth = 185;
             this.kryptonThemeComboBox1.IntegralHeight = false;
             this.kryptonThemeComboBox1.Location = new System.Drawing.Point(12, 12);
             this.kryptonThemeComboBox1.Name = "kryptonThemeComboBox1";
             this.kryptonThemeComboBox1.Size = new System.Drawing.Size(185, 21);
-            this.kryptonThemeComboBox1.StateCommon.ComboBox.Border.DrawBorders = ((Krypton.Toolkit.PaletteDrawBorders)((((Krypton.Toolkit.PaletteDrawBorders.Top | Krypton.Toolkit.PaletteDrawBorders.Bottom)
-            | Krypton.Toolkit.PaletteDrawBorders.Left)
+            this.kryptonThemeComboBox1.StateCommon.ComboBox.Border.DrawBorders = ((Krypton.Toolkit.PaletteDrawBorders)((((Krypton.Toolkit.PaletteDrawBorders.Top | Krypton.Toolkit.PaletteDrawBorders.Bottom) 
+            | Krypton.Toolkit.PaletteDrawBorders.Left) 
             | Krypton.Toolkit.PaletteDrawBorders.Right)));
             this.kryptonThemeComboBox1.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
             this.kryptonThemeComboBox1.TabIndex = 4;
@@ -377,7 +380,7 @@
             this.kryptonTextBox1.Location = new System.Drawing.Point(58, 104);
             this.kryptonTextBox1.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonTextBox1.Name = "kryptonTextBox1";
-            this.kryptonTextBox1.Size = new System.Drawing.Size(75, 23);
+            this.kryptonTextBox1.Size = new System.Drawing.Size(75, 22);
             this.kryptonTextBox1.TabIndex = 1;
             this.kryptonTextBox1.Text = "kryptonTextBox1";
             // 
@@ -457,6 +460,17 @@
             this.kryptonCheckSet1.CheckButtons.Add(this.kcbtnFixedToolWindow);
             this.kryptonCheckSet1.CheckButtons.Add(this.kcbtnSizableToolWindow);
             // 
+            // kryptonComboBox1
+            // 
+            this.kryptonComboBox1.DropDownWidth = 121;
+            this.kryptonComboBox1.IntegralHeight = false;
+            this.kryptonComboBox1.Location = new System.Drawing.Point(14, 396);
+            this.kryptonComboBox1.Name = "kryptonComboBox1";
+            this.kryptonComboBox1.Size = new System.Drawing.Size(121, 21);
+            this.kryptonComboBox1.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
+            this.kryptonComboBox1.TabIndex = 25;
+            this.kryptonComboBox1.Text = "kryptonComboBox1";
+            // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -486,6 +500,7 @@
             this.kryptonPanel1.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonThemeComboBox1)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonCheckSet1)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonComboBox1)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -538,5 +553,6 @@
         private Krypton.Toolkit.KryptonCheckButton kcbtnSizable;
         private Krypton.Toolkit.KryptonCheckButton kcbtnFixedToolWindow;
         private Krypton.Toolkit.KryptonCheckButton kcbtnSizableToolWindow;
+        private Krypton.Toolkit.KryptonComboBox kryptonComboBox1;
     }
 }

--- a/Source/Krypton Components/TestForm/Form1.resx
+++ b/Source/Krypton Components/TestForm/Form1.resx
@@ -120,9 +120,6 @@
   <metadata name="kryptonContextMenu1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>539, 16</value>
   </metadata>
-  <metadata name="kryptonLanguageManager1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>989, 16</value>
-  </metadata>
   <metadata name="kryptonCustomPaletteBase1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>166, 16</value>
   </metadata>


### PR DESCRIPTION
* New adjusting the size of a `KryptonComboBox` also changes the `DropDownWidth`
    - Note: The `DropDownWidth` can still be set independently from the `Size` property

![image](https://github.com/Krypton-Suite/Standard-Toolkit/assets/949607/28b3c776-3255-4df2-8d8f-f2be59f88726)
