### PR TITLE
Fix KryptonCustomPaletteBase import's image assignment

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
@@ -3381,17 +3381,8 @@ namespace Krypton.Toolkit
                                             }
                                             else
                                             {
-                                                // Have we already encountered the image?
-                                                if (imageCache.ContainsKey(valueValue))
-                                                {
-                                                    // Push the image from the cache into the property
-                                                    prop.SetValue(obj, valueValue, null);
-                                                }
-                                                else
-                                                {
-                                                    // Cannot find image to set to empty
-                                                    prop.SetValue(obj, null, null);
-                                                }
+                                                // If image exists in dictionary, push the image from the cache into the property, else null.
+                                                prop.SetValue(obj, imageCache.TryGetValue(valueValue, out var imageValue) ? imageValue : null, null);
                                             }
                                         }
                                         else


### PR DESCRIPTION
Fix exception in ImportObjectFromElement: do not assign string to image prop, but the image referenced by its name, if it exists in the imageCache dictionary.