### PR TITLE
- Implement `KryptonManager._globalUseKryptonFileDialogs`

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
+* Implemented [#1223](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1223), Move `UseKryptonFileDialogs` to a better designer location
 * Implemented [#1222](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1222), Remove `CustomPalette` (Should be part of the palette definition)
 * Implemented [#1204](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1204), Build on `KryptonCommandLinkButtons`
     - [#1216](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1216), Add support for fonts

--- a/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderOutlookBase.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderOutlookBase.cs
@@ -1069,19 +1069,19 @@ namespace Krypton.Navigator
                 // specifically requested to be placed on the overflow bar area.
                 foreach (var page in Navigator.Pages)
                 {
-                    if (_pageStackLookup.ContainsKey(page))
+                    if (_pageStackLookup.TryGetValue(page, out ViewDrawNavCheckButtonBase? value))
                     {
                         var showPageStack = page.LastVisibleSet && !page.AreFlagsSet(KryptonPageFlags.PageInOverflowBarForOutlookMode);
-                        _pageStackLookup[page].Visible = showPageStack;
+                        value.Visible = showPageStack;
                         if (_buttonEdgeLookup != null)
                         {
                             _buttonEdgeLookup[page].Visible = showPageStack;
                         }
 
-                        if (_pageOverflowLookup.ContainsKey(page))
+                        if (_pageOverflowLookup.TryGetValue(page, out ViewDrawNavCheckButtonBase? value1))
                         {
                             var showPageOverflow = page.LastVisibleSet && !showPageStack;
-                            _pageOverflowLookup[page].Visible = showPageOverflow;
+                            value1.Visible = showPageOverflow;
                         }
                     }
                 }

--- a/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonRibbon.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonRibbon.cs
@@ -974,7 +974,7 @@ namespace Krypton.Ribbon
         /// Internal design time method.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool InDesignMode => DesignMode;
+        public new bool InDesignMode => DesignMode;
 
         /// <summary>
         /// Internal design time method.

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupsBorderSynch.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupsBorderSynch.cs
@@ -64,10 +64,9 @@ namespace Krypton.Ribbon
         public ViewDrawRibbonGroup? ViewGroupFromPoint(Point pt)
         {
             // There can only be groups showing for the currently selected tab
-            if (Ribbon.SelectedTab != null && _tabToView.ContainsKey(Ribbon.SelectedTab))
+            if (Ribbon.SelectedTab != null && _tabToView.TryGetValue(Ribbon.SelectedTab, out ViewLayoutRibbonScrollPort? viewScrollPort))
             {
                 // Get the scroll port for this tab
-                ViewLayoutRibbonScrollPort viewScrollPort = _tabToView[Ribbon.SelectedTab];
 
                 // The first child of the scroll port is always the view control
                 var viewControl = viewScrollPort[0] as ViewLayoutControl;
@@ -212,9 +211,9 @@ namespace Krypton.Ribbon
                 ViewLayoutRibbonScrollPort? view = null;
 
                 // Get the currently cached view for the tab
-                if (_tabToView.ContainsKey(tab))
+                if (_tabToView.TryGetValue(tab, out ViewLayoutRibbonScrollPort? value))
                 {
-                    view = _tabToView[tab];
+                    view = value;
                 }
 
                 // If a new tab, create a view for it now

--- a/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonGroupContent.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonGroupContent.cs
@@ -690,8 +690,8 @@ namespace Krypton.Ribbon
             foreach (KryptonRibbonGroupContainer container in _ribbonGroup.Items)
             {
                 // Do we already have a view for this container definition
-                ViewBase containerView = _containerToView.ContainsKey(container)
-                    ? _containerToView[container]
+                ViewBase containerView = _containerToView.TryGetValue(container, out ViewBase? value)
+                    ? value
                     : container.CreateView(_ribbon, _needPaint);
 
                 // Update the visible state of the item

--- a/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonGroupLines.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonGroupLines.cs
@@ -546,11 +546,10 @@ namespace Krypton.Ribbon
                     if (previousChild != null)
                     {
                         if (_viewToItem.ContainsKey(child) &&
-                            _viewToItem.ContainsKey(previousChild))
+                            _viewToItem.TryGetValue(previousChild, out IRibbonGroupItem? previousItem))
                         {
                             // Cast to correct type
                             IRibbonGroupItem childItem = _viewToItem[child];
-                            IRibbonGroupItem previousItem = _viewToItem[previousChild];
 
                             // Find the requested gap between them
                             _viewToGap.Add(child, childItem.ItemGap(previousItem));
@@ -1001,9 +1000,9 @@ namespace Krypton.Ribbon
                     }
 
                     // If not the first item on the line, then get the pixel gap between them
-                    if ((previousChild != null) && _viewToGap.ContainsKey(child))
+                    if ((previousChild != null) && _viewToGap.TryGetValue(child, out var value))
                     {
-                        x += _viewToGap[child];
+                        x += value;
                     }
 
                     // Get the size of the child item
@@ -1088,9 +1087,9 @@ namespace Krypton.Ribbon
                     }
 
                     // If not the first item on the line, then get the pixel gap between them
-                    if ((previousChild != null) && _viewToGap.ContainsKey(child))
+                    if ((previousChild != null) && _viewToGap.TryGetValue(child, out var value))
                     {
-                        x += _viewToGap[child];
+                        x += value;
                     }
 
                     // Get the size of the child item

--- a/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonGroups.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonGroups.cs
@@ -391,9 +391,9 @@ namespace Krypton.Ribbon
                 ViewDrawRibbonGroup? view = null;
 
                 // Get the currently cached view for the group
-                if (_groupToView.ContainsKey(ribGroup))
+                if (_groupToView.TryGetValue(ribGroup, out ViewDrawRibbonGroup? value))
                 {
-                    view = _groupToView[ribGroup];
+                    view = value;
                 }
 
                 // If a new group, create a view for it now

--- a/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonRowCenter.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonRowCenter.cs
@@ -187,18 +187,18 @@ namespace Krypton.Ribbon
                     switch (CurrentSize)
                     {
                         case GroupItemSize.Small:
-                            childPreferred = _viewToSmall.ContainsKey(child)
-                                ? _viewToSmall[child]
+                            childPreferred = _viewToSmall.TryGetValue(child, out Size value)
+                                ? value
                                 : child.GetPreferredSize(context);
                             break;
                         case GroupItemSize.Medium:
-                            childPreferred = _viewToMedium.ContainsKey(child)
-                                ? _viewToMedium[child]
+                            childPreferred = _viewToMedium.TryGetValue(child, out Size value1)
+                                ? value1
                                 : child.GetPreferredSize(context);
                             break;
                         case GroupItemSize.Large:
-                            childPreferred = _viewToLarge.ContainsKey(child)
-                                ? _viewToLarge[child]
+                            childPreferred = _viewToLarge.TryGetValue(child, out Size value2)
+                                ? value2
                                 : child.GetPreferredSize(context);
                             break;
                     }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
@@ -2055,7 +2055,7 @@ namespace Krypton.Toolkit
         public string Import(bool silent = false)
         {
             string paletteFileName = string.Empty;
-            if (UseKryptonFileDialogs)
+            if (KryptonManager._globalUseKryptonFileDialogs)
             {
                 using var kofd = new KryptonOpenFileDialog
                 {
@@ -2406,7 +2406,7 @@ namespace Krypton.Toolkit
         /// <returns>Fullpath of exported filename; otherwise empty string.</returns>
         public string? Export()
         {
-            if (UseKryptonFileDialogs)
+            if (KryptonManager._globalUseKryptonFileDialogs)
             {
                 using var ksfd = new KryptonSaveFileDialog
                 {
@@ -2918,11 +2918,6 @@ namespace Krypton.Toolkit
         private bool ShouldSerializeBaseRenderer() => BaseRenderer != null;
         private void ResetBaseRenderer() => BaseRenderer = null;
 
-        //protected override void DefineFonts()
-        //{
-        //    // This class has no font fields
-        //}
-
         /// <summary>
         /// Gets access to the color table instance.
         /// </summary>
@@ -2931,16 +2926,11 @@ namespace Krypton.Toolkit
 
         /// <inheritdoc />
         [Browsable(false)]
-        public new bool UseKryptonFileDialogs
-        { get => _basePalette!.UseKryptonFileDialogs; set => _basePalette!.UseKryptonFileDialogs = value; }
-
-        /// <inheritdoc />
-        [Browsable(false)]
         [DisallowNull]
         public new Font BaseFont
         { get => _basePalette!.BaseFont; set => _basePalette!.BaseFont = value; }
-        private void ResetBaseFont() => _basePalette!.ResetBaseFont();
-        private bool ShouldSerializeBaseFont() => _basePalette!.ShouldSerializeBaseFont();
+        private new void ResetBaseFont() => _basePalette!.ResetBaseFont();
+        private new bool ShouldSerializeBaseFont() => _basePalette!.ShouldSerializeBaseFont();
 
         /// <inheritdoc />
         [Browsable(false)]
@@ -3510,7 +3500,7 @@ namespace Krypton.Toolkit
                             var name = imageElement.GetAttribute(@"Name");
 
                             // Grab the CDATA section that contains the base64 value
-                            var cdata = imageElement.ChildNodes[0] as XmlCDataSection;
+                            var cdata = (XmlCDataSection)imageElement.ChildNodes[0];
 
                             // Convert to back from a string to bytes
                             var bytes = Convert.FromBase64String(cdata.Value);
@@ -3663,21 +3653,24 @@ namespace Krypton.Toolkit
                                         }
 
                                         // Have we already encountered the image?
-                                        if (imageCache != null && imageCache.ContainsKey(image))
+                                        if (imageCache != null)
                                         {
-                                            // Save reference to the existing cached image
-                                            childElement.SetAttribute(@"Value", imageCache[image]);
-                                        }
-                                        else
-                                        {
-                                            // Generate a placeholder string
-                                            var imageName = $@"ImageCache{(imageCache.Count + 1)}";
+                                            if (imageCache.TryGetValue(image, out var value))
+                                            {
+                                                // Save reference to the existing cached image
+                                                childElement.SetAttribute(@"Value", value);
+                                            }
+                                            else
+                                            {
+                                                // Generate a placeholder string
+                                                var imageName = $@"ImageCache{(imageCache.Count + 1)}";
 
-                                            // Add the actual image instance into the cache
-                                            imageCache.Add(image, imageName);
+                                                // Add the actual image instance into the cache
+                                                imageCache.Add(image, imageName);
 
-                                            // Save the placeholder name instead of the actual image
-                                            childElement.SetAttribute(@"Value", imageName);
+                                                // Save the placeholder name instead of the actual image
+                                                childElement.SetAttribute(@"Value", imageName);
+                                            }
                                         }
                                     }
                                 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonManager.cs
@@ -26,6 +26,7 @@ namespace Krypton.Toolkit
         // Initialize the global state
         private static bool _globalApplyToolstrips = true;
         private static bool _globalAllowFormChrome = true;
+        internal static bool _globalUseKryptonFileDialogs = true;
 
         // Initialize the default modes
 
@@ -207,7 +208,9 @@ namespace Krypton.Toolkit
                                    ShouldSerializeGlobalPalette() ||
                                    ShouldSerializeGlobalApplyToolstrips() ||
                                    ShouldSerializeGlobalAllowFormChrome() ||
-                                   ShouldSerializeToolkitStrings());
+                                   ShouldSerializeToolkitStrings() ||
+                                   ShouldSerializeUseKryptonFileDialogs()
+                                   );
 
         /// <summary>
         /// Reset All values
@@ -219,7 +222,7 @@ namespace Krypton.Toolkit
             ResetGlobalApplyToolstrips();
             ResetGlobalAllowFormChrome();
             ResetToolkitStrings();
-
+            ResetUseKryptonFileDialogs();
         }
 
         /// <summary>
@@ -280,9 +283,7 @@ namespace Krypton.Toolkit
                 }
             }
         }
-
         private bool ShouldSerializeGlobalPaletteMode() => GlobalPaletteMode != PaletteMode.Microsoft365Blue;
-
         private void ResetGlobalPaletteMode() => GlobalPaletteMode = PaletteMode.Microsoft365Blue;
 
         /// <summary>
@@ -344,9 +345,7 @@ namespace Krypton.Toolkit
                 }
             }
         }
-
         private bool ShouldSerializeGlobalPalette() => GlobalPalette != CurrentGlobalPalette;
-
         private void ResetGlobalPalette() => GlobalPalette = CurrentGlobalPalette;
 
         /// <summary>
@@ -360,10 +359,22 @@ namespace Krypton.Toolkit
             get => ApplyToolstrips;
             set => ApplyToolstrips = value;
         }
