### PR TITLE
- Designer values named `State####Pressed` have changed to `State####…

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
+* Resolved / Implemented [#215](https://github.com/Krypton-Suite/Standard-Toolkit/issues/215), `KryptonTreeView` Multi Node Select
 * Resolved [#1255](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1255),Why does `CornerRoundingRadius` override the KRyptonForm StateCommon.Border.Rounding value
 * Resolved [#1252](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1252),Using V80, Setting a "Fat" Form border leads to poor layout
 * Implemented [#327](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1220), (Name) and other Standard-Properties in KryptonContextMenu Items Editor

--- a/README.md
+++ b/README.md
@@ -187,6 +187,9 @@ There are list of changes that have occurred during the development of the V90.#
 - [#124](https://github.com/Krypton-Suite/Standard-Toolkit/issues/124), When setting AllowFormChrome = false, then the Form Bar should still be Theme rendered
   - `AllowFormChrome` has been removed and replaced with `UseThemeFormChromeBorderWidth` to better explain what it is doing
   - It means that a theme can get closer to "Material Design", and that the Title bar can still be themed (And rounded)
+- [#215](https://github.com/Krypton-Suite/Standard-Toolkit/issues/215), `KryptonTreeView` Multi Node Select
+  - Designer values named `State####Pressed` have changed to `State#####MultiSelect` to reflect usage
+  - New ReeView Designer value `MultiSelect` allows drawing of selected items and retrieval via `CheckedNodes`
 
 ### Support for .NET 6/7
 As of V90.##, support for .NET 6 and 7 has been removed due to their release cadences.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckedListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckedListBox.cs
@@ -952,7 +952,7 @@ namespace Krypton.Toolkit
         private readonly ViewDrawCheckBox _drawCheckBox;
         private readonly ViewLayoutFill _layoutFill;
         private readonly ViewDrawButton _drawButton;
-        private readonly InternalCheckedListBox? _listBox;
+        private readonly InternalCheckedListBox _listBox;
         private readonly FixedContentValue? _contentValues;
         private bool? _fixedActive;
         private ButtonStyle _style;
@@ -1256,7 +1256,7 @@ namespace Krypton.Toolkit
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Browsable(false)]
-        public ListBox? ListBox => _listBox;
+        public ListBox ListBox => _listBox;
 
         /// <summary>
         /// Gets access to the contained input control.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -814,8 +814,8 @@ namespace Krypton.Toolkit
         private readonly ViewLayoutDocker _drawDockerInner;
         private readonly ViewDrawDocker _drawDockerOuter;
         private readonly ViewLayoutFill _layoutFill;
-        private readonly InternalComboBox? _comboBox;
-        private readonly InternalPanel? _comboHolder;
+        private readonly InternalComboBox _comboBox;
+        private readonly InternalPanel _comboHolder;
         private SubclassEdit? _subclassEdit;
         private ButtonStyle _dropButtonStyle;
         private PaletteBackStyle _dropBackStyle;
@@ -1308,7 +1308,7 @@ namespace Krypton.Toolkit
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Browsable(false)]
-        public ComboBox? ComboBox => _comboBox;
+        public ComboBox ComboBox => _comboBox;
 
         /// <summary>
         /// Gets access to the contained input control.
@@ -1316,7 +1316,7 @@ namespace Krypton.Toolkit
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Browsable(false)]
-        public Control? ContainedControl => ComboBox;
+        public Control ContainedControl => ComboBox;
 
         /// <summary>
         /// Gets a value indicating whether the control has input focus.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
