### PR TITLE
  - BaseFont is now part of the KryptonManager class, and will overri…

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
+* Implemented [#1224](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1224), **[Breaking Change]** Move `GlobalPaletteMode` into `GlobalPalette` and rename 
 * Implemented [#1223](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1223), Move `UseKryptonFileDialogs` to a better designer location
 * Implemented [#1222](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1222), Remove `CustomPalette` (Should be part of the palette definition)
 * Implemented [#1204](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1204), Build on `KryptonCommandLinkButtons`

--- a/README.md
+++ b/README.md
@@ -178,7 +178,11 @@ Follow the links to see the different objects and layouts that this framework al
 
 ## V90.## (2024-11-xx - Build 2411 - November 2024)
 There are list of changes that have occurred during the development of the V90.## version
-- [#1206](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1206), Remove the Font Size (as it is already covered by the actual font !)
+- [#1206](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1206), Remove the `Font Size` (as it is already covered by the actual font !)
+- [#1224](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1224), Move `GlobalPaletteMode` into `GlobalPalette` and rename 
+  - BaseFont is now part of the KryptonManager class, and will override the applied palette font(s)
+  - `CustomPalette` must be derived from the `KryptonCustomPaletteBase` class
+  - `BasePaletteMode` has been removed from `KryptonCustomPaletteBase` class
 
 ### Support for .NET 7
 As of V90.##, support for .NET 7 has been removed due to their release cadences.

--- a/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonStorePage.cs
+++ b/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonStorePage.cs
@@ -47,7 +47,7 @@ namespace Krypton.Docking
         }
 
         /// <summary>
-        /// Gets the storgate name associated with this page.
+        /// Gets the storage name associated with this page.
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Advanced)]

--- a/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavClose.cs
+++ b/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavClose.cs
@@ -34,7 +34,7 @@ namespace Krypton.Navigator
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibility.</returns>
-        public override bool GetVisible(PaletteBase? palette)
+        public override bool GetVisible(PaletteBase palette)
         {
             switch (Navigator.Button.CloseButtonDisplay)
             {
@@ -59,7 +59,7 @@ namespace Krypton.Navigator
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button enabled state.</returns>
-        public override ButtonEnabled GetEnabled(PaletteBase? palette)
+        public override ButtonEnabled GetEnabled(PaletteBase palette)
         {
             switch (Navigator.Button.CloseButtonDisplay)
             {

--- a/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavContext.cs
+++ b/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavContext.cs
@@ -38,7 +38,7 @@ namespace Krypton.Navigator
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibiliy.</returns>
-        public override bool GetVisible(PaletteBase? palette)
+        public override bool GetVisible(PaletteBase palette)
         {
             switch (Navigator.Button.ContextButtonDisplay)
             {
@@ -76,7 +76,7 @@ namespace Krypton.Navigator
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button enabled state.</returns>
-        public override ButtonEnabled GetEnabled(PaletteBase? palette)
+        public override ButtonEnabled GetEnabled(PaletteBase palette)
         {
             switch (Navigator.Button.ContextButtonDisplay)
             {

--- a/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavFormClose.cs
+++ b/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavFormClose.cs
@@ -59,7 +59,7 @@ namespace Krypton.Navigator
 
         #region ButtonSpecNavFixed Implementation
 
-        public override bool GetVisible(PaletteBase? palette)
+        public override bool GetVisible(PaletteBase palette)
         {
             // We do not show if the custom chrome is combined with composition,
             // in which case the form buttons are handled by the composition
@@ -74,7 +74,7 @@ namespace Krypton.Navigator
 
         public override ButtonCheckState GetChecked(PaletteBase? palette) => ButtonCheckState.NotCheckButton;
 
-        public override ButtonEnabled GetEnabled(PaletteBase? palette) => _navigator.Owner!.CloseBox && Enabled ? ButtonEnabled.True : ButtonEnabled.False;
+        public override ButtonEnabled GetEnabled(PaletteBase palette) => _navigator.Owner!.CloseBox && Enabled ? ButtonEnabled.True : ButtonEnabled.False;
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavFormMaximize.cs
+++ b/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavFormMaximize.cs
@@ -30,7 +30,7 @@ namespace Krypton.Navigator
 
         #region ButtonSpecNavFixed Implementation
 
-        public override bool GetVisible(PaletteBase? palette)
+        public override bool GetVisible(PaletteBase palette)
         {
             // We do not show if the custom chrome is combined with composition,
             // in which case the form buttons are handled by the composition
@@ -59,7 +59,7 @@ namespace Krypton.Navigator
 
         public override ButtonCheckState GetChecked(PaletteBase? palette) => ButtonCheckState.NotCheckButton;
 
-        public override ButtonEnabled GetEnabled(PaletteBase? palette) =>
+        public override ButtonEnabled GetEnabled(PaletteBase palette) =>
             // Has the maximize buttons been turned off?
             _navigator.Owner!.MaximizeBox ? ButtonEnabled.True : ButtonEnabled.False;
 

--- a/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavFormMinimize.cs
+++ b/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavFormMinimize.cs
@@ -15,10 +15,10 @@ namespace Krypton.Navigator
         {
         }
 
-        public override bool GetVisible(PaletteBase? palette) => throw new NotImplementedException();
+        public override bool GetVisible(PaletteBase palette) => throw new NotImplementedException();
 
         public override ButtonCheckState GetChecked(PaletteBase? palette) => throw new NotImplementedException();
 
-        public override ButtonEnabled GetEnabled(PaletteBase? palette) => throw new NotImplementedException();
+        public override ButtonEnabled GetEnabled(PaletteBase palette) => throw new NotImplementedException();
     }
 }

--- a/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavManagerLayoutBar.cs
+++ b/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavManagerLayoutBar.cs
@@ -32,7 +32,7 @@ namespace Krypton.Navigator
         /// <param name="getRenderer">Delegate for returning a tool strip renderer.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
         public ButtonSpecNavManagerLayoutBar(Control control,
-                                             PaletteRedirect? redirector,
+                                             PaletteRedirect redirector,
                                              ButtonSpecCollectionBase? variableSpecs,
                                              ViewLayoutDocker[] viewDockers,
                                              IPaletteMetric[] viewMetrics,
@@ -63,7 +63,7 @@ namespace Krypton.Navigator
         /// <param name="getRenderer">Delegate for returning a tool strip renderer.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
         public ButtonSpecNavManagerLayoutBar(Control control,
-                                             PaletteRedirect? redirector,
+                                             PaletteRedirect redirector,
                                              ButtonSpecCollectionBase? variableSpecs,
                                              ButtonSpecCollectionBase? fixedSpecs,
                                              ViewLayoutDocker[] viewDockers,
@@ -205,7 +205,7 @@ namespace Krypton.Navigator
         /// <param name="redirector">Base palette class.</param>
         /// <param name="buttonSpec">ButtonSpec instance.</param>
         /// <returns>Palette redirector for the button spec instance.</returns>
-        public override PaletteRedirect CreateButtonSpecRemap(PaletteRedirect? redirector,
+        public override PaletteRedirect CreateButtonSpecRemap(PaletteRedirect redirector,
                                                               ButtonSpec buttonSpec) =>
             new ButtonSpecNavRemap(redirector, buttonSpec, RemapTarget);
 

--- a/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavManagerLayoutHeaderBar.cs
+++ b/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavManagerLayoutHeaderBar.cs
@@ -40,7 +40,7 @@ namespace Krypton.Navigator
         /// <param name="paletteContent">Palette source for color remapping.</param>
         /// <param name="paletteState">Palette state for color remapping.</param>
         public ButtonSpecNavManagerLayoutHeaderBar(Control control,
-                                                   PaletteRedirect? redirector,
+                                                   PaletteRedirect redirector,
                                                    ButtonSpecCollectionBase? variableSpecs,
                                                    ButtonSpecCollectionBase? fixedSpecs,
                                                    ViewLayoutDocker[] viewDockers,
@@ -92,7 +92,7 @@ namespace Krypton.Navigator
         /// <param name="redirector">Base palette class.</param>
         /// <param name="buttonSpec">ButtonSpec instance.</param>
         /// <returns>Palette redirector for the button spec instance.</returns>
-        public override PaletteRedirect CreateButtonSpecRemap(PaletteRedirect? redirector,
+        public override PaletteRedirect CreateButtonSpecRemap(PaletteRedirect redirector,
                                                               ButtonSpec buttonSpec) =>
             new ButtonSpecRemapByContentCache(redirector, buttonSpec);
 

--- a/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavNext.cs
+++ b/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavNext.cs
@@ -34,7 +34,7 @@ namespace Krypton.Navigator
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibiliy.</returns>
-        public override bool GetVisible(PaletteBase? palette)
+        public override bool GetVisible(PaletteBase palette)
         {
             switch (Navigator.Button.NextButtonDisplay)
             {
@@ -72,7 +72,7 @@ namespace Krypton.Navigator
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button enabled state.</returns>
-        public override ButtonEnabled GetEnabled(PaletteBase? palette)
+        public override ButtonEnabled GetEnabled(PaletteBase palette)
         {
             switch (Navigator.Button.NextButtonDisplay)
             {

--- a/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavPrevious.cs
+++ b/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavPrevious.cs
@@ -34,7 +34,7 @@ namespace Krypton.Navigator
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibiliy.</returns>
-        public override bool GetVisible(PaletteBase? palette)
+        public override bool GetVisible(PaletteBase palette)
         {
             switch (Navigator.Button.PreviousButtonDisplay)
             {
@@ -72,7 +72,7 @@ namespace Krypton.Navigator
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button enabled state.</returns>
-        public override ButtonEnabled GetEnabled(PaletteBase? palette)
+        public override ButtonEnabled GetEnabled(PaletteBase palette)
         {
             switch (Navigator.Button.PreviousButtonDisplay)
             {

--- a/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavRemap.cs
+++ b/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavRemap.cs
@@ -127,7 +127,7 @@ namespace Krypton.Navigator
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="buttonSpec">Reference to button specification.</param>
         /// <param name="remapTarget">Target for remapping the color onto.</param>
-        public ButtonSpecNavRemap(PaletteBase? target,
+        public ButtonSpecNavRemap(PaletteBase target,
                                   [DisallowNull] ButtonSpec buttonSpec,
                                   ButtonSpecRemapTarget remapTarget)
             : base(target)

--- a/Source/Krypton Components/Krypton.Navigator/Controls Navigator/KryptonNavigator.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Controls Navigator/KryptonNavigator.cs
@@ -1830,7 +1830,7 @@ namespace Krypton.Navigator
 
         internal ButtonSpecCollectionBase? FixedSpecs => Button.FixedSpecs;
 
-        internal PaletteRedirect? InternalRedirector => Redirector;
+        internal PaletteRedirect InternalRedirector => Redirector;
 
         internal void InternalForceViewLayout() => ForceViewLayout();
 
@@ -2456,7 +2456,7 @@ namespace Krypton.Navigator
                 if (SelectedPage == page)
                 {
                     // And a change in a palette setting has occurred...
-                    if (e.PropertyName == nameof(Palette))
+                    if (e.PropertyName == @"Palette")
                     {
                         // ...then need to repaint and layout to effect change
                         if (page != null)

--- a/Source/Krypton Components/Krypton.Navigator/Controls Visuals/VisualPopupPage.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Controls Visuals/VisualPopupPage.cs
@@ -39,7 +39,7 @@ namespace Krypton.Navigator
         /// <param name="renderer">Drawing renderer.</param>
         public VisualPopupPage([DisallowNull] KryptonNavigator navigator,
             [DisallowNull] KryptonPage page,
-                               IRenderer? renderer)
+                               IRenderer renderer)
             : base(renderer, true)
         {
             Debug.Assert(navigator != null);

--- a/Source/Krypton Components/Krypton.Navigator/Converters/BarItemSizingConverter.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Converters/BarItemSizingConverter.cs
@@ -18,21 +18,21 @@ namespace Krypton.Navigator
     public class BarItemSizingConverter : StringLookupConverter<BarItemSizing>
     {
         [Localizable(true)]
-        private static readonly IReadOnlyDictionary<BarItemSizing, string> _pairs = new Dictionary<BarItemSizing, string>
+        private static readonly BiDictionary<BarItemSizing, string> _pairs = new BiDictionary<BarItemSizing, string>(
+            new Dictionary<BarItemSizing, string>
         {
             {BarItemSizing.Individual, @"Individual Sizing"},
             {BarItemSizing.SameHeight, @"All Same Height"},
             {BarItemSizing.SameWidth, @"All Same Width"},
             {BarItemSizing.SameWidthAndHeight, @"All Same Width & Height"}
-        };
+        });
 
         #region Protected
-
         /// <summary>
         /// Gets an array of lookup pairs.
         /// </summary>
-        protected override IReadOnlyDictionary<BarItemSizing /*Enum*/, string /*Display*/> Pairs => _pairs;
-
+        protected override IReadOnlyDictionary<string /*Display*/, BarItemSizing /*Enum*/ > PairsStringToEnum  => _pairs.SecondToFirst;
+        protected override IReadOnlyDictionary<BarItemSizing /*Enum*/, string /*Display*/> PairsEnumToString => _pairs.FirstToSecond;
         #endregion
     }
 }

--- a/Source/Krypton Components/Krypton.Navigator/Converters/ButtonDisplayConverter.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Converters/ButtonDisplayConverter.cs
@@ -17,20 +17,21 @@ namespace Krypton.Navigator
     /// </summary>
     public class ButtonDisplayConverter : StringLookupConverter<ButtonDisplay>
     {
-        private static readonly IReadOnlyDictionary<ButtonDisplay, string> _pairs = new Dictionary<ButtonDisplay, string>
+        private static readonly BiDictionary<ButtonDisplay, string> _pairs = new BiDictionary<ButtonDisplay, string>(
+            new Dictionary<ButtonDisplay, string>
             {
                 {ButtonDisplay.Hide, @"Hide"},
                 {ButtonDisplay.ShowDisabled, @"Show Disabled"},
                 {ButtonDisplay.ShowEnabled, @"Show Enabled"},
                 {ButtonDisplay.Logic, @"Logic"}
-            };
+            });
 
         #region Protected
         /// <summary>
         /// Gets an array of lookup pairs.
         /// </summary>
-        protected override IReadOnlyDictionary<ButtonDisplay /*Enum*/, string /*Display*/> Pairs => _pairs;
-
+        protected override IReadOnlyDictionary<string /*Display*/, ButtonDisplay /*Enum*/ > PairsStringToEnum  => _pairs.SecondToFirst;
+        protected override IReadOnlyDictionary<ButtonDisplay /*Enum*/, string /*Display*/> PairsEnumToString => _pairs.FirstToSecond;
         #endregion
     }
 }

--- a/Source/Krypton Components/Krypton.Navigator/Converters/ButtonDisplayLogicConverter.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Converters/ButtonDisplayLogicConverter.cs
@@ -17,20 +17,21 @@ namespace Krypton.Navigator
     /// </summary>
     public class ButtonDisplayLogicConverter : StringLookupConverter<ButtonDisplayLogic>
     {
-        private static readonly IReadOnlyDictionary<ButtonDisplayLogic, string> _pairs = new Dictionary<ButtonDisplayLogic, string>
+        private static readonly BiDictionary<ButtonDisplayLogic, string> _pairs = new BiDictionary<ButtonDisplayLogic, string>(
+            new Dictionary<ButtonDisplayLogic, string>
             {
                 {ButtonDisplayLogic.None, @"None"},
                 {ButtonDisplayLogic.Context, @"Context"},
                 {ButtonDisplayLogic.NextPrevious, @"Next/Previous"},
                 {ButtonDisplayLogic.ContextNextPrevious, @"Context & Next/Previous"}
-            };
+            });
 
         #region Protected
         /// <summary>
         /// Gets an array of lookup pairs.
         /// </summary>
-        protected override IReadOnlyDictionary<ButtonDisplayLogic /*Enum*/, string /*Display*/> Pairs => _pairs;
-
+        protected override IReadOnlyDictionary<string /*Display*/, ButtonDisplayLogic /*Enum*/ > PairsStringToEnum  => _pairs.SecondToFirst;
+        protected override IReadOnlyDictionary<ButtonDisplayLogic /*Enum*/, string /*Display*/> PairsEnumToString => _pairs.FirstToSecond;
         #endregion
     }
 }

--- a/Source/Krypton Components/Krypton.Navigator/Converters/CloseButtonActionConverter.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Converters/CloseButtonActionConverter.cs
@@ -20,21 +20,22 @@ namespace Krypton.Navigator
         #region Static Fields
 
         [Localizable(true)]
-        private static readonly IReadOnlyDictionary<CloseButtonAction, string> _pairs = new Dictionary<CloseButtonAction, string>
-        {
+        private static readonly BiDictionary<CloseButtonAction, string> _pairs = new BiDictionary<CloseButtonAction, string>(
+            new Dictionary<CloseButtonAction, string>
+            {
                 {CloseButtonAction.None, @"None (Do nothing)"},
                 {CloseButtonAction.RemovePage, @"Remove Page"},
                 {CloseButtonAction.RemovePageAndDispose, @"Remove Page & Dispose"},
                 { CloseButtonAction.HidePage, @"Hide Page"}
-            };
+            });
         #endregion
 
         #region Protected
         /// <summary>
         /// Gets an array of lookup pairs.
         /// </summary>
-        protected override IReadOnlyDictionary<CloseButtonAction /*Enum*/, string /*Display*/> Pairs => _pairs;
-
+        protected override IReadOnlyDictionary<string /*Display*/, CloseButtonAction /*Enum*/ > PairsStringToEnum => _pairs.SecondToFirst;
+        protected override IReadOnlyDictionary<CloseButtonAction /*Enum*/, string /*Display*/> PairsEnumToString => _pairs.FirstToSecond;
         #endregion
     }
 }

--- a/Source/Krypton Components/Krypton.Navigator/Converters/ContextButtonActionConverter.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Converters/ContextButtonActionConverter.cs
@@ -20,19 +20,20 @@ namespace Krypton.Navigator
         #region Static Fields
 
         [Localizable(true)]
-        private static readonly IReadOnlyDictionary<ContextButtonAction, string> _pairs =
+        private static readonly BiDictionary<ContextButtonAction, string> _pairs = new BiDictionary<ContextButtonAction, string>(
             new Dictionary<ContextButtonAction, string>
             {
                 { ContextButtonAction.None, @"None (Do nothing)" },
                 { ContextButtonAction.SelectPage, @"Select Page" }
-            };
+            });
         #endregion
 
         #region Protected
         /// <summary>
         /// Gets an array of lookup pairs.
         /// </summary>
-        protected override IReadOnlyDictionary<ContextButtonAction /*Enum*/, string /*Display*/> Pairs => _pairs;
+        protected override IReadOnlyDictionary<string /*Display*/, ContextButtonAction /*Enum*/ > PairsStringToEnum  => _pairs.SecondToFirst;
+        protected override IReadOnlyDictionary<ContextButtonAction /*Enum*/, string /*Display*/> PairsEnumToString => _pairs.FirstToSecond;
         #endregion
     }
 }

--- a/Source/Krypton Components/Krypton.Navigator/Converters/DirectionButtonActionConverter.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Converters/DirectionButtonActionConverter.cs
@@ -20,21 +20,22 @@ namespace Krypton.Navigator
         #region Static Fields
 
         [Localizable(true)]
-        private static readonly IReadOnlyDictionary<DirectionButtonAction, string> _pairs = new Dictionary<DirectionButtonAction, string>
+        private static readonly BiDictionary<DirectionButtonAction, string> _pairs = new BiDictionary<DirectionButtonAction, string>(
+            new Dictionary<DirectionButtonAction, string>
         {
             {DirectionButtonAction.None, @"None (Do nothing)"},
                 {DirectionButtonAction.SelectPage, @"Select Page"},
                 {DirectionButtonAction.MoveBar, @"Move Bar"},
                 {DirectionButtonAction.ModeAppropriateAction, @"Mode Appropriate Action"}
-        };
+        });
         #endregion
 
         #region Protected
         /// <summary>
         /// Gets an array of lookup pairs.
         /// </summary>
-        protected override IReadOnlyDictionary<DirectionButtonAction /*Enum*/, string /*Display*/> Pairs => _pairs;
-
+        protected override IReadOnlyDictionary<string /*Display*/, DirectionButtonAction /*Enum*/ > PairsStringToEnum  => _pairs.SecondToFirst;
+        protected override IReadOnlyDictionary<DirectionButtonAction /*Enum*/, string /*Display*/> PairsEnumToString => _pairs.FirstToSecond;
         #endregion
     }
 }

--- a/Source/Krypton Components/Krypton.Navigator/Converters/MapKryptonPageImageConverter.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Converters/MapKryptonPageImageConverter.cs
@@ -20,7 +20,8 @@ namespace Krypton.Navigator
         #region Static Fields
 
         [Localizable(true)]
-        private static readonly IReadOnlyDictionary<MapKryptonPageImage, string> _pairs = new Dictionary<MapKryptonPageImage, string>
+        private static readonly BiDictionary<MapKryptonPageImage, string> _pairs = new BiDictionary<MapKryptonPageImage, string>(
+            new Dictionary<MapKryptonPageImage, string>
         {
             {MapKryptonPageImage.None, @"None (Null image)"},
             {MapKryptonPageImage.Small, @"Small"},
@@ -33,10 +34,15 @@ namespace Krypton.Navigator
             {MapKryptonPageImage.LargeMedium, @"Large - Medium"},
             {MapKryptonPageImage.LargeMediumSmall, @"Large - Medium - Small"},
             {MapKryptonPageImage.ToolTip, nameof(ToolTip)}
-        };
+        });
         #endregion
 
-        protected override IReadOnlyDictionary<MapKryptonPageImage /*Enum*/, string /*Display*/> Pairs => _pairs;
-
+        #region Protected
+        /// <summary>
+        /// Gets an array of lookup pairs.
+        /// </summary>
+        protected override IReadOnlyDictionary<string /*Display*/, MapKryptonPageImage /*Enum*/ > PairsStringToEnum  => _pairs.SecondToFirst;
+        protected override IReadOnlyDictionary<MapKryptonPageImage /*Enum*/, string /*Display*/> PairsEnumToString => _pairs.FirstToSecond;
+        #endregion
     }
 }

--- a/Source/Krypton Components/Krypton.Navigator/Converters/MapKryptonPageTextConverter.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Converters/MapKryptonPageTextConverter.cs
@@ -20,7 +20,8 @@ namespace Krypton.Navigator
         #region Static Fields
 
         [Localizable(true)]
-        private static readonly IReadOnlyDictionary<MapKryptonPageText, string> _pairs = new Dictionary<MapKryptonPageText, string>
+        private static readonly BiDictionary<MapKryptonPageText, string> _pairs = new BiDictionary<MapKryptonPageText, string>(
+            new Dictionary<MapKryptonPageText, string>
         {
             {MapKryptonPageText.None, @"None (Empty string)"},
             {MapKryptonPageText.Text, @"Text"},
@@ -36,10 +37,16 @@ namespace Krypton.Navigator
             {MapKryptonPageText.DescriptionTitleText, @"Description - Title - Text"},
             {MapKryptonPageText.ToolTipTitle, @"ToolTipTitle"},
             {MapKryptonPageText.ToolTipBody, @"ToolTipBody"}
-        };
+        });
 
         #endregion
 
-        protected override IReadOnlyDictionary<MapKryptonPageText /*Enum*/, string /*Display*/> Pairs => _pairs;
+        #region Protected
+        /// <summary>
+        /// Gets an array of lookup pairs.
+        /// </summary>
+        protected override IReadOnlyDictionary<string /*Display*/, MapKryptonPageText /*Enum*/ > PairsStringToEnum  => _pairs.SecondToFirst;
+        protected override IReadOnlyDictionary<MapKryptonPageText /*Enum*/, string /*Display*/> PairsEnumToString => _pairs.FirstToSecond;
+        #endregion
     }
 }

--- a/Source/Krypton Components/Krypton.Navigator/Converters/NavigatorModeConverter.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Converters/NavigatorModeConverter.cs
@@ -20,7 +20,8 @@ namespace Krypton.Navigator
         #region Static Fields
 
         [Localizable(true)]
-        private static readonly IReadOnlyDictionary<NavigatorMode, string> _pairs = new Dictionary<NavigatorMode, string>
+        private static readonly BiDictionary<NavigatorMode, string> _pairs = new BiDictionary<NavigatorMode, string>(
+            new Dictionary<NavigatorMode, string>
         {
             {NavigatorMode.BarTabGroup, @"Bar - Tab - Group"},
             {NavigatorMode.BarTabOnly, @"Bar - Tab - Only"},
@@ -41,10 +42,16 @@ namespace Krypton.Navigator
             {NavigatorMode.Group, @"Group"},
             {NavigatorMode.HeaderGroup, @"HeaderGroup"},
             {NavigatorMode.HeaderGroupTab, @"HeaderGroup - Tab"}
-        };
+        });
 
         #endregion
 
-        protected override IReadOnlyDictionary<NavigatorMode /*Enum*/, string /*Display*/> Pairs => _pairs;
+        #region Protected
+        /// <summary>
+        /// Gets an array of lookup pairs.
+        /// </summary>
+        protected override IReadOnlyDictionary<string /*Display*/, NavigatorMode /*Enum*/ > PairsStringToEnum  => _pairs.SecondToFirst;
+        protected override IReadOnlyDictionary<NavigatorMode /*Enum*/, string /*Display*/> PairsEnumToString => _pairs.FirstToSecond;
+        #endregion
     }
 }

--- a/Source/Krypton Components/Krypton.Navigator/Converters/PaletteButtonSpecStyleConverter.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Converters/PaletteButtonSpecStyleConverter.cs
@@ -20,7 +20,8 @@ namespace Krypton.Navigator
         #region Static Fields
 
         [Localizable(true)]
-        private static readonly IReadOnlyDictionary<PaletteNavButtonSpecStyle, string> _pairs = new Dictionary<PaletteNavButtonSpecStyle, string>
+        private static readonly BiDictionary<PaletteNavButtonSpecStyle, string> _pairs = new BiDictionary<PaletteNavButtonSpecStyle, string>(
+            new Dictionary<PaletteNavButtonSpecStyle, string>
         {
             {PaletteNavButtonSpecStyle.Generic, @"Generic"},
             {PaletteNavButtonSpecStyle.ArrowLeft, @"Arrow Left"},
@@ -42,11 +43,17 @@ namespace Krypton.Navigator
             {PaletteNavButtonSpecStyle.WorkspaceRestore, @"Workspace Restore"},
             {PaletteNavButtonSpecStyle.RibbonMinimize, @"Ribbon Minimize"},
             {PaletteNavButtonSpecStyle.RibbonExpand, @"Ribbon Expand" }
-        };
+        });
 
         #endregion
 
-        protected override IReadOnlyDictionary<PaletteNavButtonSpecStyle /*Enum*/, string /*Display*/> Pairs => _pairs;
+        #region Protected
+        /// <summary>
+        /// Gets an array of lookup pairs.
+        /// </summary>
+        protected override IReadOnlyDictionary<string /*Display*/, PaletteNavButtonSpecStyle /*Enum*/ > PairsStringToEnum  => _pairs.SecondToFirst;
+        protected override IReadOnlyDictionary<PaletteNavButtonSpecStyle /*Enum*/, string /*Display*/> PairsEnumToString => _pairs.FirstToSecond;
+        #endregion
 
     }
 }

--- a/Source/Krypton Components/Krypton.Navigator/Converters/PopupPageAllowConverter.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Converters/PopupPageAllowConverter.cs
@@ -20,16 +20,22 @@ namespace Krypton.Navigator
         #region Static Fields
 
         [Localizable(true)]
-        private static readonly IReadOnlyDictionary<PopupPageAllow, string> _pairs = new Dictionary<PopupPageAllow, string>
+        private static readonly BiDictionary<PopupPageAllow, string> _pairs = new BiDictionary<PopupPageAllow, string>(
+            new Dictionary<PopupPageAllow, string>
         {
             {PopupPageAllow.Never, @"Never"},
             {PopupPageAllow.OnlyCompatibleModes, @"Only Compatible Modes"},
             {PopupPageAllow.OnlyOutlookMiniMode, @"Only Outlook Mini Mode"}
-        };
+        });
 
         #endregion
-        protected override IReadOnlyDictionary<PopupPageAllow /*Enum*/, string /*Display*/> Pairs => _pairs;
 
-
+        #region Protected
+        /// <summary>
+        /// Gets an array of lookup pairs.
+        /// </summary>
+        protected override IReadOnlyDictionary<string /*Display*/, PopupPageAllow /*Enum*/ > PairsStringToEnum  => _pairs.SecondToFirst;
+        protected override IReadOnlyDictionary<PopupPageAllow /*Enum*/, string /*Display*/> PairsEnumToString => _pairs.FirstToSecond;
+        #endregion
     }
 }

--- a/Source/Krypton Components/Krypton.Navigator/Converters/PopupPagePositionConverter.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Converters/PopupPagePositionConverter.cs
@@ -20,7 +20,8 @@ namespace Krypton.Navigator
         #region Static Fields
 
         [Localizable(true)]
-        private static readonly IReadOnlyDictionary<PopupPagePosition, string> _pairs = new Dictionary<PopupPagePosition, string>
+        private static readonly BiDictionary<PopupPagePosition, string> _pairs = new BiDictionary<PopupPagePosition, string>(
+            new Dictionary<PopupPagePosition, string>
         {
             {PopupPagePosition.ModeAppropriate, @"Mode Appropriate"},
             {PopupPagePosition.AboveFar, @"Above Element - Far Aligned"},
@@ -35,11 +36,15 @@ namespace Krypton.Navigator
             {PopupPagePosition.NearBottom, @"Near Side of Element - Bottom Aligned"},
             {PopupPagePosition.NearMatch, @"Near Side of Element - Element Height"},
             {PopupPagePosition.NearTop, @"Near Side of Element - Top Aligned"}
-        };
+        });
 
         #endregion
-        protected override IReadOnlyDictionary<PopupPagePosition /*Enum*/, string /*Display*/> Pairs => _pairs;
-
-
+        #region Protected
+        /// <summary>
+        /// Gets an array of lookup pairs.
+        /// </summary>
+        protected override IReadOnlyDictionary<string /*Display*/, PopupPagePosition /*Enum*/ > PairsStringToEnum  => _pairs.SecondToFirst;
+        protected override IReadOnlyDictionary<PopupPagePosition /*Enum*/, string /*Display*/> PairsEnumToString => _pairs.FirstToSecond;
+        #endregion
     }
 }

--- a/Source/Krypton Components/Krypton.Navigator/Dragging/DragFeedback.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Dragging/DragFeedback.cs
@@ -120,7 +120,7 @@ namespace Krypton.Navigator
         /// <summary>
         /// Gets access to the cached drawing renderer.
         /// </summary>
-        protected IRenderer? Renderer { get; private set; }
+        protected IRenderer Renderer { get; private set; }
 
         /// <summary>
         /// Gets access to the cached drag data.

--- a/Source/Krypton Components/Krypton.Navigator/Dragging/DragFeedbackDocking.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Dragging/DragFeedbackDocking.cs
@@ -26,7 +26,7 @@ namespace Krypton.Navigator
 
             #region Instance Fields
             private readonly IPaletteDragDrop _paletteDragDrop;
-            private readonly IRenderer? _renderer;
+            private readonly IRenderer _renderer;
             private HintToTarget? _hintToTarget;
             private IDropDockingIndicator? _indicators;
             #endregion
@@ -39,7 +39,7 @@ namespace Krypton.Navigator
             /// <param name="renderer">Drawing renderer.</param>
             /// <param name="target">Initial target for the cluster.</param>
             public DockCluster(IPaletteDragDrop paletteDragDrop,
-                               IRenderer? renderer,
+                               IRenderer renderer,
                                DragTarget target)
             {
                 _paletteDragDrop = paletteDragDrop;

--- a/Source/Krypton Components/Krypton.Navigator/Dragging/DragManager.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Dragging/DragManager.cs
@@ -29,9 +29,9 @@ namespace Krypton.Navigator
         #endregion
 
         #region Instance Fields
-        private PaletteBase? _dragPalette;
-        private PaletteBase? _localPalette;
-        private IRenderer? _dragRenderer;
+        private PaletteBase _dragPalette;
+        private PaletteBase _localPalette;
+        private IRenderer _dragRenderer;
         private PaletteMode _paletteMode;
         private readonly PaletteRedirect _redirector;
         private PageDragEndData? _pageDragEndData;
@@ -158,7 +158,7 @@ namespace Krypton.Navigator
         /// <summary>
         /// Gets and sets the custom palette implementation.
         /// </summary>
-        public PaletteBase? Palette
+        public PaletteBase Palette
         {
             get => _localPalette;
 

--- a/Source/Krypton Components/Krypton.Navigator/Dragging/DropDockingIndicatorsRounded.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Dragging/DropDockingIndicatorsRounded.cs
@@ -21,7 +21,7 @@ namespace Krypton.Navigator
                                                 IDropDockingIndicator
     {
         #region Instance Fields
-        private readonly IRenderer? _renderer;
+        private readonly IRenderer _renderer;
         private readonly IPaletteDragDrop _paletteDragDrop;
         private readonly RenderDragDockingData _dragData;
         private Rectangle _showRect;
@@ -39,7 +39,7 @@ namespace Krypton.Navigator
         /// <param name="showBottom">Show bottom hot area.</param>
         /// <param name="showMiddle">Show middle hot area.</param>
         public DropDockingIndicatorsRounded(IPaletteDragDrop paletteDragDrop,
-                                            IRenderer? renderer,
+                                            IRenderer renderer,
                                             bool showLeft, bool showRight,
                                             bool showTop, bool showBottom,
                                             bool showMiddle)

--- a/Source/Krypton Components/Krypton.Navigator/Dragging/DropDockingIndicatorsSquare.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Dragging/DropDockingIndicatorsSquare.cs
@@ -20,7 +20,7 @@ namespace Krypton.Navigator
                                                IDropDockingIndicator
     {
         #region Instance Fields
-        private readonly IRenderer? _renderer;
+        private readonly IRenderer _renderer;
         private readonly IPaletteDragDrop _paletteDragDrop;
         private readonly RenderDragDockingData _dragData;
         #endregion
@@ -37,7 +37,7 @@ namespace Krypton.Navigator
         /// <param name="showBottom">Show bottom hot area.</param>
         /// <param name="showMiddle">Show middle hot area.</param>
         public DropDockingIndicatorsSquare(IPaletteDragDrop paletteDragDrop,
-                                           IRenderer? renderer,
+                                           IRenderer renderer,
                                            bool showLeft, bool showRight,
                                            bool showTop, bool showBottom,
                                            bool showMiddle)

--- a/Source/Krypton Components/Krypton.Navigator/Dragging/DropSolidWindow.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Dragging/DropSolidWindow.cs
@@ -19,7 +19,7 @@ namespace Krypton.Navigator
     {
         #region Instance Fields
         private readonly IPaletteDragDrop _paletteDragDrop;
-        private readonly IRenderer? _renderer;
+        private readonly IRenderer _renderer;
         private Rectangle _solidRect;
         #endregion
 
@@ -29,7 +29,7 @@ namespace Krypton.Navigator
         /// </summary>
         /// <param name="paletteDragDrop">Drawing palette.</param>
         /// <param name="renderer">Drawing renderer.</param>
-        public DropSolidWindow(IPaletteDragDrop paletteDragDrop, IRenderer? renderer)
+        public DropSolidWindow(IPaletteDragDrop paletteDragDrop, IRenderer renderer)
         {
             _paletteDragDrop = paletteDragDrop;
             _renderer = renderer;

--- a/Source/Krypton Components/Krypton.Navigator/Page/KryptonPage.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Page/KryptonPage.cs
@@ -27,20 +27,20 @@ namespace Krypton.Navigator
     {
         #region Instance Fields
         private readonly ViewDrawPanel _drawPanel;
-        private readonly PaletteRedirectDoubleMetric? _redirectNavigator;
-        private readonly PaletteRedirectDoubleMetric? _redirectNavigatorHeaderGroup;
-        private readonly PaletteRedirectTripleMetric? _redirectNavigatorHeaderPrimary;
-        private readonly PaletteRedirectTripleMetric? _redirectNavigatorHeaderSecondary;
-        private readonly PaletteRedirectTripleMetric? _redirectNavigatorHeaderBar;
-        private readonly PaletteRedirectTripleMetric? _redirectNavigatorHeaderOverflow;
-        private readonly PaletteRedirectTriple? _redirectNavigatorCheckButton;
-        private readonly PaletteRedirectTriple? _redirectNavigatorOverflowButton;
-        private readonly PaletteRedirectTriple? _redirectNavigatorMiniButton;
-        private readonly PaletteRedirectTriple? _redirectNavigatorTab;
-        private readonly PaletteRedirectRibbonTabContent? _redirectNavigatorRibbonTab;
-        private readonly PaletteRedirectMetric? _redirectNavigatorBar;
-        private readonly PaletteRedirectDouble? _redirectNavigatorPage;
-        private readonly PaletteRedirectDoubleMetric? _redirectNavigatorSeparator;
+        private readonly PaletteRedirectDoubleMetric _redirectNavigator;
+        private readonly PaletteRedirectDoubleMetric _redirectNavigatorHeaderGroup;
+        private readonly PaletteRedirectTripleMetric _redirectNavigatorHeaderPrimary;
+        private readonly PaletteRedirectTripleMetric _redirectNavigatorHeaderSecondary;
+        private readonly PaletteRedirectTripleMetric _redirectNavigatorHeaderBar;
+        private readonly PaletteRedirectTripleMetric _redirectNavigatorHeaderOverflow;
+        private readonly PaletteRedirectTriple _redirectNavigatorCheckButton;
+        private readonly PaletteRedirectTriple _redirectNavigatorOverflowButton;
+        private readonly PaletteRedirectTriple _redirectNavigatorMiniButton;
+        private readonly PaletteRedirectTriple _redirectNavigatorTab;
+        private readonly PaletteRedirectRibbonTabContent _redirectNavigatorRibbonTab;
+        private readonly PaletteRedirectMetric _redirectNavigatorBar;
+        private readonly PaletteRedirectDouble _redirectNavigatorPage;
+        private readonly PaletteRedirectDoubleMetric _redirectNavigatorSeparator;
         private readonly PaletteNavigatorRedirect? _stateCommon;
         private readonly PaletteNavigator? _stateDisabled;
         private readonly PaletteNavigator? _stateNormal;
@@ -287,7 +287,7 @@ namespace Krypton.Navigator
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public new PaletteBase? Palette
+        public new PaletteBase Palette
         {
             [DebuggerStepThrough]
             get => base.Palette;

--- a/Source/Krypton Components/Krypton.Navigator/Palette/PaletteNavigatorHeaderGroupRedirect.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Palette/PaletteNavigatorHeaderGroupRedirect.cs
@@ -23,7 +23,7 @@ namespace Krypton.Navigator
         /// </summary>
         /// <param name="redirect">inheritance redirection instance.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteNavigatorHeaderGroupRedirect(PaletteRedirect? redirect,
+        public PaletteNavigatorHeaderGroupRedirect(PaletteRedirect redirect,
                                                    NeedPaintHandler needPaint)
             : this(redirect, redirect, redirect, redirect!, redirect!, needPaint)
         {
@@ -38,11 +38,11 @@ namespace Krypton.Navigator
         /// <param name="redirectHeaderBar">inheritance redirection for bar header.</param>
         /// <param name="redirectHeaderOverflow">inheritance redirection for overflow header.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteNavigatorHeaderGroupRedirect(PaletteRedirect? redirectHeaderGroup,
-                                                   PaletteRedirect? redirectHeaderPrimary,
-                                                   PaletteRedirect? redirectHeaderSecondary,
-                                                   [DisallowNull] PaletteRedirect? redirectHeaderBar,
-                                                   [DisallowNull] PaletteRedirect? redirectHeaderOverflow,
+        public PaletteNavigatorHeaderGroupRedirect(PaletteRedirect redirectHeaderGroup,
+                                                   PaletteRedirect redirectHeaderPrimary,
+                                                   PaletteRedirect redirectHeaderSecondary,
+                                                   [DisallowNull] PaletteRedirect redirectHeaderBar,
+                                                   [DisallowNull] PaletteRedirect redirectHeaderOverflow,
                                                    NeedPaintHandler needPaint)
             : base(redirectHeaderGroup!, redirectHeaderPrimary!,
                    redirectHeaderSecondary!, needPaint)

--- a/Source/Krypton Components/Krypton.Navigator/Palette/PaletteNavigatorOtherRedirect.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Palette/PaletteNavigatorOtherRedirect.cs
@@ -27,11 +27,11 @@ namespace Krypton.Navigator
         /// <param name="redirectTab">inheritance redirection instance for the tab.</param>
         /// <param name="redirectRibbonTab">inheritance redirection instance for the ribbon tab.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteNavigatorOtherRedirect(PaletteRedirect? redirectCheckButton,
-                                             PaletteRedirect? redirectOverflowButton,
-                                             PaletteRedirect? redirectMiniButton,
-                                             PaletteRedirect? redirectTab,
-                                             PaletteRedirect? redirectRibbonTab,
+        public PaletteNavigatorOtherRedirect(PaletteRedirect redirectCheckButton,
+                                             PaletteRedirect redirectOverflowButton,
+                                             PaletteRedirect redirectMiniButton,
+                                             PaletteRedirect redirectTab,
+                                             PaletteRedirect redirectRibbonTab,
                                              NeedPaintHandler needPaint)
         {
             // Create the palette storage

--- a/Source/Krypton Components/Krypton.Navigator/Palette/PaletteNavigatorRedirect.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Palette/PaletteNavigatorRedirect.cs
@@ -31,7 +31,7 @@ namespace Krypton.Navigator
         /// <param name="redirect">inheritance redirection instance.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
         public PaletteNavigatorRedirect(KryptonNavigator navigator,
-                                        PaletteRedirect? redirect,
+                                        PaletteRedirect redirect,
                                         NeedPaintHandler needPaint)
             : this(navigator, redirect, redirect, redirect,
                               redirect, redirect, redirect,
@@ -64,22 +64,22 @@ namespace Krypton.Navigator
         /// <param name="redirectNavigatorRibbonGeneral">inheritance redirection for ribbon general.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
         public PaletteNavigatorRedirect(KryptonNavigator? navigator,
-                                        PaletteRedirect? redirectNavigator,
-                                        PaletteRedirect? redirectNavigatorPage,
-                                        PaletteRedirect? redirectNavigatorHeaderGroup,
-                                        PaletteRedirect? redirectNavigatorHeaderPrimary,
-                                        PaletteRedirect? redirectNavigatorHeaderSecondary,
-                                        PaletteRedirect? redirectNavigatorHeaderBar,
-                                        PaletteRedirect? redirectNavigatorHeaderOverflow,
-                                        PaletteRedirect? redirectNavigatorCheckButton,
-                                        PaletteRedirect? redirectNavigatorOverflowButton,
-                                        PaletteRedirect? redirectNavigatorMiniButton,
-                                        PaletteRedirect? redirectNavigatorBar,
-                                        PaletteRedirect? redirectNavigatorBorderEdge,
-                                        PaletteRedirect? redirectNavigatorSeparator,
-                                        PaletteRedirect? redirectNavigatorTab,
-                                        PaletteRedirect? redirectNavigatorRibbonTab,
-                                        PaletteRedirect? redirectNavigatorRibbonGeneral,
+                                        PaletteRedirect redirectNavigator,
+                                        PaletteRedirect redirectNavigatorPage,
+                                        PaletteRedirect redirectNavigatorHeaderGroup,
+                                        PaletteRedirect redirectNavigatorHeaderPrimary,
+                                        PaletteRedirect redirectNavigatorHeaderSecondary,
+                                        PaletteRedirect redirectNavigatorHeaderBar,
+                                        PaletteRedirect redirectNavigatorHeaderOverflow,
+                                        PaletteRedirect redirectNavigatorCheckButton,
+                                        PaletteRedirect redirectNavigatorOverflowButton,
+                                        PaletteRedirect redirectNavigatorMiniButton,
+                                        PaletteRedirect redirectNavigatorBar,
+                                        PaletteRedirect redirectNavigatorBorderEdge,
+                                        PaletteRedirect redirectNavigatorSeparator,
+                                        PaletteRedirect redirectNavigatorTab,
+                                        PaletteRedirect redirectNavigatorRibbonTab,
+                                        PaletteRedirect redirectNavigatorRibbonGeneral,
                                         NeedPaintHandler needPaint)
             : base(redirectNavigator, PaletteBackStyle.PanelClient,
                    PaletteBorderStyle.ControlClient, needPaint)
@@ -105,7 +105,7 @@ namespace Krypton.Navigator
         /// <summary>
         /// Update the redirector for the border edge.
         /// </summary>
-        public PaletteRedirect? RedirectBorderEdge
+        public PaletteRedirect RedirectBorderEdge
         {
             set => _paletteBorderEdgeInheritRedirect.SetRedirector(value);
         }
@@ -115,7 +115,7 @@ namespace Krypton.Navigator
         /// <summary>
         /// Update the redirector for the ribbon general.
         /// </summary>
-        public PaletteRedirect? RedirectRibbonGeneral
+        public PaletteRedirect RedirectRibbonGeneral
         {
             set => RibbonGeneral.SetRedirector(value);
         }

--- a/Source/Krypton Components/Krypton.Navigator/Palette/PalettePageRedirect.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Palette/PalettePageRedirect.cs
@@ -23,7 +23,7 @@ namespace Krypton.Navigator
         /// </summary>
         /// <param name="redirect">inheritance redirection instance.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PalettePageRedirect(PaletteRedirect? redirect,
+        public PalettePageRedirect(PaletteRedirect redirect,
                                    NeedPaintHandler needPaint)
             : base(redirect, PaletteBackStyle.ControlClient,
                              PaletteBorderStyle.ControlClient, needPaint)

--- a/Source/Krypton Components/Krypton.Navigator/Palette/PaletteRedirectRibbonTabContent.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Palette/PaletteRedirectRibbonTabContent.cs
@@ -18,24 +18,24 @@ namespace Krypton.Navigator
     public class PaletteRedirectRibbonTabContent : PaletteRedirect
     {
         #region Instance Fields
-        private IPaletteRibbonBack? _disabledBack;
-        private IPaletteRibbonBack? _normalBack;
-        private IPaletteRibbonBack? _pressedBack;
-        private IPaletteRibbonBack? _trackingBack;
-        private IPaletteRibbonBack? _selectedBack;
-        private IPaletteRibbonBack? _focusOverrideBack;
-        private IPaletteRibbonText? _disabledText;
-        private IPaletteRibbonText? _normalText;
-        private IPaletteRibbonText? _pressedText;
-        private IPaletteRibbonText? _trackingText;
-        private IPaletteRibbonText? _selectedText;
-        private IPaletteRibbonText? _focusOverrideText;
-        private IPaletteContent? _disabledContent;
-        private IPaletteContent? _normalContent;
-        private IPaletteContent? _pressedContent;
-        private IPaletteContent? _trackingContent;
-        private IPaletteContent? _selectedContent;
-        private IPaletteContent? _focusOverrideContent;
+        private IPaletteRibbonBack _disabledBack;
+        private IPaletteRibbonBack _normalBack;
+        private IPaletteRibbonBack _pressedBack;
+        private IPaletteRibbonBack _trackingBack;
+        private IPaletteRibbonBack _selectedBack;
+        private IPaletteRibbonBack _focusOverrideBack;
+        private IPaletteRibbonText _disabledText;
+        private IPaletteRibbonText _normalText;
+        private IPaletteRibbonText _pressedText;
+        private IPaletteRibbonText _trackingText;
+        private IPaletteRibbonText _selectedText;
+        private IPaletteRibbonText _focusOverrideText;
+        private IPaletteContent _disabledContent;
+        private IPaletteContent _normalContent;
+        private IPaletteContent _pressedContent;
+        private IPaletteContent _trackingContent;
+        private IPaletteContent _selectedContent;
+        private IPaletteContent _focusOverrideContent;
         #endregion
 
         #region Identity
@@ -43,7 +43,7 @@ namespace Krypton.Navigator
         /// Initialize a new instance of the PaletteRedirectRibbonDouble class.
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
-        public PaletteRedirectRibbonTabContent(PaletteBase? target)
+        public PaletteRedirectRibbonTabContent(PaletteBase target)
             : this(target,
                    null, null, null, null, null, null,
                    null, null, null, null, null, null,
@@ -73,25 +73,25 @@ namespace Krypton.Navigator
         /// <param name="trackingContent">Redirection for content tracking state requests.</param>
         /// <param name="selectedContent">Redirection for content selected states requests.</param>
         /// <param name="focusOverrideContent">Redirection for content focus override state requests.</param>
-        public PaletteRedirectRibbonTabContent(PaletteBase? target,
-                                               IPaletteRibbonBack? disabledBack,
-                                               IPaletteRibbonBack? normalBack,
-                                               IPaletteRibbonBack? pressedBack,
-                                               IPaletteRibbonBack? trackingBack,
-                                               IPaletteRibbonBack? selectedBack,
-                                               IPaletteRibbonBack? focusOverrideBack,
-                                               IPaletteRibbonText? disabledText,
-                                               IPaletteRibbonText? normalText,
-                                               IPaletteRibbonText? pressedText,
-                                               IPaletteRibbonText? trackingText,
-                                               IPaletteRibbonText? selectedText,
-                                               IPaletteRibbonText? focusOverrideText,
-                                               IPaletteContent? disabledContent,
-                                               IPaletteContent? normalContent,
-                                               IPaletteContent? pressedContent,
-                                               IPaletteContent? trackingContent,
-                                               IPaletteContent? selectedContent,
-                                               IPaletteContent? focusOverrideContent)
+        public PaletteRedirectRibbonTabContent(PaletteBase target,
+                                               IPaletteRibbonBack disabledBack,
+                                               IPaletteRibbonBack normalBack,
+                                               IPaletteRibbonBack pressedBack,
+                                               IPaletteRibbonBack trackingBack,
+                                               IPaletteRibbonBack selectedBack,
+                                               IPaletteRibbonBack focusOverrideBack,
+                                               IPaletteRibbonText disabledText,
+                                               IPaletteRibbonText normalText,
+                                               IPaletteRibbonText pressedText,
+                                               IPaletteRibbonText trackingText,
+                                               IPaletteRibbonText selectedText,
+                                               IPaletteRibbonText focusOverrideText,
+                                               IPaletteContent disabledContent,
+                                               IPaletteContent normalContent,
+                                               IPaletteContent pressedContent,
+                                               IPaletteContent trackingContent,
+                                               IPaletteContent selectedContent,
+                                               IPaletteContent focusOverrideContent)
             : base(target)
         {
             // Remember state specific inheritance
@@ -190,7 +190,7 @@ namespace Krypton.Navigator
         /// <returns>Color value.</returns>
         public override PaletteRibbonColorStyle GetRibbonBackColorStyle(PaletteRibbonBackStyle style, PaletteState state)
         {
-            IPaletteRibbonBack? inherit = GetBackInherit(state);
+            IPaletteRibbonBack inherit = GetBackInherit(state);
 
             return inherit?.GetRibbonBackColorStyle(state) ?? Target!.GetRibbonBackColorStyle(style, state);
         }
@@ -203,7 +203,7 @@ namespace Krypton.Navigator
         /// <returns>Color value.</returns>
         public override Color GetRibbonBackColor1(PaletteRibbonBackStyle style, PaletteState state)
         {
-            IPaletteRibbonBack? inherit = GetBackInherit(state);
+            IPaletteRibbonBack inherit = GetBackInherit(state);
 
             return inherit?.GetRibbonBackColor1(state) ?? Target!.GetRibbonBackColor1(style, state);
         }
@@ -216,7 +216,7 @@ namespace Krypton.Navigator
         /// <returns>Color value.</returns>
         public override Color GetRibbonBackColor2(PaletteRibbonBackStyle style, PaletteState state)
         {
-            IPaletteRibbonBack? inherit = GetBackInherit(state);
+            IPaletteRibbonBack inherit = GetBackInherit(state);
 
             return inherit?.GetRibbonBackColor2(state) ?? Target!.GetRibbonBackColor2(style, state);
         }
@@ -229,7 +229,7 @@ namespace Krypton.Navigator
         /// <returns>Color value.</returns>
         public override Color GetRibbonBackColor3(PaletteRibbonBackStyle style, PaletteState state)
         {
-            IPaletteRibbonBack? inherit = GetBackInherit(state);
+            IPaletteRibbonBack inherit = GetBackInherit(state);
 
             return inherit?.GetRibbonBackColor3(state) ?? Target!.GetRibbonBackColor3(style, state);
         }
@@ -242,7 +242,7 @@ namespace Krypton.Navigator
         /// <returns>Color value.</returns>
         public override Color GetRibbonBackColor4(PaletteRibbonBackStyle style, PaletteState state)
         {
-            IPaletteRibbonBack? inherit = GetBackInherit(state);
+            IPaletteRibbonBack inherit = GetBackInherit(state);
 
             return inherit?.GetRibbonBackColor4(state) ?? Target!.GetRibbonBackColor4(style, state);
         }
@@ -255,7 +255,7 @@ namespace Krypton.Navigator
         /// <returns>Color value.</returns>
         public override Color GetRibbonBackColor5(PaletteRibbonBackStyle style, PaletteState state)
         {
-            IPaletteRibbonBack? inherit = GetBackInherit(state);
+            IPaletteRibbonBack inherit = GetBackInherit(state);
 
             return inherit?.GetRibbonBackColor5(state) ?? Target!.GetRibbonBackColor5(style, state);
         }
@@ -270,7 +270,7 @@ namespace Krypton.Navigator
         /// <returns>Color value.</returns>
         public override Color GetRibbonTextColor(PaletteRibbonTextStyle style, PaletteState state)
         {
-            IPaletteRibbonText? inherit = GetTextInherit(state);
+            IPaletteRibbonText inherit = GetTextInherit(state);
 
             return inherit?.GetRibbonTextColor(state) ?? Target!.GetRibbonTextColor(style, state);
         }
@@ -285,7 +285,7 @@ namespace Krypton.Navigator
         /// <returns>InheritBool value.</returns>
         public override InheritBool GetContentDraw(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentDraw(state) ?? Target!.GetContentDraw(style, state);
         }
@@ -298,7 +298,7 @@ namespace Krypton.Navigator
         /// <returns>InheritBool value.</returns>
         public override InheritBool GetContentDrawFocus(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentDrawFocus(state) ?? Target!.GetContentDrawFocus(style, state);
         }
@@ -311,7 +311,7 @@ namespace Krypton.Navigator
         /// <returns>RelativeAlignment value.</returns>
         public override PaletteRelativeAlign GetContentImageH(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentImageH(state) ?? Target!.GetContentImageH(style, state);
         }
@@ -324,7 +324,7 @@ namespace Krypton.Navigator
         /// <returns>RelativeAlignment value.</returns>
         public override PaletteRelativeAlign GetContentImageV(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentImageV(state) ?? Target!.GetContentImageV(style, state);
         }
@@ -337,7 +337,7 @@ namespace Krypton.Navigator
         /// <returns>PaletteImageEffect value.</returns>
         public override PaletteImageEffect GetContentImageEffect(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentImageEffect(state) ?? Target!.GetContentImageEffect(style, state);
         }
@@ -350,7 +350,7 @@ namespace Krypton.Navigator
         /// <returns>Font value.</returns>
         public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentShortTextFont(state) ?? Target!.GetContentShortTextFont(style, state);
         }
@@ -363,7 +363,7 @@ namespace Krypton.Navigator
         /// <returns>PaletteTextHint value.</returns>
         public override PaletteTextHint GetContentShortTextHint(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentShortTextHint(state) ?? Target!.GetContentShortTextHint(style, state);
         }
@@ -376,7 +376,7 @@ namespace Krypton.Navigator
         /// <returns>PaletteTextPrefix value.</returns>
         public override PaletteTextHotkeyPrefix GetContentShortTextPrefix(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentShortTextPrefix(state) ?? Target!.GetContentShortTextPrefix(style, state);
         }
@@ -389,7 +389,7 @@ namespace Krypton.Navigator
         /// <returns>InheritBool value.</returns>
         public override InheritBool GetContentShortTextMultiLine(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentShortTextMultiLine(state) ?? Target!.GetContentShortTextMultiLine(style, state);
         }
@@ -402,7 +402,7 @@ namespace Krypton.Navigator
         /// <returns>PaletteTextTrim value.</returns>
         public override PaletteTextTrim GetContentShortTextTrim(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentShortTextTrim(state) ?? Target!.GetContentShortTextTrim(style, state);
         }
@@ -415,7 +415,7 @@ namespace Krypton.Navigator
         /// <returns>RelativeAlignment value.</returns>
         public override PaletteRelativeAlign GetContentShortTextH(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentShortTextH(state) ?? Target!.GetContentShortTextH(style, state);
         }
@@ -428,7 +428,7 @@ namespace Krypton.Navigator
         /// <returns>RelativeAlignment value.</returns>
         public override PaletteRelativeAlign GetContentShortTextV(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentShortTextV(state) ?? Target!.GetContentShortTextV(style, state);
         }
@@ -441,7 +441,7 @@ namespace Krypton.Navigator
         /// <returns>RelativeAlignment value.</returns>
         public override PaletteRelativeAlign GetContentShortTextMultiLineH(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentShortTextMultiLineH(state) ?? Target!.GetContentShortTextMultiLineH(style, state);
         }
@@ -454,7 +454,7 @@ namespace Krypton.Navigator
         /// <returns>Color value.</returns>
         public override Color GetContentShortTextColor1(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentShortTextColor1(state) ?? Target!.GetContentShortTextColor1(style, state);
         }
@@ -467,7 +467,7 @@ namespace Krypton.Navigator
         /// <returns>Color value.</returns>
         public override Color GetContentShortTextColor2(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentShortTextColor2(state) ?? Target!.GetContentShortTextColor2(style, state);
         }
@@ -480,7 +480,7 @@ namespace Krypton.Navigator
         /// <returns>Color drawing style.</returns>
         public override PaletteColorStyle GetContentShortTextColorStyle(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentShortTextColorStyle(state) ?? Target!.GetContentShortTextColorStyle(style, state);
         }
@@ -493,7 +493,7 @@ namespace Krypton.Navigator
         /// <returns>Color alignment style.</returns>
         public override PaletteRectangleAlign GetContentShortTextColorAlign(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentShortTextColorAlign(state) ?? Target!.GetContentShortTextColorAlign(style, state);
         }
@@ -506,7 +506,7 @@ namespace Krypton.Navigator
         /// <returns>Angle used for color drawing.</returns>
         public override float GetContentShortTextColorAngle(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentShortTextColorAngle(state) ?? Target!.GetContentShortTextColorAngle(style, state);
         }
@@ -519,7 +519,7 @@ namespace Krypton.Navigator
         /// <returns>Image instance.</returns>
         public override Image? GetContentShortTextImage(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentShortTextImage(state) ?? Target!.GetContentShortTextImage(style, state);
         }
@@ -532,7 +532,7 @@ namespace Krypton.Navigator
         /// <returns>Image style value.</returns>
         public override PaletteImageStyle GetContentShortTextImageStyle(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentShortTextImageStyle(state) ?? Target!.GetContentShortTextImageStyle(style, state);
         }
@@ -545,7 +545,7 @@ namespace Krypton.Navigator
         /// <returns>Image alignment style.</returns>
         public override PaletteRectangleAlign GetContentShortTextImageAlign(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentShortTextImageAlign(state) ?? Target!.GetContentShortTextImageAlign(style, state);
         }
@@ -558,7 +558,7 @@ namespace Krypton.Navigator
         /// <returns>Font value.</returns>
         public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentLongTextFont(state) ?? Target!.GetContentLongTextFont(style, state);
         }
@@ -571,7 +571,7 @@ namespace Krypton.Navigator
         /// <returns>PaletteTextHint value.</returns>
         public override PaletteTextHint GetContentLongTextHint(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentLongTextHint(state) ?? Target!.GetContentLongTextHint(style, state);
         }
@@ -584,7 +584,7 @@ namespace Krypton.Navigator
         /// <returns>InheritBool value.</returns>
         public override InheritBool GetContentLongTextMultiLine(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentLongTextMultiLine(state) ?? Target!.GetContentLongTextMultiLine(style, state);
         }
@@ -597,7 +597,7 @@ namespace Krypton.Navigator
         /// <returns>PaletteTextTrim value.</returns>
         public override PaletteTextTrim GetContentLongTextTrim(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentLongTextTrim(state) ?? Target!.GetContentLongTextTrim(style, state);
         }
@@ -610,7 +610,7 @@ namespace Krypton.Navigator
         /// <returns>PaletteTextPrefix value.</returns>
         public override PaletteTextHotkeyPrefix GetContentLongTextPrefix(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentLongTextPrefix(state) ?? Target!.GetContentLongTextPrefix(style, state);
         }
@@ -623,7 +623,7 @@ namespace Krypton.Navigator
         /// <returns>RelativeAlignment value.</returns>
         public override PaletteRelativeAlign GetContentLongTextH(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentLongTextH(state) ?? Target!.GetContentLongTextH(style, state);
         }
@@ -636,7 +636,7 @@ namespace Krypton.Navigator
         /// <returns>RelativeAlignment value.</returns>
         public override PaletteRelativeAlign GetContentLongTextV(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentLongTextV(state) ?? Target!.GetContentLongTextV(style, state);
         }
@@ -649,7 +649,7 @@ namespace Krypton.Navigator
         /// <returns>RelativeAlignment value.</returns>
         public override PaletteRelativeAlign GetContentLongTextMultiLineH(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentLongTextMultiLineH(state) ?? Target!.GetContentLongTextMultiLineH(style, state);
         }
@@ -662,7 +662,7 @@ namespace Krypton.Navigator
         /// <returns>Color value.</returns>
         public override Color GetContentLongTextColor1(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentLongTextColor1(state) ?? Target!.GetContentLongTextColor1(style, state);
         }
@@ -675,7 +675,7 @@ namespace Krypton.Navigator
         /// <returns>Color value.</returns>
         public override Color GetContentLongTextColor2(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentLongTextColor2(state) ?? Target!.GetContentLongTextColor2(style, state);
         }
@@ -688,7 +688,7 @@ namespace Krypton.Navigator
         /// <returns>Color drawing style.</returns>
         public override PaletteColorStyle GetContentLongTextColorStyle(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentLongTextColorStyle(state) ?? Target!.GetContentLongTextColorStyle(style, state);
         }
@@ -701,7 +701,7 @@ namespace Krypton.Navigator
         /// <returns>Color alignment style.</returns>
         public override PaletteRectangleAlign GetContentLongTextColorAlign(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentLongTextColorAlign(state) ?? Target!.GetContentLongTextColorAlign(style, state);
         }
@@ -714,7 +714,7 @@ namespace Krypton.Navigator
         /// <returns>Image instance.</returns>
         public override Image? GetContentLongTextImage(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentLongTextImage(state) ?? Target!.GetContentLongTextImage(style, state);
         }
@@ -727,7 +727,7 @@ namespace Krypton.Navigator
         /// <returns>Image style value.</returns>
         public override PaletteImageStyle GetContentLongTextImageStyle(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentLongTextImageStyle(state) ?? Target!.GetContentLongTextImageStyle(style, state);
         }
@@ -740,7 +740,7 @@ namespace Krypton.Navigator
         /// <returns>Image alignment style.</returns>
         public override PaletteRectangleAlign GetContentLongTextImageAlign(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentLongTextImageAlign(state) ?? Target!.GetContentLongTextImageAlign(style, state);
         }
@@ -753,7 +753,7 @@ namespace Krypton.Navigator
         /// <returns>Padding value.</returns>
         public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentPadding(state) ?? Target!.GetContentPadding(style, state);
         }
@@ -766,14 +766,14 @@ namespace Krypton.Navigator
         /// <returns>Integer value.</returns>
         public override int GetContentAdjacentGap(PaletteContentStyle style, PaletteState state)
         {
-            IPaletteContent? inherit = GetContentInherit(state);
+            IPaletteContent inherit = GetContentInherit(state);
 
             return inherit?.GetContentAdjacentGap(state) ?? Target!.GetContentAdjacentGap(style, state);
         }
         #endregion
 
         #region Implementation
-        private IPaletteRibbonBack? GetBackInherit(PaletteState state)
+        private IPaletteRibbonBack GetBackInherit(PaletteState state)
         {
             switch (state)
             {
@@ -794,11 +794,11 @@ namespace Krypton.Navigator
                 default:
                     // Should never happen!
                     Debug.Assert(false);
-                    return null;
+                    throw new ArgumentOutOfRangeException(nameof(state), @"state must be PaletteState value.");
             }
         }
 
-        private IPaletteRibbonText? GetTextInherit(PaletteState state)
+        private IPaletteRibbonText GetTextInherit(PaletteState state)
         {
             switch (state)
             {
@@ -819,11 +819,11 @@ namespace Krypton.Navigator
                 default:
                     // Should never happen!
                     Debug.Assert(false);
-                    return null;
+                    throw new ArgumentOutOfRangeException(nameof(state), @"state must be PaletteState value.");
             }
         }
 
-        private IPaletteContent? GetContentInherit(PaletteState state)
+        private IPaletteContent GetContentInherit(PaletteState state)
         {
             switch (state)
             {
@@ -844,7 +844,7 @@ namespace Krypton.Navigator
                 default:
                     // Should never happen!
                     Debug.Assert(false);
-                    return null;
+                    throw new ArgumentOutOfRangeException(nameof(state), @"state must be PaletteState value.");
             }
         }
         #endregion

--- a/Source/Krypton Components/Krypton.Navigator/Palette/PaletteRibbonGeneralRedirect.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Palette/PaletteRibbonGeneralRedirect.cs
@@ -52,7 +52,7 @@ namespace Krypton.Navigator
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect) => _inherit.SetRedirector(redirect);
+        public void SetRedirector(PaletteRedirect redirect) => _inherit.SetRedirector(redirect);
         #endregion
 
         #region IsDefault

--- a/Source/Krypton Components/Krypton.Navigator/Palette/PaletteRibbonTabContentRedirect.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Palette/PaletteRibbonTabContentRedirect.cs
@@ -52,7 +52,7 @@ namespace Krypton.Navigator
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect)
+        public void SetRedirector(PaletteRedirect redirect)
         {
             _drawRedirect.SetRedirector(redirect);
             _contentInherit.SetRedirector(redirect);

--- a/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderBarCheckButtonGroupInside.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderBarCheckButtonGroupInside.cs
@@ -26,7 +26,7 @@ namespace Krypton.Navigator
         /// <param name="redirector">Palette redirector.</param>
         public override void Construct(KryptonNavigator navigator,
                                        ViewManager manager,
-                                       PaletteRedirect? redirector) =>
+                                       PaletteRedirect redirector) =>
             // Let base class perform common operations
             base.Construct(navigator, manager, redirector!);
 

--- a/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderBarCheckButtonGroupOnly.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderBarCheckButtonGroupOnly.cs
@@ -26,7 +26,7 @@ namespace Krypton.Navigator
         /// <param name="redirector">Palette redirector.</param>
         public override void Construct(KryptonNavigator navigator,
                                        ViewManager manager,
-                                       PaletteRedirect? redirector) =>
+                                       PaletteRedirect redirector) =>
             // Let base class perform common operations
             base.Construct(navigator, manager, redirector!);
 

--- a/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderBarCheckButtonGroupOutside.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderBarCheckButtonGroupOutside.cs
@@ -26,7 +26,7 @@ namespace Krypton.Navigator
         /// <param name="redirector">Palette redirector.</param>
         public override void Construct(KryptonNavigator navigator,
                                        ViewManager manager,
-                                       PaletteRedirect? redirector) =>
+                                       PaletteRedirect redirector) =>
             // Let base class perform common operations
             base.Construct(navigator, manager, redirector!);
 

--- a/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderBarCheckButtonOnly.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderBarCheckButtonOnly.cs
@@ -26,7 +26,7 @@ namespace Krypton.Navigator
         /// <param name="redirector">Palette redirector.</param>
         public override void Construct(KryptonNavigator navigator,
                                        ViewManager manager,
-                                       PaletteRedirect? redirector) =>
+                                       PaletteRedirect redirector) =>
             // Let base class perform common operations
             base.Construct(navigator, manager, redirector!);
 

--- a/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderBase.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderBase.cs
@@ -59,7 +59,7 @@ namespace Krypton.Navigator
         /// <summary>
         /// Gets the palette redirector.
         /// </summary>
-        public PaletteRedirect? Redirector
+        public PaletteRedirect Redirector
         {
             [DebuggerStepThrough]
             get;
@@ -81,7 +81,7 @@ namespace Krypton.Navigator
         /// <param name="redirector">Palette redirector.</param>
         public virtual void Construct([DisallowNull] KryptonNavigator navigator,
                                       [DisallowNull] ViewManager manager,
-                                       PaletteRedirect? redirector)
+                                       PaletteRedirect redirector)
         {
             Debug.Assert(navigator != null, $"{nameof(navigator)} != null");
             Debug.Assert(manager != null);

--- a/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderGroup.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderGroup.cs
@@ -31,7 +31,7 @@ namespace Krypton.Navigator
         /// <param name="redirector">Palette redirector.</param>
         public override void Construct(KryptonNavigator navigator,
                                        [DisallowNull] ViewManager manager,
-                                       PaletteRedirect? redirector)
+                                       PaletteRedirect redirector)
         {
             // Let base class perform common operations
             base.Construct(navigator, manager, redirector);

--- a/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderHeaderBarCheckButtonBase.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderHeaderBarCheckButtonBase.cs
@@ -31,7 +31,7 @@ namespace Krypton.Navigator
         /// <param name="redirector">Palette redirector.</param>
         public override void Construct(KryptonNavigator navigator,
                                        ViewManager manager,
-                                       PaletteRedirect? redirector)
+                                       PaletteRedirect redirector)
         {
             // Let base class perform common operations
             base.Construct(navigator, manager, redirector);

--- a/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderHeaderBarTabGroup.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderHeaderBarTabGroup.cs
@@ -35,7 +35,7 @@ namespace Krypton.Navigator
         /// <param name="redirector">Palette redirector.</param>
         public override void Construct(KryptonNavigator navigator,
                                        ViewManager manager,
-                                       PaletteRedirect? redirector)
+                                       PaletteRedirect redirector)
         {
             // Let base class perform common operations
             base.Construct(navigator, manager, redirector);

--- a/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderHeaderGroup.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderHeaderGroup.cs
@@ -31,7 +31,7 @@ namespace Krypton.Navigator
         /// <param name="redirector">Palette redirector.</param>
         public override void Construct([DisallowNull] KryptonNavigator navigator,
                                        [DisallowNull] ViewManager manager,
-                                       PaletteRedirect? redirector)
+                                       PaletteRedirect redirector)
         {
             // Let base class perform common operations
             base.Construct(navigator, manager, redirector);

--- a/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderItemBase.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderItemBase.cs
@@ -40,7 +40,7 @@ namespace Krypton.Navigator
         /// <param name="redirector">Palette redirector.</param>
         public override void Construct([DisallowNull] KryptonNavigator navigator,
                 [DisallowNull] ViewManager manager,
-                                        PaletteRedirect? redirector)
+                                        PaletteRedirect redirector)
         {
             // Let base class perform common operations
             base.Construct(navigator, manager, redirector!);

--- a/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderOutlookBase.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderOutlookBase.cs
@@ -282,7 +282,7 @@ namespace Krypton.Navigator
         /// <param name="redirector">Palette redirector.</param>
         public override void Construct([DisallowNull] KryptonNavigator navigator,
                                        [DisallowNull] ViewManager manager,
-                                       PaletteRedirect? redirector)
+                                       PaletteRedirect redirector)
         {
             // Let base class perform common operations
             base.Construct(navigator, manager, redirector);

--- a/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderPanel.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderPanel.cs
@@ -31,7 +31,7 @@ namespace Krypton.Navigator
         /// <param name="redirector">Palette redirector.</param>
         public override void Construct([DisallowNull] KryptonNavigator navigator,
                                        [DisallowNull] ViewManager manager,
-                                       PaletteRedirect? redirector)
+                                       PaletteRedirect redirector)
         {
             // Let base class perform common operations
             if (redirector != null)

--- a/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderStackCheckButtonBase.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderStackCheckButtonBase.cs
@@ -40,7 +40,7 @@ namespace Krypton.Navigator
         /// <param name="redirector">Palette redirector.</param>
         public override void Construct([DisallowNull] KryptonNavigator navigator,
                                        [DisallowNull] ViewManager manager,
-                                       PaletteRedirect? redirector)
+                                       PaletteRedirect redirector)
         {
             // Let base class perform common operations
             base.Construct(navigator, manager, redirector);

--- a/Source/Krypton Components/Krypton.Navigator/View Builder/ViewletHeaderGroup.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Builder/ViewletHeaderGroup.cs
@@ -36,7 +36,7 @@ namespace Krypton.Navigator
         /// <param name="redirector">Palette redirector.</param>
         /// <param name="needPaintDelegate">Delegate for notifying paint requests.</param>
         public ViewletHeaderGroup([DisallowNull] KryptonNavigator navigator,
-                                  PaletteRedirect? redirector,
+                                  PaletteRedirect redirector,
                                   [DisallowNull] NeedPaintHandler needPaintDelegate)
         {
             Debug.Assert(navigator != null);
@@ -59,7 +59,7 @@ namespace Krypton.Navigator
         /// <summary>
         /// Gets access to the palette redirector reference.
         /// </summary>
-        public PaletteRedirect? Redirector { get; }
+        public PaletteRedirect Redirector { get; }
 
         /// <summary>
         /// Construct the view appropriate for this builder.

--- a/Source/Krypton Components/Krypton.Navigator/View Builder/ViewletHeaderGroupOutlook.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Builder/ViewletHeaderGroupOutlook.cs
@@ -29,7 +29,7 @@ namespace Krypton.Navigator
         /// <param name="redirector">Palette redirector.</param>
         /// <param name="needPaintDelegate">Delegate for notifying paint requests.</param>
         public ViewletHeaderGroupOutlook(KryptonNavigator navigator,
-                                         PaletteRedirect? redirector,
+                                         PaletteRedirect redirector,
                                          NeedPaintHandler needPaintDelegate)
             : base(navigator, redirector, needPaintDelegate) =>
             // Are we using the full or mini outlook mode.

--- a/Source/Krypton Components/Krypton.Navigator/View Draw/ViewDrawNavRibbonTab.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Draw/ViewDrawNavRibbonTab.cs
@@ -306,7 +306,7 @@ namespace Krypton.Navigator
             CheckPaletteState(context);
 
             // Cache the ribbon shape
-            _lastRibbonShape = Navigator.Palette?.GetRibbonShape() ?? PaletteRibbonShape.Office2007;
+            _lastRibbonShape = Navigator.GetResolvedPalette()?.GetRibbonShape() ?? PaletteRibbonShape.Office2007;
 
             // We take on all the provided size
             ClientRectangle = context.DisplayRectangle;

--- a/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecExpandRibbon.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecExpandRibbon.cs
@@ -65,14 +65,14 @@ namespace Krypton.Ribbon
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibility.</returns>
-        public override bool GetVisible(PaletteBase? palette) => _ribbon is { ShowMinimizeButton: true, MinimizedMode: true };
+        public override bool GetVisible(PaletteBase palette) => _ribbon is { ShowMinimizeButton: true, MinimizedMode: true };
 
         /// <summary>
         /// Gets the button enabled state.
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button enabled state.</returns>
-        public override ButtonEnabled GetEnabled(PaletteBase? palette) => ButtonEnabled.True;
+        public override ButtonEnabled GetEnabled(PaletteBase palette) => ButtonEnabled.True;
 
         /// <summary>
         /// Gets the button checked state.
@@ -88,7 +88,7 @@ namespace Krypton.Ribbon
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button style.</returns>
-        public override ButtonStyle GetStyle(PaletteBase? palette) => ButtonStyle.ButtonSpec;
+        public override ButtonStyle GetStyle(PaletteBase palette) => ButtonStyle.ButtonSpec;
 
         #endregion    
 

--- a/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecManagerLayoutAppButton.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecManagerLayoutAppButton.cs
@@ -36,7 +36,7 @@ namespace Krypton.Ribbon
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
         public ButtonSpecManagerLayoutAppButton(ViewContextMenuManager viewManager,
                                                 Control control,
-                                                [DisallowNull] PaletteRedirect? redirector,
+                                                [DisallowNull] PaletteRedirect redirector,
                                                 ButtonSpecCollectionBase variableSpecs,
                                                 ButtonSpecCollectionBase? fixedSpecs,
                                                 ViewLayoutDocker[] viewDockers,

--- a/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecManagerLayoutRibbon.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecManagerLayoutRibbon.cs
@@ -34,7 +34,7 @@ namespace Krypton.Ribbon
         /// <param name="getRenderer">Delegate for returning a tool strip renderer.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
         public ButtonSpecManagerLayoutRibbon(KryptonRibbon ribbon,
-                                             PaletteRedirect? redirector,
+                                             PaletteRedirect redirector,
                                              ButtonSpecCollectionBase variableSpecs,
                                              ButtonSpecCollectionBase fixedSpecs,
                                              ViewLayoutDocker[] viewDockers,

--- a/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecMdiChildClose.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecMdiChildClose.cs
@@ -42,7 +42,7 @@ namespace Krypton.Ribbon
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibility.</returns>
-        public override bool GetVisible(PaletteBase? palette)
+        public override bool GetVisible(PaletteBase palette)
         {
             // Cannot be seen if not attached to an mdi child window and cannot be seen
             // if the window is not maximized and so needing the pendant buttons
@@ -60,7 +60,7 @@ namespace Krypton.Ribbon
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button enabled state.</returns>
-        public override ButtonEnabled GetEnabled(PaletteBase? palette) => ButtonEnabled.True;
+        public override ButtonEnabled GetEnabled(PaletteBase palette) => ButtonEnabled.True;
 
         /// <summary>
         /// Gets the button checked state.

--- a/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecMdiChildFixed.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecMdiChildFixed.cs
@@ -65,7 +65,7 @@ namespace Krypton.Ribbon
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button style.</returns>
-        public override ButtonStyle GetStyle(PaletteBase? palette) => ButtonStyle.ButtonSpec;
+        public override ButtonStyle GetStyle(PaletteBase palette) => ButtonStyle.ButtonSpec;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecMdiChildMin.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecMdiChildMin.cs
@@ -42,7 +42,7 @@ namespace Krypton.Ribbon
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibiliy.</returns>
-        public override bool GetVisible(PaletteBase? palette)
+        public override bool GetVisible(PaletteBase palette)
         {
             // Cannot be seen if not attached to an mdi child window and cannot be seen
             // if the window is not maximized and so needing the pendant buttons
@@ -74,7 +74,7 @@ namespace Krypton.Ribbon
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button enabled state.</returns>
-        public override ButtonEnabled GetEnabled(PaletteBase? palette)
+        public override ButtonEnabled GetEnabled(PaletteBase palette)
         {
             // Cannot be enabled if not attached to an mdi child window
             if (MdiChild == null || MdiChild.IsDisposed || !MdiChild.IsHandleCreated || MdiChild.Disposing)

--- a/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecMdiChildRestore.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecMdiChildRestore.cs
@@ -42,7 +42,7 @@ namespace Krypton.Ribbon
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibiliy.</returns>
-        public override bool GetVisible(PaletteBase? palette)
+        public override bool GetVisible(PaletteBase palette)
         {
             // Cannot be seen if not attached to an mdi child window and cannot be seen
             // if the window is not maximized and so needing the pendant buttons
@@ -74,7 +74,7 @@ namespace Krypton.Ribbon
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button enabled state.</returns>
-        public override ButtonEnabled GetEnabled(PaletteBase? palette)
+        public override ButtonEnabled GetEnabled(PaletteBase palette)
         {
             // Cannot be enabled if not attached to an mdi child window
             if (MdiChild == null)

--- a/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecMinimizeRibbon.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecMinimizeRibbon.cs
@@ -65,14 +65,14 @@ namespace Krypton.Ribbon
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibiliy.</returns>
-        public override bool GetVisible(PaletteBase? palette) => _ribbon is { ShowMinimizeButton: true, MinimizedMode: false };
+        public override bool GetVisible(PaletteBase palette) => _ribbon is { ShowMinimizeButton: true, MinimizedMode: false };
 
         /// <summary>
         /// Gets the button enabled state.
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button enabled state.</returns>
-        public override ButtonEnabled GetEnabled(PaletteBase? palette) => ButtonEnabled.True;
+        public override ButtonEnabled GetEnabled(PaletteBase palette) => ButtonEnabled.True;
 
         /// <summary>
         /// Gets the button checked state.
@@ -88,7 +88,7 @@ namespace Krypton.Ribbon
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button style.</returns>
-        public override ButtonStyle GetStyle(PaletteBase? palette) => ButtonStyle.ButtonSpec;
+        public override ButtonStyle GetStyle(PaletteBase palette) => ButtonStyle.ButtonSpec;
 
         #endregion    
 

--- a/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonGallery.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonGallery.cs
@@ -643,7 +643,7 @@ namespace Krypton.Ribbon
         /// </summary>
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
-        protected override void OnNeedPaint(object? sender, NeedLayoutEventArgs e)
+        protected override void OnNeedPaint(object sender, NeedLayoutEventArgs e)
         {
             if (IsHandleCreated)
             {

--- a/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonRibbon.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonRibbon.cs
@@ -1707,7 +1707,7 @@ namespace Krypton.Ribbon
         /// </summary>
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
-        protected override void OnNeedPaint(object? sender, NeedLayoutEventArgs e)
+        protected override void OnNeedPaint(object sender, NeedLayoutEventArgs e)
         {
             // When in minimized mode...
             if (RealMinimizedMode)
@@ -2552,7 +2552,7 @@ namespace Krypton.Ribbon
 
         internal PaletteRibbonShape RibbonShape => StateCommon.RibbonGeneral.GetRibbonShape();
 
-        internal PaletteRedirect? GetRedirector() => Redirector;
+        internal PaletteRedirect GetRedirector() => Redirector;
 
         internal Control? GetControllerControl(Control? c)
         {

--- a/Source/Krypton Components/Krypton.Ribbon/Controls Visuals/VisualPopupAppMenu.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controls Visuals/VisualPopupAppMenu.cs
@@ -18,7 +18,7 @@ namespace Krypton.Ribbon
     {
         #region Instance Fields
         private readonly KryptonRibbon _ribbon;
-        private PaletteBase? _palette;
+        private PaletteBase _palette;
         private IPaletteBack _drawOutsideBack;
         private IPaletteBorder _drawOutsideBorder;
         private readonly AppButtonMenuProvider _provider;
@@ -47,9 +47,9 @@ namespace Krypton.Ribbon
         /// <param name="keyboardActivated">Was the context menu activated by a keyboard action.</param>
         public VisualPopupAppMenu(KryptonRibbon ribbon,
                                   RibbonAppButton appButton,
-                                  PaletteBase? palette,
+                                  PaletteBase palette,
                                   PaletteMode paletteMode,
-                                  PaletteRedirect? redirector,
+                                  PaletteRedirect redirector,
                                   Rectangle rectAppButtonTopHalf,
                                   Rectangle rectAppButtonBottomHalf,
                                   bool keyboardActivated)
@@ -393,7 +393,7 @@ namespace Krypton.Ribbon
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override PaletteBase? GetResolvedPalette() => _palette;
+        public override PaletteBase GetResolvedPalette() => _palette;
 
         #endregion
 
@@ -401,7 +401,7 @@ namespace Krypton.Ribbon
         /// <summary>
         /// Gets access to the palette redirector.
         /// </summary>
-        protected PaletteRedirect? Redirector
+        protected PaletteRedirect Redirector
         {
             [DebuggerStepThrough]
             get;
@@ -483,7 +483,7 @@ namespace Krypton.Ribbon
             }
         }
 
-        private void SetPalette(PaletteBase? palette)
+        private void SetPalette(PaletteBase palette)
         {
             if (palette != _palette)
             {

--- a/Source/Krypton Components/Krypton.Ribbon/Controls Visuals/VisualPopupQATOverflow.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controls Visuals/VisualPopupQATOverflow.cs
@@ -31,7 +31,7 @@ namespace Krypton.Ribbon
         /// <param name="renderer">Drawing renderer.</param>
         public VisualPopupQATOverflow([DisallowNull] KryptonRibbon ribbon,
                                       ViewLayoutRibbonQATContents contents,
-                                      IRenderer? renderer)
+                                      IRenderer renderer)
             : base(renderer, true)
         {
             Debug.Assert(ribbon != null);

--- a/Source/Krypton Components/Krypton.Ribbon/General/AppButtonMenuProvider.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/General/AppButtonMenuProvider.cs
@@ -58,9 +58,9 @@ namespace Krypton.Ribbon
         public AppButtonMenuProvider(ViewContextMenuManager viewManager,
                                      KryptonContextMenuItemCollection menuCollection,
                                      ViewLayoutStack viewColumns,
-                                     PaletteBase? palette,
+                                     PaletteBase palette,
                                      PaletteMode paletteMode,
-                                     PaletteRedirect? redirector,
+                                     PaletteRedirect redirector,
                                      NeedPaintHandler needPaintDelegate)
         {
             // Store incoming state
@@ -251,7 +251,7 @@ namespace Krypton.Ribbon
         /// <summary>
         /// Gets access to the custom palette.
         /// </summary>
-        public PaletteBase? ProviderPalette { get; }
+        public PaletteBase ProviderPalette { get; }
 
         /// <summary>
         /// Gets access to the palette mode.
@@ -261,7 +261,7 @@ namespace Krypton.Ribbon
         /// <summary>
         /// Gets access to the context menu redirector.
         /// </summary>
-        public PaletteRedirect? ProviderRedirector { get; }
+        public PaletteRedirect ProviderRedirector { get; }
 
         /// <summary>
         /// Gets a delegate used to indicate a repaint is required.

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupComboBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupComboBox.cs
@@ -246,11 +246,11 @@ namespace Krypton.Ribbon
         {
             if (disposing)
             {
-                if (ComboBox != null)
+                if (ComboBox != null!)
                 {
                     UnmonitorControl(ComboBox);
                     ComboBox.Dispose();
-                    ComboBox = null;
+                    ComboBox = null!;
                 }
             }
 
@@ -275,7 +275,8 @@ namespace Krypton.Ribbon
                 {
                     // Use the same palette in the combo box as the ribbon, plus we need
                     // to know when the ribbon palette changes so we can reflect that change
-                    ComboBox.Palette = Ribbon!.GetResolvedPalette();
+                    ComboBox.PaletteMode = Ribbon!.PaletteMode;
+                    ComboBox.LocalCustomPalette = Ribbon!.LocalCustomPalette;
                     Ribbon!.PaletteChanged += OnRibbonPaletteChanged;
                 }
             }
@@ -311,7 +312,7 @@ namespace Krypton.Ribbon
         [Localizable(true)]
         [Category(@"Appearance")]
         [Description(@"Ribbon group text box key tip.")]
-        [DefaultValue("X")]
+        [DefaultValue(@"X")]
         public string KeyTip
         {
             get => _keyTip;
@@ -320,7 +321,7 @@ namespace Krypton.Ribbon
             {
                 if (string.IsNullOrEmpty(value))
                 {
-                    value = "X";
+                    value = @"X";
                 }
 
                 _keyTip = value.ToUpper();
@@ -413,7 +414,7 @@ namespace Krypton.Ribbon
         [Description(@"Text associated with the control.")]
         [Editor(typeof(MultilineStringEditor), typeof(UITypeEditor))]
         [AllowNull]
-        public string Text
+        public string? Text
         {
             get => ComboBox.Text;
             set => ComboBox.Text = value;
@@ -464,7 +465,7 @@ namespace Krypton.Ribbon
         [AttributeProvider(typeof(IListSource))]
         [RefreshProperties(RefreshProperties.Repaint)]
         [DefaultValue(null)]
-        public object DataSource
+        public object? DataSource
         {
             get => ComboBox.DataSource;
             set => ComboBox.DataSource = value;
@@ -728,7 +729,7 @@ namespace Krypton.Ribbon
         [Bindable(true)]
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public object SelectedItem
+        public object? SelectedItem
         {
             get => ComboBox.SelectedItem;
             set => ComboBox.SelectedItem = value;
@@ -739,7 +740,7 @@ namespace Krypton.Ribbon
         /// </summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public string SelectedText
+        public string? SelectedText
         {
             get => ComboBox.SelectedText;
             set => ComboBox.SelectedText = value;
@@ -822,7 +823,7 @@ namespace Krypton.Ribbon
         /// </summary>
         /// <param name="item">The object from which to get the contents to display.</param>
         /// <returns>If the DisplayMember property is not specified, the value returned by GetItemText is the value of the item's ToString method. Otherwise, the method returns the string value of the member specified in the DisplayMember property for the object specified in the item parameter.</returns>
-        public string GetItemText(object item) => ComboBox.GetItemText(item);
+        public string? GetItemText(object item) => ComboBox.GetItemText(item);
 
         /// <summary>
         /// Selects a range of text in the control.
@@ -1064,7 +1065,7 @@ namespace Krypton.Ribbon
                         // Can the combo box take the focus
                         if (LastComboBox is { CanFocus: true })
                         {
-                            LastComboBox.ComboBox.Focus();
+                            LastComboBox.ComboBox!.Focus();
                         }
 
                         return true;
@@ -1141,7 +1142,12 @@ namespace Krypton.Ribbon
 
         private void OnComboBoxValueMemberChanged(object sender, EventArgs e) => OnValueMemberChanged(e);
 
-        private void OnRibbonPaletteChanged(object sender, EventArgs e) => ComboBox.Palette = Ribbon.GetResolvedPalette();
+        private void OnRibbonPaletteChanged(object sender, EventArgs e)
+        {
+            ComboBox.PaletteMode = Ribbon!.PaletteMode;
+            ComboBox.LocalCustomPalette = Ribbon!.LocalCustomPalette;
+        }
+
         #endregion
     }
 }

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupDateTimePicker.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupDateTimePicker.cs
@@ -212,7 +212,8 @@ namespace Krypton.Ribbon
                 {
                     // Use the same palette in the date time picker as the ribbon, plus we need
                     // to know when the ribbon palette changes so we can reflect that change
-                    DateTimePicker.Palette = Ribbon!.GetResolvedPalette();
+                    DateTimePicker.PaletteMode = Ribbon!.PaletteMode;
+                    DateTimePicker.LocalCustomPalette = Ribbon!.LocalCustomPalette;
                     Ribbon!.PaletteChanged += OnRibbonPaletteChanged;
                 }
             }
@@ -1009,7 +1010,12 @@ namespace Krypton.Ribbon
 
         private void OnDateTimePickerKeyDown(object sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
 
-        private void OnRibbonPaletteChanged(object sender, EventArgs e) => DateTimePicker.Palette = Ribbon.GetResolvedPalette();
+        private void OnRibbonPaletteChanged(object sender, EventArgs e)
+        {
+            DateTimePicker.PaletteMode = Ribbon!.PaletteMode;
+            DateTimePicker.LocalCustomPalette = Ribbon!.LocalCustomPalette;
+        }
+
         #endregion
     }
 }

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupDomainUpDown.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupDomainUpDown.cs
@@ -187,7 +187,8 @@ namespace Krypton.Ribbon
                 {
                     // Use the same palette in the domain up-down as the ribbon, plus we need
                     // to know when the ribbon palette changes so we can reflect that change
-                    DomainUpDown.Palette = Ribbon!.GetResolvedPalette();
+                    DomainUpDown.PaletteMode = Ribbon!.PaletteMode;
+                    DomainUpDown.LocalCustomPalette = Ribbon!.LocalCustomPalette;
                     Ribbon!.PaletteChanged += OnRibbonPaletteChanged;
                 }
             }
@@ -710,7 +711,12 @@ namespace Krypton.Ribbon
 
         private void OnDomainUpDownPreviewKeyDown(object sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
 
-        private void OnRibbonPaletteChanged(object sender, EventArgs e) => DomainUpDown.Palette = Ribbon.GetResolvedPalette();
+        private void OnRibbonPaletteChanged(object sender, EventArgs e)
+        {
+            DomainUpDown.PaletteMode = Ribbon!.PaletteMode;
+            DomainUpDown.LocalCustomPalette = Ribbon!.LocalCustomPalette;
+        }
+
         #endregion
     }
 }

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupMaskedTextBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupMaskedTextBox.cs
@@ -165,7 +165,7 @@ namespace Krypton.Ribbon
             _enabled = true;
             _itemSizeCurrent = GroupItemSize.Medium;
             ShortcutKeys = Keys.None;
-            _keyTip = "X";
+            _keyTip = @"X";
 
             // Create the actual masked text box control and set initial settings
             MaskedTextBox = new KryptonMaskedTextBox
@@ -206,11 +206,11 @@ namespace Krypton.Ribbon
         {
             if (disposing)
             {
-                if (MaskedTextBox != null)
+                if (MaskedTextBox != null!)
                 {
                     UnmonitorControl(MaskedTextBox);
                     MaskedTextBox.Dispose();
-                    MaskedTextBox = null;
+                    MaskedTextBox = null!;
                 }
             }
 
@@ -235,7 +235,8 @@ namespace Krypton.Ribbon
                 {
                     // Use the same palette in the masked text box as the ribbon, plus we need
                     // to know when the ribbon palette changes so we can reflect that change
-                    MaskedTextBox.Palette = value.GetResolvedPalette();
+                    MaskedTextBox.PaletteMode = Ribbon!.PaletteMode;
+                    MaskedTextBox.LocalCustomPalette = Ribbon!.LocalCustomPalette;
                     value.PaletteChanged += OnRibbonPaletteChanged;
                 }
             }
@@ -263,7 +264,7 @@ namespace Krypton.Ribbon
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public KryptonMaskedTextBox? MaskedTextBox { get; private set; }
+        public KryptonMaskedTextBox MaskedTextBox { get; private set; }
 
         /// <summary>
         /// Gets and sets the key tip for the ribbon group masked text box.
@@ -285,7 +286,7 @@ namespace Krypton.Ribbon
                     value = @"X";
                 }
 
-                _keyTip = value.ToUpper();
+                _keyTip = value!.ToUpper();
             }
         }
 
@@ -352,8 +353,8 @@ namespace Krypton.Ribbon
         [DefaultValue(typeof(Size), "121, 0")]
         public Size MinimumSize
         {
-            get => MaskedTextBox!.MinimumSize;
-            set => MaskedTextBox!.MinimumSize = value;
+            get => MaskedTextBox.MinimumSize;
+            set => MaskedTextBox.MinimumSize = value;
         }
 
         /// <summary>
@@ -364,8 +365,8 @@ namespace Krypton.Ribbon
         [DefaultValue(typeof(Size), "121, 0")]
         public Size MaximumSize
         {
-            get => MaskedTextBox!.MaximumSize;
-            set => MaskedTextBox!.MaximumSize = value;
+            get => MaskedTextBox.MaximumSize;
+            set => MaskedTextBox.MaximumSize = value;
         }
 
         /// <summary>
@@ -418,10 +419,10 @@ namespace Krypton.Ribbon
         [Category(@"Appearance")]
         [Editor(@"System.Windows.Forms.Design.MaskedTextBoxTextEditor", typeof(UITypeEditor))]
         [AllowNull]
-        public string Text
+        public string? Text
         {
-            get => MaskedTextBox?.Text ?? string.Empty;
-            set => MaskedTextBox!.Text = value;
+            get => MaskedTextBox.Text;
+            set => MaskedTextBox.Text = value;
         }
 
         /// <summary>
@@ -429,7 +430,7 @@ namespace Krypton.Ribbon
         /// </summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public bool Modified => MaskedTextBox!.Modified;
+        public bool Modified => MaskedTextBox.Modified;
 
         /// <summary>
         /// Gets and sets the selected text within the control.
@@ -437,9 +438,9 @@ namespace Krypton.Ribbon
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [AllowNull]
-        public string SelectedText
+        public string? SelectedText
         {
-            get => MaskedTextBox?.SelectedText ?? string.Empty;
+            get => MaskedTextBox.SelectedText;
             set => MaskedTextBox.SelectedText = value;
         }
 
@@ -450,7 +451,7 @@ namespace Krypton.Ribbon
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public int SelectionLength
         {
-            get => MaskedTextBox?.SelectionLength ?? 0;
+            get => MaskedTextBox.SelectionLength;
             set => MaskedTextBox.SelectionLength = value;
         }
 
@@ -461,7 +462,7 @@ namespace Krypton.Ribbon
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public int SelectionStart
         {
-            get => MaskedTextBox?.SelectionStart ?? 0;
+            get => MaskedTextBox.SelectionStart;
             set => MaskedTextBox.SelectionStart = value;
         }
 
@@ -470,32 +471,32 @@ namespace Krypton.Ribbon
         /// </summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public int TextLength => MaskedTextBox?.TextLength ?? 0;
+        public int TextLength => MaskedTextBox.TextLength;
 
         /// <summary>
         /// Gets a value that specifies whether new user input overwrites existing input.
         /// </summary>
         [Browsable(false)]
-        public bool IsOverwriteMode => MaskedTextBox?.IsOverwriteMode ?? false;
+        public bool IsOverwriteMode => MaskedTextBox.IsOverwriteMode;
 
         /// <summary>
         /// Gets a value indicating whether all required inputs have been entered into the input mask.
         /// </summary>
         [Browsable(false)]
-        public bool MaskCompleted => MaskedTextBox?.MaskCompleted ?? false;
+        public bool MaskCompleted => MaskedTextBox.MaskCompleted;
 
         /// <summary>
         /// Gets a clone of the mask provider associated with this instance of the masked text box control.
         /// </summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public MaskedTextProvider? MaskedTextProvider => MaskedTextBox?.MaskedTextProvider;
+        public MaskedTextProvider? MaskedTextProvider => MaskedTextBox.MaskedTextProvider;
 
         /// <summary>
         /// Gets a value indicating whether all required and optional inputs have been entered into the input mask.
         /// </summary>
         [Browsable(false)]
-        public bool MaskFull => MaskedTextBox?.MaskFull ?? false;
+        public bool MaskFull => MaskedTextBox.MaskFull;
 
         /// <summary>
         /// Gets or sets the maximum number of characters that can be entered into the edit control.
@@ -504,7 +505,7 @@ namespace Krypton.Ribbon
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public int MaxLength
         {
-            get => MaskedTextBox?.MaxLength ?? 0;
+            get => MaskedTextBox.MaxLength;
             set => MaskedTextBox.MaxLength = value;
         }
 
@@ -515,7 +516,7 @@ namespace Krypton.Ribbon
         [DefaultValue(null)]
         public Type? ValidatingType
         {
-            get => MaskedTextBox?.ValidatingType;
+            get => MaskedTextBox.ValidatingType;
             set => MaskedTextBox.ValidatingType = value;
         }
 
@@ -528,7 +529,7 @@ namespace Krypton.Ribbon
         [Localizable(true)]
         public HorizontalAlignment TextAlign
         {
-            get => MaskedTextBox?.TextAlign ?? HorizontalAlignment.Left;
+            get => MaskedTextBox.TextAlign;
             set => MaskedTextBox.TextAlign = value;
         }
 
@@ -542,7 +543,7 @@ namespace Krypton.Ribbon
         [Localizable(true)]
         public char PromptChar
         {
-            get => MaskedTextBox?.PromptChar ?? '_';
+            get => MaskedTextBox.PromptChar;
             set => MaskedTextBox.PromptChar = value;
         }
 
@@ -554,7 +555,7 @@ namespace Krypton.Ribbon
         [DefaultValue(true)]
         public bool AllowPromptAsInput
         {
-            get => MaskedTextBox?.AllowPromptAsInput ?? false;
+            get => MaskedTextBox.AllowPromptAsInput;
             set => MaskedTextBox.AllowPromptAsInput = value;
         }
 
@@ -567,7 +568,7 @@ namespace Krypton.Ribbon
         [DefaultValue(false)]
         public bool AsciiOnly
         {
-            get => MaskedTextBox?.AsciiOnly ?? false;
+            get => MaskedTextBox.AsciiOnly;
             set => MaskedTextBox.AsciiOnly = value;
         }
 
@@ -579,7 +580,7 @@ namespace Krypton.Ribbon
         [DefaultValue(false)]
         public bool BeepOnError
         {
-            get => MaskedTextBox?.BeepOnError ?? false;
+            get => MaskedTextBox.BeepOnError;
             set => MaskedTextBox.BeepOnError = value;
         }
 
@@ -591,7 +592,7 @@ namespace Krypton.Ribbon
         [RefreshProperties(RefreshProperties.All)]
         public CultureInfo Culture
         {
-            get => MaskedTextBox?.Culture ?? CultureInfo.InvariantCulture;
+            get => MaskedTextBox.Culture;
             set => MaskedTextBox.Culture = value;
         }
 
@@ -606,7 +607,7 @@ namespace Krypton.Ribbon
         [DefaultValue(typeof(MaskFormat), @"IncludeLiterals")]
         public MaskFormat CutCopyMaskFormat
         {
-            get => MaskedTextBox?.CutCopyMaskFormat ?? MaskFormat.IncludeLiterals;
+            get => MaskedTextBox.CutCopyMaskFormat;
             set => MaskedTextBox.CutCopyMaskFormat = value;
         }
 
@@ -619,7 +620,7 @@ namespace Krypton.Ribbon
         [DefaultValue(false)]
         public bool HidePromptOnLeave
         {
-            get => MaskedTextBox?.HidePromptOnLeave ?? false;
+            get => MaskedTextBox.HidePromptOnLeave;
             set => MaskedTextBox.HidePromptOnLeave = value;
         }
 
@@ -631,7 +632,7 @@ namespace Krypton.Ribbon
         [DefaultValue(typeof(InsertKeyMode), @"Default")]
         public InsertKeyMode InsertKeyMode
         {
-            get => MaskedTextBox?.InsertKeyMode ?? InsertKeyMode.Default;
+            get => MaskedTextBox.InsertKeyMode;
             set => MaskedTextBox.InsertKeyMode = value;
         }
 
@@ -647,7 +648,7 @@ namespace Krypton.Ribbon
         [AllowNull]
         public string Mask
         {
-            get => MaskedTextBox?.Mask ?? string.Empty;
+            get => MaskedTextBox.Mask;
             set => MaskedTextBox.Mask = value;
         }
 
@@ -659,7 +660,7 @@ namespace Krypton.Ribbon
         [DefaultValue(true)]
         public bool HideSelection
         {
-            get => MaskedTextBox?.HideSelection ?? true;
+            get => MaskedTextBox.HideSelection;
             set => MaskedTextBox.HideSelection = value;
         }
 
@@ -672,7 +673,7 @@ namespace Krypton.Ribbon
         [DefaultValue(false)]
         public bool ReadOnly
         {
-            get => MaskedTextBox?.ReadOnly ?? false;
+            get => MaskedTextBox.ReadOnly;
             set => MaskedTextBox.ReadOnly = value;
         }
 
@@ -684,7 +685,7 @@ namespace Krypton.Ribbon
         [DefaultValue(false)]
         public bool RejectInputOnFirstFailure
         {
-            get => MaskedTextBox?.RejectInputOnFirstFailure ?? false;
+            get => MaskedTextBox.RejectInputOnFirstFailure;
             set => MaskedTextBox.RejectInputOnFirstFailure = value;
         }
 
@@ -696,7 +697,7 @@ namespace Krypton.Ribbon
         [DefaultValue(true)]
         public bool ResetOnPrompt
         {
-            get => MaskedTextBox?.ResetOnPrompt ?? true;
+            get => MaskedTextBox.ResetOnPrompt;
             set => MaskedTextBox.ResetOnPrompt = value;
         }
 
@@ -708,7 +709,7 @@ namespace Krypton.Ribbon
         [DefaultValue(true)]
         public bool ResetOnSpace
         {
-            get => MaskedTextBox?.ResetOnSpace ?? true;
+            get => MaskedTextBox.ResetOnSpace;
             set => MaskedTextBox.ResetOnSpace = value;
         }
 
@@ -720,7 +721,7 @@ namespace Krypton.Ribbon
         [DefaultValue(true)]
         public bool SkipLiterals
         {
-            get => MaskedTextBox?.SkipLiterals ?? true;
+            get => MaskedTextBox.SkipLiterals;
             set => MaskedTextBox.SkipLiterals = value;
         }
 
@@ -733,7 +734,7 @@ namespace Krypton.Ribbon
         [RefreshProperties(RefreshProperties.Repaint)]
         public MaskFormat TextMaskFormat
         {
-            get => MaskedTextBox?.TextMaskFormat ?? MaskFormat.IncludeLiterals;
+            get => MaskedTextBox.TextMaskFormat;
             set => MaskedTextBox.TextMaskFormat = value;
         }
 
@@ -747,7 +748,7 @@ namespace Krypton.Ribbon
         [Localizable(true)]
         public char PasswordChar
         {
-            get => MaskedTextBox?.PasswordChar ?? '\0';
+            get => MaskedTextBox.PasswordChar;
             set => MaskedTextBox.PasswordChar = value;
         }
 
@@ -760,7 +761,7 @@ namespace Krypton.Ribbon
         [DefaultValue(false)]
         public bool UseSystemPasswordChar
         {
-            get => MaskedTextBox?.UseSystemPasswordChar ?? false;
+            get => MaskedTextBox.UseSystemPasswordChar;
             set => MaskedTextBox.UseSystemPasswordChar = value;
         }
 
@@ -772,7 +773,7 @@ namespace Krypton.Ribbon
         [DefaultValue(null)]
         public ContextMenuStrip? ContextMenuStrip
         {
-            get => MaskedTextBox?.ContextMenuStrip;
+            get => MaskedTextBox.ContextMenuStrip;
             set => MaskedTextBox.ContextMenuStrip = value;
         }
 
@@ -784,7 +785,7 @@ namespace Krypton.Ribbon
         [DefaultValue(null)]
         public KryptonContextMenu? KryptonContextMenu
         {
-            get => MaskedTextBox?.KryptonContextMenu;
+            get => MaskedTextBox.KryptonContextMenu;
             set => MaskedTextBox.KryptonContextMenu = value;
         }
 
@@ -801,7 +802,7 @@ namespace Krypton.Ribbon
         [DefaultValue(false)]
         public bool AllowButtonSpecToolTips
         {
-            get => MaskedTextBox?.AllowButtonSpecToolTips ?? false;
+            get => MaskedTextBox.AllowButtonSpecToolTips;
             set => MaskedTextBox.AllowButtonSpecToolTips = value;
         }
 
@@ -813,7 +814,7 @@ namespace Krypton.Ribbon
         [DefaultValue(false)]
         public bool AllowButtonSpecToolTipPriority
         {
-            get => MaskedTextBox?.AllowButtonSpecToolTipPriority ?? false;
+            get => MaskedTextBox.AllowButtonSpecToolTipPriority;
             set => MaskedTextBox.AllowButtonSpecToolTipPriority = value;
         }
 
@@ -1045,10 +1046,8 @@ namespace Krypton.Ribbon
 
         private void OnRibbonPaletteChanged(object sender, EventArgs e)
         {
-            if (MaskedTextBox != null)
-            {
-                MaskedTextBox.Palette = Ribbon?.GetResolvedPalette();
-            }
+            MaskedTextBox.PaletteMode = Ribbon!.PaletteMode;
+            MaskedTextBox.LocalCustomPalette = Ribbon!.LocalCustomPalette;
         }
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupNumericUpDown.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupNumericUpDown.cs
@@ -179,7 +179,8 @@ namespace Krypton.Ribbon
                 {
                     // Use the same palette in the numeric up-down as the ribbon, plus we need
                     // to know when the ribbon palette changes so we can reflect that change
-                    NumericUpDown.Palette = Ribbon.GetResolvedPalette();
+                    NumericUpDown.PaletteMode = Ribbon!.PaletteMode;
+                    NumericUpDown.LocalCustomPalette = Ribbon!.LocalCustomPalette;
                     Ribbon.PaletteChanged += OnRibbonPaletteChanged;
                 }
             }
@@ -712,7 +713,12 @@ namespace Krypton.Ribbon
 
         private void OnNumericUpDownPreviewKeyDown(object sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
 
-        private void OnRibbonPaletteChanged(object sender, EventArgs e) => NumericUpDown.Palette = Ribbon.GetResolvedPalette();
+        private void OnRibbonPaletteChanged(object sender, EventArgs e)
+        {
+            NumericUpDown.PaletteMode = Ribbon!.PaletteMode;
+            NumericUpDown.LocalCustomPalette = Ribbon!.LocalCustomPalette;
+        }
+
         #endregion
     }
 }

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupRichTextBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupRichTextBox.cs
@@ -253,7 +253,8 @@ namespace Krypton.Ribbon
                 {
                     // Use the same palette in the text box as the ribbon, plus we need
                     // to know when the ribbon palette changes so we can reflect that change
-                    RichTextBox.Palette = Ribbon.GetResolvedPalette();
+                    RichTextBox.PaletteMode = Ribbon!.PaletteMode;
+                    RichTextBox.LocalCustomPalette = Ribbon!.LocalCustomPalette;
                     Ribbon.PaletteChanged += OnRibbonPaletteChanged;
                 }
             }
@@ -1406,7 +1407,12 @@ namespace Krypton.Ribbon
 
         private void OnRichTextBoxLinkClicked(object sender, LinkClickedEventArgs e) => OnLinkClicked(e);
 
-        private void OnRibbonPaletteChanged(object sender, EventArgs e) => RichTextBox.Palette = Ribbon.GetResolvedPalette();
+        private void OnRibbonPaletteChanged(object sender, EventArgs e)
+        {
+            RichTextBox.PaletteMode = Ribbon!.PaletteMode;
+            RichTextBox.LocalCustomPalette = Ribbon!.LocalCustomPalette;
+        }
+
         #endregion
     }
 }

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupTextBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupTextBox.cs
@@ -219,7 +219,8 @@ namespace Krypton.Ribbon
                 {
                     // Use the same palette in the text box as the ribbon, plus we need
                     // to know when the ribbon palette changes so we can reflect that change
-                    TextBox.Palette = Ribbon.GetResolvedPalette();
+                    TextBox.PaletteMode = Ribbon!.PaletteMode;
+                    TextBox.LocalCustomPalette = Ribbon!.LocalCustomPalette;
                     Ribbon.PaletteChanged += OnRibbonPaletteChanged;
                 }
             }
@@ -1045,7 +1046,12 @@ namespace Krypton.Ribbon
 
         private void OnTextBoxPreviewKeyDown(object sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
 
-        private void OnRibbonPaletteChanged(object sender, EventArgs e) => TextBox.Palette = Ribbon.GetResolvedPalette();
+        private void OnRibbonPaletteChanged(object sender, EventArgs e)
+        {
+            TextBox.PaletteMode = Ribbon!.PaletteMode;
+            TextBox.LocalCustomPalette = Ribbon!.LocalCustomPalette;
+        }
+
         #endregion
     }
 }

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupThemeComboBox.cs
@@ -128,7 +128,7 @@ namespace Krypton.Ribbon
             base.OnSelectedIndexChanged(e);
             if ((RibbonThemeManager.GetThemeManagerMode(Text) == PaletteMode.Custom) && (KryptonCustomPalette != null))
             {
-                Manager.GlobalPalette = KryptonCustomPalette;
+                Manager.GlobalCustomPalette = KryptonCustomPalette;
             }
         }
 

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupTrackBar.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupTrackBar.cs
@@ -144,7 +144,8 @@ namespace Krypton.Ribbon
                 {
                     // Use the same palette in the track bar as the ribbon, plus we need
                     // to know when the ribbon palette changes so we can reflect that change
-                    TrackBar.Palette = Ribbon.GetResolvedPalette();
+                    TrackBar.PaletteMode = Ribbon!.PaletteMode;
+                    TrackBar.LocalCustomPalette = Ribbon!.LocalCustomPalette;
                     Ribbon.PaletteChanged += OnRibbonPaletteChanged;
                 }
             }
@@ -588,7 +589,12 @@ namespace Krypton.Ribbon
 
         private void OnTrackBarValueChanged(object sender, EventArgs e) => ValueChanged?.Invoke(this, e);
 
-        private void OnRibbonPaletteChanged(object sender, EventArgs e) => TrackBar.Palette = Ribbon.GetResolvedPalette();
+        private void OnRibbonPaletteChanged(object sender, EventArgs e)
+        {
+            TrackBar.PaletteMode = Ribbon!.PaletteMode;
+            TrackBar.LocalCustomPalette = Ribbon!.LocalCustomPalette;
+        }
+
         #endregion
     }
 }

--- a/Source/Krypton Components/Krypton.Ribbon/Palette/PaletteCaptionRedirect.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Palette/PaletteCaptionRedirect.cs
@@ -24,7 +24,7 @@ namespace Krypton.Ribbon
         /// Initialize a new instance of the PaletteCaptionRedirect class.
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
-        public PaletteCaptionRedirect(PaletteBase? target)
+        public PaletteCaptionRedirect(PaletteBase target)
             : base(target)
         {
         }

--- a/Source/Krypton Components/Krypton.Ribbon/Palette/PaletteGalleryRedirect.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Palette/PaletteGalleryRedirect.cs
@@ -59,7 +59,7 @@ namespace Krypton.Ribbon
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public override void SetRedirector(PaletteRedirect? redirect)
+        public override void SetRedirector(PaletteRedirect redirect)
         {
             base.SetRedirector(redirect);
             _ribbonBackInherit.SetRedirector(redirect);

--- a/Source/Krypton Components/Krypton.Ribbon/Palette/PaletteRedirectRibbonAeroOverride.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Palette/PaletteRedirectRibbonAeroOverride.cs
@@ -30,7 +30,7 @@ namespace Krypton.Ribbon
         /// <param name="ribbon">Reference to owning Ribbon instance.</param>
         /// <param name="redirect">Source for inheriting values.</param>
         public PaletteRedirectRibbonAeroOverride(KryptonRibbon ribbon,
-                                                 PaletteRedirect? redirect)
+                                                 PaletteRedirect redirect)
             : base(redirect) =>
             _ribbon = ribbon;
 

--- a/Source/Krypton Components/Krypton.Ribbon/Palette/PaletteRibbonFocus.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Palette/PaletteRibbonFocus.cs
@@ -52,7 +52,7 @@ namespace Krypton.Ribbon
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public override void SetRedirector(PaletteRedirect? redirect)
+        public override void SetRedirector(PaletteRedirect redirect)
         {
             base.SetRedirector(redirect);
             _ribbonTabInherit.SetRedirector(redirect);

--- a/Source/Krypton Components/Krypton.Ribbon/Palette/PaletteRibbonRedirect.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Palette/PaletteRibbonRedirect.cs
@@ -161,7 +161,7 @@ namespace Krypton.Ribbon
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public override void SetRedirector(PaletteRedirect? redirect)
+        public override void SetRedirector(PaletteRedirect redirect)
         {
             base.SetRedirector(redirect);
             RibbonGroupButton.SetRedirector(redirect);

--- a/Source/Krypton Components/Krypton.Ribbon/Palette/RibbonThemeManager.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Palette/RibbonThemeManager.cs
@@ -86,20 +86,18 @@ namespace Krypton.Ribbon
         /// <summary>
         /// Loads the custom theme.
         /// </summary>
-        /// <param name="palette">The palette.</param>
-        /// <param name="manager">The manager.</param>
         /// <param name="themeFile">A custom theme file.</param>
         /// <param name="silent">if set to <c>true</c> [silent].</param>
-        public static void LoadCustomTheme(KryptonCustomPaletteBase palette, KryptonManager manager, string themeFile = "", bool silent = false)
+        public static void LoadCustomTheme(string themeFile = "", bool silent = false)
         {
             try
             {
                 //throw new ApplicationException(@"Currently not implemented correctly");
 
                 // Declare new instances
-                palette = new KryptonCustomPaletteBase();
+                var custPalette = new KryptonCustomPaletteBase();
 
-                manager = new KryptonManager();
+                var manager = new KryptonManager();
 
                 // Prompt user for palette definition
 
@@ -108,16 +106,16 @@ namespace Krypton.Ribbon
                 {
                     if (themeFile is not ("" and ""))
                     {
-                        palette.Import(themeFile, silent);
+                        custPalette.Import(themeFile, silent);
                     }
                 }
                 else
                 {
-                    palette.Import();
+                    custPalette.Import();
                 }
 
                 // Set manager
-                manager.GlobalPalette = palette;
+                manager.GlobalCustomPalette = custPalette;
 
                 ApplyTheme(PaletteMode.Custom, manager);
             }

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGalleryButton.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGalleryButton.cs
@@ -20,7 +20,7 @@ namespace Krypton.Ribbon
     internal class ViewDrawRibbonGalleryButton : ViewLeaf, IContentValues
     {
         #region Instance Fields
-        private readonly PaletteBase? _palette;
+        private readonly PaletteBase _palette;
         private readonly GalleryImages _images;
         private readonly GalleryButtonController _controller;
         private readonly PaletteRibbonGalleryButton _button;
@@ -49,7 +49,7 @@ namespace Krypton.Ribbon
         /// <param name="button">Button content to display.</param>
         /// <param name="images">Button images.</param>
         /// <param name="needPaint">Paint event delegate.</param>
-        public ViewDrawRibbonGalleryButton(PaletteBase? palette,
+        public ViewDrawRibbonGalleryButton(PaletteBase palette,
                                            PaletteRelativeAlign alignment,
                                            PaletteRibbonGalleryButton button,
                                            GalleryImages images,

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonPanel.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonPanel.cs
@@ -126,7 +126,7 @@ namespace Krypton.Ribbon
                     case PaletteRibbonShape.VisualStudio2010:
                         {
                             //Adjust Color of the gradient
-                            Color gradientColor = KryptonManager.CurrentGlobalPalette == KryptonManager.PaletteOffice2010Black
+                            Color gradientColor = KryptonManager.CurrentGlobalPaletteMode.ToString().StartsWith( PaletteMode.Office2010Black.ToString())
                                 ? Color.FromArgb(39, 39, 39)
                                 : Color.White;
 

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonTab.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonTab.cs
@@ -425,7 +425,8 @@ namespace Krypton.Ribbon
 
                     //_paletteContextCurrent.LightBackground = _ribbon.CaptionArea.DrawCaptionOnComposition;
                     _paletteContextCurrent.LightBackground = Ribbon.CaptionArea.DrawCaptionOnComposition
-                                                             && (KryptonManager.CurrentGlobalPalette != KryptonManager.PaletteOffice2010Black);
+                                                             && KryptonManager.CurrentGlobalPaletteMode.ToString()
+                                                                 .StartsWith(PaletteMode.Office2010Black.ToString());
                     break;
             }
 

--- a/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonTabsArea.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonTabsArea.cs
@@ -94,7 +94,7 @@ namespace Krypton.Ribbon
         /// <param name="layoutContexts">Reference to layout of the context area.</param>
         /// <param name="needPaintDelegate">Delegate for notifying paint/layout changes.</param>
         public ViewLayoutRibbonTabsArea([DisallowNull] KryptonRibbon ribbon,
-                                        [DisallowNull] PaletteRedirect? redirect,
+                                        [DisallowNull] PaletteRedirect redirect,
                                         [DisallowNull] ViewDrawRibbonCaptionArea captionArea,
                                         [DisallowNull] ViewLayoutRibbonContextTitles layoutContexts,
                                         [DisallowNull] NeedPaintHandler needPaintDelegate)
@@ -460,7 +460,7 @@ namespace Krypton.Ribbon
             _buttonSpecsFixed.AddRange(new ButtonSpec[] { _buttonSpecMinimize, _buttonSpecExpand, _buttonSpecMin, _buttonSpecRestore, _buttonSpecClose });
         }
 
-        private void CreateViewElements(PaletteRedirect? redirect)
+        private void CreateViewElements(PaletteRedirect redirect)
         {
             // Layout for individual tabs inside the header
             LayoutTabs = new ViewLayoutRibbonTabs(_ribbon, NeedPaintDelegate);
@@ -717,7 +717,7 @@ namespace Krypton.Ribbon
 
                         // Create the actual control used to show the context menu
                         _appMenu = new VisualPopupAppMenu(_ribbon, _ribbon.RibbonAppButton,
-                                                          _ribbon.Palette, _ribbon.PaletteMode,
+                                                          _ribbon.LocalCustomPalette, _ribbon.PaletteMode,
                                                           _ribbon.GetRedirector(),
                                                           appRectTop, appRectBottom,
                                                           _appButtonController.Keyboard);

--- a/Source/Krypton Components/Krypton.Toolkit/AccurateText/AccurateText.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/AccurateText/AccurateText.cs
@@ -50,7 +50,7 @@ namespace Krypton.Toolkit
         public static AccurateTextMemento MeasureString([DisallowNull] Graphics g,
                                                         RightToLeft rtl,
                                                         [DisallowNull] string text,
-                                                        [DisallowNull] Font font,
+                                                        [DisallowNull] Font? font,
                                                         PaletteTextTrim trim,
                                                         PaletteRelativeAlign align,
                                                         PaletteTextHotkeyPrefix prefix,
@@ -362,7 +362,7 @@ namespace Krypton.Toolkit
         /// <param name="copyBackground">Should existing background be copied into the bitmap.</param>
         public static void DrawCompositionGlowingText(Graphics? g,
                                                       string text,
-                                                      Font font,
+                                                      Font? font,
                                                       Rectangle bounds,
                                                       PaletteState state,
                                                       Color color,
@@ -468,7 +468,7 @@ namespace Krypton.Toolkit
         /// <param name="sf">StringFormat of the memento.</param>
         public static void DrawCompositionText(Graphics? g,
                                                       string text,
-                                                      Font font,
+                                                      Font? font,
                                                       Rectangle bounds,
                                                       PaletteState state,
                                                       Color color,

--- a/Source/Krypton Components/Krypton.Toolkit/AccurateText/AccurateTextMemento.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/AccurateText/AccurateTextMemento.cs
@@ -37,7 +37,7 @@ namespace Krypton.Toolkit
         /// <param name="hint">Drawing hint.</param>
         /// <param name="disposeFont">Should the font be disposed.</param>
         internal AccurateTextMemento(string text,
-                                     [DisallowNull] Font font,
+                                     [DisallowNull] Font? font,
                                      SizeF sizeF,
                                      StringFormat format,
                                      TextRenderingHint hint, // TODO: What was this supposed to be used for ?
@@ -73,7 +73,7 @@ namespace Krypton.Toolkit
         /// Gets the drawing font.
         /// </summary>
         [DisallowNull]
-        public Font Font { get; set; }
+        public Font? Font { get; set; }
 
         /// <summary>
         /// Gets the pixel size of the text area.

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpec.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpec.cs
@@ -912,8 +912,8 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Tooltip title string.</returns>
-        public virtual string GetToolTipTitle(PaletteBase? palette) => !string.IsNullOrEmpty(ToolTipTitle)
-                   || !AllowInheritToolTipTitle
+        public virtual string GetToolTipTitle(PaletteBase palette) => !string.IsNullOrEmpty(ToolTipTitle)
+                                                                      || !AllowInheritToolTipTitle
                 ? ToolTipTitle
                 : palette?.GetButtonSpecToolTipTitle(ProtectedType) ?? string.Empty;
 
@@ -922,7 +922,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Color value.</returns>
-        public virtual Color GetColorMap(PaletteBase? palette) => ColorMap != Color.Empty
+        public virtual Color GetColorMap(PaletteBase palette) => ColorMap != Color.Empty
                 ? ColorMap
                 : palette?.GetButtonSpecColorMap(ProtectedType) ?? Color.Empty;
 
@@ -931,7 +931,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button style.</returns>
-        public virtual ButtonStyle GetStyle(PaletteBase? palette) => ConvertToButtonStyle(Style != PaletteButtonStyle.Inherit
+        public virtual ButtonStyle GetStyle(PaletteBase palette) => ConvertToButtonStyle(Style != PaletteButtonStyle.Inherit
                 ? Style
                 : palette?.GetButtonSpecStyle(ProtectedType));
 
@@ -967,7 +967,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button enabled state.</returns>
-        public abstract ButtonEnabled GetEnabled(PaletteBase? palette);
+        public abstract ButtonEnabled GetEnabled(PaletteBase palette);
 
         /// <summary>
         /// Sets the current view associated with the button spec.
@@ -992,7 +992,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibility.</returns>
-        public abstract bool GetVisible(PaletteBase? palette);
+        public abstract bool GetVisible(PaletteBase palette);
 
         /// <summary>
         /// Gets the button checked state.

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecAny.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecAny.cs
@@ -279,14 +279,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibility.</returns>
-        public override bool GetVisible(PaletteBase? palette) => Visible;
+        public override bool GetVisible(PaletteBase palette) => Visible;
 
         /// <summary>
         /// Gets the button enabled state.
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button enabled state.</returns>
-        public override ButtonEnabled GetEnabled(PaletteBase? palette) => Enabled;
+        public override ButtonEnabled GetEnabled(PaletteBase palette) => Enabled;
 
         /// <summary>
         /// Gets the button checked state.

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecCalendar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecCalendar.cs
@@ -65,14 +65,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibility.</returns>
-        public override bool GetVisible(PaletteBase? palette) => Visible;
+        public override bool GetVisible(PaletteBase palette) => Visible;
 
         /// <summary>
         /// Gets the button enabled state.
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button enabled state.</returns>
-        public override ButtonEnabled GetEnabled(PaletteBase? palette) => Enabled ? ButtonEnabled.Container : ButtonEnabled.False;
+        public override ButtonEnabled GetEnabled(PaletteBase palette) => Enabled ? ButtonEnabled.Container : ButtonEnabled.False;
 
         /// <summary>
         /// Gets the button checked state.

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecFormWindowClose.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecFormWindowClose.cs
@@ -60,7 +60,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibility.</returns>
-        public override bool GetVisible(PaletteBase? palette)
+        public override bool GetVisible(PaletteBase palette)
         {
             // We do not show if the custom chrome is combined with composition,
             // in which case the form buttons are handled by the composition
@@ -78,7 +78,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button enabled state.</returns>
-        public override ButtonEnabled GetEnabled(PaletteBase? palette) => KryptonForm.CloseBox && Enabled ? ButtonEnabled.True : ButtonEnabled.False;
+        public override ButtonEnabled GetEnabled(PaletteBase palette) => KryptonForm.CloseBox && Enabled ? ButtonEnabled.True : ButtonEnabled.False;
 
         /// <summary>
         /// Gets the button checked state.

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecFormWindowMax.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecFormWindowMax.cs
@@ -34,7 +34,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibility.</returns>
-        public override bool GetVisible(PaletteBase? palette)
+        public override bool GetVisible(PaletteBase palette)
         {
             // We do not show if the custom chrome is combined with composition,
             // in which case the form buttons are handled by the composition
@@ -66,7 +66,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button enabled state.</returns>
-        public override ButtonEnabled GetEnabled(PaletteBase? palette) =>
+        public override ButtonEnabled GetEnabled(PaletteBase palette) =>
             // Has the maximize buttons been turned off?
             KryptonForm.MaximizeBox ? ButtonEnabled.True : ButtonEnabled.False;
 

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecFormWindowMin.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecFormWindowMin.cs
@@ -34,7 +34,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibility.</returns>
-        public override bool GetVisible(PaletteBase? palette)
+        public override bool GetVisible(PaletteBase palette)
         {
             // We do not show if the custom chrome is combined with composition,
             // in which case the form buttons are handled by the composition
@@ -66,7 +66,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button enabled state.</returns>
-        public override ButtonEnabled GetEnabled(PaletteBase? palette) =>
+        public override ButtonEnabled GetEnabled(PaletteBase palette) =>
             // Has the minimize buttons been turned off?
             !KryptonForm.MinimizeBox ? ButtonEnabled.False : ButtonEnabled.True;
 

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecManagerBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecManagerBase.cs
@@ -53,7 +53,7 @@ namespace Krypton.Toolkit
         /// <param name="getRenderer">Delegate for returning a tool strip renderer.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
         protected ButtonSpecManagerBase([DisallowNull] Control control,
-                                        PaletteRedirect? redirector,
+                                        PaletteRedirect redirector,
                                      ButtonSpecCollectionBase? variableSpecs,
                                      ButtonSpecCollectionBase? fixedSpecs,
                                      IPaletteMetric[] viewMetrics,
@@ -561,7 +561,7 @@ namespace Krypton.Toolkit
         /// <param name="redirector">Base palette class.</param>
         /// <param name="buttonSpec">ButtonSpec instance.</param>
         /// <returns>Palette redirector for the button spec instance.</returns>
-        public virtual PaletteRedirect CreateButtonSpecRemap(PaletteRedirect? redirector,
+        public virtual PaletteRedirect CreateButtonSpecRemap(PaletteRedirect redirector,
             [DisallowNull] ButtonSpec buttonSpec) =>
             new ButtonSpecRemapByContentView(redirector, buttonSpec);
 

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecManagerDraw.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecManagerDraw.cs
@@ -36,7 +36,7 @@ namespace Krypton.Toolkit
         /// <param name="getRenderer">Delegate for returning a tool strip renderer.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
         public ButtonSpecManagerDraw(Control control,
-            [DisallowNull] PaletteRedirect? redirector,
+            [DisallowNull] PaletteRedirect redirector,
                                      ButtonSpecCollectionBase? variableSpecs,
                                      ButtonSpecCollectionBase? fixedSpecs,
                                      ViewDrawDocker[] viewDockers,
@@ -66,7 +66,7 @@ namespace Krypton.Toolkit
         /// <param name="getRenderer">Delegate for returning a tool strip renderer.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
         public ButtonSpecManagerDraw(Control control,
-                                     [DisallowNull] PaletteRedirect? redirector,
+                                     [DisallowNull] PaletteRedirect redirector,
                                      ButtonSpecCollectionBase? variableSpecs,
                                      ButtonSpecCollectionBase? fixedSpecs,
                                      [DisallowNull] ViewDrawDocker[] viewDockers,

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecManagerLayout.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecManagerLayout.cs
@@ -36,7 +36,7 @@ namespace Krypton.Toolkit
         /// <param name="getRenderer">Delegate for returning a tool strip renderer.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
         public ButtonSpecManagerLayout(Control control,
-                                       PaletteRedirect? redirector,
+                                       PaletteRedirect redirector,
                                        ButtonSpecCollectionBase? variableSpecs,
                                        ButtonSpecCollectionBase? fixedSpecs,
                                        ViewLayoutDocker[] viewDockers,
@@ -66,7 +66,7 @@ namespace Krypton.Toolkit
         /// <param name="getRenderer">Delegate for returning a tool strip renderer.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
         public ButtonSpecManagerLayout(Control control,
-                                       PaletteRedirect? redirector,
+                                       PaletteRedirect redirector,
                                        ButtonSpecCollectionBase? variableSpecs,
                                        ButtonSpecCollectionBase? fixedSpecs,
                                        ViewLayoutDocker[] viewDockers,

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecRemapByContentBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecRemapByContentBase.cs
@@ -27,7 +27,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="buttonSpec">Reference to button specification.</param>
-        protected ButtonSpecRemapByContentBase(PaletteBase? target,
+        protected ButtonSpecRemapByContentBase(PaletteBase target,
                                             [DisallowNull] ButtonSpec buttonSpec)
             : base(target)
         {

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecRemapByContentCache.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecRemapByContentCache.cs
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="buttonSpec">Reference to button specification.</param>
-        public ButtonSpecRemapByContentCache(PaletteBase? target,
+        public ButtonSpecRemapByContentCache(PaletteBase target,
                                              ButtonSpec buttonSpec)
             : base(target, buttonSpec)
         {

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecRemapByContentView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecRemapByContentView.cs
@@ -23,7 +23,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="buttonSpec">Reference to button specification.</param>
-        public ButtonSpecRemapByContentView(PaletteBase? target,
+        public ButtonSpecRemapByContentView(PaletteBase target,
             [DisallowNull] ButtonSpec buttonSpec)
             : base(target, buttonSpec)
         {

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecToContent.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecToContent.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit
     {
         #region Instance Fields
         private readonly ButtonSpec _buttonSpec;
-        private readonly PaletteBase? _palette;
+        private readonly PaletteBase _palette;
         #endregion
 
         #region Identity
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette for sourcing information.</param>
         /// <param name="buttonSpec">Source button spec instance.</param>
-        public ButtonSpecToContent([DisallowNull] PaletteBase? palette,
+        public ButtonSpecToContent([DisallowNull] PaletteBase palette,
             [DisallowNull] ButtonSpec buttonSpec)
         {
             Debug.Assert(palette != null);

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecView.cs
@@ -131,7 +131,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the remapping palette.
         /// </summary>
-        public PaletteRedirect? RemapPalette { get; }
+        public PaletteRedirect RemapPalette { get; }
 
         /// <summary>
         /// Gets and sets the composition setting for the button.

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuCheckBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuCheckBox.cs
@@ -536,7 +536,7 @@ namespace Krypton.Toolkit
 
         internal PaletteRedirectCheckBox? StateCheckBoxImages { get; }
 
-        internal void SetPaletteRedirect(PaletteRedirect? redirector)
+        internal void SetPaletteRedirect(PaletteRedirect redirector)
         {
             _stateCommonRedirect.SetRedirector(redirector);
             StateCheckBoxImages!.Target = redirector;

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuCheckButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuCheckButton.cs
@@ -511,7 +511,7 @@ namespace Krypton.Toolkit
 
         internal PaletteTripleOverride OverridePressed { get; }
 
-        internal void SetPaletteRedirect(PaletteRedirect? redirector)
+        internal void SetPaletteRedirect(PaletteRedirect redirector)
         {
             StateCommon.SetRedirector(redirector);
             OverrideFocus.SetRedirector(redirector);

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuHeading.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuHeading.cs
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit
         private string? _extraText;
         private Image? _image;
         private Color _imageTransparentColor;
-        private readonly PaletteRedirectTriple? _redirectHeading;
+        private readonly PaletteRedirectTriple _redirectHeading;
         #endregion
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuItems.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuItems.cs
@@ -26,7 +26,7 @@ namespace Krypton.Toolkit
         #region Instance Fields
         private bool _standardStyle;
         private bool _imageColumn;
-        private readonly PaletteRedirectDouble? _redirectImageColumn;
+        private readonly PaletteRedirectDouble _redirectImageColumn;
         #endregion
 
         #region Identity

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuLinkLabel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuLinkLabel.cs
@@ -426,7 +426,7 @@ namespace Krypton.Toolkit
 
         internal PaletteContentInheritOverride OverridePressedFocus { get; }
 
-        internal void SetPaletteRedirect(PaletteRedirect? redirector)
+        internal void SetPaletteRedirect(PaletteRedirect redirector)
         {
             _stateNormalRedirect.SetRedirector(redirector);
             _stateVisitedRedirect.SetRedirector(redirector);

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuMonthCalendar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuMonthCalendar.cs
@@ -1295,7 +1295,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Internal
-        internal void SetPaletteRedirect(PaletteRedirect? redirector)
+        internal void SetPaletteRedirect(PaletteRedirect redirector)
         {
             StateCommon?.SetRedirector(redirector);
             OverrideFocus.SetRedirector(redirector);

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuRadioButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuRadioButton.cs
@@ -456,7 +456,7 @@ namespace Krypton.Toolkit
 
         internal PaletteRedirectRadioButton StateRadioButtonImages { get; }
 
-        internal void SetPaletteRedirect(PaletteRedirect? redirector)
+        internal void SetPaletteRedirect(PaletteRedirect redirector)
         {
             _stateCommonRedirect.SetRedirector(redirector);
             StateRadioButtonImages.Target = redirector;

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuSeparator.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuSeparator.cs
@@ -24,7 +24,7 @@ namespace Krypton.Toolkit
     {
         #region Instance Fields
         private bool _horizontal;
-        private readonly PaletteRedirectDouble? _redirectSeparator;
+        private readonly PaletteRedirectDouble _redirectSeparator;
         #endregion
 
         #region Identity

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonBreadCrumb.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonBreadCrumb.cs
@@ -644,7 +644,7 @@ namespace Krypton.Toolkit
         #region Internal
         internal PaletteBreadCrumbRedirect? GetStateCommon() => StateCommon;
 
-        internal PaletteRedirect? GetRedirector() => Redirector;
+        internal PaletteRedirect GetRedirector() => Redirector;
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonButton.cs
@@ -780,7 +780,7 @@ namespace Krypton.Toolkit
             var focusRectangle = new Rectangle(internalBorder, internalBorder,
                 bounds.Width - _dropDownRectangle.Width - internalBorder, bounds.Height - (internalBorder * 2));
 
-            PaletteBase? palette = KryptonManager.CurrentGlobalPalette;
+            PaletteBase palette = KryptonManager.CurrentGlobalPalette;
 
             Pen shadow = SystemPens.ButtonShadow, face = SystemPens.ButtonFace;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckedListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckedListBox.cs
@@ -2117,7 +2117,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
-        protected override void OnNeedPaint(object? sender, NeedLayoutEventArgs e)
+        protected override void OnNeedPaint(object sender, NeedLayoutEventArgs e)
         {
             if (IsHandleCreated && !e.NeedLayout)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonColorButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonColorButton.cs
@@ -1184,7 +1184,7 @@ namespace Krypton.Toolkit
                 }
                 else
                 {
-                    _kryptonContextMenu.Palette = Palette;
+                    _kryptonContextMenu.LocalCustomPalette = LocalCustomPalette;
                 }
             }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -435,7 +435,7 @@ namespace Krypton.Toolkit
                                     rectangle = CommonHelper.ApplyPadding(VisualOrientation.Top, rectangle, states.Content.GetContentPadding(state));
                                     // Find correct text color
                                     Color textColor = states.Content.GetContentShortTextColor1(state);
-                                    Font contentShortTextFont = states.Content.GetContentShortTextFont(state);
+                                    Font? contentShortTextFont = states.Content.GetContentShortTextFont(state);
                                     // Find correct background color
                                     Color backColor = states.PaletteBack.GetBackColor1(state);
 
@@ -2583,7 +2583,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
-        protected override void OnNeedPaint(object? sender, NeedLayoutEventArgs e)
+        protected override void OnNeedPaint(object sender, NeedLayoutEventArgs e)
         {
             if (!e.NeedLayout)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCommand.cs
@@ -407,49 +407,49 @@ namespace Krypton.Toolkit
                 case KryptonCommandType.General:
                     break;
                 case KryptonCommandType.HelpCommand:
-                    SwitchToHelpCommand(KryptonManager.InternalGlobalPaletteMode);
+                    SwitchToHelpCommand(KryptonManager.CurrentGlobalPaletteMode);
                     break;
                 case KryptonCommandType.IntegratedToolBarCopyCommand:
-                    SwitchToCopyCommand(KryptonManager.InternalGlobalPaletteMode);
+                    SwitchToCopyCommand(KryptonManager.CurrentGlobalPaletteMode);
                     break;
                 case KryptonCommandType.IntegratedToolBarCutCommand:
-                    SwitchToCutCommand(KryptonManager.InternalGlobalPaletteMode);
+                    SwitchToCutCommand(KryptonManager.CurrentGlobalPaletteMode);
                     break;
                 case KryptonCommandType.IntegratedToolBarNewCommand:
-                    SwitchToNewCommand(KryptonManager.InternalGlobalPaletteMode);
+                    SwitchToNewCommand(KryptonManager.CurrentGlobalPaletteMode);
                     break;
                 case KryptonCommandType.IntegratedToolBarOpenCommand:
-                    SwitchToOpenCommand(KryptonManager.InternalGlobalPaletteMode);
+                    SwitchToOpenCommand(KryptonManager.CurrentGlobalPaletteMode);
                     break;
                 case KryptonCommandType.IntegratedToolBarPageSetupCommand:
-                    SwitchToPageSetupCommand(KryptonManager.InternalGlobalPaletteMode);
+                    SwitchToPageSetupCommand(KryptonManager.CurrentGlobalPaletteMode);
                     break;
                 case KryptonCommandType.IntegratedToolBarPasteCommand:
-                    SwitchToPasteCommand(KryptonManager.InternalGlobalPaletteMode);
+                    SwitchToPasteCommand(KryptonManager.CurrentGlobalPaletteMode);
                     break;
                 case KryptonCommandType.IntegratedToolBarPrintCommand:
-                    SwitchToPrintCommand(KryptonManager.InternalGlobalPaletteMode);
+                    SwitchToPrintCommand(KryptonManager.CurrentGlobalPaletteMode);
                     break;
                 case KryptonCommandType.IntegratedToolBarPrintPreviewCommand:
-                    SwitchToPrintPreviewCommand(KryptonManager.InternalGlobalPaletteMode);
+                    SwitchToPrintPreviewCommand(KryptonManager.CurrentGlobalPaletteMode);
                     break;
                 case KryptonCommandType.IntegratedToolBarQuickPrintCommand:
-                    SwitchToQuickPrintCommand(KryptonManager.InternalGlobalPaletteMode);
+                    SwitchToQuickPrintCommand(KryptonManager.CurrentGlobalPaletteMode);
                     break;
                 case KryptonCommandType.IntegratedToolBarRedoCommand:
-                    SwitchToRedoCommand(KryptonManager.InternalGlobalPaletteMode);
+                    SwitchToRedoCommand(KryptonManager.CurrentGlobalPaletteMode);
                     break;
                 case KryptonCommandType.IntegratedToolBarSaveAllCommand:
-                    SwitchToSaveAllCommand(KryptonManager.InternalGlobalPaletteMode);
+                    SwitchToSaveAllCommand(KryptonManager.CurrentGlobalPaletteMode);
                     break;
                 case KryptonCommandType.IntegratedToolBarSaveAsCommand:
-                    SwitchToSaveAsCommand(KryptonManager.InternalGlobalPaletteMode);
+                    SwitchToSaveAsCommand(KryptonManager.CurrentGlobalPaletteMode);
                     break;
                 case KryptonCommandType.IntegratedToolBarSaveCommand:
-                    SwitchToSaveCommand(KryptonManager.InternalGlobalPaletteMode);
+                    SwitchToSaveCommand(KryptonManager.CurrentGlobalPaletteMode);
                     break;
                 case KryptonCommandType.IntegratedToolBarUndoCommand:
-                    SwitchToUndoCommand(KryptonManager.InternalGlobalPaletteMode);
+                    SwitchToUndoCommand(KryptonManager.CurrentGlobalPaletteMode);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(commandType), commandType, null);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonContextMenu.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonContextMenu.cs
@@ -71,7 +71,7 @@ namespace Krypton.Toolkit
             NeedPaintHandler needPaintDelegate = OnNeedPaint;
 
             // Set default settings
-            Palette = null;
+            LocalCustomPalette = null;
             PaletteMode = PaletteMode.Global;
             Images = new ContextMenuImages(needPaintDelegate);
             _redirector = new PaletteRedirect(null);
@@ -205,17 +205,11 @@ namespace Krypton.Toolkit
         [Description(@"Palette applied to drawing.")]
         public PaletteMode PaletteMode
         {
-            [DebuggerStepThrough]
-            get;
+            [DebuggerStepThrough] get;
             set;
         }
-
         private bool ShouldSerializePaletteMode() => PaletteMode != PaletteMode.Global;
-
-        /// <summary>
-        /// Resets the PaletteMode property to its default value.
-        /// </summary>
-        public void ResetPaletteMode() => PaletteMode = PaletteMode.Global;
+        private void ResetPaletteMode() => PaletteMode = PaletteMode.Global;
 
         /// <summary>
         /// Gets and sets the custom palette implementation.
@@ -223,17 +217,16 @@ namespace Krypton.Toolkit
         [Category(@"Visuals")]
         [Description(@"Custom palette applied to drawing.")]
         [DefaultValue(null)]
-        public PaletteBase? Palette
+        public KryptonCustomPaletteBase LocalCustomPalette
         {
             [DebuggerStepThrough]
             get;
             set;
         }
-
         /// <summary>
         /// Resets the Palette property to its default value.
         /// </summary>
-        public void ResetPalette() => PaletteMode = PaletteMode.Global;
+        private void ResetLocalCustomPalette() => PaletteMode = PaletteMode.Global;
 
         /// <summary>
         /// Gets a reference to the caller that caused the context menu to be shown.
@@ -354,7 +347,7 @@ namespace Krypton.Toolkit
                     CloseReason = ToolStripDropDownCloseReason.AppFocusChange;
 
                     // Create the actual control used to show the context menu
-                    VisualContextMenu = CreateContextMenu(this, Palette, PaletteMode,
+                    VisualContextMenu = CreateContextMenu(this, LocalCustomPalette, PaletteMode,
                                                      _redirector, _redirectorImages,
                                                      Items, Enabled, keyboardActivated);
 
@@ -422,9 +415,9 @@ namespace Krypton.Toolkit
         /// <param name="keyboardActivated">True is menu was keyboard initiated.</param>
         /// <returns>VisualContextMenu reference.</returns>
         protected virtual VisualContextMenu CreateContextMenu(KryptonContextMenu kcm,
-                                                              PaletteBase? palette,
+                                                              PaletteBase palette,
                                                               PaletteMode paletteMode,
-                                                              PaletteRedirect? redirector,
+                                                              PaletteRedirect redirector,
                                                               PaletteRedirectContextMenu redirectorImages,
                                                               KryptonContextMenuCollection items,
                                                               bool enabled,

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
@@ -24,7 +24,7 @@ namespace Krypton.Toolkit
     [ToolboxItem(true)]
     [ToolboxBitmap(typeof(KryptonCustomPaletteBase), "ToolboxBitmaps.KryptonPalette.bmp")]
     [DefaultEvent(nameof(PalettePaint))]
-    [DefaultProperty(nameof(BasePaletteMode))]
+    //[DefaultProperty(nameof(BasePaletteMode))]
     [DesignerCategory(@"code")]
     [Designer(typeof(KryptonCustomPaletteBaseDesigner))]
     [Description(@"A customisable palette component.")]
@@ -44,14 +44,13 @@ namespace Krypton.Toolkit
         #region Instance Fields
 
         private int _suspendCount;
-        private IRenderer? _baseRenderer;
+        private IRenderer _baseRenderer;
         private RendererMode _baseRenderMode;
-        private PaletteBase? _basePalette;
-        private PaletteMode _basePaletteMode;
+        private PaletteBase _basePalette;
+        //private PaletteMode _basePaletteMode;
         private InheritBool _allowFormChrome;
         private readonly PaletteRedirect _redirector;
         private readonly NeedPaintHandler _needPaintDelegate;
-        private string _themeName;
 
         #endregion
 
@@ -66,7 +65,6 @@ namespace Krypton.Toolkit
 
             // Set the default palette/palette mode
             _basePalette = KryptonManager.GetPaletteForMode(PaletteMode.Microsoft365Blue);
-            _basePaletteMode = PaletteMode.Microsoft365Blue;
 
             // Set the default renderer
             _baseRenderer = null;
@@ -120,8 +118,6 @@ namespace Krypton.Toolkit
                 _basePalette.BasePaletteChanged += OnBasePaletteChanged;
                 _basePalette.BaseRendererChanged += OnBaseRendererChanged;
             }
-
-            _themeName = string.Empty;
         }
 
         /// <summary>
@@ -847,7 +843,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentShortTextFont(state);
 
         /// <summary>
@@ -856,7 +852,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentShortTextFont(state);
 
         /// <summary>
@@ -1000,7 +996,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentLongTextFont(state);
 
         /// <summary>
@@ -1009,7 +1005,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
         => GetPaletteContent(style, state).GetContentLongTextFont(state);
 
         /// <summary>
@@ -2668,7 +2664,7 @@ namespace Krypton.Toolkit
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool IsDefault => !(ShouldSerializeCustomisedKryptonPaletteFilePath()
             || ShouldSerializePaletteName()
-            || ShouldSerializeBasePaletteMode()
+            //|| ShouldSerializeBasePaletteMode()
             || ShouldSerializeBasePalette()
             || ShouldSerializeBaseRendererMode()
             || ShouldSerializeBaseRenderer()
@@ -2681,7 +2677,7 @@ namespace Krypton.Toolkit
         {
             ResetCustomisedKryptonPaletteFilePath();
             ResetPaletteName();
-            ResetBasePaletteMode();
+            //ResetBasePaletteMode();
             ResetBasePalette();
             ResetBaseRendererMode();
             ResetBaseRenderer();
@@ -2709,71 +2705,69 @@ namespace Krypton.Toolkit
         private bool ShouldSerializePaletteName() => !string.IsNullOrWhiteSpace(PaletteName);
         private void ResetPaletteName() => PaletteName = string.Empty;
 
-        /// <summary>
-        /// Gets or sets the base palette used to inherit from.
-        /// </summary>
-        [KryptonPersist(false, false)]
-        [Category(@"Visuals")]
-        [Description(@"Base palette used to inherit from.")]
-        [DefaultValue(PaletteMode.Microsoft365Blue)]
-        public PaletteMode BasePaletteMode
-        {
-            get => _basePaletteMode;
+        ///// <summary>
+        ///// Gets or sets the base palette used to inherit from.
+        ///// </summary>
+        //[KryptonPersist(false, false)]
+        //[Category(@"Visuals")]
+        //[Description(@"Base palette used to inherit from.")]
+        //[DefaultValue(PaletteMode.Microsoft365Blue)]
+        //public PaletteMode BasePaletteMode
+        //{
+        //    get => _basePaletteMode;
 
-            set
-            {
-                if (_basePaletteMode != value)
-                {
-                    // Action depends on new value
-                    switch (value)
-                    {
-                        case PaletteMode.Custom:
-                            // Do nothing, you must assign a palette to the 
-                            // 'BasePalette' property in order to get the custom mode
-                            break;
-                        default:
-                            // Cache the original values
-                            PaletteMode tempMode = _basePaletteMode;
-                            PaletteBase? tempPalette = _basePalette;
+        //    set
+        //    {
+        //        if (_basePaletteMode != value)
+        //        {
+        //            // Action depends on new value
+        //            switch (value)
+        //            {
+        //                case PaletteMode.Custom:
+        //                    // Do nothing, you must assign a palette to the 
+        //                    // 'BasePalette' property in order to get the custom mode
+        //                    break;
+        //                default:
+        //                    // Cache the original values
+        //                    PaletteMode tempMode = _basePaletteMode;
+        //                    PaletteBase? tempPalette = _basePalette;
 
-                            // Use the new value
-                            _basePaletteMode = value;
-                            _basePalette = KryptonManager.GetPaletteForMode(_basePaletteMode);
+        //                    // Use the new value
+        //                    _basePaletteMode = value;
+        //                    _basePalette = KryptonManager.GetPaletteForMode(_basePaletteMode);
 
-                            // If the new value creates a circular reference
-                            if (HasCircularReference())
-                            {
-                                // Restore the original values
-                                _basePaletteMode = tempMode;
-                                _basePalette = tempPalette;
+        //                    // If the new value creates a circular reference
+        //                    if (HasCircularReference())
+        //                    {
+        //                        // Restore the original values
+        //                        _basePaletteMode = tempMode;
+        //                        _basePalette = tempPalette;
 
-                                throw new ArgumentOutOfRangeException(nameof(value), @"Cannot use palette that would create a circular reference");
-                            }
-                            else
-                            {
-                                // Restore the original base palette as 'SetPalette' will not 
-                                // work correctly unless it still has the old value in place
-                                _basePalette = tempPalette;
-                            }
+        //                        throw new ArgumentOutOfRangeException(nameof(value), @"Cannot use palette that would create a circular reference");
+        //                    }
+        //                    else
+        //                    {
+        //                        // Restore the original base palette as 'SetPalette' will not 
+        //                        // work correctly unless it still has the old value in place
+        //                        _basePalette = tempPalette;
+        //                    }
 
-                            // Get a reference to the standard palette from its name
-                            SetPalette(KryptonManager.GetPaletteForMode(_basePaletteMode));
+        //                    // Get a reference to the standard palette from its name
+        //                    SetPalette(KryptonManager.GetPaletteForMode(_basePaletteMode));
 
-                            // Fire events to indicate a change in palette values
-                            OnBasePaletteChanged(this, EventArgs.Empty);
-                            OnBaseRendererChanged(this, EventArgs.Empty);
-                            OnAllowFormChromeChanged(this, EventArgs.Empty);
-                            OnButtonSpecChanged(this, EventArgs.Empty);
-                            OnPalettePaint(this, new PaletteLayoutEventArgs(true, true));
-                            break;
-                    }
-                }
-            }
-        }
-
-        private bool ShouldSerializeBasePaletteMode() => BasePaletteMode != PaletteMode.Microsoft365Blue;
-
-        private void ResetBasePaletteMode() => BasePaletteMode = PaletteMode.Microsoft365Blue;
+        //                    // Fire events to indicate a change in palette values
+        //                    OnBasePaletteChanged(this, EventArgs.Empty);
+        //                    OnBaseRendererChanged(this, EventArgs.Empty);
+        //                    OnAllowFormChromeChanged(this, EventArgs.Empty);
+        //                    OnButtonSpecChanged(this, EventArgs.Empty);
+        //                    OnPalettePaint(this, new PaletteLayoutEventArgs(true, true));
+        //                    break;
+        //            }
+        //        }
+        //    }
+        //}
+        //private bool ShouldSerializeBasePaletteMode() => BasePaletteMode != PaletteMode.Microsoft365Blue;
+        //private void ResetBasePaletteMode() => BasePaletteMode = PaletteMode.Microsoft365Blue;
 
         /// <summary>
         /// Gets and sets the KryptonPalette used to inherit from.
@@ -2781,7 +2775,7 @@ namespace Krypton.Toolkit
         [Category(@"Visuals")]
         [Description(@"KryptonPalette used to inherit from.")]
         [DefaultValue(null)]
-        public PaletteBase? BasePalette
+        public PaletteBase BasePalette
         {
             get => _basePalette;
 
@@ -2791,23 +2785,23 @@ namespace Krypton.Toolkit
                 if (_basePalette != value)
                 {
                     // Store the original values
-                    PaletteMode tempMode = _basePaletteMode;
-                    PaletteBase? tempPalette = _basePalette;
+                    //PaletteMode tempMode = _basePaletteMode;
+                    PaletteBase tempPalette = _basePalette;
 
                     // Find the new palette mode based on the incoming value
-                    _basePaletteMode = value == null ? PaletteMode.Microsoft365Blue : PaletteMode.Custom;
+                    //_basePaletteMode = value == null ? PaletteMode.Microsoft365Blue : PaletteMode.Custom;
                     _basePalette = value;
 
                     // If the new value creates a circular reference
-                    if (HasCircularReference())
-                    {
-                        // Put back the original palette details
-                        _basePaletteMode = tempMode;
-                        _basePalette = tempPalette;
+                    //if (HasCircularReference())
+                    //{
+                    //    // Put back the original palette details
+                    //    //_basePaletteMode = tempMode;
+                    //    _basePalette = tempPalette;
 
-                        throw new ArgumentOutOfRangeException(nameof(value), @"Cannot use palette that would create a circular reference");
-                    }
-                    else
+                    //    throw new ArgumentOutOfRangeException(nameof(value), @"Cannot use palette that would create a circular reference");
+                    //}
+                    //else
                     {
                         // Restore the original base palette as 'SetPalette' will not 
                         // work correctly unless it still has the old value in place
@@ -2821,7 +2815,7 @@ namespace Krypton.Toolkit
                     if (value == null)
                     {
                         // Get the appropriate palette for the global mode
-                        SetPalette(KryptonManager.GetPaletteForMode(_basePaletteMode));
+                        SetPalette(KryptonManager.GetPaletteForMode(PaletteMode.Microsoft365Blue/*_basePaletteMode*/));
                     }
 
                     // Indicate the palette values have changed
@@ -2893,7 +2887,7 @@ namespace Krypton.Toolkit
         [Category(@"Visuals")]
         [Description(@"Custom renderer to be used with this palette.")]
         [DefaultValue(null)]
-        public IRenderer? BaseRenderer
+        public IRenderer BaseRenderer
         {
             get => _baseRenderer;
 
@@ -2914,7 +2908,6 @@ namespace Krypton.Toolkit
                 }
             }
         }
-
         private bool ShouldSerializeBaseRenderer() => BaseRenderer != null;
         private void ResetBaseRenderer() => BaseRenderer = null;
 
@@ -2922,6 +2915,7 @@ namespace Krypton.Toolkit
         /// Gets access to the color table instance.
         /// </summary>
         [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public override KryptonColorTable ColorTable => ToolMenuStatus.InternalKCT;
 
         /// <inheritdoc />
@@ -3022,49 +3016,49 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Internal
-        internal bool HasCircularReference()
-        {
-            // Use a dictionary as a set to check for existence
-            var paletteSet = new Dictionary<PaletteBase, bool>();
+        //internal bool HasCircularReference()
+        //{
+        //    // Use a dictionary as a set to check for existence
+        //    var paletteSet = new Dictionary<PaletteBase, bool>();
 
-            // Start processing from ourself upwards
-            PaletteBase? palette = this;
+        //    // Start processing from ourself upwards
+        //    PaletteBase? palette = this;
 
-            // Keep searching until no more palettes found
-            while (palette != null)
-            {
-                // If the palette has already been encountered then it is a circular reference
-                if (paletteSet.ContainsKey(palette))
-                {
-                    return true;
-                }
-                else
-                {
-                    // Otherwise, add to the set
-                    paletteSet.Add(palette, true);
-                    // Cast to correct type
+        //    // Keep searching until no more palettes found
+        //    while (palette != null)
+        //    {
+        //        // If the palette has already been encountered then it is a circular reference
+        //        if (paletteSet.ContainsKey(palette))
+        //        {
+        //            return true;
+        //        }
+        //        else
+        //        {
+        //            // Otherwise, add to the set
+        //            paletteSet.Add(palette, true);
+        //            // Cast to correct type
 
-                    // If this is a KryptonPalette instance
-                    if (palette is KryptonCustomPaletteBase owner)
-                    {
-                        // Get the next palette up in hierarchy
-                        palette = owner.BasePaletteMode switch
-                        {
-                            PaletteMode.Custom => owner.BasePalette,
-                            PaletteMode.Global => KryptonManager.InternalGlobalPalette,
-                            _ => null
-                        };
-                    }
-                    else
-                    {
-                        palette = null;
-                    }
-                }
-            }
+        //            // If this is a KryptonPalette instance
+        //            if (palette is KryptonCustomPaletteBase owner)
+        //            {
+        //                // Get the next palette up in hierarchy
+        //                palette = owner.BasePaletteMode switch
+        //                {
+        //                    PaletteMode.Custom => owner.BasePalette,
+        //                    PaletteMode.Global => KryptonManager.InternalGlobalPalette,
+        //                    _ => null
+        //                };
+        //            }
+        //            else
+        //            {
+        //                palette = null;
+        //            }
+        //        }
+        //    }
 
-            // No circular reference encountered
-            return false;
-        }
+        //    // No circular reference encountered
+        //    return false;
+        //}
         #endregion
 
         #region Implementation Persistence, Used by threading
@@ -5890,7 +5884,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void SetPalette(PaletteBase? basePalette)
+        private void SetPalette(PaletteBase basePalette)
         {
             if (basePalette != _basePalette)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -97,8 +97,8 @@ namespace Krypton.Toolkit
         private bool _paintTransparent;
         private bool _evalTransparent;
         private Size _lastLayoutSize;
-        private PaletteBase? _localPalette;
-        private PaletteBase? _palette;
+        private PaletteBase _localPalette;
+        private PaletteBase _palette;
         private PaletteMode _paletteMode;
         private ViewDrawPanel _drawPanel;
         private SimpleCall _refreshCall;
@@ -486,7 +486,7 @@ namespace Krypton.Toolkit
         [Category(@"Visuals")]
         [Description(@"Custom palette applied to drawing.")]
         [DefaultValue(null)]
-        public PaletteBase? Palette
+        public PaletteBase Palette
         {
             [DebuggerStepThrough]
             get => _localPalette;
@@ -497,7 +497,7 @@ namespace Krypton.Toolkit
                 if (_localPalette != value)
                 {
                     // Remember the starting palette
-                    PaletteBase? old = _localPalette;
+                    PaletteBase old = _localPalette;
 
                     // Use the provided palette value
                     SetPalette(value);
@@ -543,7 +543,7 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public IRenderer? Renderer
+        public IRenderer Renderer
         {
             [DebuggerStepThrough]
             get;
@@ -794,7 +794,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public PaletteBase? GetResolvedPalette() => _palette;
+        public PaletteBase GetResolvedPalette() => _palette;
 
         /// <summary>
         /// Gets or Sets the internal KryptonDataGridView CellOver
@@ -885,7 +885,7 @@ namespace Krypton.Toolkit
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
         /// <exception cref="ArgumentNullException"></exception>
-        protected void OnNeedPaint(object? sender, [DisallowNull] NeedLayoutEventArgs e)
+        protected void OnNeedPaint(object sender, [DisallowNull] NeedLayoutEventArgs e)
         {
             Debug.Assert(e != null);
 
@@ -1602,7 +1602,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Internal
-        internal PaletteRedirect? Redirector
+        internal PaletteRedirect Redirector
         {
             [DebuggerStepThrough]
             get;
@@ -2502,7 +2502,7 @@ namespace Krypton.Toolkit
             return toolTipText;
         }
 
-        private void SetPalette(PaletteBase? palette)
+        private void SetPalette(PaletteBase palette)
         {
             if (palette != _palette)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDateTimePicker.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDateTimePicker.cs
@@ -1086,10 +1086,10 @@ namespace Krypton.Toolkit
         [Category(@"Visuals - DateTimePicker")]
         [Description(@"Custom palette applied to drawing.")]
         [DefaultValue(null)]
-        public new PaletteBase? Palette
+        public new KryptonCustomPaletteBase LocalCustomPalette
         {
-            get => base.Palette;
-            set => base.Palette = value;
+            get => base.LocalCustomPalette;
+            set => base.LocalCustomPalette = value;
         }
 
         /// <summary>
@@ -2142,7 +2142,7 @@ namespace Krypton.Toolkit
                 }
                 else
                 {
-                    kcm.Palette = Palette;
+                    kcm.LocalCustomPalette = LocalCustomPalette;
                 }
 
                 // Give user a change to modify the context menu or even cancel the menu entirely
@@ -2333,9 +2333,9 @@ namespace Krypton.Toolkit
         /// <param name="keyboardActivated">True is menu was keyboard initiated.</param>
         /// <returns>VisualContextMenu reference.</returns>
         protected override VisualContextMenu CreateContextMenu(KryptonContextMenu kcm,
-                                                               PaletteBase? palette,
+                                                               PaletteBase palette,
                                                                PaletteMode paletteMode,
-                                                               PaletteRedirect? redirector,
+                                                               PaletteRedirect redirector,
                                                                PaletteRedirectContextMenu redirectorImages,
                                                                KryptonContextMenuCollection items,
                                                                bool enabled,

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
@@ -1706,7 +1706,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
-        protected override void OnNeedPaint(object? sender, NeedLayoutEventArgs e)
+        protected override void OnNeedPaint(object sender, NeedLayoutEventArgs e)
         {
             if (IsHandleCreated && !e.NeedLayout)
             {
@@ -1727,7 +1727,7 @@ namespace Krypton.Toolkit
                 _domainUpDown.ForeColor = triple.PaletteContent.GetContentShortTextColor1(state);
 
                 // Only set the font if the domain up down has been created
-                Font font = triple.PaletteContent.GetContentShortTextFont(state);
+                Font? font = triple.PaletteContent.GetContentShortTextFont(state);
                 if ((_domainUpDown.Handle != IntPtr.Zero) && !_domainUpDown.Font.Equals(font))
                 {
                     _domainUpDown.Font = font;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDropButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDropButton.cs
@@ -813,7 +813,7 @@ namespace Krypton.Toolkit
                 }
                 else
                 {
-                    KryptonContextMenu.Palette = Palette;
+                    KryptonContextMenu.LocalCustomPalette = LocalCustomPalette;
                 }
             }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -849,7 +849,7 @@ namespace Krypton.Toolkit
         {
             private readonly KryptonForm _kryptonForm;
 
-            public FormPaletteRedirect(PaletteBase? palette, KryptonForm kryptonForm)
+            public FormPaletteRedirect(PaletteBase palette, KryptonForm kryptonForm)
                 : base(palette) =>
                 _kryptonForm = kryptonForm;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonGroup.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonGroup.cs
@@ -441,7 +441,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
-        protected override void OnNeedPaint(object? sender, NeedLayoutEventArgs e)
+        protected override void OnNeedPaint(object sender, NeedLayoutEventArgs e)
         {
             if (IsInitialized || !e.NeedLayout)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonGroupBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonGroupBox.cs
@@ -723,7 +723,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
-        protected override void OnNeedPaint(object? sender, NeedLayoutEventArgs e)
+        protected override void OnNeedPaint(object sender, NeedLayoutEventArgs e)
         {
             if (IsInitialized || !e.NeedLayout)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonHeaderGroup.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonHeaderGroup.cs
@@ -1042,7 +1042,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
-        protected override void OnNeedPaint(object? sender, NeedLayoutEventArgs e)
+        protected override void OnNeedPaint(object sender, NeedLayoutEventArgs e)
         {
             if (IsInitialized || !e.NeedLayout)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonHelpCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonHelpCommand.cs
@@ -40,7 +40,7 @@ namespace Krypton.Toolkit
         public ButtonSpecAny? HelpButton
         {
             get => _helpButtonSpec ?? new ButtonSpecAny();
-            set { _helpButtonSpec = value; UpdateImage(KryptonManager.InternalGlobalPaletteMode); }
+            set { _helpButtonSpec = value; UpdateImage(KryptonManager.CurrentGlobalPaletteMode); }
         }
 
         /* /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarCopyCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarCopyCommand.cs
@@ -42,7 +42,7 @@ namespace Krypton.Toolkit
         public ButtonSpecAny? ToolBarCopyButton
         {
             get => _copyButtonSpec ?? new ButtonSpecAny();
-            set { _copyButtonSpec = value; UpdateImage(KryptonManager.InternalGlobalPaletteMode); }
+            set { _copyButtonSpec = value; UpdateImage(KryptonManager.CurrentGlobalPaletteMode); }
         }
 
         /// <summary>Gets the active image.</summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarCutCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarCutCommand.cs
@@ -42,7 +42,7 @@ namespace Krypton.Toolkit
         public ButtonSpecAny? ToolBarCutButton
         {
             get => _cutButtonSpec ?? new ButtonSpecAny();
-            set { _cutButtonSpec = value; UpdateImage(KryptonManager.InternalGlobalPaletteMode); }
+            set { _cutButtonSpec = value; UpdateImage(KryptonManager.CurrentGlobalPaletteMode); }
         }
 
         /// <summary>Gets the active image.</summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarNewCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarNewCommand.cs
@@ -42,7 +42,7 @@ namespace Krypton.Toolkit
         public ButtonSpecAny? ToolBarNewButton
         {
             get => _newButtonSpec ?? new ButtonSpecAny();
-            set { _newButtonSpec = value; UpdateImage(KryptonManager.InternalGlobalPaletteMode); }
+            set { _newButtonSpec = value; UpdateImage(KryptonManager.CurrentGlobalPaletteMode); }
         }
 
         /// <summary>Gets the active image.</summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarOpenCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarOpenCommand.cs
@@ -42,7 +42,7 @@ namespace Krypton.Toolkit
         public ButtonSpecAny? ToolBarOpenButton
         {
             get => _openButtonSpec ?? new ButtonSpecAny();
-            set { _openButtonSpec = value; UpdateImage(KryptonManager.InternalGlobalPaletteMode); }
+            set { _openButtonSpec = value; UpdateImage(KryptonManager.CurrentGlobalPaletteMode); }
         }
 
         /// <summary>Gets the active image.</summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarPageSetupCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarPageSetupCommand.cs
@@ -42,7 +42,7 @@ namespace Krypton.Toolkit
         public ButtonSpecAny? ToolBarPageSetupButton
         {
             get => _pageSetupButtonSpec ?? new ButtonSpecAny();
-            set { _pageSetupButtonSpec = value; UpdateImage(KryptonManager.InternalGlobalPaletteMode); }
+            set { _pageSetupButtonSpec = value; UpdateImage(KryptonManager.CurrentGlobalPaletteMode); }
         }
 
         /// <summary>Gets the active image.</summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarPasteCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarPasteCommand.cs
@@ -42,7 +42,7 @@ namespace Krypton.Toolkit
         public ButtonSpecAny? ToolBarPasteButton
         {
             get => _pasteButtonSpec ?? new ButtonSpecAny();
-            set { _pasteButtonSpec = value; UpdateImage(KryptonManager.InternalGlobalPaletteMode); }
+            set { _pasteButtonSpec = value; UpdateImage(KryptonManager.CurrentGlobalPaletteMode); }
         }
 
         /// <summary>Gets the active image.</summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarPrintCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarPrintCommand.cs
@@ -48,7 +48,7 @@ namespace Krypton.Toolkit
         public ButtonSpecAny? ToolBarPrintButton
         {
             get => _printButtonSpec ?? new ButtonSpecAny();
-            set { _printButtonSpec = value; UpdateImage(KryptonManager.InternalGlobalPaletteMode); UpdateButtonSpec(); }
+            set { _printButtonSpec = value; UpdateImage(KryptonManager.CurrentGlobalPaletteMode); UpdateButtonSpec(); }
         }
 
         /// <summary>Gets the active image.</summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarPrintPreviewCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarPrintPreviewCommand.cs
@@ -42,7 +42,7 @@ namespace Krypton.Toolkit
         public ButtonSpecAny? ToolBarPrintPreviewButton
         {
             get => _printPreviewButtonSpec ?? new ButtonSpecAny();
-            set { _printPreviewButtonSpec = value; UpdateImage(KryptonManager.InternalGlobalPaletteMode); }
+            set { _printPreviewButtonSpec = value; UpdateImage(KryptonManager.CurrentGlobalPaletteMode); }
         }
 
         /// <summary>Gets the active image.</summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarQuickPrintCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarQuickPrintCommand.cs
@@ -42,7 +42,7 @@ namespace Krypton.Toolkit
         public ButtonSpecAny? ToolBarQuickPrintButton
         {
             get => _quickPrintButtonSpec ?? new ButtonSpecAny();
-            set { _quickPrintButtonSpec = value; UpdateImage(KryptonManager.InternalGlobalPaletteMode); }
+            set { _quickPrintButtonSpec = value; UpdateImage(KryptonManager.CurrentGlobalPaletteMode); }
         }
 
         /// <summary>Gets the active image.</summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarRedoCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarRedoCommand.cs
@@ -42,7 +42,7 @@ namespace Krypton.Toolkit
         public ButtonSpecAny? ToolBarRedoButton
         {
             get => _redoButtonSpec ?? new ButtonSpecAny();
-            set { _redoButtonSpec = value; UpdateImage(KryptonManager.InternalGlobalPaletteMode); }
+            set { _redoButtonSpec = value; UpdateImage(KryptonManager.CurrentGlobalPaletteMode); }
         }
 
         /// <summary>Gets the active image.</summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarSaveAllCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarSaveAllCommand.cs
@@ -48,7 +48,7 @@ namespace Krypton.Toolkit
         public ButtonSpecAny? ToolBarSaveAllButton
         {
             get => _saveAllButtonSpec ?? new ButtonSpecAny();
-            set { _saveAllButtonSpec = value; UpdateImage(KryptonManager.InternalGlobalPaletteMode); }
+            set { _saveAllButtonSpec = value; UpdateImage(KryptonManager.CurrentGlobalPaletteMode); }
         }
 
         /// <summary>Gets the active image.</summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarSaveAsCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarSaveAsCommand.cs
@@ -42,7 +42,7 @@ namespace Krypton.Toolkit
         public ButtonSpecAny? ToolBarSaveAsButton
         {
             get => _saveAsButtonSpec ?? new ButtonSpecAny();
-            set { _saveAsButtonSpec = value; UpdateImage(KryptonManager.InternalGlobalPaletteMode); }
+            set { _saveAsButtonSpec = value; UpdateImage(KryptonManager.CurrentGlobalPaletteMode); }
         }
 
         /// <summary>Gets the active image.</summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarSaveCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarSaveCommand.cs
@@ -42,7 +42,7 @@ namespace Krypton.Toolkit
         public ButtonSpecAny? ToolBarSaveButton
         {
             get => _saveButtonSpec ?? new ButtonSpecAny();
-            set { _saveButtonSpec = value; UpdateImage(KryptonManager.InternalGlobalPaletteMode); }
+            set { _saveButtonSpec = value; UpdateImage(KryptonManager.CurrentGlobalPaletteMode); }
         }
 
         /// <summary>Gets the active image.</summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarUndoCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarUndoCommand.cs
@@ -42,7 +42,7 @@ namespace Krypton.Toolkit
         public ButtonSpecAny? ToolBarUndoButton
         {
             get => _undoButtonSpec ?? new ButtonSpecAny();
-            set { _undoButtonSpec = value; UpdateImage(KryptonManager.InternalGlobalPaletteMode); }
+            set { _undoButtonSpec = value; UpdateImage(KryptonManager.CurrentGlobalPaletteMode); }
         }
 
         /// <summary>Gets the active image.</summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLinkWrapLabel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLinkWrapLabel.cs
@@ -29,8 +29,8 @@ namespace Krypton.Toolkit
 
         #region Instance Fields
 
-        private PaletteBase? _localPalette;
-        private PaletteBase? _palette;
+        private PaletteBase _localPalette;
+        private PaletteBase _palette;
         private PaletteMode _paletteMode;
         private readonly PaletteRedirect _redirector;
         private LabelStyle _labelStyle;
@@ -321,7 +321,7 @@ namespace Krypton.Toolkit
         [Category(@"Visuals")]
         [Description(@"Custom palette applied to drawing.")]
         [DefaultValue(null)]
-        public PaletteBase? Palette
+        public PaletteBase Palette
         {
             [DebuggerStepThrough]
             get => _localPalette;
@@ -332,7 +332,7 @@ namespace Krypton.Toolkit
                 if (_localPalette != value)
                 {
                     // Remember the starting palette
-                    PaletteBase? old = _localPalette;
+                    PaletteBase old = _localPalette;
 
                     // Use the provided palette value
                     SetPalette(value);
@@ -406,7 +406,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public PaletteBase? GetResolvedPalette() => _palette;
+        public PaletteBase GetResolvedPalette() => _palette;
 
         /// <summary>
         /// Gets access to the current renderer.
@@ -414,7 +414,7 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public IRenderer? Renderer
+        public IRenderer Renderer
         {
             [DebuggerStepThrough]
             get;
@@ -782,7 +782,7 @@ namespace Krypton.Toolkit
 
         /// <summary>Sets the palette.</summary>
         /// <param name="palette">The palette.</param>
-        private void SetPalette(PaletteBase? palette)
+        private void SetPalette(PaletteBase palette)
         {
             if (palette != _palette)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListBox.cs
@@ -1471,7 +1471,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
-        protected override void OnNeedPaint(object? sender, NeedLayoutEventArgs e)
+        protected override void OnNeedPaint(object sender, NeedLayoutEventArgs e)
         {
             if (IsHandleCreated && !e.NeedLayout)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListView.cs
@@ -27,8 +27,8 @@ namespace Krypton.Toolkit
     public class KryptonListView : ListView
     {
         #region Variables
-        private PaletteBase? _localPalette;
-        private PaletteBase? _palette;
+        private PaletteBase _localPalette;
+        private PaletteBase _palette;
         private PaletteMode _paletteMode;
         private bool _layoutDirty;
         private bool _refreshAll;
@@ -222,7 +222,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the palette redirector.
         /// </summary>
-        protected PaletteRedirect? Redirector
+        protected PaletteRedirect Redirector
         {
             [DebuggerStepThrough]
             get;
@@ -241,7 +241,7 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public IRenderer? Renderer
+        public IRenderer Renderer
         {
             [DebuggerStepThrough]
             get;
@@ -280,7 +280,7 @@ namespace Krypton.Toolkit
         [Category(@"Visuals")]
         [Description(@"Custom palette applied to drawing.")]
         [DefaultValue(null)]
-        public PaletteBase? Palette
+        public PaletteBase Palette
         {
             [DebuggerStepThrough]
             get => _localPalette;
@@ -1088,7 +1088,7 @@ namespace Krypton.Toolkit
             Invalidate();
         }
 
-        private void CacheNewPalette(PaletteBase? palette)
+        private void CacheNewPalette(PaletteBase palette)
         {
             if (palette != _palette)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonManager.cs
@@ -27,6 +27,7 @@ namespace Krypton.Toolkit
         private static bool _globalApplyToolstrips = true;
         private static bool _globalAllowFormChrome = true;
         internal static bool _globalUseKryptonFileDialogs = true;
+        private static Font? _baseFont;
 
         // Initialize the default modes
 
@@ -160,9 +161,9 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Initialize a new instance of the KryptonManager class.
         /// </summary>
-        public KryptonManager() =>
-            // This may not be the first form / object to init, so set to the global static
-            GlobalPaletteMode = InternalGlobalPaletteMode;
+        public KryptonManager()
+        {
+        }
 
         /// <summary>
         /// Initialize a new instance of the KryptonManager class.
@@ -204,12 +205,12 @@ namespace Krypton.Toolkit
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public bool IsDefault => !(ShouldSerializeGlobalPaletteMode() ||
-                                   ShouldSerializeGlobalPalette() ||
+        public bool IsDefault => !(ShouldSerializeGlobalCustomPalette() ||
                                    ShouldSerializeGlobalApplyToolstrips() ||
                                    ShouldSerializeGlobalAllowFormChrome() ||
                                    ShouldSerializeToolkitStrings() ||
-                                   ShouldSerializeUseKryptonFileDialogs()
+                                   ShouldSerializeUseKryptonFileDialogs() ||
+                                   ShouldSerializeBaseFont()
                                    );
 
         /// <summary>
@@ -217,68 +218,43 @@ namespace Krypton.Toolkit
         /// </summary>
         public void Reset()
         {
-            ResetGlobalPaletteMode();
-            ResetGlobalPalette();
+            ResetGlobalCustomPalette();
             ResetGlobalApplyToolstrips();
             ResetGlobalAllowFormChrome();
             ResetToolkitStrings();
             ResetUseKryptonFileDialogs();
+            ResetBaseFont();
         }
 
         /// <summary>
         /// Gets or sets the global palette used for drawing.
         /// </summary>
-        [Category(@"Visuals")]
-        [Description(@"Global palette applied to drawing.")]
+        [Category(@"GlobalPalette")]
+        [Description(@"Easy Set for the theme palette")]
         [DefaultValue(PaletteMode.Microsoft365Blue)]
         public PaletteMode GlobalPaletteMode
         {
-            get => InternalGlobalPaletteMode;
-
+            get => CurrentGlobalPaletteMode;
             set
             {
-                // Only interested in changes of value
-                if (InternalGlobalPaletteMode != value)
+                if (value != CurrentGlobalPaletteMode)
                 {
-                    // Action depends on the value
-                    switch (value)
+                    if (value != PaletteMode.Custom)
                     {
-                        case PaletteMode.Custom:
-                            // Do nothing, you must assign a palette to the 
-                            // 'GlobalPalette' property in order to get the custom mode
-                            break;
-                        default:
-                            // Cache the new values
-                            PaletteMode tempMode = InternalGlobalPaletteMode;
-                            PaletteBase? tempPalette = InternalGlobalPalette;
+                        CurrentGlobalPalette = GetPaletteForMode(value);
+                        // Get a reference to the standard palette from its name
+                        SetPalette(CurrentGlobalPalette);
+                    }
+                    CurrentGlobalPaletteMode = value;
+                    if (_baseFont != null)
+                    {
+                        CurrentGlobalPalette.BaseFont = _baseFont;
+                    }
 
-                            // Use the new value
-                            InternalGlobalPaletteMode = value;
-                            InternalGlobalPalette = null;
-
-                            // If the new value creates a circular reference
-                            if (HasCircularReference())
-                            {
-                                // Restore the original values before throwing
-                                InternalGlobalPaletteMode = tempMode;
-                                InternalGlobalPalette = tempPalette;
-
-                                throw new ArgumentOutOfRangeException(nameof(value),
-                                    @"Cannot use palette that would create a circular reference");
-                            }
-                            else
-                            {
-                                // Restore the original global palette as 'SetPalette' will not 
-                                // work correctly unless it still has the old value in place
-                                InternalGlobalPalette = tempPalette;
-                            }
-
-                            // Get a reference to the standard palette from its name
-                            SetPalette(CurrentGlobalPalette);
-
-                            // Raise the palette changed event
-                            OnGlobalPaletteChanged(EventArgs.Empty);
-                            break;
+                    if (value != PaletteMode.Custom)
+                    {
+                        // Raise the palette changed event
+                        OnGlobalPaletteChanged(EventArgs.Empty);
                     }
                 }
             }
@@ -286,67 +262,76 @@ namespace Krypton.Toolkit
         private bool ShouldSerializeGlobalPaletteMode() => GlobalPaletteMode != PaletteMode.Microsoft365Blue;
         private void ResetGlobalPaletteMode() => GlobalPaletteMode = PaletteMode.Microsoft365Blue;
 
+
         /// <summary>
         /// Gets and sets the global custom applied to drawing.
         /// </summary>
-        [Category(@"Visuals")]
+        [Category(@"GlobalPalette")]
         [Description(@"Global custom palette applied to drawing.")]
         [DefaultValue(null)]
-        public PaletteBase? GlobalPalette
+        public KryptonCustomPaletteBase? GlobalCustomPalette
         {
-            get => InternalGlobalPalette;
+            get => CurrentGlobalPalette as KryptonCustomPaletteBase;
 
             set
             {
                 // Only interested in changes of value
-                if (InternalGlobalPalette != value)
+                if (CurrentGlobalPalette != value)
                 {
-                    // Cache the current values
-                    PaletteMode tempMode = InternalGlobalPaletteMode;
-                    PaletteBase? tempPalette = InternalGlobalPalette;
-
-                    // Use the new values
-                    InternalGlobalPaletteMode = (value == null) ? PaletteMode.Microsoft365Blue : PaletteMode.Custom;
-                    InternalGlobalPalette = value;
-
-                    // If the new value creates a circular reference
-                    if (HasCircularReference())
+                    if (value != null)
                     {
-                        // Restore the original values
-                        InternalGlobalPaletteMode = tempMode;
-                        InternalGlobalPalette = tempPalette;
-
-                        throw new ArgumentOutOfRangeException(nameof(value), @"Cannot use palette that would create a circular reference");
+                        // If no custom palette is required
+                        CurrentGlobalPalette = value;
+                        // Use the provided palette value
+                        SetPalette(value);
+                        CurrentGlobalPaletteMode = GetModeForPalette(value);
                     }
                     else
                     {
-                        // Restore the original global palette as 'SetPalette' will not 
-                        // work correctly unless it still has the old value in place
-                        InternalGlobalPalette = tempPalette;
+                        ResetGlobalPaletteMode();
+                        CurrentGlobalPalette = GetPaletteForMode(GlobalPaletteMode);
                     }
-
-                    // Use the provided palette value
-                    SetPalette(value);
-
-                    // If no custom palette is required
-                    if (value == null)
-                    {
-                        // Get a reference to current global palette defined by the mode
-                        SetPalette(CurrentGlobalPalette);
-                    }
-                    else
-                    {
-                        // No longer using a standard palette
-                        InternalGlobalPaletteMode = PaletteMode.Custom;
-                    }
-
                     // Raise the palette changed event
                     OnGlobalPaletteChanged(EventArgs.Empty);
                 }
             }
         }
-        private bool ShouldSerializeGlobalPalette() => GlobalPalette != CurrentGlobalPalette;
-        private void ResetGlobalPalette() => GlobalPalette = CurrentGlobalPalette;
+        private void ResetGlobalCustomPalette()
+        {
+            GlobalCustomPalette = null;
+            ResetGlobalPaletteMode();
+        }
+        private bool ShouldSerializeGlobalCustomPalette() => GlobalCustomPalette != null;
+
+        /// <summary>Override the Current global palette font.</summary>
+        [Category(@"GlobalPalette")]
+        [Description(@"Override the Current global palette font.")]
+        [AllowNull]
+        public Font BaseFont
+        {
+            get => _baseFont ?? CurrentGlobalPalette.BaseFont;
+
+            set
+            {
+                if (value != null)
+                {
+                    _baseFont = value;
+                    CurrentGlobalPalette.BaseFont = value;
+                }
+                else
+                {
+                    ResetBaseFont();
+                }
+            }
+        }
+
+        internal void ResetBaseFont()
+        {
+            _baseFont = null;
+            CurrentGlobalPalette.ResetBaseFont();
+        }
+
+        internal bool ShouldSerializeBaseFont() => _baseFont != null;
 
         /// <summary>
         /// Gets or sets a value indicating if the palette colors are applied to the tool-strips.
@@ -370,7 +355,7 @@ namespace Krypton.Toolkit
         public bool UseKryptonFileDialogs
         {
             get => _globalUseKryptonFileDialogs;
-            set => _globalUseKryptonFileDialogs = value; 
+            set => _globalUseKryptonFileDialogs = value;
         }
         private bool ShouldSerializeUseKryptonFileDialogs() => !UseKryptonFileDialogs;
         private void ResetUseKryptonFileDialogs() => UseKryptonFileDialogs = true;
@@ -387,9 +372,7 @@ namespace Krypton.Toolkit
             get => AllowFormChrome;
             set => AllowFormChrome = value;
         }
-
         private bool ShouldSerializeGlobalAllowFormChrome() => !GlobalAllowFormChrome;
-
         private void ResetGlobalAllowFormChrome() => GlobalAllowFormChrome = true;
 
         /// <summary>Gets the toolkit strings that can be localised.</summary>
@@ -399,11 +382,8 @@ namespace Krypton.Toolkit
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         [Localizable(true)]
         public KryptonGlobalToolkitStrings ToolkitStrings => Strings;
-
         private bool ShouldSerializeToolkitStrings() => !Strings.IsDefault;
-
-        /// <summary>Resets the toolkit strings.</summary>
-        public void ResetToolkitStrings() => Strings.Reset();
+        private void ResetToolkitStrings() => Strings.Reset();
 
         #endregion
 
@@ -470,126 +450,11 @@ namespace Krypton.Toolkit
 
         #region Static Palette
         /// <summary>
-        /// Gets the current global palette instance given the manager settings.
-        /// </summary>
-        public static PaletteBase? CurrentGlobalPalette
-        {
-            get
-            {
-                switch (InternalGlobalPaletteMode)
-                {
-                    case PaletteMode.ProfessionalSystem:
-                        return PaletteProfessionalSystem;
-                    case PaletteMode.ProfessionalOffice2003:
-                        return PaletteProfessionalOffice2003;
-                    case PaletteMode.Office2007DarkGray:
-                        return PaletteOffice2007DarkGray;
-                    case PaletteMode.Office2007Blue:
-                        return PaletteOffice2007Blue;
-                    case PaletteMode.Office2007BlueDarkMode:
-                        return PaletteOffice2007BlueDarkMode;
-                    case PaletteMode.Office2007BlueLightMode:
-                        return PaletteOffice2007BlueLightMode;
-                    case PaletteMode.Office2007Silver:
-                        return PaletteOffice2007Silver;
-                    case PaletteMode.Office2007SilverDarkMode:
-                        return PaletteOffice2007SilverDarkMode;
-                    case PaletteMode.Office2007SilverLightMode:
-                        return PaletteOffice2007SilverLightMode;
-                    case PaletteMode.Office2007White:
-                        return PaletteOffice2007White;
-                    case PaletteMode.Office2007Black:
-                        return PaletteOffice2007Black;
-                    case PaletteMode.Office2007BlackDarkMode:
-                        return PaletteOffice2007BlackDarkMode;
-                    case PaletteMode.Office2010DarkGray:
-                        return PaletteOffice2010DarkGray;
-                    case PaletteMode.Office2010Blue:
-                        return PaletteOffice2010Blue;
-                    case PaletteMode.Office2010BlueDarkMode:
-                        return PaletteOffice2010BlueDarkMode;
-                    case PaletteMode.Office2010BlueLightMode:
-                        return PaletteOffice2010BlueLightMode;
-                    case PaletteMode.Office2010Silver:
-                        return PaletteOffice2010Silver;
-                    case PaletteMode.Office2010SilverDarkMode:
-                        return PaletteOffice2010SilverDarkMode;
-                    case PaletteMode.Office2010SilverLightMode:
-                        return PaletteOffice2010SilverLightMode;
-                    case PaletteMode.Office2010White:
-                        return PaletteOffice2010White;
-                    case PaletteMode.Office2010Black:
-                        return PaletteOffice2010Black;
-                    case PaletteMode.Office2010BlackDarkMode:
-                        return PaletteOffice2010BlackDarkMode;
-                    case PaletteMode.Office2013DarkGray:
-                        return PaletteOffice2013DarkGray;
-                    case PaletteMode.Office2013LightGray:
-                        return PaletteOffice2013LightGray;
-                    case PaletteMode.Office2013White:
-                        return PaletteOffice2013White;
-                    case PaletteMode.SparkleBlue:
-                        return PaletteSparkleBlue;
-                    case PaletteMode.SparkleBlueDarkMode:
-                        return PaletteSparkleBlueDarkMode;
-                    case PaletteMode.SparkleBlueLightMode:
-                        return PaletteSparkleBlueLightMode;
-                    case PaletteMode.SparkleOrange:
-                        return PaletteSparkleOrange;
-                    case PaletteMode.SparkleOrangeDarkMode:
-                        return PaletteSparkleOrangeDarkMode;
-                    case PaletteMode.SparkleOrangeLightMode:
-                        return PaletteSparkleOrangeLightMode;
-                    case PaletteMode.SparklePurple:
-                        return PaletteSparklePurple;
-                    case PaletteMode.SparklePurpleDarkMode:
-                        return PaletteSparklePurpleDarkMode;
-                    case PaletteMode.SparklePurpleLightMode:
-                        return PaletteSparklePurpleLightMode;
-                    case PaletteMode.Microsoft365Black:
-                        return PaletteMicrosoft365Black;
-                    case PaletteMode.Microsoft365BlackDarkMode:
-                        return PaletteMicrosoft365BlackDarkMode;
-                    case PaletteMode.Microsoft365Blue:
-                        return PaletteMicrosoft365Blue;
-                    case PaletteMode.Microsoft365BlueDarkMode:
-                        return PaletteMicrosoft365BlueDarkMode;
-                    case PaletteMode.Microsoft365BlueLightMode:
-                        return PaletteMicrosoft365BlueLightMode;
-                    case PaletteMode.Microsoft365DarkGray:
-                        return PaletteMicrosoft365DarkGray;
-                    case PaletteMode.Microsoft365Silver:
-                        return PaletteMicrosoft365Silver;
-                    case PaletteMode.Microsoft365SilverDarkMode:
-                        return PaletteMicrosoft365SilverDarkMode;
-                    case PaletteMode.Microsoft365SilverLightMode:
-                        return PaletteMicrosoft365SilverLightMode;
-                    case PaletteMode.Microsoft365White:
-                        return PaletteMicrosoft365White;
-                    case PaletteMode.VisualStudio2010Render2007:
-                        return PaletteVisualStudio2010Office2007Variation;
-                    case PaletteMode.VisualStudio2010Render2010:
-                        return PaletteVisualStudio2010Office2010Variation;
-                    case PaletteMode.VisualStudio2010Render2013:
-                        return PaletteVisualStudio2010Office2013Variation;
-                    case PaletteMode.VisualStudio2010Render365:
-                        return PaletteVisualStudio2010Microsoft365Variation;
-                    case PaletteMode.Custom:
-                    case PaletteMode.Global:
-                        return InternalGlobalPalette;
-                    default:
-                        Debug.Assert(false);
-                        return null;
-                }
-            }
-        }
-
-        /// <summary>
         /// Gets the implementation for the requested palette mode.
         /// </summary>
         /// <param name="mode">Requested palette mode.</param>
-        /// <returns>PaletteBase reference is available; otherwise false.</returns>
-        public static PaletteBase? GetPaletteForMode(PaletteMode mode)
+        /// <returns>PaletteBase reference is available; otherwise null exception.</returns>
+        public static PaletteBase GetPaletteForMode(PaletteMode mode)
         {
             switch (mode)
             {
@@ -681,8 +546,6 @@ namespace Krypton.Toolkit
                     return PaletteMicrosoft365SilverLightMode;
                 case PaletteMode.Microsoft365White:
                     return PaletteMicrosoft365White;
-                case PaletteMode.Global:
-                    return CurrentGlobalPalette;
                 case PaletteMode.VisualStudio2010Render2007:
                     return PaletteVisualStudio2010Office2007Variation;
                 case PaletteMode.VisualStudio2010Render2010:
@@ -691,11 +554,42 @@ namespace Krypton.Toolkit
                     return PaletteVisualStudio2010Office2013Variation;
                 case PaletteMode.VisualStudio2010Render365:
                     return PaletteVisualStudio2010Microsoft365Variation;
+
                 case PaletteMode.Custom:
+                case PaletteMode.Global:
+                    return CurrentGlobalPalette;
                 default:
                     Debug.Assert(false);
-                    return null;
+                    throw new ArgumentOutOfRangeException(nameof(mode), @"mode must be PaletteMode value.");
             }
+        }
+
+        /// <summary>
+        /// Gets the implementation for the requested palette mode.
+        /// </summary>
+        /// <param name="palette">Requested palette to mode.</param>
+        /// <returns>PaletteMode is available; otherwise Custom.</returns>
+        public static PaletteMode GetModeForPalette(PaletteBase? palette)
+        {
+            if (palette is KryptonCustomPaletteBase)
+            {
+                return PaletteMode.Custom;
+            }
+
+            object? mode = null;
+            if (palette != null)
+            {
+                var modeConverter = new Krypton.Toolkit.Converters.PaletteClassTypeConverter();
+
+                mode = modeConverter.ConvertFrom(palette.GetType());
+            }
+
+            if (mode == null)
+            {
+                return PaletteMode.Global;
+            }
+
+            return (PaletteMode)mode;
         }
 
         /// <summary>
@@ -942,7 +836,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="mode">Requested renderer mode.</param>
         /// <returns>IRenderer reference is available; otherwise false.</returns>
-        public static IRenderer? GetRendererForMode(RendererMode mode)
+        public static IRenderer GetRendererForMode(RendererMode mode)
         {
             switch (mode)
             {
@@ -975,7 +869,7 @@ namespace Krypton.Toolkit
                 default:
                     // Should never be passed
                     Debug.Assert(false);
-                    return null;
+                    throw new ArgumentOutOfRangeException(nameof(mode), @"mode must be RendererMode value.");
             }
         }
 
@@ -1029,58 +923,13 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Static Internal
-        internal static PaletteMode InternalGlobalPaletteMode { get; private set; } = PaletteMode.Microsoft365Blue;
+        /// <summary>
+        /// What is the CurrentGlobalPaletteMode in use
+        /// </summary>
+        public static PaletteMode CurrentGlobalPaletteMode { get; private set; } = PaletteMode.Microsoft365Blue;
 
-        internal static PaletteBase? InternalGlobalPalette { get; private set; } = CurrentGlobalPalette;
+        internal static PaletteBase CurrentGlobalPalette { get; private set; } = GetPaletteForMode(CurrentGlobalPaletteMode);
 
-        internal static bool HasCircularReference()
-        {
-            // Use a dictionary as a set to check for existence
-            var paletteSet = new Dictionary<PaletteBase, bool>();
-
-            PaletteBase? palette = null;
-
-            // Get the next palette up in hierarchy
-            if (InternalGlobalPaletteMode == PaletteMode.Custom)
-            {
-                palette = InternalGlobalPalette;
-            }
-
-            // Keep searching until no more palettes found
-            while (palette != null)
-            {
-                // If the palette has already been encountered then it is a circular reference
-                if (paletteSet.ContainsKey(palette))
-                {
-                    return true;
-                }
-                else
-                {
-                    // Otherwise, add to the set
-                    paletteSet.Add(palette, true);
-                    // Cast to correct type
-
-                    // If this is a KryptonPalette instance
-                    if (palette is KryptonCustomPaletteBase owner)
-                    {
-                        // Get the next palette up in hierarchy
-                        palette = owner.BasePaletteMode switch
-                        {
-                            PaletteMode.Custom => owner.BasePalette,
-                            PaletteMode.Global => InternalGlobalPalette,
-                            _ => null
-                        };
-                    }
-                    else
-                    {
-                        palette = null;
-                    }
-                }
-            }
-
-            // No circular reference encountered
-            return false;
-        }
         #endregion
 
         #region Static Implementation
@@ -1130,23 +979,23 @@ namespace Krypton.Toolkit
             }
         }
 
-        private static void SetPalette(PaletteBase? globalPalette)
+        private static void SetPalette(PaletteBase globalPalette)
         {
-            if (globalPalette != InternalGlobalPalette)
+            if (globalPalette != CurrentGlobalPalette)
             {
                 // Unhook from current palette events
-                if (InternalGlobalPalette != null)
+                if (CurrentGlobalPalette != null)
                 {
-                    InternalGlobalPalette.PalettePaint -= OnPalettePaint;
+                    CurrentGlobalPalette.PalettePaint -= OnPalettePaint;
                 }
 
                 // Remember the new palette
-                InternalGlobalPalette = globalPalette;
+                CurrentGlobalPalette = globalPalette;
 
                 // Hook to new palette events
-                if (InternalGlobalPalette != null)
+                if (CurrentGlobalPalette != null)
                 {
-                    InternalGlobalPalette.PalettePaint += OnPalettePaint;
+                    CurrentGlobalPalette.PalettePaint += OnPalettePaint;
                 }
             }
         }
@@ -1164,7 +1013,7 @@ namespace Krypton.Toolkit
         {
             if (_globalApplyToolstrips)
             {
-                ToolStripManager.Renderer = InternalGlobalPalette?.GetRenderer()?.RenderToolStrip(InternalGlobalPalette);
+                ToolStripManager.Renderer = CurrentGlobalPalette?.GetRenderer()?.RenderToolStrip(CurrentGlobalPalette);
             }
         }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonManager.cs
@@ -928,7 +928,10 @@ namespace Krypton.Toolkit
         /// </summary>
         public static PaletteMode CurrentGlobalPaletteMode { get; private set; } = PaletteMode.Microsoft365Blue;
 
-        internal static PaletteBase CurrentGlobalPalette { get; private set; } = GetPaletteForMode(CurrentGlobalPaletteMode);
+        /// <summary>
+        /// Access the Current Palette
+        /// </summary>
+        public static PaletteBase CurrentGlobalPalette { get; private set; } = GetPaletteForMode(CurrentGlobalPaletteMode);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs
@@ -601,7 +601,7 @@ namespace Krypton.Toolkit
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Browsable(false)]
-        public MaskedTextBox? MaskedTextBox => _maskedTextBox;
+        public MaskedTextBox MaskedTextBox => _maskedTextBox;
 
         /// <summary>
         /// Gets access to the contained input control.
@@ -1676,7 +1676,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
-        protected override void OnNeedPaint(object? sender, NeedLayoutEventArgs e)
+        protected override void OnNeedPaint(object sender, NeedLayoutEventArgs e)
         {
             if (!e.NeedLayout)
             {
@@ -1697,7 +1697,7 @@ namespace Krypton.Toolkit
                 _maskedTextBox.ForeColor = triple.PaletteContent.GetContentShortTextColor1(state);
 
                 // Only set the font if the masked text box has been created
-                Font font = triple.PaletteContent.GetContentShortTextFont(state);
+                Font? font = triple.PaletteContent.GetContentShortTextFont(state);
                 if ((_maskedTextBox.Handle != IntPtr.Zero) && !_maskedTextBox.Font.Equals(font))
                 {
                     _maskedTextBox.Font = font;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
@@ -1830,7 +1830,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
-        protected override void OnNeedPaint(object? sender, NeedLayoutEventArgs e)
+        protected override void OnNeedPaint(object sender, NeedLayoutEventArgs e)
         {
             if (IsHandleCreated && !e.NeedLayout)
             {
@@ -1851,7 +1851,7 @@ namespace Krypton.Toolkit
                 _numericUpDown.ForeColor = triple.PaletteContent.GetContentShortTextColor1(state);
 
                 // Only set the font if the numeric up down has been created
-                Font font = triple.PaletteContent.GetContentShortTextFont(state);
+                Font? font = triple.PaletteContent.GetContentShortTextFont(state);
                 if ((_numericUpDown.Handle != IntPtr.Zero) && !_numericUpDown.Font.Equals(font))
                 {
                     _numericUpDown.Font = font;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonProgressBar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonProgressBar.cs
@@ -25,7 +25,7 @@ namespace Krypton.Toolkit
 
         private ProgressBarStyle _style;
         private VisualOrientation _orientation;
-        private PaletteBase? _palette;
+        private PaletteBase _palette;
         private readonly PaletteRedirect _paletteRedirect;
         private readonly PaletteBackInheritRedirect _paletteBackClientPanel;
         private IDisposable? _mementoContent;
@@ -586,7 +586,7 @@ namespace Krypton.Toolkit
             if (_palette != null)
             {
                 // Get the renderer associated with this palette
-                IRenderer? renderer = _palette.GetRenderer();
+                IRenderer renderer = _palette.GetRenderer();
 
                 // Create the rendering context that is passed into all renderer calls
                 using var renderContext = new RenderContext(this, e.Graphics, e.ClipRectangle, renderer);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPropertyGrid.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPropertyGrid.cs
@@ -17,7 +17,7 @@ namespace Krypton.Toolkit
     public class KryptonPropertyGrid : PropertyGrid
     {
         #region Variables
-        private PaletteBase? _palette;
+        private PaletteBase _palette;
 
         private readonly PaletteRedirect? _paletteRedirect;
         private readonly PaletteInputControlTripleRedirect _stateCommon;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
@@ -2005,7 +2005,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
-        protected override void OnNeedPaint(object? sender, NeedLayoutEventArgs e)
+        protected override void OnNeedPaint(object sender, NeedLayoutEventArgs e)
         {
             if (!e.NeedLayout)
             {
@@ -2036,7 +2036,7 @@ namespace Krypton.Toolkit
                 }
 
                 // Only set the font if the rich text box has been created
-                Font font = triple.PaletteContent.GetContentShortTextFont(state);
+                Font? font = triple.PaletteContent.GetContentShortTextFont(state);
                 if ((_richTextBox.Handle != IntPtr.Zero) && !_richTextBox.Font.Equals(font))
                 {
                     _richTextBox.Font = font;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTableLayoutPanel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTableLayoutPanel.cs
@@ -166,7 +166,7 @@ namespace Krypton.Toolkit
         [Category(@"Visuals")]
         [Description(@"Custom palette applied to drawing.")]
         [DefaultValue(null)]
-        public PaletteBase? Palette
+        public PaletteBase Palette
         {
             [DebuggerStepThrough]
             get => _backGroundPanel.Palette;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
@@ -1713,7 +1713,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
-        protected override void OnNeedPaint(object? sender, NeedLayoutEventArgs e)
+        protected override void OnNeedPaint(object sender, NeedLayoutEventArgs e)
         {
             if (IsHandleCreated && !e.NeedLayout)
             {
@@ -1734,7 +1734,7 @@ namespace Krypton.Toolkit
                 _textBox.ForeColor = triple.PaletteContent.GetContentShortTextColor1(state);
 
                 // Only set the font if the text box has been created
-                Font font = triple.PaletteContent.GetContentShortTextFont(state);
+                Font? font = triple.PaletteContent.GetContentShortTextFont(state);
                 if ((_textBox.Handle != IntPtr.Zero) && !_textBox.Font.Equals(font))
                 {
                     _textBox.Font = font;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
@@ -70,7 +70,7 @@ namespace Krypton.Toolkit
         [DefaultValue(null)]
         public KryptonCustomPaletteBase? KryptonCustomPalette { get; set; }
 
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        //[EditorBrowsable(EditorBrowsableState.Never)]
         public KryptonManager Manager
         {
             get;
@@ -133,7 +133,7 @@ namespace Krypton.Toolkit
                 && (KryptonCustomPalette != null)
                )
             {
-                Manager.GlobalPalette = KryptonCustomPalette;
+                Manager.GlobalCustomPalette= KryptonCustomPalette;
             }
         }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeListBox.cs
@@ -100,7 +100,7 @@ namespace Krypton.Toolkit
 
             if ((ThemeManager.GetThemeManagerMode(GetItemText(SelectedItem)) == PaletteMode.Custom) && (KryptonCustomPalette != null))
             {
-                Manager.GlobalPalette = KryptonCustomPalette;
+                Manager.GlobalCustomPalette = KryptonCustomPalette;
             }
         }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeNode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeNode.cs
@@ -21,7 +21,7 @@ namespace Krypton.Toolkit
         #region Instance Fields
         private string _longText;
         private Color _longForeColor;
-        private Font _longNodeFont;
+        private Font? _longNodeFont;
         private bool _isCheckBoxVisible;
         #endregion
 
@@ -153,7 +153,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Category(@"Appearance")]
         [Description(@"Font of the long text")]
-        public Font LongNodeFont
+        public Font? LongNodeFont
         {
             get => _longNodeFont;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
@@ -1798,7 +1798,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
-        protected override void OnNeedPaint(object? sender, NeedLayoutEventArgs e)
+        protected override void OnNeedPaint(object sender, NeedLayoutEventArgs e)
         {
             if (IsHandleCreated && !e.NeedLayout)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonWebBrowser.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonWebBrowser.cs
@@ -23,7 +23,7 @@ namespace Krypton.Toolkit
     public class KryptonWebBrowser : WebBrowser
     {
         #region Instance Fields
-        private PaletteBase? _palette;
+        private PaletteBase _palette;
         private readonly PaletteMode _paletteMode = PaletteMode.Global;
         private KryptonContextMenu? _kryptonContextMenu;
         private IRenderer _renderer;
@@ -197,7 +197,7 @@ namespace Krypton.Toolkit
 
         /// <summary>Sets the palette being used.</summary>
         /// <param name="palette">The chosen palette.</param>
-        private void SetPalette(PaletteBase? palette)
+        private void SetPalette(PaletteBase palette)
         {
             if (palette != _palette)
             {
@@ -258,7 +258,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public PaletteBase? GetResolvedPalette() => _palette;
+        public PaletteBase GetResolvedPalette() => _palette;
 
         #endregion Palette Controls
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonWrapLabel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonWrapLabel.cs
@@ -31,8 +31,8 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Instance Fields
-        private PaletteBase? _localPalette;
-        private PaletteBase? _palette;
+        private PaletteBase _localPalette;
+        private PaletteBase _palette;
         private PaletteMode _paletteMode;
         private readonly PaletteRedirect _redirector;
         private LabelStyle _labelStyle;
@@ -323,7 +323,7 @@ namespace Krypton.Toolkit
         [Category(@"Visuals")]
         [Description(@"Custom palette applied to drawing.")]
         [DefaultValue(null)]
-        public PaletteBase? Palette
+        public PaletteBase Palette
         {
             [DebuggerStepThrough]
             get => _localPalette;
@@ -334,7 +334,7 @@ namespace Krypton.Toolkit
                 if (_localPalette != value)
                 {
                     // Remember the starting palette
-                    PaletteBase? old = _localPalette;
+                    PaletteBase old = _localPalette;
 
                     // Use the provided palette value
                     SetPalette(value);
@@ -408,7 +408,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public PaletteBase? GetResolvedPalette() => _palette;
+        public PaletteBase GetResolvedPalette() => _palette;
 
         /// <summary>
         /// Gets access to the current renderer.
@@ -416,7 +416,7 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public IRenderer? Renderer
+        public IRenderer Renderer
         {
             [DebuggerStepThrough]
             get;
@@ -784,7 +784,7 @@ namespace Krypton.Toolkit
 
         /// <summary>Sets the palette.</summary>
         /// <param name="palette">The palette.</param>
-        private void SetPalette(PaletteBase? palette)
+        private void SetPalette(PaletteBase palette)
         {
             if (palette != _palette)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/CommonDialogHandler.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/CommonDialogHandler.cs
@@ -20,7 +20,6 @@ namespace Krypton.Toolkit
     internal class CommonDialogHandler
     {
         private readonly bool _embed;
-        private readonly KryptonManager _kryptonManager;
 
         internal class Attributes
         {
@@ -49,11 +48,11 @@ namespace Krypton.Toolkit
         {
             _embed = embed;
             // Gain access to the global palette
-            _kryptonManager = new KryptonManager();
-            _backColour = _kryptonManager.GlobalPalette!.GetBackColor1(PaletteBackStyle.PanelClient, PaletteState.Normal);
-            _defaultFontColour = _kryptonManager.GlobalPalette.GetContentShortTextColor1(PaletteContentStyle.LabelNormalPanel, PaletteState.Normal);
-            _inputFontColour = _kryptonManager.GlobalPalette.GetContentShortTextColor1(PaletteContentStyle.InputControlStandalone, PaletteState.Normal);
-            _labelFont = _kryptonManager.GlobalPalette.GetContentShortTextFont(PaletteContentStyle.LabelNormalPanel, PaletteState.Normal);
+            var igp = KryptonManager.CurrentGlobalPalette!;
+            _backColour = igp.GetBackColor1(PaletteBackStyle.PanelClient, PaletteState.Normal);
+            _defaultFontColour = igp.GetContentShortTextColor1(PaletteContentStyle.LabelNormalPanel, PaletteState.Normal);
+            _inputFontColour = igp.GetContentShortTextColor1(PaletteContentStyle.InputControlStandalone, PaletteState.Normal);
+            _labelFont = igp.GetContentShortTextFont(PaletteContentStyle.LabelNormalPanel, PaletteState.Normal)!;
         }
 
         internal string Title { get; set; }
@@ -113,7 +112,7 @@ namespace Krypton.Toolkit
                         var labelLogFont = _labelFont.ToHfont();
                         //var buttonFont = _kryptonManager.GlobalPalette.GetContentShortTextFont(PaletteContentStyle.ButtonStandalone, PaletteState.Normal);
                         //var buttonLogFont = buttonFont.ToHfont();
-                        var editFont = _kryptonManager.GlobalPalette?.GetContentShortTextFont(PaletteContentStyle.InputControlStandalone, PaletteState.Normal);
+                        var editFont = KryptonManager.CurrentGlobalPalette?.GetContentShortTextFont(PaletteContentStyle.InputControlStandalone, PaletteState.Normal);
                         var editLogFont = editFont!.ToHfont();
                         foreach (Attributes control in _controls)
                         {
@@ -321,10 +320,10 @@ namespace Krypton.Toolkit
                             using (Graphics g = Graphics.FromHdc(hdc))
                             {
                                 g.SmoothingMode = SmoothingMode.AntiAlias;
-                                var lineColor = _kryptonManager.GlobalPalette!.GetBorderColor1(PaletteBorderStyle.ControlGroupBox, PaletteState.Normal);
+                                var lineColor = KryptonManager.CurrentGlobalPalette!.GetBorderColor1(PaletteBorderStyle.ControlGroupBox, PaletteState.Normal);
                                 DrawRoundedRectangle(g, new Pen(lineColor), new Point(0, 10),
                                     control.Size - new Size(1, 11), 5);
-                                var font = _kryptonManager.GlobalPalette.GetContentShortTextFont(PaletteContentStyle.LabelNormalPanel, PaletteState.Normal);
+                                var font = KryptonManager.CurrentGlobalPalette.GetContentShortTextFont(PaletteContentStyle.LabelNormalPanel, PaletteState.Normal);
                                 TextRenderer.DrawText(g, control.Text, font, new Point(4, 0), _defaultFontColour,
                                     _backColour,
                                     TextFormatFlags.HidePrefix | TextFormatFlags.NoClipping);
@@ -366,8 +365,8 @@ namespace Krypton.Toolkit
                         // Buttons with these styles are always drawn with the default system colors.
                         // Drawing push buttons requires several different brushes-face, highlight, and shadow
                         // but the WM_CTLCOLORBTN message allows only one brush to be returned.
-                        var fontColour = _kryptonManager.GlobalPalette!.GetContentShortTextColor1(PaletteContentStyle.ButtonStandalone, PaletteState.Normal);
-                        var backColour = _kryptonManager.GlobalPalette.GetBackColor1(PaletteBackStyle.ButtonStandalone, PaletteState.Normal);
+                        var fontColour = KryptonManager.CurrentGlobalPalette!.GetContentShortTextColor1(PaletteContentStyle.ButtonStandalone, PaletteState.Normal);
+                        var backColour = KryptonManager.CurrentGlobalPalette.GetBackColor1(PaletteBackStyle.ButtonStandalone, PaletteState.Normal);
                         PI.SetTextColor(wParam, ColorTranslator.ToWin32(fontColour));
                         PI.SetDCBrushColor(wParam, ColorTranslator.ToWin32(backColour));
                         PI.SetBkMode(wParam, ColorTranslator.ToWin32(Color.Transparent));

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContainerControlBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContainerControlBase.cs
@@ -30,8 +30,8 @@ namespace Krypton.Toolkit
         private bool _refreshAll;
         private bool _paintTransparent;
         private bool _evalTransparent;
-        private PaletteBase? _localPalette;
-        private PaletteBase? _palette;
+        private PaletteBase _localPalette;
+        private PaletteBase _palette;
         private PaletteMode _paletteMode;
         private readonly SimpleCall _refreshCall;
         private readonly SimpleCall _layoutCall;
@@ -315,7 +315,7 @@ namespace Krypton.Toolkit
         [Category(@"Visuals")]
         [Description(@"Custom palette applied to drawing.")]
         [DefaultValue(null)]
-        public PaletteBase? Palette
+        public PaletteBase Palette
         {
             [DebuggerStepThrough]
             get => _localPalette;
@@ -326,7 +326,7 @@ namespace Krypton.Toolkit
                 if (_localPalette != value)
                 {
                     // Remember the starting palette
-                    PaletteBase? old = _localPalette;
+                    PaletteBase old = _localPalette;
 
                     // Use the provided palette value
                     SetPalette(value);
@@ -372,7 +372,7 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public IRenderer? Renderer
+        public IRenderer Renderer
         {
             [DebuggerStepThrough]
             get;
@@ -420,7 +420,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public PaletteBase? GetResolvedPalette() => _palette;
+        public PaletteBase GetResolvedPalette() => _palette;
 
         /// <summary>
         /// Gets and sets the dirty palette counter.
@@ -471,7 +471,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the palette redirector.
         /// </summary>
-        protected PaletteRedirect? Redirector
+        protected PaletteRedirect Redirector
         {
             [DebuggerStepThrough]
             get;
@@ -659,7 +659,7 @@ namespace Krypton.Toolkit
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
         /// <exception cref="ArgumentNullException"></exception>
-        protected virtual void OnNeedPaint(object? sender, [DisallowNull] NeedLayoutEventArgs e)
+        protected virtual void OnNeedPaint(object sender, [DisallowNull] NeedLayoutEventArgs e)
         {
             Debug.Assert(e != null);
 
@@ -710,7 +710,7 @@ namespace Krypton.Toolkit
         /// Create the redirector instance.
         /// </summary>
         /// <returns>PaletteRedirect derived class.</returns>
-        protected virtual PaletteRedirect? CreateRedirector() => new PaletteRedirect(_palette);
+        protected virtual PaletteRedirect CreateRedirector() => new PaletteRedirect(_palette);
         // ReSharper restore VirtualMemberNeverOverridden.Global
         #endregion
 
@@ -1075,7 +1075,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void SetPalette(PaletteBase? palette)
+        private void SetPalette(PaletteBase palette)
         {
             if (palette != _palette)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContextMenu.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContextMenu.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit
     {
         #region Instance Fields
         private readonly KryptonContextMenu? _contextMenu;
-        private PaletteBase? _palette;
+        private PaletteBase _palette;
         private readonly ContextMenuProvider _provider;
         private ViewDrawDocker _drawDocker;
         private readonly ViewLayoutStack _viewColumns;
@@ -70,9 +70,9 @@ namespace Krypton.Toolkit
         /// <param name="enabled">Enabled state of the context menu.</param>
         /// <param name="keyboardActivated">Was the context menu activate by a keyboard action.</param>
         public VisualContextMenu(KryptonContextMenu contextMenu,
-                                 PaletteBase? palette,
+                                 PaletteBase palette,
                                  PaletteMode paletteMode,
-                                 PaletteRedirect? redirector,
+                                 PaletteRedirect redirector,
                                  PaletteRedirectContextMenu redirectorImages,
                                  KryptonContextMenuCollection items,
                                  bool enabled,
@@ -350,7 +350,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the palette redirector.
         /// </summary>
-        protected PaletteRedirect? Redirector
+        protected PaletteRedirect Redirector
         {
             [DebuggerStepThrough]
             get;
@@ -469,7 +469,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void SetPalette(PaletteBase? palette)
+        private void SetPalette(PaletteBase palette)
         {
             if (palette != _palette)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContextMenuDTP.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContextMenuDTP.cs
@@ -35,9 +35,9 @@ namespace Krypton.Toolkit
         /// <param name="keyboardActivated">Was the context menu activate by a keyboard action.</param>
         /// <param name="dropScreenRect">Screen rectangle of the drop down button.</param>
         public VisualContextMenuDTP(KryptonContextMenu contextMenu,
-                                    PaletteBase? palette,
+                                    PaletteBase palette,
                                     PaletteMode paletteMode,
-                                    PaletteRedirect? redirector,
+                                    PaletteRedirect redirector,
                                     PaletteRedirectContextMenu redirectorImages,
                                     KryptonContextMenuCollection items,
                                     bool enabled,

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPanel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPanel.cs
@@ -34,8 +34,8 @@ namespace Krypton.Toolkit
         private bool _evalTransparent;
         private bool _globalEvents;
         private Size _lastLayoutSize;
-        private PaletteBase? _localPalette;
-        private PaletteBase? _palette;
+        private PaletteBase _localPalette;
+        private PaletteBase _palette;
         private PaletteMode _paletteMode;
         private readonly SimpleCall _refreshCall;
         private KryptonContextMenu? _kryptonContextMenu;
@@ -353,7 +353,7 @@ namespace Krypton.Toolkit
         [Category(@"Visuals")]
         [Description(@"Custom palette applied to drawing.")]
         [DefaultValue(null)]
-        public PaletteBase? Palette
+        public PaletteBase Palette
         {
             [DebuggerStepThrough]
             get => _localPalette;
@@ -364,7 +364,7 @@ namespace Krypton.Toolkit
                 if (_localPalette != value)
                 {
                     // Remember the starting palette
-                    PaletteBase? old = _localPalette;
+                    PaletteBase old = _localPalette;
 
                     // Use the provided palette value
                     SetPalette(value);
@@ -410,7 +410,7 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public IRenderer? Renderer
+        public IRenderer Renderer
         {
             [DebuggerStepThrough]
             get;
@@ -615,7 +615,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the palette redirector.
         /// </summary>
-        protected PaletteRedirect? Redirector
+        protected PaletteRedirect Redirector
         {
             [DebuggerStepThrough]
             get;
@@ -636,7 +636,7 @@ namespace Krypton.Toolkit
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
         /// <exception cref="ArgumentNullException"></exception>
-        protected void OnNeedPaint(object? sender, [DisallowNull] NeedLayoutEventArgs e)
+        protected void OnNeedPaint(object sender, [DisallowNull] NeedLayoutEventArgs e)
         {
             Debug.Assert(e != null);
 
@@ -704,7 +704,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public PaletteBase? GetResolvedPalette() => _palette;
+        public PaletteBase GetResolvedPalette() => _palette;
 
         #endregion
 
@@ -1060,7 +1060,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void SetPalette(PaletteBase? palette)
+        private void SetPalette(PaletteBase palette)
         {
             if (palette != _palette)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPopup.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPopup.cs
@@ -42,7 +42,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="renderer">Drawing renderer.</param>
         /// <param name="shadow">Does the popup need a shadow effect.</param>
-        public VisualPopup(IRenderer? renderer,
+        public VisualPopup(IRenderer renderer,
                            bool shadow)
             : this(new ViewManager(), renderer, shadow)
         {
@@ -55,7 +55,7 @@ namespace Krypton.Toolkit
         /// <param name="renderer">Drawing renderer.</param>
         /// <param name="shadow">Does the popup need a shadow effect.</param>
         public VisualPopup(ViewManager viewManager,
-                           IRenderer? renderer,
+                           IRenderer renderer,
                            bool shadow)
         {
             #region Default ControlStyle Values
@@ -292,7 +292,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public virtual PaletteBase? GetResolvedPalette() => null;
+        public virtual PaletteBase GetResolvedPalette() => null;
 
         /// <summary>
         /// Gets access to the current renderer.
@@ -300,7 +300,7 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public IRenderer? Renderer
+        public IRenderer Renderer
         {
             [DebuggerStepThrough]
             get;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPopupTooltip.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPopupTooltip.cs
@@ -32,7 +32,7 @@ namespace Krypton.Toolkit
         /// <param name="contentValues">Source of content values.</param>
         /// <param name="renderer">Drawing renderer.</param>
         /// <param name="shadow">Does the Tooltip need a shadow effect.</param>
-        public VisualPopupToolTip(PaletteRedirect? redirector,
+        public VisualPopupToolTip(PaletteRedirect redirector,
             IContentValues contentValues,
             IRenderer renderer,
             bool shadow)
@@ -54,9 +54,9 @@ namespace Krypton.Toolkit
         /// <param name="borderStyle">Style for the tooltip border.</param>
         /// <param name="contentStyle">Style for the tooltip content.</param>
         /// <param name="shadow">Does the Tooltip need a shadow effect.</param>
-        public VisualPopupToolTip([DisallowNull] PaletteRedirect? redirector,
+        public VisualPopupToolTip([DisallowNull] PaletteRedirect redirector,
             [DisallowNull] IContentValues contentValues,
-                                    IRenderer? renderer,
+                                    IRenderer renderer,
                                     PaletteBackStyle backStyle,
                                     PaletteBorderStyle borderStyle,
                                     PaletteContentStyle contentStyle,

--- a/Source/Krypton Components/Krypton.Toolkit/Converters/ButtonStyleConverter.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Converters/ButtonStyleConverter.cs
@@ -20,7 +20,8 @@ namespace Krypton.Toolkit
         #region Static Fields
 
         [Localizable(true)]
-        private static readonly IReadOnlyDictionary<ButtonStyle, string> _pairs = new Dictionary<ButtonStyle, string>
+        private static readonly BiDictionary<ButtonStyle, string> _pairs = new BiDictionary<ButtonStyle, string>(
+            new Dictionary<ButtonStyle, string>
         {
             {ButtonStyle.Standalone, DesignTimeUtilities.DEFAULT_BUTTON_SPEC_STYLE_STANDALONE},
             {ButtonStyle.Alternate, DesignTimeUtilities.DEFAULT_BUTTON_SPEC_STYLE_ALTERNATE},
@@ -41,7 +42,7 @@ namespace Krypton.Toolkit
             {ButtonStyle.Custom1, DesignTimeUtilities.DEFAULT_BUTTON_SPEC_STYLE_CUSTOM_ONE},
             {ButtonStyle.Custom2, DesignTimeUtilities.DEFAULT_BUTTON_SPEC_STYLE_CUSTOM_TWO},
             {ButtonStyle.Custom3, DesignTimeUtilities.DEFAULT_BUTTON_SPEC_STYLE_CUSTOM_THREE}
-        };
+        });
 
         #endregion
 
@@ -50,7 +51,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets an array of lookup pairs.
         /// </summary>
-        protected override IReadOnlyDictionary<ButtonStyle /*Enum*/, string /*Display*/> Pairs => _pairs;
+        protected override IReadOnlyDictionary<ButtonStyle /*Enum*/, string /*Display*/> PairsEnumToString => _pairs.FirstToSecond;
+        protected override IReadOnlyDictionary<string /*Display*/, ButtonStyle /*Enum*/ > PairsStringToEnum => _pairs.SecondToFirst;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Converters/DataGridViewStyleConverter.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Converters/DataGridViewStyleConverter.cs
@@ -20,7 +20,8 @@ namespace Krypton.Toolkit
         #region Static Fields
 
         [Localizable(true)]
-        private static readonly IReadOnlyDictionary<DataGridViewStyle, string> _pairs = new Dictionary<DataGridViewStyle, string>
+        private static readonly BiDictionary<DataGridViewStyle, string> _pairs = new BiDictionary<DataGridViewStyle, string>( 
+            new Dictionary<DataGridViewStyle, string>
         {
             {DataGridViewStyle.List, DesignTimeUtilities.DEFAULT_DATA_GRID_VIEW_STYLE_LIST},
             {DataGridViewStyle.Sheet, DesignTimeUtilities.DEFAULT_DATA_GRID_VIEW_STYLE_SHEET},
@@ -28,7 +29,7 @@ namespace Krypton.Toolkit
             {DataGridViewStyle.Custom2, DesignTimeUtilities.DEFAULT_DATA_GRID_VIEW_STYLE_CUSTOM_TWO},
             {DataGridViewStyle.Custom3, DesignTimeUtilities.DEFAULT_DATA_GRID_VIEW_STYLE_CUSTOM_THREE},
             {DataGridViewStyle.Mixed, DesignTimeUtilities.DEFAULT_DATA_GRID_VIEW_STYLE_MIXED}
-        };
+        });
 
         #endregion
 
@@ -37,7 +38,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets an array of lookup pairs.
         /// </summary>
-        protected override IReadOnlyDictionary<DataGridViewStyle /*Enum*/, string /*Display*/> Pairs => _pairs;
+        protected override IReadOnlyDictionary<DataGridViewStyle /*Enum*/, string /*Display*/> PairsEnumToString => _pairs.FirstToSecond;
+        protected override IReadOnlyDictionary<string /*Display*/, DataGridViewStyle /*Enum*/ > PairsStringToEnum => _pairs.SecondToFirst;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Converters/GridStyleConverter.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Converters/GridStyleConverter.cs
@@ -20,14 +20,15 @@ namespace Krypton.Toolkit
         #region Static Fields
 
         [Localizable(true)]
-        private static readonly IReadOnlyDictionary<GridStyle, string> _pairs = new Dictionary<GridStyle, string>
+        private static readonly BiDictionary<GridStyle, string> _pairs = new BiDictionary<GridStyle, string>( 
+            new Dictionary<GridStyle, string>
         {
             {GridStyle.List, DesignTimeUtilities.DEFAULT_GRID_STYLE_LIST},
             {GridStyle.Sheet, DesignTimeUtilities.DEFAULT_GRID_STYLE_SHEET},
             {GridStyle.Custom1, DesignTimeUtilities.DEFAULT_GRID_STYLE_CUSTOM_ONE},
             {GridStyle.Custom2, DesignTimeUtilities.DEFAULT_GRID_STYLE_CUSTOM_TWO},
             {GridStyle.Custom3, DesignTimeUtilities.DEFAULT_GRID_STYLE_CUSTOM_THREE}
-        };
+        });
 
         #endregion
 
@@ -36,7 +37,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets an array of lookup pairs.
         /// </summary>
-        protected override IReadOnlyDictionary<GridStyle /*Enum*/, string /*Display*/> Pairs => _pairs;
+        protected override IReadOnlyDictionary<GridStyle /*Enum*/, string /*Display*/> PairsEnumToString => _pairs.FirstToSecond;
+        protected override IReadOnlyDictionary<string /*Display*/, GridStyle /*Enum*/ > PairsStringToEnum => _pairs.SecondToFirst;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Converters/HeaderGroupCollapseTargetConverter.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Converters/HeaderGroupCollapseTargetConverter.cs
@@ -20,12 +20,13 @@ namespace Krypton.Toolkit
         #region Static Fields
 
         [Localizable(true)]
-        private static readonly IReadOnlyDictionary<HeaderGroupCollapsedTarget, string> _pairs = new Dictionary<HeaderGroupCollapsedTarget, string>
+        private static readonly BiDictionary<HeaderGroupCollapsedTarget, string> _pairs = new BiDictionary<HeaderGroupCollapsedTarget, string>(
+            new Dictionary<HeaderGroupCollapsedTarget, string>
         {
             { HeaderGroupCollapsedTarget.CollapsedToPrimary, DesignTimeUtilities.DEFAULT_HEADER_GROUP_COLLAPSED_TARGET_COLLAPSED_TO_PRIMARY},
             {HeaderGroupCollapsedTarget.CollapsedToSecondary, DesignTimeUtilities.DEFAULT_HEADER_GROUP_COLLAPSED_TARGET_COLLAPSED_TO_SECONDARY},
             {HeaderGroupCollapsedTarget.CollapsedToBoth, DesignTimeUtilities.DEFAULT_HEADER_GROUP_COLLAPSED_TARGET_COLLAPSED_TO_BOTH}
-        };
+        });
 
         #endregion
 
@@ -34,7 +35,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets an array of lookup pairs.
         /// </summary>
-        protected override IReadOnlyDictionary<HeaderGroupCollapsedTarget /*Enum*/, string /*Display*/> Pairs => _pairs;
+        protected override IReadOnlyDictionary<HeaderGroupCollapsedTarget /*Enum*/, string /*Display*/> PairsEnumToString => _pairs.FirstToSecond;
+        protected override IReadOnlyDictionary<string /*Display*/, HeaderGroupCollapsedTarget /*Enum*/ > PairsStringToEnum => _pairs.SecondToFirst;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Converters/HeaderStyleConverter.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Converters/HeaderStyleConverter.cs
@@ -20,7 +20,8 @@ namespace Krypton.Toolkit
         #region Static Fields
 
         [Localizable(true)]
-        private static readonly IReadOnlyDictionary<HeaderStyle, string> _pairs = new Dictionary<HeaderStyle, string>
+        private static readonly BiDictionary<HeaderStyle, string> _pairs = new BiDictionary<HeaderStyle, string>(
+            new Dictionary<HeaderStyle, string>
         {
             {HeaderStyle.Primary, DesignTimeUtilities.DEFAULT_HEADER_STYLE_PRIMARY},
             {HeaderStyle.Secondary, DesignTimeUtilities.DEFAULT_HEADER_STYLE_SECONDARY},
@@ -31,7 +32,7 @@ namespace Krypton.Toolkit
             {HeaderStyle.Custom1, DesignTimeUtilities.DEFAULT_HEADER_STYLE_CUSTOM_ONE},
             {HeaderStyle.Custom2, DesignTimeUtilities.DEFAULT_HEADER_STYLE_CUSTOM_TWO},
             {HeaderStyle.Custom3, DesignTimeUtilities.DEFAULT_HEADER_STYLE_CUSTOM_THREE}
-        };
+        });
 
         #endregion
 
@@ -39,7 +40,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets an array of lookup pairs.
         /// </summary>
-        protected override IReadOnlyDictionary<HeaderStyle /*Enum*/, string /*Display*/> Pairs => _pairs;
+        protected override IReadOnlyDictionary<HeaderStyle /*Enum*/, string /*Display*/> PairsEnumToString => _pairs.FirstToSecond;
+        protected override IReadOnlyDictionary<string /*Display*/, HeaderStyle /*Enum*/ > PairsStringToEnum => _pairs.SecondToFirst;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Converters/InputControlStyleConverter.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Converters/InputControlStyleConverter.cs
@@ -20,7 +20,8 @@ namespace Krypton.Toolkit
         #region Static Fields
 
         [Localizable(true)]
-        private static readonly IReadOnlyDictionary<InputControlStyle, string> _pairs = new Dictionary<InputControlStyle, string>
+        private static readonly BiDictionary<InputControlStyle, string> _pairs = new BiDictionary<InputControlStyle, string>(
+            new Dictionary<InputControlStyle, string>
         {
             {InputControlStyle.Standalone, DesignTimeUtilities.DEFAULT_INPUT_CONTROL_STYLE_STANDALONE},
             {InputControlStyle.Ribbon, DesignTimeUtilities.DEFAULT_INPUT_CONTROL_STYLE_RIBBON},
@@ -30,7 +31,7 @@ namespace Krypton.Toolkit
             {InputControlStyle.PanelClient, DesignTimeUtilities.DEFAULT_INPUT_CONTROL_STYLE_PANEL_CLIENT},
             {InputControlStyle.PanelAlternate, DesignTimeUtilities.DEFAULT_INPUT_CONTROL_STYLE_PANEL_ALTERNATE},
             // new(InputControlStyle.Disabled, "Disabled")
-        };
+        });
 
         #endregion
 
@@ -38,7 +39,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets an array of lookup pairs.
         /// </summary>
-        protected override IReadOnlyDictionary<InputControlStyle /*Enum*/, string /*Display*/> Pairs => _pairs;
+        protected override IReadOnlyDictionary<InputControlStyle /*Enum*/, string /*Display*/> PairsEnumToString => _pairs.FirstToSecond;
+        protected override IReadOnlyDictionary<string /*Display*/, InputControlStyle /*Enum*/ > PairsStringToEnum => _pairs.SecondToFirst;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Converters/KryptonLinkBehaviorConverter.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Converters/KryptonLinkBehaviorConverter.cs
@@ -20,12 +20,13 @@ namespace Krypton.Toolkit
         #region Static Fields
 
         [Localizable(true)]
-        private static readonly IReadOnlyDictionary<KryptonLinkBehavior, string> _pairs = new Dictionary<KryptonLinkBehavior, string>
+        private static readonly BiDictionary<KryptonLinkBehavior, string> _pairs = new BiDictionary<KryptonLinkBehavior, string>(
+            new Dictionary<KryptonLinkBehavior, string>
         {
             {KryptonLinkBehavior.AlwaysUnderline, DesignTimeUtilities.DEFAULT_LINK_BEHAVIOR_ALWAYS_UNDERLINE},
             {KryptonLinkBehavior.HoverUnderline, DesignTimeUtilities.DEFAULT_LINK_BEHAVIOR_HOVER_UNDERLINE},
             {KryptonLinkBehavior.NeverUnderline, DesignTimeUtilities.DEFAULT_LINK_BEHAVIOR_NEVER_UNDERLINE}
-        };
+        });
 
         #endregion
 
@@ -33,7 +34,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets an array of lookup pairs.
         /// </summary>
-        protected override IReadOnlyDictionary<KryptonLinkBehavior /*Enum*/, string /*Display*/> Pairs => _pairs;
+        protected override IReadOnlyDictionary<KryptonLinkBehavior /*Enum*/, string /*Display*/> PairsEnumToString => _pairs.FirstToSecond;
+        protected override IReadOnlyDictionary<string /*Display*/, KryptonLinkBehavior /*Enum*/ > PairsStringToEnum => _pairs.SecondToFirst;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Converters/LabelStyleConverter.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Converters/LabelStyleConverter.cs
@@ -20,7 +20,8 @@ namespace Krypton.Toolkit
         #region Static Fields
 
         [Localizable(true)]
-        private static readonly IReadOnlyDictionary<LabelStyle, string> _pairs = new Dictionary<LabelStyle, string>
+        private static readonly BiDictionary<LabelStyle, string> _pairs = new BiDictionary<LabelStyle, string>(
+            new Dictionary<LabelStyle, string>
         {
             {LabelStyle.AlternateControl, DesignTimeUtilities.DEFAULT_LABEL_STYLE_ALTERNATE_CONTROL},
             {LabelStyle.NormalControl, DesignTimeUtilities.DEFAULT_LABEL_STYLE_NORMAL_CONTROL},
@@ -39,7 +40,7 @@ namespace Krypton.Toolkit
             {LabelStyle.Custom1, DesignTimeUtilities.DEFAULT_LABEL_STYLE_CUSTOM_ONE},
             {LabelStyle.Custom2, DesignTimeUtilities.DEFAULT_LABEL_STYLE_CUSTOM_TWO},
             {LabelStyle.Custom3, DesignTimeUtilities.DEFAULT_LABEL_STYLE_CUSTOM_THREE}
-        };
+        });
 
         #endregion
 
@@ -48,7 +49,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets an array of lookup pairs.
         /// </summary>
-        protected override IReadOnlyDictionary<LabelStyle /*Enum*/, string /*Display*/> Pairs => _pairs;
+        protected override IReadOnlyDictionary<LabelStyle /*Enum*/, string /*Display*/> PairsEnumToString => _pairs.FirstToSecond;
+        protected override IReadOnlyDictionary<string /*Display*/, LabelStyle /*Enum*/ > PairsStringToEnum => _pairs.SecondToFirst;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Converters/PaletteBackStyleConverter.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Converters/PaletteBackStyleConverter.cs
@@ -20,7 +20,8 @@ namespace Krypton.Toolkit
         #region Static Fields
 
         [Localizable(true)]
-        private static readonly IReadOnlyDictionary<PaletteBackStyle, string> _pairs = new Dictionary<PaletteBackStyle, string>
+        private static readonly BiDictionary<PaletteBackStyle, string> _pairs = new BiDictionary<PaletteBackStyle, string>(
+            new Dictionary<PaletteBackStyle, string>
         {
             {PaletteBackStyle.ButtonStandalone, DesignTimeUtilities.DEFAULT_BUTTON_STANDALONE},
             {PaletteBackStyle.ButtonAlternate, DesignTimeUtilities.DEFAULT_BUTTON_ALTERNATE},
@@ -115,7 +116,7 @@ namespace Krypton.Toolkit
             {PaletteBackStyle.TabCustom2, DesignTimeUtilities.DEFAULT_TAB_CUSTOM2},
             {PaletteBackStyle.TabCustom3, DesignTimeUtilities.DEFAULT_TAB_CUSTOM3},
             {PaletteBackStyle.Control, DesignTimeUtilities.DEFAULT_CONTROL}
-        };
+        });
 
         #endregion
 
@@ -124,7 +125,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets an array of lookup pairs.
         /// </summary>
-        protected override IReadOnlyDictionary<PaletteBackStyle /*Enum*/, string /*Display*/> Pairs => _pairs;
+        protected override IReadOnlyDictionary<PaletteBackStyle /*Enum*/, string /*Display*/> PairsEnumToString => _pairs.FirstToSecond;
+        protected override IReadOnlyDictionary<string /*Display*/, PaletteBackStyle /*Enum*/ > PairsStringToEnum => _pairs.SecondToFirst;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Converters/PaletteBorderStyleConverter.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Converters/PaletteBorderStyleConverter.cs
@@ -20,7 +20,8 @@ namespace Krypton.Toolkit
         #region Static Fields
 
         [Localizable(true)]
-        private static readonly IReadOnlyDictionary<PaletteBorderStyle, string> _pairs = new Dictionary<PaletteBorderStyle, string>
+        private static readonly BiDictionary<PaletteBorderStyle, string> _pairs = new BiDictionary<PaletteBorderStyle, string>(
+            new Dictionary<PaletteBorderStyle, string>
         {
             {PaletteBorderStyle.ButtonStandalone, DesignTimeUtilities.DEFAULT_PALETTE_BORDER_BUTTON_STANDALONE},
             {PaletteBorderStyle.ButtonAlternate, DesignTimeUtilities.DEFAULT_PALETTE_BORDER_BUTTON_ALTERNATE},
@@ -103,7 +104,7 @@ namespace Krypton.Toolkit
             {PaletteBorderStyle.TabCustom1, DesignTimeUtilities.DEFAULT_PALETTE_BORDER_TAB_CUSTOM1},
             {PaletteBorderStyle.TabCustom2, DesignTimeUtilities.DEFAULT_PALETTE_BORDER_TAB_CUSTOM2},
             {PaletteBorderStyle.TabCustom3, DesignTimeUtilities.DEFAULT_PALETTE_BORDER_TAB_CUSTOM3},
-        };
+        });
 
         #endregion
 
@@ -112,7 +113,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets an array of lookup pairs.
         /// </summary>
-        protected override IReadOnlyDictionary<PaletteBorderStyle /*Enum*/, string /*Display*/> Pairs => _pairs;
+        protected override IReadOnlyDictionary<PaletteBorderStyle /*Enum*/, string /*Display*/> PairsEnumToString => _pairs.FirstToSecond;
+        protected override IReadOnlyDictionary<string /*Display*/, PaletteBorderStyle /*Enum*/ > PairsStringToEnum => _pairs.SecondToFirst;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Converters/PaletteButtonOrientationConverter.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Converters/PaletteButtonOrientationConverter.cs
@@ -20,7 +20,8 @@ namespace Krypton.Toolkit
         #region Static Fields
 
         [Localizable(true)]
-        private static readonly IReadOnlyDictionary<PaletteButtonOrientation, string> _pairs = new Dictionary<PaletteButtonOrientation, string>
+        private static readonly BiDictionary<PaletteButtonOrientation, string> _pairs = new BiDictionary<PaletteButtonOrientation, string>(
+            new Dictionary<PaletteButtonOrientation, string>
         {
             {PaletteButtonOrientation.Inherit, DesignTimeUtilities.DEFAULT_PALETTE_BUTTON_ORIENTATION_INHERIT},
             {PaletteButtonOrientation.Auto, DesignTimeUtilities.DEFAULT_PALETTE_BUTTON_ORIENTATION_AUTO},
@@ -28,7 +29,7 @@ namespace Krypton.Toolkit
             {PaletteButtonOrientation.FixedBottom, DesignTimeUtilities.DEFAULT_PALETTE_BUTTON_ORIENTATION_FIXED_BOTTOM},
             {PaletteButtonOrientation.FixedLeft, DesignTimeUtilities.DEFAULT_PALETTE_BUTTON_ORIENTATION_FIXED_LEFT},
             {PaletteButtonOrientation.FixedRight, DesignTimeUtilities.DEFAULT_PALETTE_BUTTON_ORIENTATION_FIXED_RIGHT}
-        };
+        });
 
         #endregion
 
@@ -36,7 +37,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets an array of lookup pairs.
         /// </summary>
-        protected override IReadOnlyDictionary<PaletteButtonOrientation /*Enum*/, string /*Display*/> Pairs => _pairs;
+        protected override IReadOnlyDictionary<PaletteButtonOrientation /*Enum*/, string /*Display*/> PairsEnumToString => _pairs.FirstToSecond;
+        protected override IReadOnlyDictionary<string /*Display*/, PaletteButtonOrientation /*Enum*/ > PairsStringToEnum => _pairs.SecondToFirst;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Converters/PaletteButtonSpecStyleConverter.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Converters/PaletteButtonSpecStyleConverter.cs
@@ -20,7 +20,8 @@ namespace Krypton.Toolkit
         #region Static Fields
 
         [Localizable(true)]
-        private static readonly IReadOnlyDictionary<PaletteButtonSpecStyle, string> _pairs = new Dictionary<PaletteButtonSpecStyle, string>
+        private static readonly BiDictionary<PaletteButtonSpecStyle, string> _pairs = new BiDictionary<PaletteButtonSpecStyle, string>(
+            new Dictionary<PaletteButtonSpecStyle, string>
         {
             {PaletteButtonSpecStyle.Close, DesignTimeUtilities.DEFAULT_PALETTE_BUTTON_SPEC_STYLE_CLOSE},
             {PaletteButtonSpecStyle.Context, DesignTimeUtilities.DEFAULT_PALETTE_BUTTON_SPEC_STYLE_CONTEXT},
@@ -60,7 +61,7 @@ namespace Krypton.Toolkit
             {PaletteButtonSpecStyle.PrintPreview, DesignTimeUtilities.DEFAULT_PALETTE_BUTTON_SPEC_STYLE_PRINT_PREVIEW},
             {PaletteButtonSpecStyle.Print, DesignTimeUtilities.DEFAULT_PALETTE_BUTTON_SPEC_STYLE_PRINT},
             {PaletteButtonSpecStyle.QuickPrint, DesignTimeUtilities.DEFAULT_PALETTE_BUTTON_SPEC_STYLE_QUICK_PRINT}
-        };
+        });
 
         #endregion
 
@@ -69,7 +70,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets an array of lookup pairs.
         /// </summary>
-        protected override IReadOnlyDictionary<PaletteButtonSpecStyle /*Enum*/, string /*Display*/> Pairs => _pairs;
+        protected override IReadOnlyDictionary<PaletteButtonSpecStyle /*Enum*/, string /*Display*/> PairsEnumToString => _pairs.FirstToSecond;
+        protected override IReadOnlyDictionary<string /*Display*/, PaletteButtonSpecStyle /*Enum*/ > PairsStringToEnum => _pairs.SecondToFirst;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Converters/PaletteButtonStyleConverter.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Converters/PaletteButtonStyleConverter.cs
@@ -20,7 +20,8 @@ namespace Krypton.Toolkit
         #region Static Fields
 
         [Localizable(true)]
-        private static readonly IReadOnlyDictionary<PaletteButtonStyle, string> _pairs = new Dictionary<PaletteButtonStyle, string>
+        private static readonly BiDictionary<PaletteButtonStyle, string> _pairs = new BiDictionary<PaletteButtonStyle, string>(
+            new Dictionary<PaletteButtonStyle, string>
         {
             {PaletteButtonStyle.Inherit, DesignTimeUtilities.DEFAULT_PALETTE_BUTTON_STYLE_INHERIT},
             {PaletteButtonStyle.Standalone, DesignTimeUtilities.DEFAULT_PALETTE_BUTTON_STYLE_STANDALONE},
@@ -40,7 +41,7 @@ namespace Krypton.Toolkit
             {PaletteButtonStyle.Custom1, DesignTimeUtilities.DEFAULT_PALETTE_BUTTON_STYLE_CUSTOM1},
             {PaletteButtonStyle.Custom2, DesignTimeUtilities.DEFAULT_PALETTE_BUTTON_STYLE_CUSTOM2},
             {PaletteButtonStyle.Custom3, DesignTimeUtilities.DEFAULT_PALETTE_BUTTON_STYLE_CUSTOM3}
-        };
+        });
 
         #endregion
 
@@ -48,7 +49,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets an array of lookup pairs.
         /// </summary>
-        protected override IReadOnlyDictionary<PaletteButtonStyle /*Enum*/, string /*Display*/> Pairs => _pairs;
+        protected override IReadOnlyDictionary<PaletteButtonStyle /*Enum*/, string /*Display*/> PairsEnumToString => _pairs.FirstToSecond;
+        protected override IReadOnlyDictionary<string /*Display*/, PaletteButtonStyle /*Enum*/ > PairsStringToEnum => _pairs.SecondToFirst;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Converters/PaletteClassTypeConverter.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Converters/PaletteClassTypeConverter.cs
@@ -1,0 +1,127 @@
+﻿namespace Krypton.Toolkit.Converters;
+
+/// <summary>
+/// Custom type converter so that PaletteBase Class type are converted to their appropriate mode type
+/// </summary>
+internal class PaletteClassTypeConverter : EnumConverter
+{
+    #region Static Fields
+
+    [Localizable(true)]
+    private static readonly BiDictionary<PaletteMode, Type> _pairs = new BiDictionary<PaletteMode, Type>
+    (new Dictionary<PaletteMode, Type>
+        {
+            {PaletteMode.ProfessionalSystem, typeof(PaletteProfessionalSystem)},
+            {PaletteMode.ProfessionalOffice2003, typeof(PaletteProfessionalOffice2003)},
+            {PaletteMode.Office2007Blue, typeof(PaletteOffice2007Blue)},
+            {PaletteMode.Office2007DarkGray, typeof(PaletteOffice2007DarkGray)},
+            {PaletteMode.Office2007BlueDarkMode, typeof(PaletteOffice2007BlueDarkMode)},
+            {PaletteMode.Office2007BlueLightMode, typeof(PaletteOffice2007BlueLightMode)},
+            {PaletteMode.Office2007Silver, typeof(PaletteOffice2007Silver)},
+            {PaletteMode.Office2007SilverDarkMode, typeof(PaletteOffice2007SilverDarkMode)},
+            {PaletteMode.Office2007SilverLightMode, typeof(PaletteOffice2007SilverLightMode)},
+            {PaletteMode.Office2007White, typeof(PaletteOffice2007White)},
+            {PaletteMode.Office2007Black, typeof(PaletteOffice2007Black)},
+            {PaletteMode.Office2010DarkGray, typeof(PaletteOffice2010DarkGray)},
+            {PaletteMode.Office2007BlackDarkMode, typeof(PaletteOffice2007BlackDarkMode)},
+            {PaletteMode.Office2010Blue, typeof(PaletteOffice2010Blue)},
+            {PaletteMode.Office2010BlueDarkMode, typeof(PaletteOffice2010BlueDarkMode)},
+            {PaletteMode.Office2010BlueLightMode, typeof(PaletteOffice2010BlueLightMode)},
+            {PaletteMode.Office2010Silver, typeof(PaletteOffice2010Silver)},
+            {PaletteMode.Office2010SilverDarkMode, typeof(PaletteOffice2010SilverDarkMode)},
+            {PaletteMode.Office2010SilverLightMode, typeof(PaletteOffice2010SilverLightMode)},
+            {PaletteMode.Office2010White, typeof(PaletteOffice2010White)},
+            {PaletteMode.Office2010Black, typeof(PaletteOffice2010Black)},
+            {PaletteMode.Office2010BlackDarkMode, typeof(PaletteOffice2010BlackDarkMode)},
+            {PaletteMode.Office2013LightGray, typeof(PaletteOffice2013LightGray)},
+            {PaletteMode.Office2013White, typeof(PaletteOffice2013White)},
+            {PaletteMode.SparkleBlue, typeof(PaletteSparkleBlue)},
+            {PaletteMode.SparkleBlueDarkMode, typeof(PaletteSparkleBlueDarkMode)},
+            {PaletteMode.SparkleBlueLightMode, typeof(PaletteSparkleBlueLightMode)},
+            {PaletteMode.SparkleOrange, typeof(PaletteSparkleOrange)},
+            {PaletteMode.SparkleOrangeDarkMode, typeof(PaletteSparkleOrangeDarkMode)},
+            {PaletteMode.SparkleOrangeLightMode, typeof(PaletteSparkleOrangeLightMode)},
+            {PaletteMode.SparklePurple, typeof(PaletteSparklePurple)},
+            {PaletteMode.SparklePurpleDarkMode, typeof(PaletteSparklePurpleDarkMode)},
+            {PaletteMode.SparklePurpleLightMode, typeof(PaletteSparklePurpleLightMode)},
+            {PaletteMode.Microsoft365Black, typeof(PaletteMicrosoft365Black)},
+            {PaletteMode.Microsoft365BlackDarkMode, typeof(PaletteMicrosoft365BlackDarkMode)},
+            {PaletteMode.Microsoft365BlueDarkMode, typeof(PaletteMicrosoft365BlueDarkMode)},
+            {PaletteMode.Microsoft365BlueLightMode, typeof(PaletteMicrosoft365BlueLightMode)},
+            {PaletteMode.Microsoft365Blue, typeof(PaletteMicrosoft365Blue)},
+            {PaletteMode.Microsoft365DarkGray, typeof(PaletteMicrosoft365DarkGray)},
+            {PaletteMode.Microsoft365Silver, typeof(PaletteMicrosoft365Silver)},
+            {PaletteMode.Microsoft365SilverDarkMode, typeof(PaletteMicrosoft365SilverDarkMode)},
+            {PaletteMode.Microsoft365SilverLightMode, typeof(PaletteMicrosoft365SilverLightMode)},
+            {PaletteMode.Microsoft365White, typeof(PaletteMicrosoft365White)},
+            {PaletteMode.VisualStudio2010Render2007, typeof(PaletteVisualStudio2010Office2007Variation)},
+            {PaletteMode.VisualStudio2010Render2010, typeof(PaletteVisualStudio2010Office2010Variation)},
+            {PaletteMode.VisualStudio2010Render2013, typeof(PaletteVisualStudio2010Office2013Variation)},
+            {PaletteMode.VisualStudio2010Render365, typeof(PaletteVisualStudio2010Microsoft365Variation)},
+            //{PaletteMode.Custom, typeof(KryptonCustomPaletteBase)}
+        });
+
+    #endregion
+
+    #region Identity
+    /// <summary>
+    /// Initialize a new instance of the PaletteClassTypeConverter class.
+    /// </summary>
+    public PaletteClassTypeConverter()
+        : base(typeof(PaletteMode))
+    {
+    }
+    #endregion
+
+    #region Public
+    /// <summary>
+    /// Converts the given value object to the specified type, using the specified context and culture information.
+    /// </summary>
+    /// <param name="context">An ITypeDescriptorContext that provides a format context.</param>
+    /// <param name="culture">A CultureInfo object. If a null reference the current culture is assumed.</param>
+    /// <param name="value">The Object to convert.</param>
+    /// <param name="destinationType">The Type to convert the value parameter to.</param>
+    /// <returns>An Object that represents the converted value.</returns>
+    public override object? ConvertTo(ITypeDescriptorContext? context,
+                                     CultureInfo? culture,
+                                     object? value,
+                                     Type destinationType)
+    {
+        if (value is PaletteMode val)
+        {
+            // Search for a matching value
+            if (_pairs.FirstToSecond.TryGetValue(val, out var classType))
+            {
+                return classType;
+            }
+        }
+
+        // Let base class perform default conversion
+        return base.ConvertTo(context, culture, value, destinationType);
+    }
+
+    /// <summary>
+    /// Converts the given object to the type of this converter, using the specified context and culture information.
+    /// </summary>
+    /// <param name="context">An ITypeDescriptorContext that provides a format context.</param>
+    /// <param name="culture">The CultureInfo to use as the current culture.</param>
+    /// <param name="value">The Object to convert.</param>
+    /// <returns>An Object that represents the converted value.</returns>
+    public override object? ConvertFrom(ITypeDescriptorContext? context,
+        CultureInfo? culture,
+        object? value)
+    {
+        if (value is Type val)
+        {
+            // Search for a matching Class
+            if( _pairs.SecondToFirst.TryGetValue(val, out var mode))
+            {
+                return mode;
+            }
+        }
+
+        // Let base class perform default conversion
+        return base.ConvertFrom(context!, culture!, value);
+    }
+    #endregion
+}

--- a/Source/Krypton Components/Krypton.Toolkit/Converters/PaletteContentStyleConverter.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Converters/PaletteContentStyleConverter.cs
@@ -20,7 +20,8 @@ namespace Krypton.Toolkit
         #region Static Fields
 
         [Localizable(true)]
-        private static readonly IReadOnlyDictionary<PaletteContentStyle, string> _pairs = new Dictionary<PaletteContentStyle, string>
+        private static readonly BiDictionary<PaletteContentStyle, string> _pairs = new BiDictionary<PaletteContentStyle, string>(
+            new Dictionary<PaletteContentStyle, string>
         {
             {PaletteContentStyle.ButtonStandalone, DesignTimeUtilities.DEFAULT_PALETTE_CONTENT_STYLE_BUTTON_STANDALONE},
             {PaletteContentStyle.ButtonLowProfile, DesignTimeUtilities.DEFAULT_PALETTE_CONTENT_STYLE_BUTTON_LOW_PROFILE},
@@ -99,7 +100,7 @@ namespace Krypton.Toolkit
             {PaletteContentStyle.InputControlCustom1, DesignTimeUtilities.DEFAULT_PALETTE_CONTENT_STYLE_INPUT_CONTROL_CUSTOM1},
             {PaletteContentStyle.InputControlCustom2, DesignTimeUtilities.DEFAULT_PALETTE_CONTENT_STYLE_INPUT_CONTROL_CUSTOM2},
             {PaletteContentStyle.InputControlCustom3,DesignTimeUtilities.DEFAULT_PALETTE_CONTENT_STYLE_INPUT_CONTROL_CUSTOM3}
-        };
+        });
 
         #endregion
 
@@ -107,7 +108,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets an array of lookup pairs.
         /// </summary>
-        protected override IReadOnlyDictionary<PaletteContentStyle /*Enum*/, string /*Display*/> Pairs => _pairs;
+        protected override IReadOnlyDictionary<PaletteContentStyle /*Enum*/, string /*Display*/> PairsEnumToString => _pairs.FirstToSecond;
+        protected override IReadOnlyDictionary<string /*Display*/, PaletteContentStyle /*Enum*/ > PairsStringToEnum => _pairs.SecondToFirst;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Converters/PaletteDrawBordersConverter.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Converters/PaletteDrawBordersConverter.cs
@@ -115,7 +115,7 @@ namespace Krypton.Toolkit
         /// <returns>An Object that represents the converted value.</returns>
         public override object? ConvertFrom(ITypeDescriptorContext? context,
                                            CultureInfo? culture,
-                                           object value)
+                                           object? value)
         {
             // Convert incoming value to a string
             // We are only interested in adding functionality for converting from strings
@@ -162,7 +162,7 @@ namespace Krypton.Toolkit
             }
 
             // Let base class perform default conversion
-            return base.ConvertFrom(context, culture, value);
+            return base.ConvertFrom(context!, culture!, value);
         }
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Converters/PaletteImageEffectConverter.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Converters/PaletteImageEffectConverter.cs
@@ -20,7 +20,8 @@ namespace Krypton.Toolkit
         #region Static Fields
 
         [Localizable(true)]
-        private static readonly IReadOnlyDictionary<PaletteImageEffect, string> _pairs = new Dictionary<PaletteImageEffect, string>
+        private static readonly BiDictionary<PaletteImageEffect, string> _pairs = new BiDictionary<PaletteImageEffect, string>(
+            new Dictionary<PaletteImageEffect, string>
         {
             {PaletteImageEffect.Inherit, DesignTimeUtilities.DEFAULT_PALETTE_IMAGE_EFFECT_INHERIT},
             {PaletteImageEffect.Light, DesignTimeUtilities.DEFAULT_PALETTE_IMAGE_EFFECT_LIGHT},
@@ -33,7 +34,7 @@ namespace Krypton.Toolkit
             {PaletteImageEffect.GrayScaleRed, DesignTimeUtilities.DEFAULT_PALETTE_IMAGE_EFFECT_GRAY_SCALE_RED},
             {PaletteImageEffect.GrayScaleGreen, DesignTimeUtilities.DEFAULT_PALETTE_IMAGE_EFFECT_GRAY_SCALE_GREEN},
             {PaletteImageEffect.GrayScaleBlue, DesignTimeUtilities.DEFAULT_PALETTE_IMAGE_EFFECT_GRAY_SCALE_BLUE}
-        };
+        });
 
         #endregion
 
@@ -41,7 +42,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets an array of lookup pairs.
         /// </summary>
-        protected override IReadOnlyDictionary<PaletteImageEffect /*Enum*/, string /*Display*/> Pairs => _pairs;
+        protected override IReadOnlyDictionary<PaletteImageEffect /*Enum*/, string /*Display*/> PairsEnumToString => _pairs.FirstToSecond;
+        protected override IReadOnlyDictionary<string /*Display*/, PaletteImageEffect /*Enum*/ > PairsStringToEnum => _pairs.SecondToFirst;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Converters/PaletteImageStyleConverter.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Converters/PaletteImageStyleConverter.cs
@@ -20,7 +20,8 @@ namespace Krypton.Toolkit
         #region Static Fields
 
         [Localizable(true)]
-        private static readonly IReadOnlyDictionary<PaletteImageStyle, string> _pairs = new Dictionary<PaletteImageStyle, string>
+        private static readonly BiDictionary<PaletteImageStyle, string> _pairs = new BiDictionary<PaletteImageStyle, string>(
+            new Dictionary<PaletteImageStyle, string>
         {
             {PaletteImageStyle.Inherit, DesignTimeUtilities.DEFAULT_PALETTE_IMAGE_STYLE_INHERIT},
             {PaletteImageStyle.Stretch, DesignTimeUtilities.DEFAULT_PALETTE_IMAGE_STYLE_STRETCH},
@@ -37,7 +38,7 @@ namespace Krypton.Toolkit
             {PaletteImageStyle.BottomLeft, DesignTimeUtilities.DEFAULT_PALETTE_IMAGE_STYLE_BOTTOM_LEFT},
             {PaletteImageStyle.BottomMiddle, DesignTimeUtilities.DEFAULT_PALETTE_IMAGE_STYLE_BOTTOM_MIDDLE},
             {PaletteImageStyle.BottomRight, DesignTimeUtilities.DEFAULT_PALETTE_IMAGE_STYLE_BOTTOM_RIGHT}
-        };
+        });
 
         #endregion
 
@@ -45,7 +46,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets an array of lookup pairs.
         /// </summary>
-        protected override IReadOnlyDictionary<PaletteImageStyle /*Enum*/, string /*Display*/> Pairs => _pairs;
+        protected override IReadOnlyDictionary<PaletteImageStyle /*Enum*/, string /*Display*/> PairsEnumToString => _pairs.FirstToSecond;
+        protected override IReadOnlyDictionary<string /*Display*/, PaletteImageStyle /*Enum*/ > PairsStringToEnum => _pairs.SecondToFirst;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Converters/PaletteModeConverter.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Converters/PaletteModeConverter.cs
@@ -21,7 +21,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets an array of lookup pairs.
         /// </summary>
-        protected override IReadOnlyDictionary<PaletteMode /*Enum*/, string /*Display*/> Pairs => PaletteModeStrings.SupportedThemes.SecondToFirst;
+        protected override IReadOnlyDictionary<string /*Display*/, PaletteMode /*Enum*/ > PairsStringToEnum => PaletteModeStrings.SupportedThemes.FirstToSecond;
+        protected override IReadOnlyDictionary<PaletteMode /*Enum*/, string /*Display*/> PairsEnumToString => PaletteModeStrings.SupportedThemes.SecondToFirst;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Converters/PaletteTextTrimConverter.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Converters/PaletteTextTrimConverter.cs
@@ -20,7 +20,8 @@ namespace Krypton.Toolkit
         #region Static Fields
 
         [Localizable(true)]
-        private static readonly IReadOnlyDictionary<PaletteTextTrim, string> _pairs = new Dictionary<PaletteTextTrim, string>
+        private static readonly BiDictionary<PaletteTextTrim, string> _pairs = new BiDictionary<PaletteTextTrim, string>(
+            new Dictionary<PaletteTextTrim, string>
         {
             {PaletteTextTrim.Inherit, DesignTimeUtilities.DEFAULT_PALETTE_TEXT_TRIM_INHERIT},
             {PaletteTextTrim.Hide, DesignTimeUtilities.DEFAULT_PALETTE_TEXT_TRIM_HIDE},
@@ -29,7 +30,7 @@ namespace Krypton.Toolkit
             {PaletteTextTrim.EllipsisCharacter, DesignTimeUtilities.DEFAULT_PALETTE_TEXT_TRIM_ELLIPSIS_CHARACTER},
             {PaletteTextTrim.EllipsisWord, DesignTimeUtilities.DEFAULT_PALETTE_TEXT_TRIM_ELLIPSIS_WORD},
             {PaletteTextTrim.EllipsisPath, DesignTimeUtilities.DEFAULT_PALETTE_TEXT_TRIM_ELLIPSIS_PATH}
-        };
+        });
 
         #endregion
 
@@ -37,7 +38,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets an array of lookup pairs.
         /// </summary>
-        protected override IReadOnlyDictionary<PaletteTextTrim /*Enum*/, string /*Display*/> Pairs => _pairs;
+        protected override IReadOnlyDictionary<PaletteTextTrim /*Enum*/, string /*Display*/> PairsEnumToString => _pairs.FirstToSecond;
+        protected override IReadOnlyDictionary<string /*Display*/, PaletteTextTrim /*Enum*/ > PairsStringToEnum => _pairs.SecondToFirst;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Converters/PlacementModeConverter.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Converters/PlacementModeConverter.cs
@@ -17,7 +17,8 @@ namespace Krypton.Toolkit
         #region Static Fields
 
         [Localizable(true)]
-        private static readonly IReadOnlyDictionary<PlacementMode, string> _pairs = new Dictionary<PlacementMode, string>
+        private static readonly BiDictionary<PlacementMode, string> _pairs = new BiDictionary<PlacementMode, string>(
+            new Dictionary<PlacementMode, string>
         {
             {PlacementMode.Absolute, DesignTimeUtilities.DEFAULT_PLACEMENT_MODE_ABSOLUTE},
             {PlacementMode.AbsolutePoint, DesignTimeUtilities.DEFAULT_PLACEMENT_MODE_ABSOLUTE_POINT},
@@ -30,13 +31,14 @@ namespace Krypton.Toolkit
             {PlacementMode.RelativePoint, DesignTimeUtilities.DEFAULT_PLACEMENT_MODE_RELATIVE_POINT},
             {PlacementMode.Right, DesignTimeUtilities.DEFAULT_PLACEMENT_MODE_RIGHT},
             {PlacementMode.Top, DesignTimeUtilities.DEFAULT_PLACEMENT_MODE_TOP}
-        };
+        });
 
         #endregion
 
         #region Protected
 
-        protected override IReadOnlyDictionary<PlacementMode /*Enum*/, string /*Display*/> Pairs => _pairs;
+        protected override IReadOnlyDictionary<PlacementMode /*Enum*/, string /*Display*/> PairsEnumToString => _pairs.FirstToSecond;
+        protected override IReadOnlyDictionary<string /*Display*/, PlacementMode /*Enum*/ > PairsStringToEnum => _pairs.SecondToFirst;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Converters/SeparatorStyleConverter.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Converters/SeparatorStyleConverter.cs
@@ -20,7 +20,8 @@ namespace Krypton.Toolkit
         #region Static Fields
 
         [Localizable(true)]
-        private static readonly IReadOnlyDictionary<SeparatorStyle, string> _pairs = new Dictionary<SeparatorStyle, string>
+        private static readonly BiDictionary<SeparatorStyle, string> _pairs = new BiDictionary<SeparatorStyle, string>(
+            new Dictionary<SeparatorStyle, string>
         {
             {SeparatorStyle.LowProfile, DesignTimeUtilities.DEFAULT_SEPARATOR_STYLE_LOW_PROFILE},
             {SeparatorStyle.HighProfile, DesignTimeUtilities.DEFAULT_SEPARATOR_STYLE_HIGH_PROFILE},
@@ -28,7 +29,7 @@ namespace Krypton.Toolkit
             {SeparatorStyle.Custom1, DesignTimeUtilities.DEFAULT_SEPARATOR_STYLE_CUSTOM1},
             {SeparatorStyle.Custom2, DesignTimeUtilities.DEFAULT_SEPARATOR_STYLE_CUSTOM2},
             {SeparatorStyle.Custom3, DesignTimeUtilities.DEFAULT_SEPARATOR_STYLE_CUSTOM3}
-        };
+        });
 
         #endregion
 
@@ -37,7 +38,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets an array of lookup pairs.
         /// </summary>
-        protected override IReadOnlyDictionary<SeparatorStyle /*Enum*/, string /*Display*/> Pairs => _pairs;
+        protected override IReadOnlyDictionary<SeparatorStyle /*Enum*/, string /*Display*/> PairsEnumToString => _pairs.FirstToSecond;
+        protected override IReadOnlyDictionary<string /*Display*/, SeparatorStyle /*Enum*/ > PairsStringToEnum => _pairs.SecondToFirst;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Converters/StringLookupConverter.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Converters/StringLookupConverter.cs
@@ -21,7 +21,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Initialize a new instance of the StringLookupConverter class.
         /// </summary>
-        public StringLookupConverter()
+        protected StringLookupConverter()
             : base(typeof(TEnumType))
         {
         }
@@ -31,7 +31,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets an array of lookup pairs.
         /// </summary>
-        protected abstract IReadOnlyDictionary<TEnumType /*Enum*/, string /*Display*/> Pairs { get; }
+        protected abstract IReadOnlyDictionary<string /*Display*/, TEnumType /*Enum*/ > PairsStringToEnum { get; }
+        protected abstract IReadOnlyDictionary<TEnumType /*Enum*/, string /*Display*/> PairsEnumToString { get; }
         #endregion
 
         #region Public
@@ -44,8 +45,8 @@ namespace Krypton.Toolkit
         /// <param name="destinationType">The Type to convert the value parameter to.</param>
         /// <returns>An Object that represents the converted value.</returns>
         public override object? ConvertTo(ITypeDescriptorContext? context,
-                                         CultureInfo? culture, 
-                                         object? value, 
+                                         CultureInfo? culture,
+                                         object? value,
                                          Type destinationType)
         {
             // We are only interested in adding functionality for converting to strings
@@ -54,9 +55,9 @@ namespace Krypton.Toolkit
                 )
             {
                 // Search for a matching value
-                if ( Pairs.TryGetValue(val, out var display) )
+                if (PairsEnumToString.TryGetValue(val, out var display))
                 {
-                        return display;
+                    return display;
                 }
             }
 
@@ -72,22 +73,21 @@ namespace Krypton.Toolkit
         /// <param name="value">The Object to convert.</param>
         /// <returns>An Object that represents the converted value.</returns>
         public override object? ConvertFrom(ITypeDescriptorContext? context,
-                                           CultureInfo? culture, 
+                                           CultureInfo? culture,
                                            object? value)
         {
             // We are only interested in adding functionality for converting from strings
             if (value is string val)
             {
                 // Search for a matching string
-                var key = Pairs.FirstOrDefault(x => x.Value == val).Key;
-                if ( key != null)
-                { 
-                    return key; 
+                if (PairsStringToEnum.TryGetValue(val, out TEnumType? key))
+                {
+                    return key;
                 }
             }
 
             // Let base class perform default conversion
-            return base.ConvertFrom(context, culture, value);
+            return base.ConvertFrom(context!, culture!, value);
         }
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Converters/TabBorderStyleConverter.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Converters/TabBorderStyleConverter.cs
@@ -20,7 +20,8 @@ namespace Krypton.Toolkit
         #region Static Fields
 
         [Localizable(true)]
-        private static readonly IReadOnlyDictionary<TabBorderStyle, string> _pairs = new Dictionary<TabBorderStyle, string>
+        private static readonly BiDictionary<TabBorderStyle, string> _pairs = new BiDictionary<TabBorderStyle, string>(
+            new Dictionary<TabBorderStyle, string>
         {
             {TabBorderStyle.OneNote, DesignTimeUtilities.DEFAULT_TAB_BORDER_STYLE_ONE_NOTE},
             {TabBorderStyle.SquareEqualSmall, DesignTimeUtilities.DEFAULT_TAB_BORDER_STYLE_SQUARE_EQUAL_SMALL},
@@ -45,7 +46,7 @@ namespace Krypton.Toolkit
             {TabBorderStyle.SmoothOutsize, DesignTimeUtilities.DEFAULT_TAB_BORDER_STYLE_SMOOTH_OUTSIZE},
             {TabBorderStyle.DockEqual, DesignTimeUtilities.DEFAULT_TAB_BORDER_STYLE_DOCK_EQUAL},
             {TabBorderStyle.DockOutsize, DesignTimeUtilities.DEFAULT_TAB_BORDER_STYLE_DOCK_OUTSIZE}
-        };
+        });
 
         #endregion  
 
@@ -54,7 +55,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets an array of lookup pairs.
         /// </summary>
-        protected override IReadOnlyDictionary<TabBorderStyle /*Enum*/, string /*Display*/> Pairs => _pairs;
+        protected override IReadOnlyDictionary<TabBorderStyle /*Enum*/, string /*Display*/> PairsEnumToString => _pairs.FirstToSecond;
+        protected override IReadOnlyDictionary<string /*Display*/, TabBorderStyle /*Enum*/ > PairsStringToEnum => _pairs.SecondToFirst;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Converters/TabStyleConverter.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Converters/TabStyleConverter.cs
@@ -20,7 +20,8 @@ namespace Krypton.Toolkit
         #region Static Fields
 
         [Localizable(true)]
-        private static readonly IReadOnlyDictionary<TabStyle, string> _pairs = new Dictionary<TabStyle, string>
+        private static readonly BiDictionary<TabStyle, string> _pairs = new BiDictionary<TabStyle, string>(
+            new Dictionary<TabStyle, string>
         {
             {TabStyle.HighProfile, DesignTimeUtilities.DEFAULT_TAB_STYLE_HIGH_PROFILE},
             {TabStyle.StandardProfile, DesignTimeUtilities.DEFAULT_TAB_STYLE_STANDARD_PROFILE},
@@ -31,7 +32,7 @@ namespace Krypton.Toolkit
             {TabStyle.Custom1, DesignTimeUtilities.DEFAULT_TAB_STYLE_CUSTOM1},
             {TabStyle.Custom2, DesignTimeUtilities.DEFAULT_TAB_STYLE_CUSTOM2},
             {TabStyle.Custom3, DesignTimeUtilities.DEFAULT_TAB_STYLE_CUSTOM3}
-        };
+        });
 
         #endregion
 
@@ -40,7 +41,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets an array of lookup pairs.
         /// </summary>
-        protected override IReadOnlyDictionary<TabStyle /*Enum*/, string /*Display*/> Pairs => _pairs;
+        protected override IReadOnlyDictionary<TabStyle /*Enum*/, string /*Display*/> PairsEnumToString => _pairs.FirstToSecond;
+        protected override IReadOnlyDictionary<string /*Display*/, TabStyle /*Enum*/ > PairsStringToEnum => _pairs.SecondToFirst;
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/General/ContextMenuProvider.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/ContextMenuProvider.cs
@@ -88,9 +88,9 @@ namespace Krypton.Toolkit
         public ContextMenuProvider(KryptonContextMenu contextMenu,
                                    ViewContextMenuManager viewManager,
                                    ViewLayoutStack viewColumns,
-                                   PaletteBase? palette,
+                                   PaletteBase palette,
                                    PaletteMode paletteMode,
-                                   PaletteRedirect? redirector,
+                                   PaletteRedirect redirector,
                                    PaletteRedirectContextMenu redirectorImages,
                                    NeedPaintHandler needPaintDelegate,
                                    bool enabled)
@@ -132,14 +132,14 @@ namespace Krypton.Toolkit
         /// <param name="enabled">Enabled state of the context menu.</param>
         public ContextMenuProvider(ViewContextMenuManager viewManager,
                                    ViewLayoutStack viewColumns,
-                                   PaletteBase? palette,
+                                   PaletteBase palette,
                                    PaletteMode paletteMode,
                                    PaletteContextMenuRedirect stateCommon,
                                    PaletteContextMenuItemState stateDisabled,
                                    PaletteContextMenuItemState stateNormal,
                                    PaletteContextMenuItemStateHighlight stateHighlight,
                                    PaletteContextMenuItemStateChecked stateChecked,
-                                   PaletteRedirect? redirector,
+                                   PaletteRedirect redirector,
                                    PaletteRedirectContextMenu redirectorImages,
                                    NeedPaintHandler needPaintDelegate,
                                    bool enabled)
@@ -305,7 +305,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the custom palette.
         /// </summary>
-        public PaletteBase? ProviderPalette { get; }
+        public PaletteBase ProviderPalette { get; }
 
         /// <summary>
         /// Gets access to the palette mode.
@@ -315,7 +315,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the context menu redirector.
         /// </summary>
-        public PaletteRedirect? ProviderRedirector { get; }
+        public PaletteRedirect ProviderRedirector { get; }
 
         /// <summary>
         /// Gets a delegate used to indicate a repaint is required.

--- a/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
@@ -95,7 +95,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Tooltip title string.</returns>
-        string GetToolTipTitle(PaletteBase? palette);
+        string GetToolTipTitle(PaletteBase palette);
 
         /// <summary>
         /// Gets and image color to remap to container foreground.
@@ -109,14 +109,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibility value.</returns>
-        bool GetVisible(PaletteBase? palette);
+        bool GetVisible(PaletteBase palette);
 
         /// <summary>
         /// Gets the button enabled state.
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button enabled value.</returns>
-        ButtonEnabled GetEnabled(PaletteBase? palette);
+        ButtonEnabled GetEnabled(PaletteBase palette);
 
         /// <summary>
         /// Sets the current view associated with the button spec.
@@ -148,7 +148,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button style value.</returns>
-        ButtonStyle GetStyle(PaletteBase? palette);
+        ButtonStyle GetStyle(PaletteBase palette);
 
         /// <summary>
         /// Gets the button location value.
@@ -292,7 +292,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the custom palette.
         /// </summary>
-        PaletteBase? ProviderPalette { get; }
+        PaletteBase ProviderPalette { get; }
 
         /// <summary>
         /// Gets access to the palette mode.
@@ -302,7 +302,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the context menu redirector.
         /// </summary>
-        PaletteRedirect? ProviderRedirector { get; }
+        PaletteRedirect ProviderRedirector { get; }
 
         /// <summary>
         /// Gets a delegate used to indicate a repaint is required.

--- a/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/HScrollSkin.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/HScrollSkin.cs
@@ -35,7 +35,7 @@ namespace Krypton.Toolkit
 
         private HScrollBar HSB;
 
-        private static PaletteBase? _palette;
+        private static PaletteBase _palette;
         private readonly PaletteRedirect _paletteRedirect;
         #endregion
 
@@ -539,7 +539,7 @@ namespace Krypton.Toolkit
         #region ... Krypton ...
 
 
-        //Kripton Palette Events
+        //Krypton Palette Events
         private void OnGlobalPaletteChanged(object sender, EventArgs e)
         {
             if (_palette != null)
@@ -558,7 +558,7 @@ namespace Krypton.Toolkit
             Invalidate();
         }
 
-        //Kripton Palette Events
+        //Krypton Palette Events
         private void OnPalettePaint(object sender, PaletteLayoutEventArgs e) => Invalidate();
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/ScrollBarExtendedRenderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/ScrollBarExtendedRenderer.cs
@@ -54,7 +54,7 @@ namespace Krypton.Toolkit
         /// </summary>
         public static Color[] gripColours = new Color[2];
 
-        private static PaletteBase? _palette;
+        private static PaletteBase _palette;
         private static PaletteRedirect _paletteRedirect;
         #endregion
 
@@ -931,7 +931,7 @@ namespace Krypton.Toolkit
         #region ... Krypton ...
 
 
-        //Kripton Palette Events
+        //Krypton Palette Events
         private static void OnGlobalPaletteChanged(object sender, EventArgs e)
         {
             if (_palette != null)
@@ -953,7 +953,7 @@ namespace Krypton.Toolkit
             //Invalidate();
         }
 
-        //Kripton Palette Events
+        //Krypton Palette Events
         private static void OnPalettePaint(object sender, PaletteLayoutEventArgs e)
         {
             //Invalidate();

--- a/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/ScrollBarKryptonRenderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/ScrollBarKryptonRenderer.cs
@@ -54,7 +54,7 @@ namespace Krypton.Toolkit
         /// </summary>
         public static Color[] gripColours = new Color[2];
 
-        private static PaletteBase? _palette;
+        private static PaletteBase _palette;
         private static PaletteRedirect _paletteRedirect;
         #endregion
 
@@ -952,7 +952,7 @@ namespace Krypton.Toolkit
         #region ... Krypton ...
 
 
-        //Kripton Palette Events
+        //Krypton Palette Events
         private static void OnGlobalPaletteChanged(object sender, EventArgs e)
         {
             if (_palette != null)
@@ -974,7 +974,7 @@ namespace Krypton.Toolkit
             //Invalidate();
         }
 
-        //Kripton Palette Events
+        //Krypton Palette Events
         private static void OnPalettePaint(object sender, PaletteLayoutEventArgs e)
         {
             //Invalidate();

--- a/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/VScrollSkin.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/VScrollSkin.cs
@@ -35,7 +35,7 @@ namespace Krypton.Toolkit
         private VScrollBar VSB;
         private HScrollBar HSC;
 
-        private static PaletteBase? _palette;
+        private static PaletteBase _palette;
         private readonly PaletteRedirect _paletteRedirect;
 
         #endregion
@@ -731,7 +731,7 @@ namespace Krypton.Toolkit
         #region ... Krypton ...
 
 
-        //Kripton Palette Events
+        //Krypton Palette Events
         private void OnGlobalPaletteChanged(object sender, EventArgs e)
         {
             if (_palette != null)
@@ -750,7 +750,7 @@ namespace Krypton.Toolkit
             Invalidate();
         }
 
-        //Kripton Palette Events
+        //Krypton Palette Events
         private void OnPalettePaint(object sender, PaletteLayoutEventArgs e) => Invalidate();
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBack/PaletteBackInheritRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBack/PaletteBackInheritRedirect.cs
@@ -18,7 +18,7 @@ namespace Krypton.Toolkit
     public class PaletteBackInheritRedirect : PaletteBackInherit
     {
         #region Instance Fields
-        private PaletteRedirect? _redirect;
+        private PaletteRedirect _redirect;
 
         #endregion
 
@@ -27,7 +27,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteBackInheritRedirect class.
         /// </summary>
         /// <param name="redirect">Source for inherit requests.</param>
-        public PaletteBackInheritRedirect(PaletteRedirect? redirect)
+        public PaletteBackInheritRedirect(PaletteRedirect redirect)
             : this(redirect, PaletteBackStyle.ButtonStandalone)
         {
         }
@@ -37,7 +37,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">Source for inherit requests.</param>
         /// <param name="style">Style used in requests.</param>
-        public PaletteBackInheritRedirect(PaletteRedirect? redirect,
+        public PaletteBackInheritRedirect(PaletteRedirect redirect,
                                           PaletteBackStyle style)
         {
             _redirect = redirect;
@@ -50,7 +50,7 @@ namespace Krypton.Toolkit
         /// Gets the redirector instance.
         /// </summary>
         /// <returns>Return the currently used redirector.</returns>
-        public PaletteRedirect? GetRedirector() => _redirect;
+        public PaletteRedirect GetRedirector() => _redirect;
 
         #endregion
 
@@ -59,7 +59,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect) => _redirect = redirect;
+        public void SetRedirector(PaletteRedirect redirect) => _redirect = redirect;
         #endregion
 
         #region Style

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBack/PaletteBackToPalette.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBack/PaletteBackToPalette.cs
@@ -18,7 +18,7 @@ namespace Krypton.Toolkit
     public class PaletteBackToPalette : IPaletteBack
     {
         #region Instance Fields
-        private readonly PaletteBase? _palette;
+        private readonly PaletteBase _palette;
 
         #endregion
 
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Source for getting all values.</param>
         /// <param name="style">Style of values required.</param>
-        public PaletteBackToPalette(PaletteBase? palette, PaletteBackStyle style)
+        public PaletteBackToPalette(PaletteBase palette, PaletteBackStyle style)
         {
             // Remember source palette
             _palette = palette;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBorder/PaletteBorderInheritRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBorder/PaletteBorderInheritRedirect.cs
@@ -18,7 +18,7 @@ namespace Krypton.Toolkit
     public class PaletteBorderInheritRedirect : PaletteBorderInherit
     {
         #region Instance Fields
-        private PaletteRedirect? _redirect;
+        private PaletteRedirect _redirect;
 
         #endregion
 
@@ -27,7 +27,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteBorderInheritRedirect class.
         /// </summary>
         /// <param name="redirect">Source for inherit requests.</param>
-        public PaletteBorderInheritRedirect(PaletteRedirect? redirect)
+        public PaletteBorderInheritRedirect(PaletteRedirect redirect)
             : this(redirect, PaletteBorderStyle.ButtonStandalone)
         {
         }
@@ -37,7 +37,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">Source for inherit requests.</param>
         /// <param name="style">Style used in requests.</param>
-        public PaletteBorderInheritRedirect(PaletteRedirect? redirect,
+        public PaletteBorderInheritRedirect(PaletteRedirect redirect,
                                             PaletteBorderStyle style)
         {
             _redirect = redirect;
@@ -58,7 +58,7 @@ namespace Krypton.Toolkit
         /// Gets the redirector instance.
         /// </summary>
         /// <returns>Return the currently used redirector.</returns>
-        public PaletteRedirect? GetRedirector() => _redirect;
+        public PaletteRedirect GetRedirector() => _redirect;
 
         #endregion
 
@@ -67,7 +67,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect) => _redirect = redirect;
+        public void SetRedirector(PaletteRedirect redirect) => _redirect = redirect;
         #endregion
 
         #region Style

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBorder/PaletteBorderToPalette.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBorder/PaletteBorderToPalette.cs
@@ -18,7 +18,7 @@ namespace Krypton.Toolkit
     public class PaletteBorderToPalette : IPaletteBorder
     {
         #region Instance Fields
-        private readonly PaletteBase? _palette;
+        private readonly PaletteBase _palette;
 
         #endregion
 
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Source for getting all values.</param>
         /// <param name="style">Style of values required.</param>
-        public PaletteBorderToPalette(PaletteBase? palette,
+        public PaletteBorderToPalette(PaletteBase palette,
                                       PaletteBorderStyle style)
         {
             // Remember inheritance

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContent.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContent.cs
@@ -340,14 +340,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public Font GetContentShortTextFont(PaletteState state) => _shortText.Font ?? _inherit.GetContentShortTextFont(state);
+        public Font? GetContentShortTextFont(PaletteState state) => _shortText.Font ?? _inherit.GetContentShortTextFont(state);
 
         /// <summary>
         /// Gets the font for the short text by generating a new font instance.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public Font GetContentShortTextNewFont(PaletteState state) => _shortText.Font ?? _inherit.GetContentShortTextNewFont(state);
+        public Font? GetContentShortTextNewFont(PaletteState state) => _shortText.Font ?? _inherit.GetContentShortTextNewFont(state);
 
         /// <summary>
         /// Gets the actual text rendering hint for short text.
@@ -508,14 +508,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <returns>Font value.</returns>
         /// <param name="state">Palette value should be applicable to this state.</param>
-        public Font GetContentLongTextFont(PaletteState state) => _longText.Font ?? _inherit.GetContentLongTextFont(state);
+        public Font? GetContentLongTextFont(PaletteState state) => _longText.Font ?? _inherit.GetContentLongTextFont(state);
 
         /// <summary>
         /// Gets the font for the long text by generating a new font instance.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public Font GetContentLongTextNewFont(PaletteState state) => _longText.Font ?? _inherit.GetContentLongTextNewFont(state);
+        public Font? GetContentLongTextNewFont(PaletteState state) => _longText.Font ?? _inherit.GetContentLongTextNewFont(state);
 
         /// <summary>
         /// Gets the actual text rendering hint for long text.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentInherit.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentInherit.cs
@@ -73,14 +73,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public abstract Font GetContentShortTextFont(PaletteState state);
+        public abstract Font? GetContentShortTextFont(PaletteState state);
 
         /// <summary>
         /// Gets the font for the short text by generating a new font instance.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public abstract Font GetContentShortTextNewFont(PaletteState state);
+        public abstract Font? GetContentShortTextNewFont(PaletteState state);
 
         /// <summary>
         /// Gets the rendering hint for the short text.
@@ -192,14 +192,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public abstract Font GetContentLongTextFont(PaletteState state);
+        public abstract Font? GetContentLongTextFont(PaletteState state);
 
         /// <summary>
         /// Gets the font for the long text by generating a new font instance.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public abstract Font GetContentLongTextNewFont(PaletteState state);
+        public abstract Font? GetContentLongTextNewFont(PaletteState state);
         
         /// <summary>
         /// Gets the rendering hint for the long text.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentInheritForced.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentInheritForced.cs
@@ -111,14 +111,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteState state) => _inherit.GetContentShortTextFont(state);
+        public override Font? GetContentShortTextFont(PaletteState state) => _inherit.GetContentShortTextFont(state);
 
         /// <summary>
         /// Gets the font for the short text by generating a new font instance.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteState state) => _inherit.GetContentShortTextNewFont(state);
+        public override Font? GetContentShortTextNewFont(PaletteState state) => _inherit.GetContentShortTextNewFont(state);
 
         /// <summary>
         /// Gets the rendering hint for the short text.
@@ -232,14 +232,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteState state) => _inherit.GetContentLongTextFont(state);
+        public override Font? GetContentLongTextFont(PaletteState state) => _inherit.GetContentLongTextFont(state);
 
         /// <summary>
         /// Gets the font for the long text by generating a new font instance.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteState state) => _inherit.GetContentLongTextNewFont(state);
+        public override Font? GetContentLongTextNewFont(PaletteState state) => _inherit.GetContentLongTextNewFont(state);
 
         /// <summary>
         /// Gets the rendering hint for the long text.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentInheritOverride.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentInheritOverride.cs
@@ -274,11 +274,11 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteState state)
         {
             if (Apply)
             {
-                Font ret = _primary.GetContentShortTextFont(Override ? OverrideState : state) ?? _backup.GetContentShortTextFont(state);
+                Font? ret = _primary.GetContentShortTextFont(Override ? OverrideState : state) ?? _backup.GetContentShortTextFont(state);
 
                 return ret;
             }
@@ -293,11 +293,11 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteState state)
         {
             if (Apply)
             {
-                Font ret = _primary.GetContentShortTextNewFont(Override ? OverrideState : state) ?? _backup.GetContentShortTextNewFont(state);
+                Font? ret = _primary.GetContentShortTextNewFont(Override ? OverrideState : state) ?? _backup.GetContentShortTextNewFont(state);
 
                 return ret;
             }
@@ -667,11 +667,11 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteState state)
         {
             if (Apply)
             {
-                Font ret = _primary.GetContentLongTextFont(Override ? OverrideState : state) ?? _backup.GetContentLongTextFont(state);
+                Font? ret = _primary.GetContentLongTextFont(Override ? OverrideState : state) ?? _backup.GetContentLongTextFont(state);
 
                 return ret;
             }
@@ -686,11 +686,11 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteState state)
+        public override Font? GetContentLongTextNewFont(PaletteState state)
         {
             if (Apply)
             {
-                Font ret = _primary.GetContentLongTextNewFont(Override ? OverrideState : state) ?? _backup.GetContentLongTextNewFont(state);
+                Font? ret = _primary.GetContentLongTextNewFont(Override ? OverrideState : state) ?? _backup.GetContentLongTextNewFont(state);
 
                 return ret;
             }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentInheritRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentInheritRedirect.cs
@@ -18,7 +18,7 @@ namespace Krypton.Toolkit
     public class PaletteContentInheritRedirect : PaletteContentInherit
     {
         #region Instance Fields
-        private PaletteRedirect? _redirect;
+        private PaletteRedirect _redirect;
 
         #endregion
 
@@ -36,7 +36,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteContentInheritRedirect class.
         /// </summary>
         /// <param name="redirect">Source for inherit requests.</param>
-        public PaletteContentInheritRedirect(PaletteRedirect? redirect)
+        public PaletteContentInheritRedirect(PaletteRedirect redirect)
             : this(redirect, PaletteContentStyle.ButtonStandalone)
         {
         }
@@ -46,7 +46,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">Source for inherit requests.</param>
         /// <param name="style">Style used in requests.</param>
-        public PaletteContentInheritRedirect(PaletteRedirect? redirect,
+        public PaletteContentInheritRedirect(PaletteRedirect redirect,
                                              PaletteContentStyle style)
         {
             _redirect = redirect;
@@ -59,7 +59,7 @@ namespace Krypton.Toolkit
         /// Gets the redirector instance.
         /// </summary>
         /// <returns>Return the currently used redirector.</returns>
-        public PaletteRedirect? GetRedirector() => _redirect;
+        public PaletteRedirect GetRedirector() => _redirect;
 
         #endregion
 
@@ -68,7 +68,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect) => _redirect = redirect;
+        public void SetRedirector(PaletteRedirect redirect) => _redirect = redirect;
         #endregion
 
         #region Style
@@ -134,14 +134,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteState state) => _redirect.GetContentShortTextFont(Style, state);
+        public override Font? GetContentShortTextFont(PaletteState state) => _redirect.GetContentShortTextFont(Style, state);
 
         /// <summary>
         /// Gets the font for the short text by generating a new font instance.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteState state) => _redirect.GetContentShortTextNewFont(Style, state);
+        public override Font? GetContentShortTextNewFont(PaletteState state) => _redirect.GetContentShortTextNewFont(Style, state);
 
         /// <summary>
         /// Gets the rendering hint for the short text.
@@ -253,14 +253,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteState state) => _redirect.GetContentLongTextFont(Style, state);
+        public override Font? GetContentLongTextFont(PaletteState state) => _redirect.GetContentLongTextFont(Style, state);
 
         /// <summary>
         /// Gets the font for the long text by generating a new font instance.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteState state) => _redirect.GetContentLongTextNewFont(Style, state);
+        public override Font? GetContentLongTextNewFont(PaletteState state) => _redirect.GetContentLongTextNewFont(Style, state);
 
         /// <summary>
         /// Gets the rendering hint for the long text.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentToPalette.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentToPalette.cs
@@ -18,7 +18,7 @@ namespace Krypton.Toolkit
     public class PaletteContentToPalette : IPaletteContent
     {
         #region Instance Fields
-        private readonly PaletteBase? _palette;
+        private readonly PaletteBase _palette;
 
         #endregion
 
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Source for getting all values.</param>
         /// <param name="style">Style of values required.</param>
-        public PaletteContentToPalette(PaletteBase? palette, PaletteContentStyle style)
+        public PaletteContentToPalette(PaletteBase palette, PaletteContentStyle style)
         {
             // Remember source palette
             _palette = palette;
@@ -117,14 +117,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public Font GetContentShortTextFont(PaletteState state) => _palette.GetContentShortTextFont(ContentStyle, state);
+        public Font? GetContentShortTextFont(PaletteState state) => _palette.GetContentShortTextFont(ContentStyle, state);
 
         /// <summary>
         /// Gets the font for the short text by generating a new font instance.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public Font GetContentShortTextNewFont(PaletteState state) => _palette.GetContentShortTextNewFont(ContentStyle, state);
+        public Font? GetContentShortTextNewFont(PaletteState state) => _palette.GetContentShortTextNewFont(ContentStyle, state);
 
         /// <summary>
         /// Gets the actual text rendering hint for short text.
@@ -239,14 +239,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <returns>Font value.</returns>
         /// <param name="state">Palette value should be applicable to this state.</param>
-        public Font GetContentLongTextFont(PaletteState state) => _palette.GetContentLongTextFont(ContentStyle, state);
+        public Font? GetContentLongTextFont(PaletteState state) => _palette.GetContentLongTextFont(ContentStyle, state);
 
         /// <summary>
         /// Gets the font for the long text by generating a new font instance.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public Font GetContentLongTextNewFont(PaletteState state) => _palette.GetContentLongTextNewFont(ContentStyle, state);
+        public Font? GetContentLongTextNewFont(PaletteState state) => _palette.GetContentLongTextNewFont(ContentStyle, state);
 
         /// <summary>
         /// Gets the actual text rendering hint for long text.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDefinitions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDefinitions.cs
@@ -252,14 +252,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        Font GetContentShortTextFont(PaletteState state);
+        Font? GetContentShortTextFont(PaletteState state);
 
         /// <summary>
         /// Gets the font for the short text by generating a new font instance.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        Font GetContentShortTextNewFont(PaletteState state);
+        Font? GetContentShortTextNewFont(PaletteState state);
 
         /// <summary>
         /// Gets the rendering hint for the short text.
@@ -371,14 +371,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        Font GetContentLongTextFont(PaletteState state);
+        Font? GetContentLongTextFont(PaletteState state);
 
         /// <summary>
         /// Gets the font for the long text by generating a new font instance.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        Font GetContentLongTextNewFont(PaletteState state);
+        Font? GetContentLongTextNewFont(PaletteState state);
 
         /// <summary>
         /// Gets the rendering hint for the long text.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDouble/PaletteDoubleMetricRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDouble/PaletteDoubleMetricRedirect.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit
                                                IPaletteMetric
     {
         #region Instance Fields
-        private PaletteRedirect? _redirect;
+        private PaletteRedirect _redirect;
         #endregion
 
         #region Identity
@@ -29,7 +29,7 @@ namespace Krypton.Toolkit
         /// <param name="redirect">inheritance redirection instance.</param>
         /// <param name="backStyle">Style for the background.</param>
         /// <param name="borderStyle">Style for the border.</param>
-        public PaletteDoubleMetricRedirect(PaletteRedirect? redirect,
+        public PaletteDoubleMetricRedirect(PaletteRedirect redirect,
                                            PaletteBackStyle backStyle,
                                            PaletteBorderStyle borderStyle)
             : this(redirect, backStyle, borderStyle, null)
@@ -43,7 +43,7 @@ namespace Krypton.Toolkit
         /// <param name="backStyle">Style for the background.</param>
         /// <param name="borderStyle">Style for the border.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteDoubleMetricRedirect(PaletteRedirect? redirect,
+        public PaletteDoubleMetricRedirect(PaletteRedirect redirect,
                                            PaletteBackStyle backStyle,
                                            PaletteBorderStyle borderStyle,
                                            NeedPaintHandler needPaint)
@@ -61,7 +61,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public override void SetRedirector(PaletteRedirect? redirect)
+        public override void SetRedirector(PaletteRedirect redirect)
         {
             base.SetRedirector(redirect);
             _redirect = redirect;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDouble/PaletteDoubleRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDouble/PaletteDoubleRedirect.cs
@@ -32,7 +32,7 @@ namespace Krypton.Toolkit
         /// <param name="redirect">inheritance redirection instance.</param>
         /// <param name="backStyle">Initial background style.</param>
         /// <param name="borderStyle">Initial border style.</param>
-        public PaletteDoubleRedirect(PaletteRedirect? redirect,
+        public PaletteDoubleRedirect(PaletteRedirect redirect,
                                      PaletteBackStyle backStyle,
                                      PaletteBorderStyle borderStyle)
             : this(redirect, backStyle, borderStyle, null)
@@ -46,7 +46,7 @@ namespace Krypton.Toolkit
         /// <param name="backStyle">Initial background style.</param>
         /// <param name="borderStyle">Initial border style.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteDoubleRedirect(PaletteRedirect? redirect,
+        public PaletteDoubleRedirect(PaletteRedirect redirect,
                                      PaletteBackStyle backStyle,
                                      PaletteBorderStyle borderStyle,
                                      NeedPaintHandler needPaint)
@@ -71,7 +71,7 @@ namespace Krypton.Toolkit
         /// <param name="border">Storage for border values.</param>
         /// <param name="borderInherit">inheritance for border values.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteDoubleRedirect(PaletteRedirect? redirect,
+        public PaletteDoubleRedirect(PaletteRedirect redirect,
                                      PaletteBack back,
                                      PaletteBackInheritRedirect backInherit,
                                      PaletteBorder border,
@@ -87,7 +87,7 @@ namespace Krypton.Toolkit
         /// Gets the redirector instance.
         /// </summary>
         /// <returns>Return the currently used redirector.</returns>
-        public PaletteRedirect? GetRedirector() => _backInherit.GetRedirector();
+        public PaletteRedirect GetRedirector() => _backInherit.GetRedirector();
 
         #endregion
 
@@ -96,7 +96,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public virtual void SetRedirector(PaletteRedirect? redirect)
+        public virtual void SetRedirector(PaletteRedirect redirect)
         {
             _backInherit.SetRedirector(redirect);
             BorderRedirect.SetRedirector(redirect);
@@ -276,7 +276,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Private
-        private void Construct(PaletteRedirect? redirect,
+        private void Construct(PaletteRedirect redirect,
                                PaletteBack back,
                                PaletteBackInheritRedirect backInherit,
                                PaletteBorder border,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDragDrop/PaletteDragDrop.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDragDrop/PaletteDragDrop.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit
                                    IPaletteDragDrop
     {
         #region Instance Fields
-        private PaletteBase? _inherit;
+        private PaletteBase _inherit;
         private PaletteDragFeedback _feedback;
         private Color _solidBack;
         private Color _solidBorder;
@@ -36,7 +36,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="inherit">Source for inheriting values.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteDragDrop(PaletteBase? inherit,
+        public PaletteDragDrop(PaletteBase inherit,
                                NeedPaintHandler? needPaint)
         {
             // Remember inheritance
@@ -77,7 +77,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Sets the inheritance parent.
         /// </summary>
-        public void SetInherit(PaletteBase? inherit) => _inherit = inherit;
+        public void SetInherit(PaletteBase inherit) => _inherit = inherit;
         #endregion
 
         #region PopulateFromBase

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteElementColor/PaletteElementColorInheritRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteElementColor/PaletteElementColorInheritRedirect.cs
@@ -18,7 +18,7 @@ namespace Krypton.Toolkit
     public class PaletteElementColorInheritRedirect : PaletteElementColorInherit
     {
         #region Instance Fields
-        private PaletteRedirect? _redirect;
+        private PaletteRedirect _redirect;
 
         #endregion
 
@@ -43,7 +43,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect) => _redirect = redirect;
+        public void SetRedirector(PaletteRedirect redirect) => _redirect = redirect;
         #endregion
 
         #region StyleBack

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteElementColor/PaletteElementColorRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteElementColor/PaletteElementColorRedirect.cs
@@ -44,7 +44,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public virtual void SetRedirector(PaletteRedirect? redirect) => _redirect.SetRedirector(redirect);
+        public virtual void SetRedirector(PaletteRedirect redirect) => _redirect.SetRedirector(redirect);
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteMetric/PaletteMetricRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteMetric/PaletteMetricRedirect.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit
                                          IPaletteMetric
     {
         #region Instance Fields
-        private PaletteRedirect? _redirect;
+        private PaletteRedirect _redirect;
         #endregion
 
         #region Identity
@@ -27,7 +27,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteMetricRedirect class.
         /// </summary>
         /// <param name="redirect">inheritance redirection instance.</param>
-        public PaletteMetricRedirect([DisallowNull] PaletteRedirect? redirect)
+        public PaletteMetricRedirect([DisallowNull] PaletteRedirect redirect)
         {
             Debug.Assert(redirect != null);
 
@@ -41,7 +41,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public virtual void SetRedirector(PaletteRedirect? redirect) => _redirect = redirect;
+        public virtual void SetRedirector(PaletteRedirect redirect) => _redirect = redirect;
         #endregion
 
         #region IsDefault

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirect.cs
@@ -18,7 +18,7 @@ namespace Krypton.Toolkit
     public class PaletteRedirect : PaletteBase, IGlobalId
     {
         #region Instance Fields
-        private PaletteBase? _target;
+        private PaletteBase _target;
         #endregion
 
         #region Identity
@@ -34,7 +34,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteRedirect class.
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
-        public PaletteRedirect(PaletteBase? target)
+        public PaletteRedirect(PaletteBase target)
         {
             Id = CommonHelper.NextId;
             // Remember incoming target
@@ -47,7 +47,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the redirection target.
         /// </summary>
-        public virtual PaletteBase? Target
+        public virtual PaletteBase Target
         {
             get => _target;
             set => _target = value;
@@ -68,7 +68,7 @@ namespace Krypton.Toolkit
         /// Gets the renderer to use for this palette.
         /// </summary>
         /// <returns>Renderer to use for drawing palette settings.</returns>
-        public override IRenderer? GetRenderer() => _target?.GetRenderer();
+        public override IRenderer GetRenderer() => _target?.GetRenderer();
 
         #endregion
 
@@ -327,7 +327,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextFont(style, state);
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextFont(style, state);
 
         /// <summary>
         /// Gets the font for the short text by generating a new font instance.
@@ -335,7 +335,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextNewFont(style, state);
+        public override Font? GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state) => _target.GetContentShortTextNewFont(style, state);
 
         /// <summary>
         /// Gets the rendering hint for the short text.
@@ -463,7 +463,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextFont(style, state);
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextFont(style, state);
 
         /// <summary>
         /// Gets the font for the long text by generating a new font instance.
@@ -471,7 +471,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextNewFont(style, state);
+        public override Font? GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state) => _target.GetContentLongTextNewFont(style, state);
 
         /// <summary>
         /// Gets the rendering hint for the long text.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectBack.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectBack.cs
@@ -34,7 +34,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteRedirectBack class.
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
-        public PaletteRedirectBack(PaletteBase? target)
+        public PaletteRedirectBack(PaletteBase target)
             : this(target, null, null, null, null, null, null, null, null, null)
         {
         }
@@ -45,7 +45,7 @@ namespace Krypton.Toolkit
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="disabled">Redirection for disabled state requests.</param>
         /// <param name="normal">Redirection for normal state requests.</param>
-        public PaletteRedirectBack(PaletteBase? target,
+        public PaletteRedirectBack(PaletteBase target,
                                    IPaletteBack disabled,
                                    IPaletteBack normal)
             : this(target, disabled, normal, null, null, null, null, null, null, null)
@@ -65,7 +65,7 @@ namespace Krypton.Toolkit
         /// <param name="checkedTracking">Redirection for checked tracking state requests.</param>
         /// <param name="focusOverride">Redirection for focus override state requests.</param>
         /// <param name="normalDefaultOverride">Redirection for normal default override state requests.</param>
-        public PaletteRedirectBack(PaletteBase? target,
+        public PaletteRedirectBack(PaletteBase target,
                                    IPaletteBack disabled,
                                    IPaletteBack normal,
                                    IPaletteBack pressed,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectBorder.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectBorder.cs
@@ -34,7 +34,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteRedirectBorder class.
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
-        public PaletteRedirectBorder(PaletteBase? target)
+        public PaletteRedirectBorder(PaletteBase target)
             : this(target, null, null, null, null, null, null, null, null, null)
         {
         }
@@ -45,7 +45,7 @@ namespace Krypton.Toolkit
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="disabled">Redirection for disabled state requests.</param>
         /// <param name="normal">Redirection for normal state requests.</param>
-        public PaletteRedirectBorder(PaletteBase? target,
+        public PaletteRedirectBorder(PaletteBase target,
                                      IPaletteBorder disabled,
                                      IPaletteBorder normal)
             : this(target, disabled, normal, null, null, null, null, null, null, null)
@@ -60,7 +60,7 @@ namespace Krypton.Toolkit
         /// <param name="normal">Redirection for normal state requests.</param>
         /// <param name="pressed">Redirection for pressed state requests.</param>
         /// <param name="tracking">Redirection for tracking state requests.</param>
-        public PaletteRedirectBorder(PaletteBase? target,
+        public PaletteRedirectBorder(PaletteBase target,
                                      IPaletteBorder disabled,
                                      IPaletteBorder normal,
                                      IPaletteBorder pressed,
@@ -82,7 +82,7 @@ namespace Krypton.Toolkit
         /// <param name="checkedTracking">Redirection for checked tracking state requests.</param>
         /// <param name="focusOverride">Redirection for focus override state requests.</param>
         /// <param name="normalDefaultOverride">Redirection for normal default override state requests.</param>
-        public PaletteRedirectBorder(PaletteBase? target,
+        public PaletteRedirectBorder(PaletteBase target,
                                      IPaletteBorder disabled,
                                      IPaletteBorder normal,
                                      IPaletteBorder pressed,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectBorderEdge.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectBorderEdge.cs
@@ -27,7 +27,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteRedirectBorderEdge class.
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
-        public PaletteRedirectBorderEdge(PaletteBase? target)
+        public PaletteRedirectBorderEdge(PaletteBase target)
             : this(target, null, null)
         {
         }
@@ -38,7 +38,7 @@ namespace Krypton.Toolkit
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="disabled">Redirection for disabled state requests.</param>
         /// <param name="normal">Redirection for normal state requests.</param>
-        public PaletteRedirectBorderEdge(PaletteBase? target,
+        public PaletteRedirectBorderEdge(PaletteBase target,
                                          PaletteBorderEdge? disabled,
                                          PaletteBorderEdge? normal)
             : base(target)

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectButtonSpec.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectButtonSpec.cs
@@ -27,7 +27,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="inherit">Redirection button spec requests.</param>
-        public PaletteRedirectButtonSpec(PaletteBase? target, IPaletteButtonSpec inherit)
+        public PaletteRedirectButtonSpec(PaletteBase target, IPaletteButtonSpec inherit)
             : base(target) =>
             _inherit = inherit;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectContent.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectContent.cs
@@ -47,7 +47,7 @@ namespace Krypton.Toolkit
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="disabled">Redirection for disabled state requests.</param>
         /// <param name="normal">Redirection for normal state requests.</param>
-        public PaletteRedirectContent(PaletteBase? target,
+        public PaletteRedirectContent(PaletteBase target,
                                       IPaletteContent disabled,
                                       IPaletteContent normal)
             : this(target, disabled, normal, null, null, null, null, null, null, null, null, null, null)
@@ -70,7 +70,7 @@ namespace Krypton.Toolkit
         /// <param name="linkVisitedOverride">Redirection for link visited override state requests.</param>
         /// <param name="linkNotVisitedOverride">Redirection for link not visited override state requests.</param>
         /// <param name="linkPressedOverride">Redirection for link pressed override state requests.</param>
-        public PaletteRedirectContent(PaletteBase? target,
+        public PaletteRedirectContent(PaletteBase target,
                                       IPaletteContent disabled,
                                       IPaletteContent normal,
                                       IPaletteContent pressed,
@@ -250,7 +250,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             IPaletteContent? inherit = GetInherit(state);
 
@@ -458,7 +458,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             IPaletteContent? inherit = GetInherit(state);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectDouble.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectDouble.cs
@@ -42,7 +42,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteRedirectDouble class.
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
-        public PaletteRedirectDouble(PaletteBase? target)
+        public PaletteRedirectDouble(PaletteBase target)
             : this(target, null, null, null, null, null, null, null, null, null)
         {
         }
@@ -53,7 +53,7 @@ namespace Krypton.Toolkit
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="disabled">Redirection for disabled state requests.</param>
         /// <param name="normal">Redirection for normal state requests.</param>
-        public PaletteRedirectDouble(PaletteBase? target,
+        public PaletteRedirectDouble(PaletteBase target,
                                      IPaletteDouble? disabled,
                                      IPaletteDouble? normal)
             : this(target, disabled, normal, null, null, null, null, null, null, null)
@@ -68,7 +68,7 @@ namespace Krypton.Toolkit
         /// <param name="normal">Redirection for normal state requests.</param>
         /// <param name="pressed">Redirection for pressed state requests.</param>
         /// <param name="tracking">Redirection for tracking state requests.</param>
-        public PaletteRedirectDouble(PaletteBase? target,
+        public PaletteRedirectDouble(PaletteBase target,
                                      IPaletteDouble? disabled,
                                      IPaletteDouble? normal,
                                      IPaletteDouble? pressed,
@@ -90,7 +90,7 @@ namespace Krypton.Toolkit
         /// <param name="checkedTracking">Redirection for checked tracking state requests.</param>
         /// <param name="focusOverride">Redirection for focus override state requests.</param>
         /// <param name="normalDefaultOverride">Redirection for normal default override state requests.</param>
-        public PaletteRedirectDouble(PaletteBase? target,
+        public PaletteRedirectDouble(PaletteBase target,
                                      IPaletteDouble? disabled,
                                      IPaletteDouble? normal,
                                      IPaletteDouble? pressed,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectDoubleMetric.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectDoubleMetric.cs
@@ -29,7 +29,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteRedirectDoubleMetric class.
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
-        public PaletteRedirectDoubleMetric(PaletteBase? target)
+        public PaletteRedirectDoubleMetric(PaletteBase target)
             : this(target, null, null, null, null)
         {
         }
@@ -42,7 +42,7 @@ namespace Krypton.Toolkit
         /// <param name="disableMetric">Redirection for disabled metric requests.</param>
         /// <param name="normal">Redirection for normal state requests.</param>
         /// <param name="normalMetric">Redirection for normal metric requests.</param>
-        public PaletteRedirectDoubleMetric(PaletteBase? target,
+        public PaletteRedirectDoubleMetric(PaletteBase target,
                                            IPaletteDouble? disabled, IPaletteMetric? disableMetric,
                                            IPaletteDouble? normal, IPaletteMetric? normalMetric)
             : base(target, disabled, normal)

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectGrids.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectGrids.cs
@@ -27,7 +27,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="grid">Grid reference for directing palette requests.</param>
-        public PaletteRedirectGrids(PaletteBase? target, [DisallowNull] KryptonPaletteGrid grid)
+        public PaletteRedirectGrids(PaletteBase target, [DisallowNull] KryptonPaletteGrid grid)
             : base(target)
         {
             Debug.Assert(grid != null);
@@ -410,7 +410,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             IPaletteContent inherit = GetInheritContent(style, state);
 
@@ -618,7 +618,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             IPaletteContent inherit = GetInheritContent(style, state);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectMetric.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectMetric.cs
@@ -27,7 +27,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteRedirectMetric class.
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
-        public PaletteRedirectMetric(PaletteBase? target)
+        public PaletteRedirectMetric(PaletteBase target)
             : this(target, null, null)
         {
         }
@@ -38,7 +38,7 @@ namespace Krypton.Toolkit
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="disableMetric">Redirection for disabled metric requests.</param>
         /// <param name="normalMetric">Redirection for normal metric requests.</param>
-        public PaletteRedirectMetric(PaletteBase? target,
+        public PaletteRedirectMetric(PaletteBase target,
                                      IPaletteMetric disableMetric,
                                      IPaletteMetric normalMetric)
             : base(target)

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectRibbonGeneral.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectRibbonGeneral.cs
@@ -29,7 +29,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteRedirectRibbonGeneral class.
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
-        public PaletteRedirectRibbonGeneral(PaletteBase? target)
+        public PaletteRedirectRibbonGeneral(PaletteBase target)
             : this(target, null, null, null, null)
         {
         }
@@ -42,7 +42,7 @@ namespace Krypton.Toolkit
         /// <param name="normal">Redirection for normal state requests.</param>
         /// <param name="pressed">Redirection for pressed state requests.</param>
         /// <param name="tracking">Redirection for tracking state requests.</param>
-        public PaletteRedirectRibbonGeneral(PaletteBase? target,
+        public PaletteRedirectRibbonGeneral(PaletteBase target,
                                             IPaletteRibbonGeneral disabled,
                                             IPaletteRibbonGeneral normal,
                                             IPaletteRibbonGeneral pressed,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectTriple.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectTriple.cs
@@ -45,7 +45,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteRedirectTriple class.
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
-        public PaletteRedirectTriple(PaletteBase? target)
+        public PaletteRedirectTriple(PaletteBase target)
             : this(target, null, null, null, null, null, null, null, null, null)
         {
         }
@@ -56,7 +56,7 @@ namespace Krypton.Toolkit
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="disabled">Redirection for disabled state requests.</param>
         /// <param name="normal">Redirection for normal state requests.</param>
-        public PaletteRedirectTriple(PaletteBase? target,
+        public PaletteRedirectTriple(PaletteBase target,
                                      IPaletteTriple disabled,
                                      IPaletteTriple normal)
             : this(target, disabled, normal, null, null, null, null, null, null, null)
@@ -70,7 +70,7 @@ namespace Krypton.Toolkit
         /// <param name="disabled">Redirection for disabled state requests.</param>
         /// <param name="normal">Redirection for normal state requests.</param>
         /// <param name="tracking">Redirection for tracking state requests.</param>
-        public PaletteRedirectTriple(PaletteBase? target,
+        public PaletteRedirectTriple(PaletteBase target,
                                      IPaletteTriple disabled,
                                      IPaletteTriple normal,
                                      IPaletteTriple tracking)
@@ -89,7 +89,7 @@ namespace Krypton.Toolkit
         /// <param name="contextNormal">Redirection for context normal state requests.</param>
         /// <param name="contextPressed">Redirection for context pressed state requests.</param>
         /// <param name="contextTracking">Redirection for context tracking state requests.</param>
-        public PaletteRedirectTriple(PaletteBase? target,
+        public PaletteRedirectTriple(PaletteBase target,
                                     IPaletteTriple disabled,
                                     IPaletteTriple normal,
                                     IPaletteTriple tracking,
@@ -114,7 +114,7 @@ namespace Krypton.Toolkit
         /// <param name="tracking">Redirection for tracking state requests.</param>
         /// <param name="selected">Redirection for all checked states.</param>
         /// <param name="focusOverride">Redirection for focus override state requests.</param>
-        public PaletteRedirectTriple(PaletteBase? target,
+        public PaletteRedirectTriple(PaletteBase target,
                                      IPaletteTriple disabled,
                                      IPaletteTriple normal,
                                      IPaletteTriple pressed,
@@ -139,7 +139,7 @@ namespace Krypton.Toolkit
         /// <param name="checkedTracking">Redirection for checked tracking state requests.</param>
         /// <param name="focusOverride">Redirection for focus override state requests.</param>
         /// <param name="normalDefaultOverride">Redirection for normal default override state requests.</param>
-        public PaletteRedirectTriple(PaletteBase? target,
+        public PaletteRedirectTriple(PaletteBase target,
                                      IPaletteTriple? disabled,
                                      IPaletteTriple? normal,
                                      IPaletteTriple? pressed,
@@ -630,7 +630,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
 
@@ -852,7 +852,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectTripleMetric.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectTripleMetric.cs
@@ -27,7 +27,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteRedirectTripleMetric class.
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
-        public PaletteRedirectTripleMetric(PaletteBase? target)
+        public PaletteRedirectTripleMetric(PaletteBase target)
             : this(target, null, null, null, null)
         {
         }
@@ -40,7 +40,7 @@ namespace Krypton.Toolkit
         /// <param name="disableMetric">Redirection for disabled metric requests.</param>
         /// <param name="normal">Redirection for normal state requests.</param>
         /// <param name="normalMetric">Redirection for normal metric requests.</param>
-        public PaletteRedirectTripleMetric(PaletteBase? target,
+        public PaletteRedirectTripleMetric(PaletteBase target,
                                            IPaletteTriple disabled, IPaletteMetric disableMetric,
                                            IPaletteTriple normal, IPaletteMetric normalMetric)
             : base(target, disabled, normal)

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonBackInheritRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonBackInheritRedirect.cs
@@ -18,7 +18,7 @@ namespace Krypton.Toolkit
     public class PaletteRibbonBackInheritRedirect : PaletteRibbonBackInherit
     {
         #region Instance Fields
-        private PaletteRedirect? _redirect;
+        private PaletteRedirect _redirect;
 
         #endregion
 
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">Source for inherit requests.</param>
         /// <param name="styleBack">Ribbon item background style.</param>
-        public PaletteRibbonBackInheritRedirect([DisallowNull] PaletteRedirect? redirect,
+        public PaletteRibbonBackInheritRedirect([DisallowNull] PaletteRedirect redirect,
                                                 PaletteRibbonBackStyle styleBack)
         {
             Debug.Assert(redirect != null);
@@ -43,7 +43,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect) => _redirect = redirect;
+        public void SetRedirector(PaletteRedirect redirect) => _redirect = redirect;
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonBackRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonBackRedirect.cs
@@ -34,7 +34,7 @@ namespace Krypton.Toolkit
         /// <param name="redirect">inheritance redirection instance.</param>
         /// <param name="backStyle">inheritance ribbon back style.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteRibbonBackRedirect([DisallowNull] PaletteRedirect? redirect,
+        public PaletteRibbonBackRedirect([DisallowNull] PaletteRedirect redirect,
                                          PaletteRibbonBackStyle backStyle,
                                          NeedPaintHandler needPaint) 
         {
@@ -60,7 +60,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect) => _inheritBack.SetRedirector(redirect);
+        public void SetRedirector(PaletteRedirect redirect) => _inheritBack.SetRedirector(redirect);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonDoubleInheritRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonDoubleInheritRedirect.cs
@@ -18,7 +18,7 @@ namespace Krypton.Toolkit
     public class PaletteRibbonDoubleInheritRedirect : PaletteRibbonDoubleInherit
     {
         #region Instance Fields
-        private PaletteRedirect? _redirect;
+        private PaletteRedirect _redirect;
 
         #endregion
 
@@ -29,7 +29,7 @@ namespace Krypton.Toolkit
         /// <param name="redirect">Source for inherit requests.</param>
         /// <param name="styleBack">Ribbon item background style.</param>
         /// <param name="styleText">Ribbon item text style.</param>
-        public PaletteRibbonDoubleInheritRedirect([DisallowNull] PaletteRedirect? redirect,
+        public PaletteRibbonDoubleInheritRedirect([DisallowNull] PaletteRedirect redirect,
                                                   PaletteRibbonBackStyle styleBack,
                                                   PaletteRibbonTextStyle styleText)
         {
@@ -46,7 +46,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect) => _redirect = redirect;
+        public void SetRedirector(PaletteRedirect redirect) => _redirect = redirect;
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonDoubleRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonDoubleRedirect.cs
@@ -38,7 +38,7 @@ namespace Krypton.Toolkit
         /// <param name="backStyle">inheritance ribbon back style.</param>
         /// <param name="textStyle">inheritance ribbon text style.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteRibbonDoubleRedirect([DisallowNull] PaletteRedirect? redirect,
+        public PaletteRibbonDoubleRedirect([DisallowNull] PaletteRedirect redirect,
                                            PaletteRibbonBackStyle backStyle,
                                            PaletteRibbonTextStyle textStyle,
                                            NeedPaintHandler needPaint) 
@@ -67,7 +67,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect)
+        public void SetRedirector(PaletteRedirect redirect)
         {
             _inheritBack.SetRedirector(redirect);
             _inheritText.SetRedirector(redirect);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonGeneralInheritRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonGeneralInheritRedirect.cs
@@ -18,7 +18,7 @@ namespace Krypton.Toolkit
     public class PaletteRibbonGeneralInheritRedirect : PaletteRibbonGeneralInherit
     {
         #region Instance Fields
-        private PaletteRedirect? _redirect;
+        private PaletteRedirect _redirect;
         #endregion
 
         #region Identity
@@ -26,7 +26,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteRibbonGeneralInheritRedirect class.
         /// </summary>
         /// <param name="redirect">Source for inherit requests.</param>
-        public PaletteRibbonGeneralInheritRedirect([DisallowNull] PaletteRedirect? redirect)
+        public PaletteRibbonGeneralInheritRedirect([DisallowNull] PaletteRedirect redirect)
         {
             Debug.Assert(redirect != null);
             _redirect = redirect;
@@ -38,7 +38,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect) => _redirect = redirect;
+        public void SetRedirector(PaletteRedirect redirect) => _redirect = redirect;
         #endregion
 
         #region IPaletteRibbon

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonTextInheritRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonTextInheritRedirect.cs
@@ -18,7 +18,7 @@ namespace Krypton.Toolkit
     public class PaletteRibbonTextInheritRedirect : PaletteRibbonTextInherit
     {
         #region Instance Fields
-        private PaletteRedirect? _redirect;
+        private PaletteRedirect _redirect;
 
         #endregion
 
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">Source for inherit requests.</param>
         /// <param name="styleText">Ribbon item text style.</param>
-        public PaletteRibbonTextInheritRedirect([DisallowNull] PaletteRedirect? redirect,
+        public PaletteRibbonTextInheritRedirect([DisallowNull] PaletteRedirect redirect,
                                                 PaletteRibbonTextStyle styleText)
         {
             Debug.Assert(redirect != null);
@@ -43,7 +43,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect) => _redirect = redirect;
+        public void SetRedirector(PaletteRedirect redirect) => _redirect = redirect;
         #endregion
 
         #region StyleText

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTab/PaletteTabTripleRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTab/PaletteTabTripleRedirect.cs
@@ -73,7 +73,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public virtual void SetRedirector(PaletteRedirect? redirect)
+        public virtual void SetRedirector(PaletteRedirect redirect)
         {
             _backInherit.SetRedirector(redirect);
             _borderInherit.SetRedirector(redirect);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTools/PaletteTools.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTools/PaletteTools.cs
@@ -12,44 +12,44 @@
 
 namespace Krypton.Toolkit
 {
-    public class PaletteTools
-    {
-        #region Properties
-        /// <summary>Gets the theme list.</summary>
-        /// <value>The theme list.</value>
-        public static List<string?> ThemeList1 => ThemeManager.SupportedInternalThemeNames.ToList();
+    //public class PaletteTools
+    //{
+    //    #region Properties
+    //    /// <summary>Gets the theme list.</summary>
+    //    /// <value>The theme list.</value>
+    //    public static List<string?> ThemeList1 => ThemeManager.SupportedInternalThemeNames.ToList();
 
-        #endregion
+    //    #endregion
 
-        #region Methods
-        /// <summary>Links the type of the palette to the correct theme style.</summary>
-        /// <param name="themeName">Name of the theme.</param>
-        /// <returns></returns>
-        public PaletteMode LinkPaletteType1(string themeName)
-        {
-            var cnvtr = new PaletteModeConverter();
-            return (PaletteMode)cnvtr.ConvertFromString(themeName);
-        }
+    //    #region Methods
+    //    /// <summary>Links the type of the palette to the correct theme style.</summary>
+    //    /// <param name="themeName">Name of the theme.</param>
+    //    /// <returns></returns>
+    //    public PaletteMode LinkPaletteType1(string themeName)
+    //    {
+    //        var cnvtr = new PaletteModeConverter();
+    //        return (PaletteMode)cnvtr.ConvertFromString(themeName);
+    //    }
 
-        /// <summary>Applies the theme.</summary>
-        /// <param name="manager">The manager.</param>
-        /// <param name="paletteMode">The palette mode.</param>
-        /// <param name="customThemePath">The custom theme path.</param>
-        public static void ApplyTheme(KryptonManager manager, PaletteMode paletteMode = PaletteMode.Microsoft365Blue, string customThemePath = "")
-        {
-            manager.GlobalPaletteMode = paletteMode;
+    //    /// <summary>Applies the theme.</summary>
+    //    /// <param name="manager">The manager.</param>
+    //    /// <param name="paletteMode">The palette mode.</param>
+    //    /// <param name="customThemePath">The custom theme path.</param>
+    //    public static void ApplyTheme(KryptonManager manager, PaletteMode paletteMode = PaletteMode.Microsoft365Blue, string customThemePath = "")
+    //    {
+    //        manager.GlobalPaletteMode = paletteMode;
 
-            if (!string.IsNullOrWhiteSpace(customThemePath))
-            {
-                var palette = new KryptonCustomPaletteBase();
+    //        if (!string.IsNullOrWhiteSpace(customThemePath))
+    //        {
+    //            var palette = new KryptonCustomPaletteBase();
 
-                palette.Import(customThemePath);
+    //            palette.Import(customThemePath);
 
-                manager.GlobalPalette = palette;
+    //            manager.GlobalPalette = palette;
 
-                manager.GlobalPaletteMode = PaletteMode.Custom;
-            }
-        }
-        #endregion
-    }
+    //            manager.GlobalPaletteMode = PaletteMode.Custom;
+    //        }
+    //    }
+    //    #endregion
+    //}
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTripleJustImageRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTripleJustImageRedirect.cs
@@ -46,7 +46,7 @@ namespace Krypton.Toolkit
         /// <param name="backStyle">Initial background style.</param>
         /// <param name="borderStyle">Initial border style.</param>
         /// <param name="contentStyle">Initial content style.</param>
-        public PaletteTripleJustImageRedirect(PaletteRedirect? redirect,
+        public PaletteTripleJustImageRedirect(PaletteRedirect redirect,
                                               PaletteBackStyle backStyle,
                                               PaletteBorderStyle borderStyle,
                                               PaletteContentStyle contentStyle)
@@ -62,7 +62,7 @@ namespace Krypton.Toolkit
         /// <param name="borderStyle">Initial border style.</param>
         /// <param name="contentStyle">Initial content style.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteTripleJustImageRedirect(PaletteRedirect? redirect,
+        public PaletteTripleJustImageRedirect(PaletteRedirect redirect,
                                               PaletteBackStyle backStyle,
                                               PaletteBorderStyle borderStyle,
                                               PaletteContentStyle contentStyle,
@@ -99,7 +99,7 @@ namespace Krypton.Toolkit
         /// Gets the redirector instance.
         /// </summary>
         /// <returns>Return the currently used redirector.</returns>
-        public PaletteRedirect? GetRedirector() => _backInherit.GetRedirector();
+        public PaletteRedirect GetRedirector() => _backInherit.GetRedirector();
 
         #endregion
 
@@ -108,7 +108,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public virtual void SetRedirector(PaletteRedirect? redirect)
+        public virtual void SetRedirector(PaletteRedirect redirect)
         {
             _backInherit.SetRedirector(redirect);
             _borderInherit.SetRedirector(redirect);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTripleMetricRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTripleMetricRedirect.cs
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit
                                                IPaletteMetric
     {
         #region Instance Fields
-        private PaletteRedirect? _redirect;
+        private PaletteRedirect _redirect;
         #endregion
 
         #region Identity
@@ -31,7 +31,7 @@ namespace Krypton.Toolkit
         /// <param name="borderStyle">Style for the border.</param>
         /// <param name="contentStyle">Style for the content.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteTripleMetricRedirect([DisallowNull] PaletteRedirect? redirect,
+        public PaletteTripleMetricRedirect([DisallowNull] PaletteRedirect redirect,
                                            PaletteBackStyle backStyle,
                                            PaletteBorderStyle borderStyle,
                                            PaletteContentStyle contentStyle,
@@ -54,7 +54,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public override void SetRedirector(PaletteRedirect? redirect)
+        public override void SetRedirector(PaletteRedirect redirect)
         {
             base.SetRedirector(redirect);
             _redirect = redirect;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTripleRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTripleRedirect.cs
@@ -46,7 +46,7 @@ namespace Krypton.Toolkit
         /// <param name="backStyle">Initial background style.</param>
         /// <param name="borderStyle">Initial border style.</param>
         /// <param name="contentStyle">Initial content style.</param>
-        public PaletteTripleRedirect(PaletteRedirect? redirect,
+        public PaletteTripleRedirect(PaletteRedirect redirect,
                                      PaletteBackStyle backStyle,
                                      PaletteBorderStyle borderStyle,
                                      PaletteContentStyle contentStyle)
@@ -62,7 +62,7 @@ namespace Krypton.Toolkit
         /// <param name="borderStyle">Initial border style.</param>
         /// <param name="contentStyle">Initial content style.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteTripleRedirect(PaletteRedirect? redirect,
+        public PaletteTripleRedirect(PaletteRedirect redirect,
                                      PaletteBackStyle backStyle,
                                      PaletteBorderStyle borderStyle,
                                      PaletteContentStyle contentStyle,
@@ -99,7 +99,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public virtual void SetRedirector(PaletteRedirect? redirect)
+        public virtual void SetRedirector(PaletteRedirect redirect)
         {
             _backInherit.SetRedirector(redirect);
             _borderInherit.SetRedirector(redirect);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTripleToPalette.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTripleToPalette.cs
@@ -31,7 +31,7 @@ namespace Krypton.Toolkit
         /// <param name="backStyle">Initial background style.</param>
         /// <param name="borderStyle">Initial border style.</param>
         /// <param name="contentStyle">Initial content style.</param>
-        public PaletteTripleToPalette(PaletteBase? palette,
+        public PaletteTripleToPalette(PaletteBase palette,
                                       PaletteBackStyle backStyle,
                                       PaletteBorderStyle borderStyle,
                                       PaletteContentStyle contentStyle)

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Base/PaletteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Base/PaletteBase.cs
@@ -107,7 +107,7 @@ namespace Krypton.Toolkit
         /// Gets the renderer to use for this palette.
         /// </summary>
         /// <returns>Renderer to use for drawing palette settings.</returns>
-        public abstract IRenderer? GetRenderer();
+        public abstract IRenderer GetRenderer();
         #endregion
 
         #region Back
@@ -369,7 +369,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public abstract Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state);
+        public abstract Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state);
 
         /// <summary>
         /// Gets the font for the short text by generating a new font instance.
@@ -377,7 +377,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public abstract Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state);
+        public abstract Font? GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state);
 
         /// <summary>
         /// Gets the rendering hint for the short text.
@@ -505,7 +505,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public abstract Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state);
+        public abstract Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state);
 
         /// <summary>
         /// Gets the font for the long text by generating a new font instance.
@@ -513,7 +513,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public abstract Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state);
+        public abstract Font? GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state);
 
         /// <summary>
         /// Gets the rendering hint for the long text.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Bases/PaletteMicrosoft365Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Bases/PaletteMicrosoft365Base.cs
@@ -1830,7 +1830,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -1869,7 +1869,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentShortTextFont(style, state);
@@ -2338,7 +2338,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2368,7 +2368,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentLongTextFont(style, state);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkMode.cs
@@ -2419,7 +2419,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2456,7 +2456,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentShortTextFont(style, state);
@@ -2933,7 +2933,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2963,7 +2963,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentLongTextFont(style, state);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueDarkMode.cs
@@ -2419,7 +2419,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2456,7 +2456,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentShortTextFont(style, state);
@@ -2925,7 +2925,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2955,7 +2955,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentLongTextFont(style, state);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueLightMode.cs
@@ -2418,7 +2418,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2455,7 +2455,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentShortTextFont(style, state);
@@ -2924,7 +2924,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2954,7 +2954,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentLongTextFont(style, state);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverDarkMode.cs
@@ -2425,7 +2425,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2462,7 +2462,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentShortTextFont(style, state);
@@ -2931,7 +2931,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2961,7 +2961,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentLongTextFont(style, state);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverLightMode.cs
@@ -2423,7 +2423,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2460,7 +2460,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentShortTextFont(style, state);
@@ -2929,7 +2929,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2959,7 +2959,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentLongTextFont(style, state);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Black.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Black.cs
@@ -2336,7 +2336,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2373,7 +2373,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentShortTextFont(style, state);
@@ -2842,7 +2842,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2872,7 +2872,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentLongTextFont(style, state);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Bases/PaletteOffice2007Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Bases/PaletteOffice2007Base.cs
@@ -2407,7 +2407,7 @@ namespace Krypton.Toolkit
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2444,7 +2444,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentShortTextFont(style, state);
@@ -2923,7 +2923,7 @@ namespace Krypton.Toolkit
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2953,7 +2953,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentLongTextFont(style, state);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlackDarkMode.cs
@@ -3118,7 +3118,7 @@ namespace Krypton.Toolkit
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -3155,7 +3155,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentShortTextFont(style, state);
@@ -3644,7 +3644,7 @@ namespace Krypton.Toolkit
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -3674,7 +3674,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentLongTextFont(style, state);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueDarkMode.cs
@@ -2428,7 +2428,7 @@ namespace Krypton.Toolkit
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2465,7 +2465,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentShortTextFont(style, state);
@@ -2944,7 +2944,7 @@ namespace Krypton.Toolkit
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2974,7 +2974,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentLongTextFont(style, state);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueLightMode.cs
@@ -2895,7 +2895,7 @@ namespace Krypton.Toolkit
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2932,7 +2932,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentShortTextFont(style, state);
@@ -3411,7 +3411,7 @@ namespace Krypton.Toolkit
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -3441,7 +3441,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentLongTextFont(style, state);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverDarkMode.cs
@@ -2885,7 +2885,7 @@ namespace Krypton.Toolkit
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2922,7 +2922,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentShortTextFont(style, state);
@@ -3401,7 +3401,7 @@ namespace Krypton.Toolkit
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -3431,7 +3431,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentLongTextFont(style, state);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverLightMode.cs
@@ -2322,8 +2322,12 @@ namespace Krypton.Toolkit
                 {
                     if (style == PaletteBorderStyle.ButtonCalendarDay)
                     {
-                        return state == PaletteState.Disabled ? _disabledBorder : _todayBorder;
+                        return _todayBorder;
                     }
+                }
+                else if (state == PaletteState.Disabled)
+                {
+                    return _disabledBorder;
                 }
 
                 return Color.Empty;
@@ -2444,8 +2448,12 @@ namespace Krypton.Toolkit
                 {
                     if (style == PaletteBorderStyle.ButtonCalendarDay)
                     {
-                        return state == PaletteState.Disabled ? _disabledBorder : _todayBorder;
+                        return _todayBorder;
                     }
+                }
+                else if (state == PaletteState.Disabled)
+                {
+                    return _disabledBorder;
                 }
 
                 return Color.Empty;
@@ -2935,7 +2943,7 @@ namespace Krypton.Toolkit
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2972,7 +2980,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentShortTextFont(style, state);
@@ -3451,7 +3459,7 @@ namespace Krypton.Toolkit
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -3481,7 +3489,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentLongTextFont(style, state);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Bases/PaletteOffice2010Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Bases/PaletteOffice2010Base.cs
@@ -1790,7 +1790,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -1827,7 +1827,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentShortTextFont(style, state);
@@ -2369,7 +2369,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2399,7 +2399,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentLongTextFont(style, state);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlackDarkMode.cs
@@ -2602,7 +2602,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2639,7 +2639,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentShortTextFont(style, state);
@@ -3191,7 +3191,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -3221,7 +3221,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentLongTextFont(style, state);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueDarkMode.cs
@@ -2247,7 +2247,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2284,7 +2284,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentShortTextFont(style, state);
@@ -2826,7 +2826,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2856,7 +2856,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentLongTextFont(style, state);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueLightMode.cs
@@ -2226,7 +2226,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2263,7 +2263,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentShortTextFont(style, state);
@@ -2805,7 +2805,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2835,7 +2835,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentLongTextFont(style, state);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverDarkMode.cs
@@ -2233,7 +2233,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2270,7 +2270,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentShortTextFont(style, state);
@@ -2812,7 +2812,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2842,7 +2842,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentLongTextFont(style, state);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverLightMode.cs
@@ -2263,7 +2263,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2300,7 +2300,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentShortTextFont(style, state);
@@ -2842,7 +2842,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2872,7 +2872,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentLongTextFont(style, state);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Bases/PaletteOffice2013Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Bases/PaletteOffice2013Base.cs
@@ -1804,7 +1804,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -1841,7 +1841,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentShortTextFont(style, state);
@@ -2304,7 +2304,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2334,7 +2334,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentLongTextFont(style, state);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013White.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013White.cs
@@ -2183,7 +2183,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2220,7 +2220,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentShortTextFont(style, state);
@@ -2683,7 +2683,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2713,7 +2713,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentLongTextFont(style, state);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Professional/PaletteProfessionalOffice2003.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Professional/PaletteProfessionalOffice2003.cs
@@ -1964,7 +1964,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2000,7 +2000,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentShortTextFont(style, state);
@@ -2392,7 +2392,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2422,7 +2422,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentLongTextFont(style, state);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Professional/PaletteProfessionalSystem.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Professional/PaletteProfessionalSystem.cs
@@ -1711,7 +1711,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -1747,7 +1747,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentShortTextFont(style, state);
@@ -2139,7 +2139,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2169,7 +2169,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentLongTextFont(style, state);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/Base/PaletteSparkleBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/Base/PaletteSparkleBase.cs
@@ -1808,7 +1808,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -1845,7 +1845,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentShortTextFont(style, state);
@@ -2311,7 +2311,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2341,7 +2341,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentLongTextFont(style, state);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/Extra Themes/PaletteSparkleBlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/Extra Themes/PaletteSparkleBlueDarkMode.cs
@@ -1980,7 +1980,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2022,7 +2022,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentShortTextFont(style, state);
@@ -2488,7 +2488,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2523,7 +2523,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentLongTextFont(style, state);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/PaletteVisualStudioBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/PaletteVisualStudioBase.cs
@@ -1009,7 +1009,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -1048,7 +1048,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentShortTextFont(style, state);
@@ -1517,7 +1517,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -1547,7 +1547,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentLongTextFont(style, state);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2007/PaletteVisualStudio2010With2007Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2007/PaletteVisualStudio2010With2007Base.cs
@@ -1799,7 +1799,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -1838,7 +1838,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentShortTextFont(style, state);
@@ -2309,7 +2309,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2339,7 +2339,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentLongTextFont(style, state);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2010/PaletteVisualStudio2010With2010Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2010/PaletteVisualStudio2010With2010Base.cs
@@ -1800,7 +1800,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -1839,7 +1839,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentShortTextFont(style, state);
@@ -2310,7 +2310,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2340,7 +2340,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentLongTextFont(style, state);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2013/PaletteVisualStudio2010With2013Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2013/PaletteVisualStudio2010With2013Base.cs
@@ -1797,7 +1797,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -1836,7 +1836,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentShortTextFont(style, state);
@@ -2307,7 +2307,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2337,7 +2337,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentLongTextFont(style, state);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/365/PaletteVisualStudio2010With365Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/365/PaletteVisualStudio2010With365Base.cs
@@ -1799,7 +1799,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -1838,7 +1838,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentShortTextFont(style, state);
@@ -2309,7 +2309,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             if (CommonHelper.IsOverrideState(state))
             {
@@ -2339,7 +2339,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextNewFont(PaletteContentStyle style, PaletteState state)
         {
             DefineFonts();
             return GetContentLongTextFont(style, state);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteCalendarDay.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteCalendarDay.cs
@@ -23,7 +23,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">Redirector to inherit values from.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public KryptonPaletteCalendarDay(PaletteRedirect? redirect,
+        public KryptonPaletteCalendarDay(PaletteRedirect redirect,
                                          NeedPaintHandler needPaint) 
         {
             // Create the storage objects
@@ -46,7 +46,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect)
+        public void SetRedirector(PaletteRedirect redirect)
         {
             OverrideFocus.SetRedirector(redirect);
             OverrideBolded.SetRedirector(redirect);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteCheckButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteCheckButton.cs
@@ -26,7 +26,7 @@ namespace Krypton.Toolkit
         /// <param name="borderStyle">Border style.</param>
         /// <param name="contentStyle">Content style.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public KryptonPaletteCheckButton(PaletteRedirect? redirect,
+        public KryptonPaletteCheckButton(PaletteRedirect redirect,
                                          PaletteBackStyle backStyle,
                                          PaletteBorderStyle borderStyle,
                                          PaletteContentStyle contentStyle,
@@ -51,7 +51,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect)
+        public void SetRedirector(PaletteRedirect redirect)
         {
             OverrideDefault.SetRedirector(redirect);
             OverrideFocus.SetRedirector(redirect);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteContextMenu.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteContextMenu.cs
@@ -40,7 +40,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect) => StateCommon.SetRedirector(redirect);
+        public void SetRedirector(PaletteRedirect redirect) => StateCommon.SetRedirector(redirect);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteControl.cs
@@ -25,7 +25,7 @@ namespace Krypton.Toolkit
         /// <param name="backStyle">Background style.</param>
         /// <param name="borderStyle">Border style.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public KryptonPaletteControl(PaletteRedirect? redirect,
+        public KryptonPaletteControl(PaletteRedirect redirect,
                                      PaletteBackStyle backStyle,
                                      PaletteBorderStyle borderStyle,
                                      NeedPaintHandler needPaint)

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteDouble3.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteDouble3.cs
@@ -31,7 +31,7 @@ namespace Krypton.Toolkit
         /// <param name="backStyle">Background style.</param>
         /// <param name="borderStyle">Border style.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        protected KryptonPaletteDouble3(PaletteRedirect? redirect,
+        protected KryptonPaletteDouble3(PaletteRedirect redirect,
                                      PaletteBackStyle backStyle,
                                      PaletteBorderStyle borderStyle,
                                      NeedPaintHandler needPaint)
@@ -48,7 +48,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect) => _stateCommon!.SetRedirector(redirect);
+        public void SetRedirector(PaletteRedirect redirect) => _stateCommon!.SetRedirector(redirect);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteForm.cs
@@ -25,7 +25,7 @@ namespace Krypton.Toolkit
         /// <param name="backStyle">Background style.</param>
         /// <param name="borderStyle">Border style.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public KryptonPaletteForm(PaletteRedirect? redirect,
+        public KryptonPaletteForm(PaletteRedirect redirect,
                                   PaletteBackStyle backStyle,
                                   PaletteBorderStyle borderStyle,
                                   NeedPaintHandler needPaint) 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteGrid.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteGrid.cs
@@ -24,7 +24,7 @@ namespace Krypton.Toolkit
         /// <param name="redirect">Redirector to inherit values from.</param>
         /// <param name="gridStyle">Grid style.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public KryptonPaletteGrid(PaletteRedirect? redirect,
+        public KryptonPaletteGrid(PaletteRedirect redirect,
                                   GridStyle gridStyle,
                                   NeedPaintHandler needPaint) 
         {
@@ -43,7 +43,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect) => StateCommon.SetRedirector(redirect);
+        public void SetRedirector(PaletteRedirect redirect) => StateCommon.SetRedirector(redirect);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteHeader.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteHeader.cs
@@ -26,7 +26,7 @@ namespace Krypton.Toolkit
         /// <param name="borderStyle">Border style.</param>
         /// <param name="contentStyle">Content style.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public KryptonPaletteHeader(PaletteRedirect? redirect,
+        public KryptonPaletteHeader(PaletteRedirect redirect,
                                     PaletteBackStyle backStyle,
                                     PaletteBorderStyle borderStyle,
                                     PaletteContentStyle contentStyle,
@@ -44,7 +44,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect) => StateCommon.SetRedirector(redirect);
+        public void SetRedirector(PaletteRedirect redirect) => StateCommon.SetRedirector(redirect);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteInputControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteInputControl.cs
@@ -39,7 +39,7 @@ namespace Krypton.Toolkit
         /// <param name="borderStyle">Border style.</param>
         /// <param name="contentStyle">Content style.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public KryptonPaletteInputControl(PaletteRedirect? redirect,
+        public KryptonPaletteInputControl(PaletteRedirect redirect,
                                           PaletteBackStyle backStyle,
                                           PaletteBorderStyle borderStyle,
                                           PaletteContentStyle contentStyle,
@@ -62,7 +62,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect) => _stateCommon.SetRedirector(redirect);
+        public void SetRedirector(PaletteRedirect redirect) => _stateCommon.SetRedirector(redirect);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteLabel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteLabel.cs
@@ -29,7 +29,7 @@ namespace Krypton.Toolkit
         /// <param name="redirect">Redirector to inherit values from.</param>
         /// <param name="contentStyle">Content style.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public KryptonPaletteLabel(PaletteRedirect? redirect,
+        public KryptonPaletteLabel(PaletteRedirect redirect,
                                    PaletteContentStyle contentStyle,
                                    NeedPaintHandler needPaint) 
         {
@@ -50,7 +50,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect) => _stateInherit.SetRedirector(redirect);
+        public void SetRedirector(PaletteRedirect redirect) => _stateInherit.SetRedirector(redirect);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPalettePanel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPalettePanel.cs
@@ -29,7 +29,7 @@ namespace Krypton.Toolkit
         /// <param name="redirect">Redirector to inherit values from.</param>
         /// <param name="backStyle">Back style.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public KryptonPalettePanel(PaletteRedirect? redirect,
+        public KryptonPalettePanel(PaletteRedirect redirect,
                                    PaletteBackStyle backStyle,
                                    NeedPaintHandler needPaint) 
         {
@@ -46,7 +46,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect) => _stateInherit.SetRedirector(redirect);
+        public void SetRedirector(PaletteRedirect redirect) => _stateInherit.SetRedirector(redirect);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbon.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbon.cs
@@ -18,7 +18,7 @@ namespace Krypton.Toolkit
     public class KryptonPaletteRibbon : Storage
     {
         #region Instance Fields
-        private readonly PaletteRedirect? _redirect;
+        private readonly PaletteRedirect _redirect;
         private readonly PaletteRibbonBackInheritRedirect _ribbonAppMenuOuterInherit;
         private readonly PaletteRibbonBackInheritRedirect _ribbonAppMenuInnerInherit;
         private readonly PaletteRibbonBackInheritRedirect _ribbonAppMenuDocsInherit;
@@ -45,7 +45,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">Redirector to inherit values from.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public KryptonPaletteRibbon([DisallowNull] PaletteRedirect? redirect,
+        public KryptonPaletteRibbon([DisallowNull] PaletteRedirect redirect,
                                       NeedPaintHandler needPaint)
         {
             Debug.Assert(redirect != null);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonAppButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonAppButton.cs
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">Redirector to inherit values from.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public KryptonPaletteRibbonAppButton(PaletteRedirect? redirect,
+        public KryptonPaletteRibbonAppButton(PaletteRedirect redirect,
                                              NeedPaintHandler needPaint) 
         {
             // Create the storage objects
@@ -45,7 +45,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect) => _stateInherit.SetRedirector(redirect);
+        public void SetRedirector(PaletteRedirect redirect) => _stateInherit.SetRedirector(redirect);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonGroupArea.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonGroupArea.cs
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">Redirector to inherit values from.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public KryptonPaletteRibbonGroupArea(PaletteRedirect? redirect,
+        public KryptonPaletteRibbonGroupArea(PaletteRedirect redirect,
                                              NeedPaintHandler needPaint) 
         {
             // Create the storage objects
@@ -47,7 +47,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect) => _stateInherit.SetRedirector(redirect);
+        public void SetRedirector(PaletteRedirect redirect) => _stateInherit.SetRedirector(redirect);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonGroupBaseText.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonGroupBaseText.cs
@@ -29,7 +29,7 @@ namespace Krypton.Toolkit
         /// <param name="redirect">Redirector to inherit values from.</param>
         /// <param name="textStyle">Inherit text style.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public KryptonPaletteRibbonGroupBaseText(PaletteRedirect? redirect,
+        public KryptonPaletteRibbonGroupBaseText(PaletteRedirect redirect,
                                                  PaletteRibbonTextStyle textStyle,
                                                  NeedPaintHandler needPaint) 
         {
@@ -46,7 +46,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect) => _stateInherit.SetRedirector(redirect);
+        public void SetRedirector(PaletteRedirect redirect) => _stateInherit.SetRedirector(redirect);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonGroupButtonText.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonGroupButtonText.cs
@@ -23,7 +23,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">Redirector to inherit values from.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public KryptonPaletteRibbonGroupButtonText(PaletteRedirect? redirect,
+        public KryptonPaletteRibbonGroupButtonText(PaletteRedirect redirect,
                                                    NeedPaintHandler needPaint)
             : base(redirect, PaletteRibbonTextStyle.RibbonGroupButtonText, needPaint)
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonGroupCheckBoxText.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonGroupCheckBoxText.cs
@@ -23,7 +23,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">Redirector to inherit values from.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public KryptonPaletteRibbonGroupCheckBoxText(PaletteRedirect? redirect,
+        public KryptonPaletteRibbonGroupCheckBoxText(PaletteRedirect redirect,
                                                      NeedPaintHandler needPaint)
             : base(redirect, PaletteRibbonTextStyle.RibbonGroupCheckBoxText, needPaint)
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonGroupCollapsedBack.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonGroupCollapsedBack.cs
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">Redirector to inherit values from.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public KryptonPaletteRibbonGroupCollapsedBack(PaletteRedirect? redirect,
+        public KryptonPaletteRibbonGroupCollapsedBack(PaletteRedirect redirect,
                                                       NeedPaintHandler needPaint) 
         {
             // Create the storage objects
@@ -46,7 +46,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect) => _stateInherit.SetRedirector(redirect);
+        public void SetRedirector(PaletteRedirect redirect) => _stateInherit.SetRedirector(redirect);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonGroupCollapsedBorder.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonGroupCollapsedBorder.cs
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">Redirector to inherit values from.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public KryptonPaletteRibbonGroupCollapsedBorder(PaletteRedirect? redirect,
+        public KryptonPaletteRibbonGroupCollapsedBorder(PaletteRedirect redirect,
                                                         NeedPaintHandler needPaint) 
         {
             // Create the storage objects
@@ -46,7 +46,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect) => _stateInherit.SetRedirector(redirect);
+        public void SetRedirector(PaletteRedirect redirect) => _stateInherit.SetRedirector(redirect);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonGroupCollapsedFrameBack.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonGroupCollapsedFrameBack.cs
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">Redirector to inherit values from.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public KryptonPaletteRibbonGroupCollapsedFrameBack(PaletteRedirect? redirect,
+        public KryptonPaletteRibbonGroupCollapsedFrameBack(PaletteRedirect redirect,
                                                            NeedPaintHandler needPaint) 
         {
             // Create the storage objects
@@ -46,7 +46,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect) => _stateInherit.SetRedirector(redirect);
+        public void SetRedirector(PaletteRedirect redirect) => _stateInherit.SetRedirector(redirect);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonGroupCollapsedFrameBorder.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonGroupCollapsedFrameBorder.cs
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">Redirector to inherit values from.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public KryptonPaletteRibbonGroupCollapsedFrameBorder(PaletteRedirect? redirect,
+        public KryptonPaletteRibbonGroupCollapsedFrameBorder(PaletteRedirect redirect,
                                                              NeedPaintHandler needPaint) 
         {
             // Create the storage objects
@@ -46,7 +46,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect) => _stateInherit.SetRedirector(redirect);
+        public void SetRedirector(PaletteRedirect redirect) => _stateInherit.SetRedirector(redirect);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonGroupCollapsedText.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonGroupCollapsedText.cs
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">Redirector to inherit values from.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public KryptonPaletteRibbonGroupCollapsedText(PaletteRedirect? redirect,
+        public KryptonPaletteRibbonGroupCollapsedText(PaletteRedirect redirect,
                                                       NeedPaintHandler needPaint) 
         {
             // Create the storage objects
@@ -46,7 +46,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect) => _stateInherit.SetRedirector(redirect);
+        public void SetRedirector(PaletteRedirect redirect) => _stateInherit.SetRedirector(redirect);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonGroupLabelText.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonGroupLabelText.cs
@@ -23,7 +23,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">Redirector to inherit values from.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public KryptonPaletteRibbonGroupLabelText(PaletteRedirect? redirect,
+        public KryptonPaletteRibbonGroupLabelText(PaletteRedirect redirect,
                                                   NeedPaintHandler needPaint)
             : base(redirect, PaletteRibbonTextStyle.RibbonGroupLabelText, needPaint)
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonGroupNormalBorder.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonGroupNormalBorder.cs
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">Redirector to inherit values from.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public KryptonPaletteRibbonGroupNormalBorder(PaletteRedirect? redirect,
+        public KryptonPaletteRibbonGroupNormalBorder(PaletteRedirect redirect,
                                                      NeedPaintHandler needPaint) 
         {
             // Create the storage objects
@@ -46,7 +46,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect) => _stateInherit.SetRedirector(redirect);
+        public void SetRedirector(PaletteRedirect redirect) => _stateInherit.SetRedirector(redirect);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonGroupNormalTitle.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonGroupNormalTitle.cs
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">Redirector to inherit values from.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public KryptonPaletteRibbonGroupNormalTitle(PaletteRedirect? redirect,
+        public KryptonPaletteRibbonGroupNormalTitle(PaletteRedirect redirect,
                                                     NeedPaintHandler needPaint) 
         {
             // Create the storage objects
@@ -46,7 +46,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect) => _stateInherit.SetRedirector(redirect);
+        public void SetRedirector(PaletteRedirect redirect) => _stateInherit.SetRedirector(redirect);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonGroupRadioButtonText.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonGroupRadioButtonText.cs
@@ -23,7 +23,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">Redirector to inherit values from.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public KryptonPaletteRibbonGroupRadioButtonText(PaletteRedirect? redirect,
+        public KryptonPaletteRibbonGroupRadioButtonText(PaletteRedirect redirect,
                                                         NeedPaintHandler needPaint)
             : base(redirect, PaletteRibbonTextStyle.RibbonGroupRadioButtonText, needPaint)
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonQATMinibar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonQATMinibar.cs
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">Redirector to inherit values from.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public KryptonPaletteRibbonQATMinibar(PaletteRedirect? redirect,
+        public KryptonPaletteRibbonQATMinibar(PaletteRedirect redirect,
                                               NeedPaintHandler needPaint) 
         {
             // Create the storage objects
@@ -44,7 +44,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect) => _stateInherit.SetRedirector(redirect);
+        public void SetRedirector(PaletteRedirect redirect) => _stateInherit.SetRedirector(redirect);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonTab.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteRibbonTab.cs
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">Redirector to inherit values from.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public KryptonPaletteRibbonTab(PaletteRedirect? redirect,
+        public KryptonPaletteRibbonTab(PaletteRedirect redirect,
                                        NeedPaintHandler needPaint) 
         {
             // Create the storage objects
@@ -50,7 +50,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect) => _stateInherit.SetRedirector(redirect);
+        public void SetRedirector(PaletteRedirect redirect) => _stateInherit.SetRedirector(redirect);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteSeparator.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteSeparator.cs
@@ -44,7 +44,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect) => StateCommon.SetRedirector(redirect);
+        public void SetRedirector(PaletteRedirect redirect) => StateCommon.SetRedirector(redirect);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteTabButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteTabButton.cs
@@ -48,7 +48,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect)
+        public void SetRedirector(PaletteRedirect redirect)
         {
             OverrideFocus.SetRedirector(redirect);
             StateCommon.SetRedirector(redirect);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteTrackBar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteTrackBar.cs
@@ -41,7 +41,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect)
+        public void SetRedirector(PaletteRedirect redirect)
         {
             StateCommon.SetRedirector(redirect);
             OverrideFocus.SetRedirector(redirect);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/LinkLabelBehaviorInherit.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/LinkLabelBehaviorInherit.cs
@@ -97,10 +97,10 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteState state)
         {
             // Get the actual base font from inheritance chain
-            Font ret = _inherit.GetContentShortTextFont(state);
+            Font? ret = _inherit.GetContentShortTextFont(state);
 
             // We never try and modify an empty font
             if (ret != null)
@@ -116,10 +116,10 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteState state)
         {
             // Get the actual base font from inheritance chain
-            Font ret = _inherit.GetContentShortTextNewFont(state);
+            Font? ret = _inherit.GetContentShortTextNewFont(state);
 
             // We never try and modify an empty font
             if (ret != null)
@@ -240,14 +240,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteState state) => _inherit.GetContentLongTextFont(state);
+        public override Font? GetContentLongTextFont(PaletteState state) => _inherit.GetContentLongTextFont(state);
 
         /// <summary>
         /// Gets the font for the long text by generating a new font instance.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteState state) => _inherit.GetContentLongTextNewFont(state);
+        public override Font? GetContentLongTextNewFont(PaletteState state) => _inherit.GetContentLongTextNewFont(state);
 
         /// <summary>
         /// Gets the rendering hint for the long text.
@@ -377,7 +377,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Private
-        private Font GetContentFont(PaletteState state, Font font)
+        private Font? GetContentFont(PaletteState state, Font? font)
         {
             // We never do anything for the override states
             if (!CommonHelper.IsOverrideState(state))

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteBreadCrumbRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteBreadCrumbRedirect.cs
@@ -23,7 +23,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">inheritance redirection for bread crumb level.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteBreadCrumbRedirect(PaletteRedirect? redirect,
+        public PaletteBreadCrumbRedirect(PaletteRedirect redirect,
                                          NeedPaintHandler needPaint)
             : base(redirect, PaletteBackStyle.PanelAlternate, PaletteBorderStyle.ControlClient) =>
             BreadCrumb = new PaletteTripleRedirect(redirect, 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteComboBoxRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteComboBoxRedirect.cs
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">inheritance redirection instance.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteComboBoxRedirect([DisallowNull] PaletteRedirect? redirect,
+        public PaletteComboBoxRedirect([DisallowNull] PaletteRedirect redirect,
                                        NeedPaintHandler needPaint)
         {
             Debug.Assert(redirect != null);
@@ -79,7 +79,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public virtual void SetRedirector(PaletteRedirect? redirect)
+        public virtual void SetRedirector(PaletteRedirect redirect)
         {
             Item.SetRedirector(redirect);
             ComboBox.SetRedirector(redirect);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteContentInheritNode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteContentInheritNode.cs
@@ -96,14 +96,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteState state) => TreeNode?.NodeFont ?? _inherit.GetContentShortTextFont(state);
+        public override Font? GetContentShortTextFont(PaletteState state) => TreeNode?.NodeFont ?? _inherit.GetContentShortTextFont(state);
 
         /// <summary>
         /// Gets the font for the short text by generating a new font instance.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteState state) => TreeNode?.NodeFont ?? _inherit.GetContentShortTextNewFont(state);
+        public override Font? GetContentShortTextNewFont(PaletteState state) => TreeNode?.NodeFont ?? _inherit.GetContentShortTextNewFont(state);
 
         /// <summary>
         /// Gets the rendering hint for the short text.
@@ -215,7 +215,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteState state) =>
+        public override Font? GetContentLongTextFont(PaletteState state) =>
             (TreeNode is KryptonTreeNode { LongNodeFont: not null } kryptonNode)
                 ? kryptonNode.LongNodeFont
                 : _inherit.GetContentLongTextFont(state);
@@ -225,7 +225,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteState state) => _inherit.GetContentLongTextNewFont(state);
+        public override Font? GetContentLongTextNewFont(PaletteState state) => _inherit.GetContentLongTextNewFont(state);
 
         /// <summary>
         /// Gets the rendering hint for the long text.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteContextMenuItemStateRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteContextMenuItemStateRedirect.cs
@@ -18,12 +18,12 @@ namespace Krypton.Toolkit
     public class PaletteContextMenuItemStateRedirect : Storage
     {
         #region Instance Fields
-        private readonly PaletteRedirectDouble? _itemHighlight;
-        private readonly PaletteRedirectTriple? _itemImage;
-        private readonly PaletteRedirectContent? _itemShortcutText;
-        private readonly PaletteRedirectDouble? _itemSplit;
-        private readonly PaletteRedirectContent? _itemStandard;
-        private readonly PaletteRedirectContent? _itemAlternate;
+        private readonly PaletteRedirectDouble _itemHighlight;
+        private readonly PaletteRedirectTriple _itemImage;
+        private readonly PaletteRedirectContent _itemShortcutText;
+        private readonly PaletteRedirectDouble _itemSplit;
+        private readonly PaletteRedirectContent _itemStandard;
+        private readonly PaletteRedirectContent _itemAlternate;
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteContextMenuRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteContextMenuRedirect.cs
@@ -99,7 +99,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect)
+        public void SetRedirector(PaletteRedirect redirect)
         {
             ControlInner.SetRedirector(redirect);
             ControlOuter.SetRedirector(redirect);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteCueHintText.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteCueHintText.cs
@@ -24,7 +24,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Initialize a new instance of the PaletteCueHintText class.
         /// </summary>
-        public PaletteCueHintText(PaletteRedirect? redirect,
+        public PaletteCueHintText(PaletteRedirect redirect,
             NeedPaintHandler needPaint)
             : base(new PaletteContentInheritRedirect(redirect, PaletteContentStyle.InputControlStandalone), needPaint)
         {
@@ -99,7 +99,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteState state)
+        public override Font? GetContentShortTextNewFont(PaletteState state)
         {
             if (Font != null)
             {
@@ -163,7 +163,7 @@ namespace Krypton.Toolkit
                 layoutRectangle.Height -= padding.Top + padding.Bottom;
             }
 
-            using Font font = GetContentShortTextNewFont(PaletteState.Normal);
+            using Font? font = GetContentShortTextNewFont(PaletteState.Normal);
             using var foreBrush = new SolidBrush(GetContentShortTextColor1(PaletteState.Normal));
             var drawText = string.IsNullOrEmpty(CueHintText) ? textBox.Text : CueHintText;
             g.DrawString(drawText, font, foreBrush, layoutRectangle, stringFormat);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteDataGridViewContentCommon.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteDataGridViewContentCommon.cs
@@ -98,7 +98,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteState state) => _font ?? Inherit.GetContentShortTextFont(state);
+        public override Font? GetContentShortTextFont(PaletteState state) => _font ?? Inherit.GetContentShortTextFont(state);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteDataGridViewContentInherit.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteDataGridViewContentInherit.cs
@@ -94,14 +94,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteState state) => _cellStyle != null ? _cellStyle.Font : SystemFonts.DefaultFont;
+        public override Font? GetContentShortTextFont(PaletteState state) => _cellStyle != null ? _cellStyle.Font : SystemFonts.DefaultFont;
 
         /// <summary>
         /// Gets the font for the short text by generating a new font instance.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextNewFont(PaletteState state) => _cellStyle != null ? _cellStyle.Font : SystemFonts.DefaultFont;
+        public override Font? GetContentShortTextNewFont(PaletteState state) => _cellStyle != null ? _cellStyle.Font : SystemFonts.DefaultFont;
 
         /// <summary>
         /// Gets the rendering hint for the short text.
@@ -230,14 +230,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteState state) => _cellStyle.Font;
+        public override Font? GetContentLongTextFont(PaletteState state) => _cellStyle.Font;
 
         /// <summary>
         /// Gets the font for the long text by generating a new font instance.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextNewFont(PaletteState state) => _cellStyle.Font;
+        public override Font? GetContentLongTextNewFont(PaletteState state) => _cellStyle.Font;
 
         /// <summary>
         /// Gets the rendering hint for the long text.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteDataGridViewContentStates.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteDataGridViewContentStates.cs
@@ -213,14 +213,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public virtual Font GetContentShortTextFont(PaletteState state) => Inherit.GetContentShortTextFont(state);
+        public virtual Font? GetContentShortTextFont(PaletteState state) => Inherit.GetContentShortTextFont(state);
 
         /// <summary>
         /// Gets the font for the short text by generating a new font instance.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public virtual Font GetContentShortTextNewFont(PaletteState state) => Inherit.GetContentShortTextNewFont(state);
+        public virtual Font? GetContentShortTextNewFont(PaletteState state) => Inherit.GetContentShortTextNewFont(state);
 
         #endregion
 
@@ -645,14 +645,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <returns>Font value.</returns>
         /// <param name="state">Palette value should be applicable to this state.</param>
-        public Font GetContentLongTextFont(PaletteState state) => Inherit.GetContentLongTextFont(state);
+        public Font? GetContentLongTextFont(PaletteState state) => Inherit.GetContentLongTextFont(state);
 
         /// <summary>
         /// Gets the font for the long text by generating a new font instance.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public Font GetContentLongTextNewFont(PaletteState state) => Inherit.GetContentLongTextNewFont(state);
+        public Font? GetContentLongTextNewFont(PaletteState state) => Inherit.GetContentLongTextNewFont(state);
 
         /// <summary>
         /// Gets the actual text rendering hint for long text.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteDataGridViewRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteDataGridViewRedirect.cs
@@ -30,7 +30,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">Source for inheriting values.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteDataGridViewRedirect([DisallowNull] PaletteRedirect? redirect,
+        public PaletteDataGridViewRedirect([DisallowNull] PaletteRedirect redirect,
                                            NeedPaintHandler needPaint)
         {
             Debug.Assert(redirect != null);
@@ -63,7 +63,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect)
+        public void SetRedirector(PaletteRedirect redirect)
         {
             _background.SetRedirector(redirect);
             _dataCell.SetRedirector(redirect);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteDataGridViewTripleRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteDataGridViewTripleRedirect.cs
@@ -34,7 +34,7 @@ namespace Krypton.Toolkit
         /// <param name="borderStyle">Initial border style.</param>
         /// <param name="contentStyle">Initial content style.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteDataGridViewTripleRedirect([DisallowNull] PaletteRedirect? redirect,
+        public PaletteDataGridViewTripleRedirect([DisallowNull] PaletteRedirect redirect,
                                                  PaletteBackStyle backStyle,
                                                  PaletteBorderStyle borderStyle,
                                                  PaletteContentStyle contentStyle,
@@ -73,7 +73,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public virtual void SetRedirector(PaletteRedirect? redirect)
+        public virtual void SetRedirector(PaletteRedirect redirect)
         {
             _backInherit.SetRedirector(redirect);
             _borderInherit.SetRedirector(redirect);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteFormRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteFormRedirect.cs
@@ -30,7 +30,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">inheritance redirection instance.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteFormRedirect(PaletteRedirect? redirect,
+        public PaletteFormRedirect(PaletteRedirect redirect,
                                    NeedPaintHandler needPaint)
             : this(redirect, redirect, needPaint)
         {
@@ -43,7 +43,7 @@ namespace Krypton.Toolkit
         /// <param name="redirectHeader">inheritance redirection for header.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
         public PaletteFormRedirect([DisallowNull] PaletteRedirect redirectForm,
-                                   [DisallowNull] PaletteRedirect? redirectHeader,
+                                   [DisallowNull] PaletteRedirect redirectHeader,
                                    NeedPaintHandler needPaint)
             : base(redirectForm, 
                    PaletteBackStyle.FormMain,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteGroupBoxRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteGroupBoxRedirect.cs
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">inheritance redirection instance.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteGroupBoxRedirect(PaletteRedirect? redirect,
+        public PaletteGroupBoxRedirect(PaletteRedirect redirect,
                                        NeedPaintHandler needPaint)
             : this(redirect, redirect, needPaint)
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteHeaderButtonRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteHeaderButtonRedirect.cs
@@ -18,7 +18,7 @@ namespace Krypton.Toolkit
     public class PaletteHeaderButtonRedirect : PaletteTripleMetricRedirect
     {
         #region Instance Fields
-        private readonly PaletteRedirect? _redirect;
+        private readonly PaletteRedirect _redirect;
         private Padding _buttonPadding;
         private int _buttonEdgeInset;
         #endregion
@@ -32,7 +32,7 @@ namespace Krypton.Toolkit
         /// <param name="borderStyle">Initial border style.</param>
         /// <param name="contentStyle">Initial content style.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteHeaderButtonRedirect([DisallowNull] PaletteRedirect? redirect,
+        public PaletteHeaderButtonRedirect([DisallowNull] PaletteRedirect redirect,
                                            PaletteBackStyle backStyle,
                                            PaletteBorderStyle borderStyle,
                                            PaletteContentStyle contentStyle,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteHeaderGroupRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteHeaderGroupRedirect.cs
@@ -30,7 +30,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">inheritance redirection instance.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteHeaderGroupRedirect(PaletteRedirect? redirect,
+        public PaletteHeaderGroupRedirect(PaletteRedirect redirect,
                                           NeedPaintHandler needPaint)
             : this(redirect, redirect, redirect, needPaint)
         {
@@ -44,8 +44,8 @@ namespace Krypton.Toolkit
         /// <param name="redirectHeaderSecondary">inheritance redirection for secondary header.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
         public PaletteHeaderGroupRedirect([DisallowNull] PaletteRedirect redirectHeaderGroup,
-                                          [DisallowNull] PaletteRedirect? redirectHeaderPrimary,
-                                          [DisallowNull] PaletteRedirect? redirectHeaderSecondary,
+                                          [DisallowNull] PaletteRedirect redirectHeaderPrimary,
+                                          [DisallowNull] PaletteRedirect redirectHeaderSecondary,
                                           NeedPaintHandler needPaint)
             : base(redirectHeaderGroup, PaletteBackStyle.ControlClient, 
                    PaletteBorderStyle.ControlClient, needPaint)

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteHeaderPaddingRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteHeaderPaddingRedirect.cs
@@ -18,7 +18,7 @@ namespace Krypton.Toolkit
     public class PaletteHeaderPaddingRedirect : PaletteHeaderButtonRedirect
     {
         #region Instance Fields
-        private readonly PaletteRedirect? _redirect;
+        private readonly PaletteRedirect _redirect;
         private Padding _headerPadding;
         #endregion
 
@@ -31,7 +31,7 @@ namespace Krypton.Toolkit
         /// <param name="borderStyle">Initial border style.</param>
         /// <param name="contentStyle">Initial content style.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteHeaderPaddingRedirect([DisallowNull] PaletteRedirect? redirect,
+        public PaletteHeaderPaddingRedirect([DisallowNull] PaletteRedirect redirect,
                                             PaletteBackStyle backStyle,
                                             PaletteBorderStyle borderStyle,
                                             PaletteContentStyle contentStyle,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteHeaderRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteHeaderRedirect.cs
@@ -18,7 +18,7 @@ namespace Krypton.Toolkit
     public class PaletteHeaderRedirect : PaletteTripleMetricRedirect
     {
         #region Instance Fields
-        private PaletteRedirect? _redirect;
+        private PaletteRedirect _redirect;
         private Padding _buttonPadding;
         private int _buttonEdgeInset;
         #endregion
@@ -32,7 +32,7 @@ namespace Krypton.Toolkit
         /// <param name="borderStyle">Style for the border.</param>
         /// <param name="contentStyle">Style for the content.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteHeaderRedirect([DisallowNull] PaletteRedirect? redirect,
+        public PaletteHeaderRedirect([DisallowNull] PaletteRedirect redirect,
                                      PaletteBackStyle backStyle,
                                      PaletteBorderStyle borderStyle,
                                      PaletteContentStyle contentStyle,
@@ -59,7 +59,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public override void SetRedirector(PaletteRedirect? redirect)
+        public override void SetRedirector(PaletteRedirect redirect)
         {
             base.SetRedirector(redirect);
             _redirect = redirect;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteInputControlContentStates.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteInputControlContentStates.cs
@@ -172,14 +172,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public virtual Font GetContentShortTextFont(PaletteState state) => _font ?? Inherit.GetContentShortTextFont(state);
+        public virtual Font? GetContentShortTextFont(PaletteState state) => _font ?? Inherit.GetContentShortTextFont(state);
 
         /// <summary>
         /// Gets the font for the short text by generating a new font instance.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public virtual Font GetContentShortTextNewFont(PaletteState state) => _font ?? Inherit.GetContentShortTextNewFont(state);
+        public virtual Font? GetContentShortTextNewFont(PaletteState state) => _font ?? Inherit.GetContentShortTextNewFont(state);
 
         /// <summary>
         /// Gets the actual text rendering hint for short text.
@@ -342,14 +342,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <returns>Font value.</returns>
         /// <param name="state">Palette value should be applicable to this state.</param>
-        public Font GetContentLongTextFont(PaletteState state) => Inherit.GetContentLongTextFont(state);
+        public Font? GetContentLongTextFont(PaletteState state) => Inherit.GetContentLongTextFont(state);
 
         /// <summary>
         /// Gets the font for the long text by generating a new font instance.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public Font GetContentLongTextNewFont(PaletteState state) => Inherit.GetContentLongTextNewFont(state);
+        public Font? GetContentLongTextNewFont(PaletteState state) => Inherit.GetContentLongTextNewFont(state);
 
         /// <summary>
         /// Gets the actual text rendering hint for long text.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteInputControlTripleRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteInputControlTripleRedirect.cs
@@ -76,7 +76,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public virtual void SetRedirector(PaletteRedirect? redirect)
+        public virtual void SetRedirector(PaletteRedirect redirect)
         {
             _backInherit.SetRedirector(redirect);
             _borderInherit.SetRedirector(redirect);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteMonthCalendarRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteMonthCalendarRedirect.cs
@@ -31,7 +31,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">inheritance redirection for bread crumb level.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteMonthCalendarRedirect(PaletteRedirect? redirect,
+        public PaletteMonthCalendarRedirect(PaletteRedirect redirect,
                                             NeedPaintHandler needPaint)
             : base(redirect, PaletteBackStyle.ControlClient, 
                              PaletteBorderStyle.ControlClient)
@@ -59,7 +59,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public override void SetRedirector(PaletteRedirect? redirect)
+        public override void SetRedirector(PaletteRedirect redirect)
         {
             base.SetRedirector(redirect);
             Header.SetRedirector(redirect);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteMonthCalendarStateRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteMonthCalendarStateRedirect.cs
@@ -31,7 +31,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">inheritance redirection instance.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteMonthCalendarStateRedirect(PaletteRedirect? redirect,
+        public PaletteMonthCalendarStateRedirect(PaletteRedirect redirect,
                                                  NeedPaintHandler needPaint) =>
                 Day = new PaletteTripleRedirect(redirect, 
                     PaletteBackStyle.ButtonCalendarDay, 
@@ -55,7 +55,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public void SetRedirector(PaletteRedirect? redirect) => Day.SetRedirector(redirect);
+        public void SetRedirector(PaletteRedirect redirect) => Day.SetRedirector(redirect);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectBreadCrumb.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectBreadCrumb.cs
@@ -22,7 +22,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteRedirectBreadCrumb class.
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
-        public PaletteRedirectBreadCrumb(PaletteBase? target)
+        public PaletteRedirectBreadCrumb(PaletteBase target)
             : base(target)
         {
             Left = false;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectCheckBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectCheckBox.cs
@@ -36,7 +36,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="images">Reference to source of check box images.</param>
-        public PaletteRedirectCheckBox(PaletteBase? target,
+        public PaletteRedirectCheckBox(PaletteBase target,
             [DisallowNull] CheckBoxImages images)
             : base(target)
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectCommon.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectCommon.cs
@@ -29,7 +29,7 @@ namespace Krypton.Toolkit
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="disabled">Redirection for disabled state requests.</param>
         /// <param name="others">Redirection for all other state requests.</param>
-        public PaletteRedirectCommon(PaletteBase? target,
+        public PaletteRedirectCommon(PaletteBase target,
                                      [DisallowNull] IPaletteTriple disabled,
                                      [DisallowNull] IPaletteTriple others)
             : base(target)
@@ -390,7 +390,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple inherit = GetInherit(state);
             return inherit != null ? inherit.PaletteContent.GetContentShortTextFont(state) : base.GetContentShortTextFont(style, state);
@@ -594,7 +594,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Font value.</returns>
-        public override Font GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
+        public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple inherit = GetInherit(state);
             return inherit != null ? inherit.PaletteContent.GetContentLongTextFont(state) : base.GetContentLongTextFont(style, state);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectContextMenu.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectContextMenu.cs
@@ -27,7 +27,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="images">Reference to source of context menu images.</param>
-        public PaletteRedirectContextMenu(PaletteBase? target,
+        public PaletteRedirectContextMenu(PaletteBase target,
             [DisallowNull] ContextMenuImages images)
             : base(target)
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectDropDownButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectDropDownButton.cs
@@ -36,7 +36,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="images">Reference to source of drop down button images.</param>
-        public PaletteRedirectDropDownButton(PaletteBase? target,
+        public PaletteRedirectDropDownButton(PaletteBase target,
                                              [DisallowNull] DropDownButtonImages images)
             : base(target)
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectRadioButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectRadioButton.cs
@@ -36,7 +36,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="images">Reference to source of radio button images.</param>
-        public PaletteRedirectRadioButton(PaletteBase? target,
+        public PaletteRedirectRadioButton(PaletteBase target,
             [DisallowNull] RadioButtonImages images)
             : base(target)
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectTreeView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectTreeView.cs
@@ -40,7 +40,7 @@ namespace Krypton.Toolkit
         /// <param name="target">Initial palette target for redirection.</param>
         /// <param name="plusMinusImages">Reference to source of tree view images.</param>
         /// <param name="checkboxImages">Reference to source of check box images.</param>
-        public PaletteRedirectTreeView(PaletteBase? target,
+        public PaletteRedirectTreeView(PaletteBase target,
             [DisallowNull] TreeViewImages plusMinusImages,
                                        CheckBoxImages checkboxImages)
             : base(target)

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteSplitContainerRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteSplitContainerRedirect.cs
@@ -27,7 +27,7 @@ namespace Krypton.Toolkit
         /// <param name="backSeparatorStyle">Initial separator background style.</param>
         /// <param name="borderSeparatorStyle">Initial separator border style.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteSplitContainerRedirect(PaletteRedirect? redirect,
+        public PaletteSplitContainerRedirect(PaletteRedirect redirect,
                                              PaletteBackStyle backContainerStyle,
                                              PaletteBorderStyle borderContainerStyle,
                                              PaletteBackStyle backSeparatorStyle,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteTrackBarRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteTrackBarRedirect.cs
@@ -61,7 +61,7 @@ namespace Krypton.Toolkit
         /// Update the redirector with new reference.
         /// </summary>
         /// <param name="redirect">Target redirector.</param>
-        public virtual void SetRedirector(PaletteRedirect? redirect)
+        public virtual void SetRedirector(PaletteRedirect redirect)
         {
             _backRedirect.SetRedirector(redirect);
             Tick.SetRedirector(redirect);

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderBase.cs
@@ -136,7 +136,7 @@ namespace Krypton.Toolkit
         /// Gets a renderer for drawing the toolstrips.
         /// </summary>
         /// <param name="colorPalette">Color palette to use when rendering toolstrip.</param>
-        public abstract ToolStripRenderer RenderToolStrip(PaletteBase? colorPalette);
+        public abstract ToolStripRenderer RenderToolStrip(PaletteBase colorPalette);
         #endregion
 
         #region RenderStandardBorder
@@ -544,7 +544,7 @@ namespace Krypton.Toolkit
         /// <param name="tracking">Should check box be Displayed as hot tracking.</param>
         /// <param name="pressed">Should check box be Displayed as pressed.</param>
         public abstract Size GetCheckBoxPreferredSize(ViewLayoutContext context,
-                                                      PaletteBase? palette,
+                                                      PaletteBase palette,
                                                       bool enabled,
                                                       CheckState checkState,
                                                       bool tracking,
@@ -562,7 +562,7 @@ namespace Krypton.Toolkit
         /// <param name="pressed">Should check box be Displayed as pressed.</param>
         public abstract void DrawCheckBox(RenderContext context,
                                           Rectangle displayRect,
-                                          PaletteBase? palette,
+                                          PaletteBase palette,
                                           bool enabled,
                                           CheckState checkState,
                                           bool tracking,
@@ -609,7 +609,7 @@ namespace Krypton.Toolkit
         /// <param name="state">State for which image size is needed.</param>
         /// <param name="orientation">How to orientate the image.</param>
         public abstract Size GetDropDownButtonPreferredSize(ViewLayoutContext context,
-                                                            PaletteBase? palette,
+                                                            PaletteBase palette,
                                                             PaletteState state,
                                                             VisualOrientation orientation);
 
@@ -623,7 +623,7 @@ namespace Krypton.Toolkit
         /// <param name="orientation">How to orientate the image.</param>
         public abstract void DrawDropDownButton(RenderContext context,
                                                 Rectangle displayRect,
-                                                PaletteBase? palette,
+                                                PaletteBase palette,
                                                 PaletteState state,
                                                 VisualOrientation orientation);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderContext.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderContext.cs
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit
         public RenderContext(Control? control,
                              Graphics? graphics,
                              Rectangle clipRect,
-                             IRenderer? renderer)
+                             IRenderer renderer)
             : this(null, control, control, graphics, clipRect, renderer)
         {
         }
@@ -45,7 +45,7 @@ namespace Krypton.Toolkit
                              Control? alignControl,
                              Graphics? graphics,
                              Rectangle clipRect,
-                             IRenderer? renderer)
+                             IRenderer renderer)
             : this(null, control, alignControl, graphics, clipRect, renderer)
         {
         }
@@ -64,7 +64,7 @@ namespace Krypton.Toolkit
                              Control? alignControl,
                              Graphics? graphics,
                              Rectangle clipRect,
-                             IRenderer? renderer)
+                             IRenderer renderer)
             : base(manager, control, alignControl, graphics, renderer) =>
             ClipRect = clipRect;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderDefinitions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderDefinitions.cs
@@ -72,7 +72,7 @@ namespace Krypton.Toolkit
         /// Gets a renderer for drawing the toolstrips.
         /// </summary>
         /// <param name="colorPalette">Color palette to use when rendering toolstrip.</param>
-        ToolStripRenderer RenderToolStrip(PaletteBase? colorPalette);
+        ToolStripRenderer RenderToolStrip(PaletteBase colorPalette);
     }
     #endregion
 
@@ -515,7 +515,7 @@ namespace Krypton.Toolkit
         /// <param name="tracking">Should check box be Displayed as hot tracking.</param>
         /// <param name="pressed">Should check box be Displayed as pressed.</param>
         Size GetCheckBoxPreferredSize(ViewLayoutContext context,
-                                      PaletteBase? palette,
+                                      PaletteBase palette,
                                       bool enabled,
                                       CheckState checkState,
                                       bool tracking,
@@ -533,7 +533,7 @@ namespace Krypton.Toolkit
         /// <param name="pressed">Should check box be Displayed as pressed.</param>
         void DrawCheckBox(RenderContext context,
                           Rectangle displayRect,
-                          PaletteBase? palette,
+                          PaletteBase palette,
                           bool enabled,
                           CheckState checkState,
                           bool tracking,
@@ -581,7 +581,7 @@ namespace Krypton.Toolkit
         /// <param name="state">State for which image size is needed.</param>
         /// <param name="orientation">How to orientate the image.</param>
         Size GetDropDownButtonPreferredSize(ViewLayoutContext context,
-                                            PaletteBase? palette,
+                                            PaletteBase palette,
                                             PaletteState state,
                                             VisualOrientation orientation);
 
@@ -595,7 +595,7 @@ namespace Krypton.Toolkit
         /// <param name="orientation">How to orientate the image.</param>
         void DrawDropDownButton(RenderContext context,
                                 Rectangle displayRect,
-                                PaletteBase? palette,
+                                PaletteBase palette,
                                 PaletteState state,
                                 VisualOrientation orientation);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
@@ -375,7 +375,7 @@ namespace Krypton.Toolkit
         /// Gets a renderer for drawing the toolstrips.
         /// </summary>
         /// <param name="colorPalette">Color palette to use when rendering toolstrip.</param>
-        public override ToolStripRenderer RenderToolStrip([DisallowNull] PaletteBase? colorPalette)
+        public override ToolStripRenderer RenderToolStrip([DisallowNull] PaletteBase colorPalette)
         {
             Debug.Assert(colorPalette != null);
 
@@ -2325,7 +2325,7 @@ namespace Krypton.Toolkit
         /// <param name="pressed">Should check box be Displayed as pressed.</param>
         /// <exception cref="ArgumentNullException"></exception>
         public override Size GetCheckBoxPreferredSize([DisallowNull] ViewLayoutContext context,
-            [DisallowNull] PaletteBase? palette,
+            [DisallowNull] PaletteBase palette,
                                                       bool enabled,
                                                       CheckState checkState,
                                                       bool tracking,
@@ -2376,7 +2376,7 @@ namespace Krypton.Toolkit
         /// <exception cref="ArgumentNullException"></exception>
         public override void DrawCheckBox([DisallowNull] RenderContext context,
                                           Rectangle displayRect,
-                                          [DisallowNull] PaletteBase? palette,
+                                          [DisallowNull] PaletteBase palette,
                                           bool enabled,
                                           CheckState checkState,
                                           bool tracking,
@@ -2520,7 +2520,7 @@ namespace Krypton.Toolkit
         /// <param name="state">State for which image size is needed.</param>
         /// <param name="orientation">How to orientate the image.</param>
         public override Size GetDropDownButtonPreferredSize(ViewLayoutContext context,
-                                                            [DisallowNull] PaletteBase? palette,
+                                                            [DisallowNull] PaletteBase palette,
                                                             PaletteState state,
                                                             VisualOrientation orientation)
         {
@@ -2555,7 +2555,7 @@ namespace Krypton.Toolkit
         /// <exception cref="ArgumentNullException"></exception>
         public override void DrawDropDownButton([DisallowNull] RenderContext context,
                                                 Rectangle displayRect,
-                                                [DisallowNull] PaletteBase? palette,
+                                                [DisallowNull] PaletteBase palette,
                                                 PaletteState state,
                                                 VisualOrientation orientation)
         {
@@ -5666,8 +5666,8 @@ namespace Krypton.Toolkit
             return original;
         }
 
-        private static Font ContentFontForButtonForm(ViewLayoutContext context,
-                                                     Font font)
+        private static Font? ContentFontForButtonForm(ViewLayoutContext context,
+                                                     Font? font)
         {
             // Get the krypton form that contains this control
             KryptonForm? kryptonForm = OwningKryptonForm(context.TopControl);
@@ -5807,12 +5807,12 @@ namespace Krypton.Toolkit
             memento.ShortTextTrimming = paletteContent.GetContentShortTextTrim(state);
 
             var fontChanged = false;
-            Font textFont = paletteContent.GetContentShortTextFont(state);
+            Font? textFont = paletteContent.GetContentShortTextFont(state);
 
             // Get the appropriate font to use in the caption area
             if (paletteContent.GetContentStyle() == PaletteContentStyle.HeaderForm)
             {
-                Font captionFont = ContentFontForButtonForm(context, textFont);
+                Font? captionFont = ContentFontForButtonForm(context, textFont);
                 fontChanged = captionFont != textFont;
                 textFont = captionFont;
             }
@@ -5891,12 +5891,12 @@ namespace Krypton.Toolkit
                 memento.LongTextTrimming = paletteContent.GetContentLongTextTrim(state);
 
                 var fontChanged = false;
-                Font textFont = paletteContent.GetContentLongTextFont(state);
+                Font? textFont = paletteContent.GetContentLongTextFont(state);
 
                 // Get the appropriate font to use in the caption area
                 if (paletteContent.GetContentStyle() == PaletteContentStyle.HeaderForm)
                 {
-                    Font captionFont = ContentFontForButtonForm(context, textFont);
+                    Font? captionFont = ContentFontForButtonForm(context, textFont);
                     fontChanged = captionFont != textFont;
                     textFont = captionFont;
                 }

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/ThemeManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/ThemeManager.cs
@@ -122,7 +122,7 @@ namespace Krypton.Toolkit
                 }
 
                 // Set manager
-                manager.GlobalPalette = palette;
+                manager.GlobalCustomPalette = palette;
 
                 ApplyTheme(PaletteMode.Custom, manager);
             }

--- a/Source/Krypton Components/Krypton.Toolkit/Utilities/BiDictionary.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Utilities/BiDictionary.cs
@@ -14,7 +14,7 @@ namespace Krypton.Toolkit
     /// </summary>
     /// <typeparam name="TFirst"></typeparam>
     /// <typeparam name="TSecond"></typeparam>
-    internal class BiDictionary<TFirst, TSecond> where TFirst : notnull where TSecond : notnull
+    public class BiDictionary<TFirst, TSecond> where TFirst : notnull where TSecond : notnull
     {
         private static readonly IList<TFirst> _emptyFirstList = Array.Empty<TFirst>();
         private static readonly IList<TSecond> _emptySecondList = Array.Empty<TSecond>();

--- a/Source/Krypton Components/Krypton.Toolkit/View Base/ViewContext.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Base/ViewContext.cs
@@ -37,7 +37,7 @@ namespace Krypton.Toolkit
         public ViewContext(ViewManager? manager,
                            Control control, 
                            Control alignControl, 
-                           IRenderer? renderer)
+                           IRenderer renderer)
             : this(manager, control, alignControl, null, renderer)
         {
         }
@@ -52,7 +52,7 @@ namespace Krypton.Toolkit
         public ViewContext(Control control,
                            Control alignControl,
                            Graphics? graphics,
-                           IRenderer? renderer)
+                           IRenderer renderer)
             : this(null, control, alignControl, graphics, renderer)
         {
         }
@@ -69,7 +69,7 @@ namespace Krypton.Toolkit
                            Control control,
                            Control alignControl,
                            Graphics? graphics,
-                           IRenderer? renderer)
+                           IRenderer renderer)
         {
             // Use the manager is provided, otherwise create a temporary one with a null view
             if (manager != null)
@@ -229,7 +229,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the renderer provider.
         /// </summary>
-        public IRenderer? Renderer
+        public IRenderer Renderer
         {
             [DebuggerStepThrough]
             get;

--- a/Source/Krypton Components/Krypton.Toolkit/View Base/ViewControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Base/ViewControl.cs
@@ -453,7 +453,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private IRenderer? Renderer
+        private IRenderer Renderer
         {
             get
             {

--- a/Source/Krypton Components/Krypton.Toolkit/View Base/ViewManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Base/ViewManager.cs
@@ -162,7 +162,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="renderer">Renderer provider.</param>
         /// <param name="proposedSize">The custom-sized area for a control.</param>
-        public virtual Size GetPreferredSize(IRenderer? renderer,
+        public virtual Size GetPreferredSize(IRenderer renderer,
                                              Size proposedSize)
         {
             if ((renderer == null) || (Root == null))

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawButton.cs
@@ -234,7 +234,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the drop down capability of the button.
         /// </summary>
-        public PaletteBase? DropDownPalette
+        public PaletteBase DropDownPalette
         {
             get => _drawDropDownButton.Palette;
             set => _drawDropDownButton.Palette = value;

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawCheckBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawCheckBox.cs
@@ -18,7 +18,7 @@ namespace Krypton.Toolkit
     public class ViewDrawCheckBox : ViewLeaf
     {
         #region Instance Fields
-        private readonly PaletteBase? _palette;
+        private readonly PaletteBase _palette;
         private bool _tracking;
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawDateTimeText.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawDateTimeText.cs
@@ -495,7 +495,7 @@ namespace Krypton.Toolkit
             /// <param name="format">Format string to parse.</param>
             /// <param name="g">Graphics instance used to measure text.</param>
             /// <param name="font">Font used to measure text.</param>
-            public void ParseFormat(string format, Graphics? g, Font font)
+            public void ParseFormat(string format, Graphics? g, Font? font)
             {
                 // Split the format into a set of fragments
                 _fragments = ParseFormatToFragments(format);
@@ -520,7 +520,7 @@ namespace Krypton.Toolkit
             /// <param name="textColor">Text color.</param>
             /// <param name="backColor">Back color.</param>
             /// <param name="enabled">If text enabled.</param>
-            public void Render(RenderContext context, Font font, Rectangle rect, 
+            public void Render(RenderContext context, Font? font, Rectangle rect, 
                                Color textColor, Color backColor, bool enabled)
             {
                 if (enabled || string.IsNullOrEmpty(_dateTimePicker.CustomNullText))
@@ -632,7 +632,7 @@ namespace Krypton.Toolkit
 
             private bool ImplRightToLeft => RightToLeftLayout && (_dateTimePicker.RightToLeft == RightToLeft.Yes);
 
-            private void MeasureFragments(Graphics? g, Font font, DateTime dt)
+            private void MeasureFragments(Graphics? g, Font? font, DateTime dt)
             {
                 // Create a character range/character region for each of the fragments
                 var charRanges = new CharacterRange[_fragments.Count];
@@ -1599,7 +1599,7 @@ namespace Krypton.Toolkit
             _formatHandler.DateTime = _dateTimePicker.Value;
 
             // Grab the font used to draw the text
-            Font font = GetFont();
+            Font? font = GetFont();
 
             // Find the width of the text we are drawing
             Size retSize = TextRenderer.MeasureText(GetFullDisplayText(), font, Size.Empty, MEASURE_FLAGS);
@@ -1665,7 +1665,7 @@ namespace Krypton.Toolkit
 
         private void PerformNeedPaint(bool needLayout) => _needPaint(this, new NeedLayoutEventArgs(needLayout));
 
-        private Font GetFont()
+        private Font? GetFont()
         {
             if (!Enabled || _dateTimePicker.InternalDateTimeNull())
             {

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawDropDownButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawDropDownButton.cs
@@ -37,7 +37,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the palette to use.
         /// </summary>
-        public PaletteBase? Palette { get; set; }
+        public PaletteBase Palette { get; set; }
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMonth.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMonth.cs
@@ -67,7 +67,7 @@ namespace Krypton.Toolkit
         /// <param name="needPaintDelegate">Delegate for requesting paint changes.</param>
         public ViewDrawMonth(IKryptonMonthCalendar calendar, 
                              ViewLayoutMonths months,
-                             PaletteRedirect? redirector,
+                             PaletteRedirect redirector,
                              NeedPaintHandler needPaintDelegate)
             : base(false)
         {

--- a/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutContext.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutContext.cs
@@ -24,7 +24,7 @@ namespace Krypton.Toolkit
         /// <param name="control">Control associated with rendering.</param>
         /// <param name="renderer">Rendering provider.</param>
         public ViewLayoutContext(Control control,
-                                 IRenderer? renderer)
+                                 IRenderer renderer)
             : this(null, control, control, null, renderer, control.Size)
         {
         }
@@ -39,7 +39,7 @@ namespace Krypton.Toolkit
         public ViewLayoutContext(ViewManager? manager,
                                  Control control,
                                  Control alignControl,
-                                 IRenderer? renderer)
+                                 IRenderer renderer)
             : this(manager, control, alignControl, null, renderer, control.Size)
         {
         }
@@ -55,7 +55,7 @@ namespace Krypton.Toolkit
         public ViewLayoutContext(ViewManager? manager,
                                  Control control,
                                  Control alignControl,
-                                 IRenderer? renderer,
+                                 IRenderer renderer,
                                  Size displaySize)
             : this(manager, control, alignControl, null, renderer, displaySize)
         {
@@ -71,7 +71,7 @@ namespace Krypton.Toolkit
         public ViewLayoutContext(ViewManager? manager,
                                  Form form,
                                  Rectangle formRect,
-                                 IRenderer? renderer)
+                                 IRenderer renderer)
             : base(manager, form, form, null, renderer) =>
             // The initial display rectangle is the provided size
             DisplayRectangle = new Rectangle(Point.Empty, formRect.Size);
@@ -89,7 +89,7 @@ namespace Krypton.Toolkit
                                  Control control,
                                  Control alignControl,
                                  Graphics? graphics,
-                                 IRenderer? renderer,
+                                 IRenderer renderer,
                                  Size displaySize)
             : base(manager, control, alignControl, graphics, renderer) =>
             // The initial display rectangle is the provided size

--- a/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutCrumbs.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutCrumbs.cs
@@ -407,9 +407,9 @@ namespace Krypton.Toolkit
                     var kcm = new KryptonContextMenu
                     {
                         // Use same palette settings for context menu as the main control
-                        Palette = _kryptonBreadCrumb.Palette
+                        LocalCustomPalette = _kryptonBreadCrumb.LocalCustomPalette
                     };
-                    if (kcm.Palette == null)
+                    if (kcm.LocalCustomPalette == null)
                     {
                         kcm.PaletteMode = _kryptonBreadCrumb.PaletteMode;
                     }
@@ -517,9 +517,9 @@ namespace Krypton.Toolkit
                 var kcm = new KryptonContextMenu
                 {
                     // Use same palette settings for context menu as the main control
-                    Palette = _kryptonBreadCrumb.Palette
+                    LocalCustomPalette = _kryptonBreadCrumb.LocalCustomPalette
                 };
-                if (kcm.Palette == null)
+                if (kcm.LocalCustomPalette == null)
                 {
                     kcm.PaletteMode = _kryptonBreadCrumb.PaletteMode;
                 }

--- a/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutMenuItemSelect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutMenuItemSelect.cs
@@ -68,7 +68,7 @@ namespace Krypton.Toolkit
             _imageIndexEnd = Math.Min(_imageIndexEnd, _imageCount - 1);
             _imageIndexCount = Math.Max(0, _imageIndexEnd - _imageIndexStart + 1);
 
-            PaletteBase? palette = provider.ProviderPalette ?? KryptonManager.GetPaletteForMode(provider.ProviderPaletteMode);
+            PaletteBase palette = provider.ProviderPalette ?? KryptonManager.GetPaletteForMode(provider.ProviderPaletteMode);
 
             // Create triple that can be used by the draw button
             _triple = new PaletteTripleToPalette(palette,

--- a/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutMonths.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutMonths.cs
@@ -28,7 +28,7 @@ namespace Krypton.Toolkit
         private readonly PaletteBorderInheritForced _borderForced;
         private VisualPopupToolTip? _visualPopupToolTip;
         private readonly ViewDrawToday _drawToday;
-        private readonly ButtonSpecRemapByContentView? _remapPalette;
+        private readonly ButtonSpecRemapByContentView _remapPalette;
         private readonly ViewDrawEmptyContent _emptyContent;
         private readonly PaletteTripleRedirect _palette;
         private readonly ToolTipManager _toolTipManager;
@@ -43,7 +43,7 @@ namespace Krypton.Toolkit
         private DateTime? _trackingDay;
         private DateTime? _anchorDay;
         private readonly NeedPaintHandler _needPaintDelegate;
-        private readonly PaletteRedirect? _redirector;
+        private readonly PaletteRedirect _redirector;
         private bool _showWeekNumbers;
         private bool _showTodayCircle;
         private bool _showToday;
@@ -64,7 +64,7 @@ namespace Krypton.Toolkit
                                 KryptonContextMenuMonthCalendar monthCalendar,
                                 ViewContextMenuManager viewManager,
                                 IKryptonMonthCalendar calendar,
-                                PaletteRedirect? redirector,
+                                PaletteRedirect redirector,
                                 NeedPaintHandler needPaintDelegate)
         {
             Provider = provider;

--- a/Source/Krypton Components/TestForm/Form1.Designer.cs
+++ b/Source/Krypton Components/TestForm/Form1.Designer.cs
@@ -64,7 +64,6 @@
             this.kryptonListBox1 = new Krypton.Toolkit.KryptonListBox();
             this.kryptonTextBox1 = new Krypton.Toolkit.KryptonTextBox();
             this.textBox1 = new System.Windows.Forms.TextBox();
-            this.kryptonCustomPaletteBase1 = new Krypton.Toolkit.KryptonCustomPaletteBase(this.components);
             this.kcmdMessageboxTest = new Krypton.Toolkit.KryptonCommand();
             this.buttonSpecAny1 = new Krypton.Toolkit.ButtonSpecAny();
             this.buttonSpecAny2 = new Krypton.Toolkit.ButtonSpecAny();
@@ -118,16 +117,17 @@
             this.kryptonPanel1.Controls.Add(this.textBox1);
             this.kryptonPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonPanel1.Location = new System.Drawing.Point(0, 0);
-            this.kryptonPanel1.Margin = new System.Windows.Forms.Padding(2);
+            this.kryptonPanel1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kryptonPanel1.Name = "kryptonPanel1";
-            this.kryptonPanel1.Size = new System.Drawing.Size(1112, 752);
+            this.kryptonPanel1.Size = new System.Drawing.Size(1483, 926);
             this.kryptonPanel1.TabIndex = 0;
             // 
             // kryptonColorButton1
             // 
-            this.kryptonColorButton1.Location = new System.Drawing.Point(204, 132);
+            this.kryptonColorButton1.Location = new System.Drawing.Point(272, 162);
+            this.kryptonColorButton1.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonColorButton1.Name = "kryptonColorButton1";
-            this.kryptonColorButton1.Size = new System.Drawing.Size(188, 25);
+            this.kryptonColorButton1.Size = new System.Drawing.Size(327, 31);
             this.kryptonColorButton1.TabIndex = 35;
             this.kryptonColorButton1.Values.Image = ((System.Drawing.Image)(resources.GetObject("kryptonColorButton1.Values.Image")));
             this.kryptonColorButton1.Values.Text = "Drop Down Arrow Color";
@@ -135,177 +135,180 @@
             // 
             // kryptonButton9
             // 
-            this.kryptonButton9.Location = new System.Drawing.Point(15, 415);
+            this.kryptonButton9.Location = new System.Drawing.Point(20, 511);
+            this.kryptonButton9.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonButton9.Name = "kryptonButton9";
-            this.kryptonButton9.Size = new System.Drawing.Size(183, 25);
+            this.kryptonButton9.Size = new System.Drawing.Size(244, 31);
             this.kryptonButton9.TabIndex = 34;
-            this.kryptonButton9.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton9.Values.Text = "Command Links";
             this.kryptonButton9.Click += new System.EventHandler(this.kryptonButton9_Click);
             // 
             // kryptonButton5
             // 
-            this.kryptonButton5.Location = new System.Drawing.Point(15, 384);
+            this.kryptonButton5.Location = new System.Drawing.Point(20, 473);
+            this.kryptonButton5.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonButton5.Name = "kryptonButton5";
-            this.kryptonButton5.Size = new System.Drawing.Size(183, 25);
+            this.kryptonButton5.Size = new System.Drawing.Size(244, 31);
             this.kryptonButton5.TabIndex = 33;
-            this.kryptonButton5.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton5.Values.Text = "Task Dialog";
             this.kryptonButton5.Click += new System.EventHandler(this.kryptonButton5_Click);
             // 
             // kryptonButton8
             // 
-            this.kryptonButton8.Location = new System.Drawing.Point(15, 353);
+            this.kryptonButton8.Location = new System.Drawing.Point(20, 434);
+            this.kryptonButton8.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonButton8.Name = "kryptonButton8";
-            this.kryptonButton8.Size = new System.Drawing.Size(183, 25);
+            this.kryptonButton8.Size = new System.Drawing.Size(244, 31);
             this.kryptonButton8.TabIndex = 32;
-            this.kryptonButton8.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton8.Values.Text = "About Box";
             this.kryptonButton8.Click += new System.EventHandler(this.kryptonButton8_Click);
             // 
             // kcbtnSizableToolWindow
             // 
             this.kcbtnSizableToolWindow.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.kcbtnSizableToolWindow.Location = new System.Drawing.Point(14, 715);
+            this.kcbtnSizableToolWindow.Location = new System.Drawing.Point(19, 880);
+            this.kcbtnSizableToolWindow.Margin = new System.Windows.Forms.Padding(4);
             this.kcbtnSizableToolWindow.Name = "kcbtnSizableToolWindow";
-            this.kcbtnSizableToolWindow.Size = new System.Drawing.Size(141, 25);
+            this.kcbtnSizableToolWindow.Size = new System.Drawing.Size(188, 31);
             this.kcbtnSizableToolWindow.TabIndex = 31;
-            this.kcbtnSizableToolWindow.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kcbtnSizableToolWindow.Values.Text = "SizableToolWindow";
             this.kcbtnSizableToolWindow.Click += new System.EventHandler(this.kcbtnSizableToolWindow_Click);
             // 
             // kcbtnFixedToolWindow
             // 
             this.kcbtnFixedToolWindow.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.kcbtnFixedToolWindow.Location = new System.Drawing.Point(308, 683);
+            this.kcbtnFixedToolWindow.Location = new System.Drawing.Point(411, 841);
+            this.kcbtnFixedToolWindow.Margin = new System.Windows.Forms.Padding(4);
             this.kcbtnFixedToolWindow.Name = "kcbtnFixedToolWindow";
-            this.kcbtnFixedToolWindow.Size = new System.Drawing.Size(141, 25);
+            this.kcbtnFixedToolWindow.Size = new System.Drawing.Size(188, 31);
             this.kcbtnFixedToolWindow.TabIndex = 30;
-            this.kcbtnFixedToolWindow.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kcbtnFixedToolWindow.Values.Text = "FixedToolWindow";
             this.kcbtnFixedToolWindow.Click += new System.EventHandler(this.kcbtnFixedToolWindow_Click);
             // 
             // kcbtnSizable
             // 
             this.kcbtnSizable.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.kcbtnSizable.Location = new System.Drawing.Point(161, 683);
+            this.kcbtnSizable.Location = new System.Drawing.Point(215, 841);
+            this.kcbtnSizable.Margin = new System.Windows.Forms.Padding(4);
             this.kcbtnSizable.Name = "kcbtnSizable";
-            this.kcbtnSizable.Size = new System.Drawing.Size(141, 25);
+            this.kcbtnSizable.Size = new System.Drawing.Size(188, 31);
             this.kcbtnSizable.TabIndex = 29;
-            this.kcbtnSizable.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kcbtnSizable.Values.Text = "Sizable";
             this.kcbtnSizable.Click += new System.EventHandler(this.kcbtnSizable_Click);
             // 
             // kcbtnFixedDialog
             // 
             this.kcbtnFixedDialog.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.kcbtnFixedDialog.Location = new System.Drawing.Point(14, 683);
+            this.kcbtnFixedDialog.Location = new System.Drawing.Point(19, 841);
+            this.kcbtnFixedDialog.Margin = new System.Windows.Forms.Padding(4);
             this.kcbtnFixedDialog.Name = "kcbtnFixedDialog";
-            this.kcbtnFixedDialog.Size = new System.Drawing.Size(141, 25);
+            this.kcbtnFixedDialog.Size = new System.Drawing.Size(188, 31);
             this.kcbtnFixedDialog.TabIndex = 28;
-            this.kcbtnFixedDialog.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kcbtnFixedDialog.Values.Text = "FixedDialog";
             this.kcbtnFixedDialog.Click += new System.EventHandler(this.kcbtnFixedDialog_Click);
             // 
             // kcbtnFixed3D
             // 
             this.kcbtnFixed3D.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.kcbtnFixed3D.Location = new System.Drawing.Point(308, 651);
+            this.kcbtnFixed3D.Location = new System.Drawing.Point(411, 801);
+            this.kcbtnFixed3D.Margin = new System.Windows.Forms.Padding(4);
             this.kcbtnFixed3D.Name = "kcbtnFixed3D";
-            this.kcbtnFixed3D.Size = new System.Drawing.Size(141, 25);
+            this.kcbtnFixed3D.Size = new System.Drawing.Size(188, 31);
             this.kcbtnFixed3D.TabIndex = 27;
-            this.kcbtnFixed3D.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kcbtnFixed3D.Values.Text = "Fixed3D";
             this.kcbtnFixed3D.Click += new System.EventHandler(this.kcbtnFixed3D_Click);
             // 
             // kcbtnFixedSingle
             // 
             this.kcbtnFixedSingle.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.kcbtnFixedSingle.Location = new System.Drawing.Point(161, 651);
+            this.kcbtnFixedSingle.Location = new System.Drawing.Point(215, 801);
+            this.kcbtnFixedSingle.Margin = new System.Windows.Forms.Padding(4);
             this.kcbtnFixedSingle.Name = "kcbtnFixedSingle";
-            this.kcbtnFixedSingle.Size = new System.Drawing.Size(141, 25);
+            this.kcbtnFixedSingle.Size = new System.Drawing.Size(188, 31);
             this.kcbtnFixedSingle.TabIndex = 26;
-            this.kcbtnFixedSingle.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kcbtnFixedSingle.Values.Text = "FixedSingle";
             this.kcbtnFixedSingle.Click += new System.EventHandler(this.kcbtnFixedSingle_Click);
             // 
             // kcbtnNone
             // 
             this.kcbtnNone.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.kcbtnNone.Location = new System.Drawing.Point(14, 651);
+            this.kcbtnNone.Location = new System.Drawing.Point(19, 801);
+            this.kcbtnNone.Margin = new System.Windows.Forms.Padding(4);
             this.kcbtnNone.Name = "kcbtnNone";
-            this.kcbtnNone.Size = new System.Drawing.Size(141, 25);
+            this.kcbtnNone.Size = new System.Drawing.Size(188, 31);
             this.kcbtnNone.TabIndex = 25;
-            this.kcbtnNone.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kcbtnNone.Values.Text = "None";
             this.kcbtnNone.Click += new System.EventHandler(this.kcbtnNone_Click);
             // 
             // kryptonButton7
             // 
             this.kryptonButton7.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.kryptonButton7.Location = new System.Drawing.Point(812, 456);
+            this.kryptonButton7.Location = new System.Drawing.Point(1081, 606);
+            this.kryptonButton7.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonButton7.Name = "kryptonButton7";
-            this.kryptonButton7.Size = new System.Drawing.Size(90, 25);
+            this.kryptonButton7.Size = new System.Drawing.Size(120, 31);
             this.kryptonButton7.TabIndex = 17;
-            this.kryptonButton7.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton7.Values.Text = "Export";
             // 
             // kryptonButton6
             // 
             this.kryptonButton6.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.kryptonButton6.Location = new System.Drawing.Point(715, 456);
+            this.kryptonButton6.Location = new System.Drawing.Point(953, 606);
+            this.kryptonButton6.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonButton6.Name = "kryptonButton6";
-            this.kryptonButton6.Size = new System.Drawing.Size(90, 25);
+            this.kryptonButton6.Size = new System.Drawing.Size(120, 31);
             this.kryptonButton6.TabIndex = 16;
-            this.kryptonButton6.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton6.Values.Text = "Import";
             // 
             // kbtnExit
             // 
             this.kbtnExit.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.kbtnExit.Location = new System.Drawing.Point(1010, 715);
+            this.kbtnExit.Location = new System.Drawing.Point(1347, 880);
+            this.kbtnExit.Margin = new System.Windows.Forms.Padding(4);
             this.kbtnExit.Name = "kbtnExit";
-            this.kbtnExit.Size = new System.Drawing.Size(90, 25);
+            this.kbtnExit.Size = new System.Drawing.Size(120, 31);
             this.kbtnExit.TabIndex = 15;
-            this.kbtnExit.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnExit.Values.Text = "Exit";
             this.kbtnExit.Click += new System.EventHandler(this.kbtnExit_Click);
             // 
             // kryptonButton4
             // 
-            this.kryptonButton4.Location = new System.Drawing.Point(13, 195);
+            this.kryptonButton4.Location = new System.Drawing.Point(17, 240);
+            this.kryptonButton4.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonButton4.Name = "kryptonButton4";
-            this.kryptonButton4.Size = new System.Drawing.Size(185, 25);
+            this.kryptonButton4.Size = new System.Drawing.Size(247, 31);
             this.kryptonButton4.TabIndex = 14;
-            this.kryptonButton4.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton4.Values.Text = "Form 4";
             this.kryptonButton4.Click += new System.EventHandler(this.kryptonButton4_Click);
             // 
             // kbtnVisualStudio2010Theme
             // 
-            this.kbtnVisualStudio2010Theme.Location = new System.Drawing.Point(14, 322);
+            this.kbtnVisualStudio2010Theme.Location = new System.Drawing.Point(19, 396);
+            this.kbtnVisualStudio2010Theme.Margin = new System.Windows.Forms.Padding(4);
             this.kbtnVisualStudio2010Theme.Name = "kbtnVisualStudio2010Theme";
-            this.kbtnVisualStudio2010Theme.Size = new System.Drawing.Size(184, 25);
+            this.kbtnVisualStudio2010Theme.Size = new System.Drawing.Size(404, 31);
             this.kbtnVisualStudio2010Theme.TabIndex = 13;
-            this.kbtnVisualStudio2010Theme.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnVisualStudio2010Theme.Values.Text = "Visual Studio 2010 Theme (Form5)";
             this.kbtnVisualStudio2010Theme.Click += new System.EventHandler(this.kbtnVisualStudio2010Theme_Click);
             // 
             // kchkUseProgressValueAsText
             // 
             this.kchkUseProgressValueAsText.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.kchkUseProgressValueAsText.Location = new System.Drawing.Point(714, 429);
+            this.kchkUseProgressValueAsText.Location = new System.Drawing.Point(952, 527);
+            this.kchkUseProgressValueAsText.Margin = new System.Windows.Forms.Padding(4);
             this.kchkUseProgressValueAsText.Name = "kchkUseProgressValueAsText";
-            this.kchkUseProgressValueAsText.Size = new System.Drawing.Size(165, 20);
+            this.kchkUseProgressValueAsText.Size = new System.Drawing.Size(316, 23);
             this.kchkUseProgressValueAsText.TabIndex = 12;
             this.kchkUseProgressValueAsText.Values.Text = "Use progress value as text";
+            this.kchkUseProgressValueAsText.CheckedChanged += new System.EventHandler(this.kchkUseProgressValueAsText_CheckedChanged);
             // 
             // kryptonProgressBar1
             // 
             this.kryptonProgressBar1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.kryptonProgressBar1.Location = new System.Drawing.Point(714, 396);
+            this.kryptonProgressBar1.Location = new System.Drawing.Point(952, 487);
+            this.kryptonProgressBar1.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonProgressBar1.Name = "kryptonProgressBar1";
-            this.kryptonProgressBar1.Size = new System.Drawing.Size(388, 26);
+            this.kryptonProgressBar1.Size = new System.Drawing.Size(517, 32);
             this.kryptonProgressBar1.StateCommon.Back.Color1 = System.Drawing.Color.Green;
             this.kryptonProgressBar1.StateDisabled.Back.ColorStyle = Krypton.Toolkit.PaletteColorStyle.OneNote;
             this.kryptonProgressBar1.StateNormal.Back.ColorStyle = Krypton.Toolkit.PaletteColorStyle.OneNote;
@@ -316,50 +319,52 @@
             // ktrkProgressValues
             // 
             this.ktrkProgressValues.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.ktrkProgressValues.Location = new System.Drawing.Point(714, 362);
+            this.ktrkProgressValues.Location = new System.Drawing.Point(952, 446);
+            this.ktrkProgressValues.Margin = new System.Windows.Forms.Padding(4);
             this.ktrkProgressValues.Maximum = 100;
             this.ktrkProgressValues.Name = "ktrkProgressValues";
-            this.ktrkProgressValues.Size = new System.Drawing.Size(388, 33);
+            this.ktrkProgressValues.Size = new System.Drawing.Size(517, 33);
             this.ktrkProgressValues.TabIndex = 10;
             this.ktrkProgressValues.TickStyle = System.Windows.Forms.TickStyle.Both;
+            this.ktrkProgressValues.ValueChanged += new System.EventHandler(this.ktrkProgressValues_ValueChanged);
             // 
             // kryptonButton3
             // 
-            this.kryptonButton3.Location = new System.Drawing.Point(14, 290);
+            this.kryptonButton3.Location = new System.Drawing.Point(19, 357);
+            this.kryptonButton3.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonButton3.Name = "kryptonButton3";
-            this.kryptonButton3.Size = new System.Drawing.Size(184, 25);
+            this.kryptonButton3.Size = new System.Drawing.Size(245, 31);
             this.kryptonButton3.TabIndex = 9;
-            this.kryptonButton3.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton3.Values.Text = "ThemeBrowser Form";
             this.kryptonButton3.Click += new System.EventHandler(this.kryptonButton3_Click);
             // 
             // kbtnIntegratedToolbar
             // 
-            this.kbtnIntegratedToolbar.Location = new System.Drawing.Point(14, 258);
+            this.kbtnIntegratedToolbar.Location = new System.Drawing.Point(19, 318);
+            this.kbtnIntegratedToolbar.Margin = new System.Windows.Forms.Padding(4);
             this.kbtnIntegratedToolbar.Name = "kbtnIntegratedToolbar";
-            this.kbtnIntegratedToolbar.Size = new System.Drawing.Size(184, 25);
+            this.kbtnIntegratedToolbar.Size = new System.Drawing.Size(404, 31);
             this.kbtnIntegratedToolbar.TabIndex = 8;
-            this.kbtnIntegratedToolbar.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnIntegratedToolbar.Values.Text = "Integrated Toolbar (Form5)";
             this.kbtnIntegratedToolbar.Click += new System.EventHandler(this.kbtnIntegratedToolbar_Click);
             // 
             // kbtnTestMessagebox
             // 
-            this.kbtnTestMessagebox.Location = new System.Drawing.Point(13, 227);
+            this.kbtnTestMessagebox.Location = new System.Drawing.Point(17, 279);
+            this.kbtnTestMessagebox.Margin = new System.Windows.Forms.Padding(4);
             this.kbtnTestMessagebox.Name = "kbtnTestMessagebox";
-            this.kbtnTestMessagebox.Size = new System.Drawing.Size(185, 25);
+            this.kbtnTestMessagebox.Size = new System.Drawing.Size(247, 31);
             this.kbtnTestMessagebox.TabIndex = 7;
-            this.kbtnTestMessagebox.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnTestMessagebox.Values.Text = "Test Messagebox";
             this.kbtnTestMessagebox.Click += new System.EventHandler(this.kbtnTestMessagebox_Click);
             // 
             // kryptonButton2
             // 
-            this.kryptonButton2.Location = new System.Drawing.Point(13, 163);
+            this.kryptonButton2.Location = new System.Drawing.Point(17, 201);
+            this.kryptonButton2.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonButton2.Name = "kryptonButton2";
-            this.kryptonButton2.Size = new System.Drawing.Size(185, 25);
+            this.kryptonButton2.Size = new System.Drawing.Size(247, 31);
             this.kryptonButton2.TabIndex = 6;
-            this.kryptonButton2.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton2.Values.Image = ((System.Drawing.Image)(resources.GetObject("kryptonButton2.Values.Image")));
             this.kryptonButton2.Values.Text = "Ribbon (Form3)";
             this.kryptonButton2.Values.UseAsUACElevationButton = true;
@@ -368,13 +373,14 @@
             // kryptonThemeComboBox1
             // 
             this.kryptonThemeComboBox1.DisplayMember = "Key";
-            this.kryptonThemeComboBox1.DropDownWidth = 185;
+            this.kryptonThemeComboBox1.DropDownWidth = 713;
             this.kryptonThemeComboBox1.IntegralHeight = false;
-            this.kryptonThemeComboBox1.Location = new System.Drawing.Point(12, 12);
+            this.kryptonThemeComboBox1.Location = new System.Drawing.Point(16, 15);
+            this.kryptonThemeComboBox1.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonThemeComboBox1.Name = "kryptonThemeComboBox1";
-            this.kryptonThemeComboBox1.Size = new System.Drawing.Size(185, 21);
-            this.kryptonThemeComboBox1.StateCommon.ComboBox.Border.DrawBorders = ((Krypton.Toolkit.PaletteDrawBorders)((((Krypton.Toolkit.PaletteDrawBorders.Top | Krypton.Toolkit.PaletteDrawBorders.Bottom)
-            | Krypton.Toolkit.PaletteDrawBorders.Left)
+            this.kryptonThemeComboBox1.Size = new System.Drawing.Size(713, 23);
+            this.kryptonThemeComboBox1.StateCommon.ComboBox.Border.DrawBorders = ((Krypton.Toolkit.PaletteDrawBorders)((((Krypton.Toolkit.PaletteDrawBorders.Top | Krypton.Toolkit.PaletteDrawBorders.Bottom) 
+            | Krypton.Toolkit.PaletteDrawBorders.Left) 
             | Krypton.Toolkit.PaletteDrawBorders.Right)));
             this.kryptonThemeComboBox1.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
             this.kryptonThemeComboBox1.TabIndex = 4;
@@ -383,11 +389,11 @@
             // kryptonButton1
             // 
             this.kryptonButton1.KryptonContextMenu = this.kryptonContextMenu1;
-            this.kryptonButton1.Location = new System.Drawing.Point(12, 132);
+            this.kryptonButton1.Location = new System.Drawing.Point(16, 162);
+            this.kryptonButton1.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonButton1.Name = "kryptonButton1";
-            this.kryptonButton1.Size = new System.Drawing.Size(185, 25);
+            this.kryptonButton1.Size = new System.Drawing.Size(247, 31);
             this.kryptonButton1.TabIndex = 5;
-            this.kryptonButton1.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton1.Values.ShowSplitOption = true;
             this.kryptonButton1.Values.Text = "Button (form2)";
             this.kryptonButton1.Click += new System.EventHandler(this.kryptonButton1_Click);
@@ -424,34 +430,28 @@
             // kryptonListBox1
             // 
             this.kryptonListBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.kryptonListBox1.Location = new System.Drawing.Point(715, 9);
-            this.kryptonListBox1.Margin = new System.Windows.Forms.Padding(2);
+            this.kryptonListBox1.Location = new System.Drawing.Point(953, 11);
+            this.kryptonListBox1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kryptonListBox1.Name = "kryptonListBox1";
-            this.kryptonListBox1.Size = new System.Drawing.Size(388, 346);
+            this.kryptonListBox1.Size = new System.Drawing.Size(517, 426);
             this.kryptonListBox1.TabIndex = 2;
             // 
             // kryptonTextBox1
             // 
-            this.kryptonTextBox1.Location = new System.Drawing.Point(58, 104);
-            this.kryptonTextBox1.Margin = new System.Windows.Forms.Padding(2);
+            this.kryptonTextBox1.Location = new System.Drawing.Point(16, 128);
+            this.kryptonTextBox1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kryptonTextBox1.Name = "kryptonTextBox1";
-            this.kryptonTextBox1.Size = new System.Drawing.Size(75, 23);
+            this.kryptonTextBox1.Size = new System.Drawing.Size(248, 25);
             this.kryptonTextBox1.TabIndex = 1;
             this.kryptonTextBox1.Text = "kryptonTextBox1";
             // 
             // textBox1
             // 
-            this.textBox1.Location = new System.Drawing.Point(55, 49);
-            this.textBox1.Margin = new System.Windows.Forms.Padding(2);
+            this.textBox1.Location = new System.Drawing.Point(73, 60);
+            this.textBox1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.textBox1.Name = "textBox1";
-            this.textBox1.Size = new System.Drawing.Size(76, 20);
+            this.textBox1.Size = new System.Drawing.Size(100, 22);
             this.textBox1.TabIndex = 0;
-            // 
-            // kryptonCustomPaletteBase1
-            // 
-            this.kryptonCustomPaletteBase1.BasePaletteMode = Krypton.Toolkit.PaletteMode.Microsoft365Black;
-            this.kryptonCustomPaletteBase1.BasePaletteType = Krypton.Toolkit.BasePaletteType.Microsoft365;
-            this.kryptonCustomPaletteBase1.ThemeName = "";
             // 
             // kcmdMessageboxTest
             // 
@@ -503,6 +503,7 @@
             // 
             // kryptonManager1
             // 
+            this.kryptonManager1.BaseFont = new System.Drawing.Font("Lucida Console", 10.8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Microsoft365BlackDarkMode;
             // 
             // kryptonTaskDialog1
@@ -520,7 +521,7 @@
             // 
             // Form1
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ButtonSpecs.Add(this.buttonSpecAny1);
             this.ButtonSpecs.Add(this.buttonSpecAny2);
@@ -532,11 +533,11 @@
             this.ButtonSpecs.Add(this.buttonSpecAny8);
             this.ButtonSpecs.Add(this.buttonSpecAny9);
             this.ButtonSpecs.Add(this.buttonSpecAny10);
-            this.ClientSize = new System.Drawing.Size(1112, 752);
+            this.ClientSize = new System.Drawing.Size(1483, 926);
             this.Controls.Add(this.kryptonPanel1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
             this.FormTitleAlign = Krypton.Toolkit.PaletteRelativeAlign.Inherit;
-            this.Margin = new System.Windows.Forms.Padding(2);
+            this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.Name = "Form1";
             this.Text = "Form1";
             this.WindowState = System.Windows.Forms.FormWindowState.Maximized;
@@ -558,7 +559,6 @@
         private Krypton.Toolkit.KryptonThemeComboBox kryptonThemeComboBox1;
         private Krypton.Toolkit.KryptonButton kryptonButton1;
         private Krypton.Toolkit.KryptonButton kryptonButton2;
-        private Krypton.Toolkit.KryptonCustomPaletteBase kryptonCustomPaletteBase1;
         private Krypton.Toolkit.KryptonCommand kcmdMessageboxTest;
         private Krypton.Toolkit.KryptonButton kbtnTestMessagebox;
         private Krypton.Toolkit.KryptonContextMenu kryptonContextMenu1;

--- a/Source/Krypton Components/TestForm/Form1.cs
+++ b/Source/Krypton Components/TestForm/Form1.cs
@@ -133,15 +133,15 @@ namespace TestForm
             Application.Exit();
         }
 
-        private void kryptonButton6_Click(object sender, EventArgs e)
-        {
-            kryptonCustomPaletteBase1.Import();
-        }
+        //private void kryptonButton6_Click(object sender, EventArgs e)
+        //{
+        //    kryptonCustomPaletteBase1.Import();
+        //}
 
-        private void kryptonButton7_Click(object sender, EventArgs e)
-        {
-            kryptonCustomPaletteBase1.Export();
-        }
+        //private void kryptonButton7_Click(object sender, EventArgs e)
+        //{
+        //    kryptonCustomPaletteBase1.Export();
+        //}
 
         private void kryptonThemeComboBox1_SelectedIndexChanged(object sender, EventArgs e)
         {

--- a/Source/Krypton Components/TestForm/Form1.resx
+++ b/Source/Krypton Components/TestForm/Form1.resx
@@ -121,7 +121,7 @@
   <data name="kryptonColorButton1.Values.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
-        DwAACw8BkvkDpQAAAAd0SU1FB9gBBwMpBNNjwEAAAADzSURBVDhPnZGhCoUwFIYHgiD4AlbB5AuYfAGT
+        DAAACwwBP0AiyAAAAAd0SU1FB9gBBwMpBNNjwEAAAADzSURBVDhPnZGhCoUwFIYHgiD4AlbB5AuYfAGT
         SRBMZsFkMhlMJkEQBIPVahJsstc6lzPYcG4X7m74wvl3zrcdRiilX1nXFVzXheu6QHeOaENOmqZACIG6
         rs0FeKvv+0zgeR7c962VKAGnaRqoqgriOGaSvu/NBGEYwnEcMI4jE2Ct61MCZFkWiKJIDARBwCTzPCsS
         qeAkSQJd14nmtm2ZANd59iFSgZznCbZts4E3lmXBvu+SRBpG8MvyPFduKoqCSbIs+y4YhgEcx4FpmhTB
@@ -131,26 +131,23 @@
   <data name="kryptonButton2.Values.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAK/SURBVDhPrZJbSNNRHMfPLrDmcpuFS21u5jTNwjShBwl8
-        iMKHeojyyfcgetOox9HLSKdmoYE1N28tZqSUZgmW5W3et7Y551Jzw43N4X95hUT/387mIKioHvrAl3P7
-        fb/8zuGQP3GtulrYb1AeiC3/nXy9/XKWMdhVaJoO+ayHAruzpGd1gFccO/6VQt1QfH7dlDK3YepqbrPb
-        mNPuh6p7DwVdS9j2JAAhgl0nB2tmTnugj3cl2CFQjbYScdRcpDYcONXkcuaYfOvZJj+yXm1B9TwEuXEV
-        ee2zYJw0wE2ABaplDvYcXHyzcTaZj1wXIte7dL0h7njT/KaKGtNNK0h76kdamx8pLSHkGp0IO6SAi4B1
-        RsSJzuEl2BzhbvWrEw9GAzJ1c6tK0yqUrT5W0bIMRfMyZIYgTrbOgLHSgBlqthOWtXPA2mjAHMHGADfc
-        W05ENEAdp3jkDie1rUHWGGRluiASdQGIGxio9C5sWESAgwbYCAsrNX+imiXY7idMb/kRESkpKeHl1w+6
-        ThjnkW1wIFtvR1ajDelPXCgwDMNrTkV4UoLwONVYRGJ8tUrg6ZHOqYsIP/qQX14fblp3JYCZkIIZl7LM
-        WHSEZ0SOM48HoKh3QFVvQXrdNI5RZercyLvb2RY1R9h4QS5gjLZG78dO0lYn6ThF2C2zEPKHdvC1QQir
-        vBBqvRDUBCDVuJF4493FmH2flQ5+M+xcYJy+tJlqlCA8KIaydgqCCg/iKz5DpF2E9L4P8rK3LTHbDyxq
-        iZTp5A3BFjFTDdOADxKkVk2Ar1mC8N4C4mv8SLrVN3y2VL3/iX7GqhXJgiZ+N0YjndCA92IkV4yDaPwQ
-        axaRXNb7JqekMilW/nseFGcI/AaeZruL7OwMSpBSZYfwtmX36M2XlcUZGYJY2d/x1ZJzDn3y6Ok7pgFZ
-        6bPzse3/DSHfAf2EqkKNe37BAAAAAElFTkSuQmCC
+        YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAALBSURBVDhPjZFvSFNhFMYPi8zU6pMafoi2SkuwVPw7depy
+        trzpzDWydC7CqNkMK/sDYnNgKYXhh8gELZNQkwSVtrR0VqamVFYIBrUvYpH/yjSzEPb03uuFCox64HC5
+        vO/zO885Ly0lEEk0ccE7OI4zpiVzRt+gJDWRWSIe/12NnuSRHuu/R5564OnavVdR0OTA5HAl2svDYDIk
+        9koDOB2RzkO8viidTueiVHNlCo2+PlB73CE1XIHrsT7QwUFY7AvAbB3Q7Y/vHbFovaxEkUnpyM5QNWi4
+        xDK1Wr2CXhK5++4rdq48PQRJ3iAobwiU+xyU9QTm9q/AZC2c9/2BR3KgL5J9o/CjR4Hqwlg2KUvznsht
+        fWb5FOW/ZcZnINMAKKcflPkboN0fTnsknJ0MYI8ABsLRVKr4RHTSXQBIMy5N0YnhX2YjD+iGuY0BJnjA
+        ZsHs7IhgFc6ShOF2sQjgR9ioOzdN2S9Y7F6hM2+mZDvyW2aAsUo4W7zgtPmx8gVsm4BOX1Scjf4ijNBI
+        5KLNKRyxdHxjkeeE2HxnMzN3vQOw8IpBKoDxGywNX9eBqRqUFhhGidgSeZmy9Y34cAv4XCvMzMfGeKVg
+        fugALM0zsNhmYbHOoMg6hwt3p5CedfiOYOblFxCf0lwSAvRsYfOK1erFOl/DGWYm1QNQWhdoN6u0fqze
+        eRGJ0dtSRTsvsyRdq7JOWOMZhC2KXxibmY9tsTEAb2bPSlkDWGNoh0KtvcfecJloFuWdLD2VnTAyb48B
+        HocvLowHsNhCZ2Z2NXQjdNehUWO0l0x0/alVG5LkBUdUH6fbGMTOts0ARdZZlqAP7oYuhKQcHdsfJ4sS
+        ry+t5T5JgUa96vWbmq3AfB1K7ICbph5RnOG1XuETJF77l5K9ue2hVQ3V51FYdhMB8oSq3EDyFA//X+tk
+        YcqYYJlS/F1CRD8BOQO3yqWFS54AAAAASUVORK5CYII=
 </value>
   </data>
   <metadata name="kryptonContextMenu1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>539, 16</value>
-  </metadata>
-  <metadata name="kryptonCustomPaletteBase1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>166, 16</value>
   </metadata>
   <metadata name="kcmdMessageboxTest.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>369, 16</value>


### PR DESCRIPTION
…de the applied palette font(s)

  - `CustomPalette` must be derived from the `KryptonCustomPaletteBase` class
  - `BasePaletteMode` has been removed from `KryptonCustomPaletteBase` class
- Remove a load of nullable weirdnesses

#1224

![image](https://github.com/Krypton-Suite/Standard-Toolkit/assets/2418812/def37a9c-07a3-41ac-9ed3-e2a4a08dfa4d)