-
         private bool ShouldSerializeGlobalApplyToolstrips() => !GlobalApplyToolstrips;
-
         private void ResetGlobalApplyToolstrips() => GlobalApplyToolstrips = true;
+
+        /// <summary>Gets or sets a value indicating whether [use krypton file dialogs for internal openings like CustomPalette Import].</summary>
+        /// <value><c>true</c> if [use krypton file dialogs]; otherwise, <c>false</c>.</value>
+        [Category(@"Visuals")]
+        [Description(@"Should use krypton file dialogs for internal openings like CustomPalette Import")]
+        [DefaultValue(true)]
+        public bool UseKryptonFileDialogs
+        {
+            get => _globalUseKryptonFileDialogs;
+            set => _globalUseKryptonFileDialogs = value; 
+        }
+        private bool ShouldSerializeUseKryptonFileDialogs() => !UseKryptonFileDialogs;
+        private void ResetUseKryptonFileDialogs() => UseKryptonFileDialogs = true;
+
 
         /// <summary>
         /// Gets or sets a value indicating if KryptonForm instances are allowed to show custom chrome.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPopupShadow.resx
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPopupShadow.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualThemeBrowserForm.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualThemeBrowserForm.Designer.cs
@@ -48,11 +48,6 @@
             // 
             // kcpbCustom
             // 