@@ -186,7 +186,7 @@ namespace Krypton.Toolkit
         {
             #region Instance Fields
 
-            private readonly InternalDomainUpDown? _internalDomainUpDown;
+            private readonly InternalDomainUpDown _internalDomainUpDown;
             private bool _mouseOver;
 
             #endregion
@@ -212,7 +212,7 @@ namespace Krypton.Toolkit
             /// <param name="internalDomainUpDown">Reference to internal domain control.</param>
             public SubclassEdit(IntPtr editControl,
                                 KryptonDomainUpDown kryptonDomainUpDown,
-                                InternalDomainUpDown? internalDomainUpDown)
+                                InternalDomainUpDown internalDomainUpDown)
             {
                 DomainUpDown = kryptonDomainUpDown;
                 _internalDomainUpDown = internalDomainUpDown;
@@ -455,7 +455,7 @@ namespace Krypton.Toolkit
             /// <param name="internalDomainUpDown">Reference to internal domain control.</param>
             public SubclassButtons(IntPtr buttonsPtr,
                                    KryptonDomainUpDown kryptonDomainUpDown,
-                                   InternalDomainUpDown? internalDomainUpDown)
+                                   InternalDomainUpDown internalDomainUpDown)
                 : base(buttonsPtr, kryptonDomainUpDown, internalDomainUpDown)
             {
                 _mousePressed = new Point(-int.MaxValue, -int.MaxValue);
@@ -697,7 +697,7 @@ namespace Krypton.Toolkit
         private readonly ViewLayoutDocker _drawDockerInner;
         private readonly ViewDrawDocker _drawDockerOuter;
         private readonly ViewLayoutFill _layoutFill;
-        private readonly InternalDomainUpDown? _domainUpDown;
+        private readonly InternalDomainUpDown _domainUpDown;
         private InputControlStyle _inputControlStyle;
         private ButtonStyle _upDownButtonStyle;
         private SubclassEdit? _subclassEdit;
@@ -927,7 +927,7 @@ namespace Krypton.Toolkit
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Browsable(false)]
-        public DomainUpDown? DomainUpDown => _domainUpDown;
+        public DomainUpDown DomainUpDown => _domainUpDown;
 
         /// <summary>
         /// Gets access to the contained input control.
@@ -935,7 +935,7 @@ namespace Krypton.Toolkit
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Browsable(false)]
-        public Control? ContainedControl => DomainUpDown;
+        public Control ContainedControl => DomainUpDown;
 
         /// <summary>
         /// Gets or sets the background color for the control.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonGroup.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonGroup.cs
@@ -171,7 +171,7 @@ namespace Krypton.Toolkit
         [Category(@"Appearance")]
         [Description(@"The internal panel that contains group content.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-        public KryptonGroupPanel? Panel { get; }
+        public KryptonGroupPanel Panel { get; }
 
         /// <summary>
         /// Gets and sets the border style.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonGroupBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonGroupBox.cs
@@ -250,7 +250,7 @@ namespace Krypton.Toolkit
         [Category(@"Appearance")]
         [Description(@"The internal panel that contains group content.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-        public KryptonGroupBoxPanel? Panel { get; }
+        public KryptonGroupBoxPanel Panel { get; }
 
         /// <summary>
         /// Gets and the sets the percentage of overlap for the caption and group area.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonHeaderGroup.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonHeaderGroup.cs
@@ -399,7 +399,7 @@ namespace Krypton.Toolkit
         [Category(@"Appearance")]
         [Description(@"The internal panel that contains group content.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-        public KryptonGroupPanel? Panel { get; }
+        public KryptonGroupPanel Panel { get; }
 
         /// <summary>
         /// Gets or sets a value indicating if collapsed mode is auto toggled by arrow button specs.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListBox.cs
@@ -349,7 +349,7 @@ namespace Krypton.Toolkit
         private readonly ViewDrawDocker _drawDockerOuter;
         private readonly ViewLayoutFill _layoutFill;
         private readonly ViewDrawButton _drawButton;
-        private readonly InternalListBox? _listBox;
+        private readonly InternalListBox _listBox;
         private readonly FixedContentValue? _contentValues;
         private bool? _fixedActive;
         private ButtonStyle _style;
@@ -659,7 +659,7 @@ namespace Krypton.Toolkit
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Browsable(false)]
-        public ListBox? ListBox => _listBox;
+        public ListBox ListBox => _listBox;
 
         /// <summary>
         /// Gets access to the contained input control.
@@ -667,7 +667,7 @@ namespace Krypton.Toolkit
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Browsable(false)]
-        public Control? ContainedControl => ListBox!;
+        public Control ContainedControl => ListBox!;
 
         /// <summary>
         /// Gets or sets the text for the control.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs
@@ -316,7 +316,7 @@ namespace Krypton.Toolkit
         private readonly ViewLayoutDocker _drawDockerInner;
         private readonly ViewDrawDocker _drawDockerOuter;
         private readonly ViewLayoutFill _layoutFill;
-        private readonly InternalMaskedTextBox? _maskedTextBox;
+        private readonly InternalMaskedTextBox _maskedTextBox;
         private InputControlStyle _inputControlStyle;
         private bool? _fixedActive;
         private bool _forcedLayout;
@@ -601,7 +601,7 @@ namespace Krypton.Toolkit
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Browsable(false)]
-        public MaskedTextBox? MaskedTextBox => _maskedTextBox;
+        public MaskedTextBox MaskedTextBox => _maskedTextBox;
 
         /// <summary>
         /// Gets access to the contained input control.
@@ -609,7 +609,7 @@ namespace Krypton.Toolkit
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Browsable(false)]
-        public Control? ContainedControl => MaskedTextBox;
+        public Control ContainedControl => MaskedTextBox;
 
         /// <summary>
         /// Gets a value indicating whether the control has input focus.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
@@ -723,7 +723,7 @@ namespace Krypton.Toolkit
         private readonly ViewLayoutDocker _drawDockerInner;
         private readonly ViewDrawDocker _drawDockerOuter;
         private readonly ViewLayoutFill _layoutFill;
-        private readonly InternalNumericUpDown? _numericUpDown;
+        private readonly InternalNumericUpDown _numericUpDown;
         private InputControlStyle _inputControlStyle;
         private ButtonStyle _upDownButtonStyle;
         private SubclassEdit? _subclassEdit;
@@ -951,7 +951,7 @@ namespace Krypton.Toolkit
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Browsable(false)]
-        public NumericUpDown? NumericUpDown => _numericUpDown;
+        public NumericUpDown NumericUpDown => _numericUpDown;
 
         /// <summary>
         /// Gets access to the contained input control.
@@ -959,7 +959,7 @@ namespace Krypton.Toolkit
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Browsable(false)]
-        public Control? ContainedControl => NumericUpDown!;
+        public Control ContainedControl => NumericUpDown!;
 
         /// <summary>
         /// Gets a value indicating whether the control has input focus.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
