### PR TITLE
- Disable default action, if this is a drop button and it is clicked

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
+* Resolved [#1169](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1169), Button Spec Krypton Context Menu (Canary)
 * New adjusting the size of a `KryptonComboBox` also changes the `DropDownWidth`
     - Note: The `DropDownWidth` can still be set independently from the `Size` property
 * Resolved [#1091](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1091), Krypton File Dialogs Missing Buttons

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecView.cs
@@ -379,21 +379,18 @@ namespace Krypton.Toolkit
             // Never show a context menu in design mode
             if (!CommonHelper.DesignMode(Manager.Control))
             {
-                var showMenu = false;
-                var performDefaultClick = true;
-                if (ButtonSpec is ButtonSpecAny { ShowDrop: true })
-                {
-                    showMenu = ViewButton?.SplitRectangle.Contains(e.Location) ?? false;
-                    performDefaultClick = !showMenu;
-                }
-
+                // ButtonSpec's used to drop menu's if they had a context menu;
+                // BUT; Disable default action, if this is a drop button and it is clicked
+                bool performDefaultClick = !(ButtonSpec is ButtonSpecAny { ShowDrop: true }
+                                             && ViewButton != null
+                                             && ViewButton.SplitRectangle.Contains(e.Location));
+                
                 if (performDefaultClick)
                 {
                     // Fire the event handlers hooked into the button spec click event
                     ButtonSpec.PerformClick(e);
                 }
 
-                if (showMenu)
                 {
                     // Does the button spec define a krypton context menu?
                     if ((ButtonSpec.KryptonContextMenu != null) && (ViewButton != null))
@@ -444,7 +441,7 @@ namespace Krypton.Toolkit
 
         private void OnKryptonContextMenuClosed(object sender, ToolStripDropDownClosedEventArgs e)
         {
-            // Unhook from context menu event so it could garbage collected in the future
+            // Unhook from context menu event, so that it can garbage collected in the future
             var kcm = (KryptonContextMenu)sender;
             kcm.Closed -= OnKryptonContextMenuClosed;
 


### PR DESCRIPTION
- ButtonSpec's used to drop menu's if they had a context menu;
- Also make sure that the default actions still work (i.e. Close button!)

#1169

![image](https://github.com/Krypton-Suite/Standard-Toolkit/assets/2418812/f89a99fe-faea-4c21-906f-a4f100f9cb91)