-            this.kcpbCustom.BaseFont = new System.Drawing.Font("Segoe UI", 9F);
-            this.kcpbCustom.BasePaletteMode = Krypton.Toolkit.PaletteMode.Microsoft365Blue;
-            this.kcpbCustom.BasePaletteType = Krypton.Toolkit.BasePaletteType.Custom;
-            this.kcpbCustom.ThemeName = null;
-            this.kcpbCustom.UseKryptonFileDialogs = true;
             // 
             // kryptonPanel1
             // 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Base/PaletteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Base/PaletteBase.cs
@@ -90,8 +90,6 @@ namespace Krypton.Toolkit
 
             ThemeName = string.Empty;
 
-            UseKryptonFileDialogs = true;
-
             BaseFont = _defaultFontStyle;
         }
         #endregion
@@ -1691,11 +1689,6 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Public
-
-        /// <summary>Gets or sets a value indicating whether [use krypton file dialogs].</summary>
-        /// <value><c>true</c> if [use krypton file dialogs]; otherwise, <c>false</c>.</value>
-        [DefaultValue(false), Description(@"Use Krypton style file dialogs for exporting/importing palettes.")]
-        public bool UseKryptonFileDialogs { get; set; }
 
         /// <summary>Gets or sets the base palette font.</summary>
         /// <value>The base palette font.</value>

--- a/Source/Krypton Components/TestForm/Form1.Designer.cs
+++ b/Source/Krypton Components/TestForm/Form1.Designer.cs
@@ -452,7 +452,6 @@
             this.kryptonCustomPaletteBase1.BasePaletteMode = Krypton.Toolkit.PaletteMode.Microsoft365Black;
             this.kryptonCustomPaletteBase1.BasePaletteType = Krypton.Toolkit.BasePaletteType.Microsoft365;
             this.kryptonCustomPaletteBase1.ThemeName = "";
-            this.kryptonCustomPaletteBase1.UseKryptonFileDialogs = true;
             // 
             // kcmdMessageboxTest
             // 


### PR DESCRIPTION
- Fix fallout from move
- let ReSharper use `TryGetValue` for performance

#1223

![image](https://github.com/Krypton-Suite/Standard-Toolkit/assets/2418812/dc9655a2-665b-46b8-85f9-5c95710b75b3)