@@ -307,7 +307,7 @@ namespace Krypton.Toolkit
         private readonly ViewLayoutDocker _drawDockerInner;
         private readonly ViewDrawDocker _drawDockerOuter;
         private readonly ViewLayoutFill _layoutFill;
-        private readonly InternalRichTextBox? _richTextBox;
+        private readonly InternalRichTextBox _richTextBox;
         private InputControlStyle _inputControlStyle;
         private bool? _fixedActive;
         private bool _forcedLayout;
@@ -600,7 +600,7 @@ namespace Krypton.Toolkit
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Browsable(false)]
-        public RichTextBox? RichTextBox => _richTextBox;
+        public RichTextBox RichTextBox => _richTextBox;
 
         /// <summary>
         /// Gets access to the contained input control.
@@ -608,7 +608,7 @@ namespace Krypton.Toolkit
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Browsable(false)]
-        public Control? ContainedControl => RichTextBox!;
+        public Control ContainedControl => RichTextBox!;
 
         /// <summary>
         /// Gets a value indicating whether the control has input focus.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonSplitContainer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonSplitContainer.cs
@@ -299,7 +299,7 @@ namespace Krypton.Toolkit
         [Category(@"Appearance")]
         [Description(@"The Left or Top panel in the KryptonSplitContainer.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-        public KryptonSplitterPanel? Panel1 { get; }
+        public KryptonSplitterPanel Panel1 { get; }
 
         /// <summary>
         /// Gets and sets the minium size of panel1.
@@ -403,7 +403,7 @@ namespace Krypton.Toolkit
         [Category(@"Appearance")]
         [Description(@"The Right or Bottom panel in the KryptonSplitContainer.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-        public KryptonSplitterPanel? Panel2 { get; }
+        public KryptonSplitterPanel Panel2 { get; }
 
         /// <summary>
         /// Gets and sets the minium size of panel2.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
@@ -325,7 +325,7 @@ namespace Krypton.Toolkit
         private readonly ViewLayoutDocker _drawDockerInner;
         private readonly ViewDrawDocker _drawDockerOuter;
         private readonly ViewLayoutFill _layoutFill;
-        private readonly InternalTextBox? _textBox;
+        private readonly InternalTextBox _textBox;
         private InputControlStyle _inputControlStyle;
         private bool? _fixedActive;
         private bool _forcedLayout;
@@ -654,7 +654,7 @@ namespace Krypton.Toolkit
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Browsable(false)]
-        public TextBox? TextBox => _textBox;
+        public TextBox TextBox => _textBox;
 
         /// <summary>
         /// Gets access to the contained input control.
@@ -662,7 +662,7 @@ namespace Krypton.Toolkit
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Browsable(false)]
-        public Control? ContainedControl => TextBox;
+        public Control ContainedControl => TextBox;
 
         /// <summary>
         /// Gets and sets a value indicating if the control is automatically sized.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualControlBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualControlBase.cs
@@ -526,7 +526,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the palette redirector.
         /// </summary>
-        protected PaletteRedirect? Redirector
+        protected PaletteRedirect Redirector
         {
             [DebuggerStepThrough]
             get;

--- a/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
@@ -406,7 +406,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the contained input control.
         /// </summary>
-        Control? ContainedControl { get; }
+        Control ContainedControl { get; }
     }
     #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/General/KryptonControlCollection.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/KryptonControlCollection.cs
@@ -35,7 +35,7 @@ namespace Krypton.Toolkit
         /// <param name="control">Control to be added.</param>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void AddInternal([DisallowNull] Control? control) =>
+        public void AddInternal([DisallowNull] Control control) =>
             // ReSharper disable RedundantBaseQualifier
             // Do not remove base, as the KryptonReadOnlyControls is a mess !
             base.Add(control);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBack/PaletteBackInheritRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBack/PaletteBackInheritRedirect.cs
@@ -18,7 +18,7 @@ namespace Krypton.Toolkit
     public class PaletteBackInheritRedirect : PaletteBackInherit
     {
         #region Instance Fields
-        private PaletteRedirect? _redirect;
+        private PaletteRedirect _redirect;
 
         #endregion
 
@@ -37,7 +37,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">Source for inherit requests.</param>
         /// <param name="style">Style used in requests.</param>
-        public PaletteBackInheritRedirect(PaletteRedirect? redirect,
+        public PaletteBackInheritRedirect(PaletteRedirect redirect,
                                           PaletteBackStyle style)
         {
             _redirect = redirect;
@@ -50,7 +50,7 @@ namespace Krypton.Toolkit
         /// Gets the redirector instance.
         /// </summary>
         /// <returns>Return the currently used redirector.</returns>
-        public PaletteRedirect? GetRedirector() => _redirect;
+        public PaletteRedirect GetRedirector() => _redirect;
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTripleRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTripleRedirect.cs
@@ -62,7 +62,7 @@ namespace Krypton.Toolkit
         /// <param name="borderStyle">Initial border style.</param>
         /// <param name="contentStyle">Initial content style.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteTripleRedirect(PaletteRedirect? redirect,
+        public PaletteTripleRedirect(PaletteRedirect redirect,
                                      PaletteBackStyle backStyle,
                                      PaletteBorderStyle borderStyle,
                                      PaletteContentStyle contentStyle,

--- a/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutFill.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutFill.cs
@@ -18,7 +18,7 @@ namespace Krypton.Toolkit
     public class ViewLayoutFill : ViewLayoutNull
     {
         #region Instance Fields
-        private readonly Control? _control;
+        private readonly Control _control;
 
         #endregion
 
@@ -34,7 +34,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the ViewLayoutNull class.
         /// </summary>
         /// <param name="control">Control to position in fill location.</param>
-        public ViewLayoutFill(Control? control) => _control = control;
+        public ViewLayoutFill(Control control) => _control = control;
 
         /// <summary>
         /// Obtains the String representation of this instance.


### PR DESCRIPTION
- Designer values named `State####Pressed` have changed to `State#####MultiSelect` to reflect usage

- New TreeView Designer value `MultiSelect` allows drawing of selected items and retrieval via `CheckedNodes`
- Some Nullables

Demo in #215

![image](https://github.com/Krypton-Suite/Standard-Toolkit/assets/2418812/751b8aef-7a3e-4e9b-9c8d-7706c2a7962b)
