### PR TITLE
Fix white themes, theme combo and propertygrid.

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
+* Resolved [#1331](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1331), Fix white menu text in White themes (2010, 2013, 365); fixes to `KryptonPropertyGrid` and `KryptonThemeComboBox` with regard to theme switching
 * Resolved [#1313](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1313), White background in tabs area
 * Implement [#1309](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1309), Is it time to bring over `KryptonOutlookGrid`
 * Resolved [#1316](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1316), `KryptonCustomPaletteBase` Import fails if XML contains images (fix courtesy of [tobitege](https://github.com/tobitege))

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonManager.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved.
+ *
  */
 #endregion
 
@@ -184,7 +184,7 @@ namespace Krypton.Toolkit
             container.Add(this);
         }
 
-        /// <summary> 
+        /// <summary>
         /// Clean up any resources being used.
         /// </summary>
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
@@ -244,9 +244,8 @@ namespace Krypton.Toolkit
                 {
                     if (value != PaletteMode.Custom)
                     {
-                        CurrentGlobalPalette = GetPaletteForMode(value);
                         // Get a reference to the standard palette from its name
-                        SetPalette(CurrentGlobalPalette);
+                        SetPalette(GetPaletteForMode(value));
                     }
                     CurrentGlobalPaletteMode = value;
                     if (_baseFont != null)
@@ -482,7 +481,7 @@ namespace Krypton.Toolkit
                 case PaletteMode.Office2007White:
                     return PaletteOffice2007White;
                 case PaletteMode.Office2007Black:
-                    return PaletteOffice2007Black; 
+                    return PaletteOffice2007Black;
                 // TODO: Re-enable this once completed
                 // case PaletteMode.Office2010DarkGray:
                 // return PaletteOffice2010DarkGray;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPropertyGrid.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPropertyGrid.cs
@@ -11,7 +11,7 @@ using System.Windows.Forms;
 
 namespace Krypton.Toolkit
 {
-    /// <summary>A property grid control that supports the Krypton render.</summary>
+    ///<summary>A property grid control that supports the Krypton render.</summary>
     [Description(@"A property grid control that supports the Krypton render.")]
     [Designer(typeof(KryptonPropertyGridDesigner))]
     [ToolboxBitmap(typeof(PropertyGrid), "ToolboxBitmaps.KryptonPropertyGridVersion2.bmp")]
@@ -31,6 +31,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Constructor
+        ///<summary>A property grid control that supports the Krypton render.</summary>
         public KryptonPropertyGrid()
         {
             SetStyle(ControlStyles.UserPaint
@@ -62,10 +63,19 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Public
-
         /// <summary>Refreshes the colours.</summary>
         public void RefreshColours() => InitColours();
+        #endregion
 
+        #region Protected Overrides
+        /// <inheritdoc />
+        protected override void Dispose(bool disposing)
+        {
+            // Unhook from the static events, otherwise we cannot be garbage collected
+            KryptonManager.GlobalPaletteChanged -= OnGlobalPaletteChanged;
+
+            base.Dispose(disposing);
+        }
         #endregion
 
         #region Krypton
@@ -87,9 +97,7 @@ namespace Krypton.Toolkit
             {
                 _palette.PalettePaint += OnPalettePaint;
                 //repaint with new values
-
                 InitColours();
-
             }
 
             Invalidate();

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPropertyGrid.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPropertyGrid.cs
@@ -139,7 +139,9 @@ namespace Krypton.Toolkit
                 {
                     state = PaletteState.ContextNormal;
                     triple = _stateNormal;
-                    control.Font = normalFont!;
+                    // tobitege commented out to avoid unrecoverable exception in System.Drawing
+                    // when toggling theme back and forth
+                    //control.Font = normalFont!;
                 }
                 else
                 {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
@@ -1,237 +1,277 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved.
+ *
  */
 #endregion
 
 namespace Krypton.Toolkit
 {
-	/// <summary>Allows the user to change themes using a <see cref="KryptonComboBox"/>.</summary>
-	/// <seealso cref="KryptonComboBox" />
-	public class KryptonThemeComboBox : KryptonComboBox
-	{
-		#region Instance Fields
+    /// <summary>Allows the user to change themes using a <see cref="KryptonComboBox"/>.</summary>
+    /// <seealso cref="KryptonComboBox" />
+    public class KryptonThemeComboBox : KryptonComboBox
+    {
+        #region Instance Fields
 
-		private bool _reportSelectedThemeIndex;
+        private bool _isUpdating = false;
+        private bool _handleCreated = false;
+        private bool _pendingPaletteUpdate = false;
+        private PaletteMode _pendingPaletteMode;
 
-		private int _selectedIndex;
+        private bool _reportSelectedThemeIndex;
 
-		private readonly int? _defaultPaletteIndex = GlobalStaticValues.GLOBAL_DEFAULT_THEME_INDEX;
+        private int _selectedIndex;
 
-		private PaletteMode _defaultPalette;
+        private readonly int? _defaultPaletteIndex = GlobalStaticValues.GLOBAL_DEFAULT_THEME_INDEX;
 
-		private KryptonManager? _manager;
+        private PaletteMode _defaultPalette;
 
-		#endregion
+        private KryptonManager? _manager;
 
-		#region Public
+        #endregion
 
-		/// <summary>Gets or sets a value indicating whether [report selected theme index].</summary>
-		/// <value><c>true</c> if [report selected theme index]; otherwise, <c>false</c>.</value>
-		public bool ReportSelectedThemeIndex
-		{
-			get => _reportSelectedThemeIndex;
+        #region Public
 
-			set => _reportSelectedThemeIndex = value;
-		}
+        /// <summary>Gets or sets a value indicating whether [report selected theme index].</summary>
+        /// <value><c>true</c> if [report selected theme index]; otherwise, <c>false</c>.</value>
+        public bool ReportSelectedThemeIndex
+        {
+            get => _reportSelectedThemeIndex;
 
-		/// <summary>Gets or sets the default palette mode.</summary>
-		/// <value>The default palette mode.</value>
-		[Category(@"Visuals")]
-		[Description(@"The default palette mode.")]
-		[DefaultValue(PaletteMode.Microsoft365Blue)]
-		public PaletteMode DefaultPalette
-		{
-			get => _defaultPalette;
+            set => _reportSelectedThemeIndex = value;
+        }
 
-			set
-			{
-				_defaultPalette = value;
+        /// <summary>Gets or sets the default palette mode.</summary>
+        /// <value>The default palette mode.</value>
+        [Category(@"Visuals")]
+        [Description(@"The default palette mode.")]
+        [DefaultValue(PaletteMode.Microsoft365Blue)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public PaletteMode DefaultPalette
+        {
+            get => _defaultPalette;
 
-				UpdateDefaultPaletteIndex(value);
-			}
-		}
+            set
+            {
+                if (_defaultPalette == value) return;
+                if (_handleCreated)
+                {
+                    // Safe to directly access UI thread now
+                    _defaultPalette = value;
+                    UpdateDefaultPaletteIndex(value);
+                }
+                else
+                {
+                    // Defer until the handle is created
+                    _pendingPaletteUpdate = true;
+                    _pendingPaletteMode = value;
+                }
+            }
+        }
 
-		/// <summary>
-		/// Gets and sets the ThemeSelectedIndex.
-		/// </summary>
-		[Category(@"Visuals")]
-		[Description(@"Theme Selected Index. (Default = `Office 365 - Blue`)")]
-		[DefaultValue((int)PaletteMode.Microsoft365Blue)]
-		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-		public int ThemeSelectedIndex
-		{
-			get => _selectedIndex = _defaultPaletteIndex ?? 30;
+        /// <summary>
+        /// Gets and sets the ThemeSelectedIndex.
+        /// </summary>
+        [Category(@"Visuals")]
+        [Description(@"Theme Selected Index. (Default = `Office 365 - Blue`)")]
+        [DefaultValue((int)PaletteMode.Microsoft365Blue)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        private int ThemeSelectedIndex
+        {
+            get => _selectedIndex = _defaultPaletteIndex ?? 30;
 
-			private set => _selectedIndex = SelectedIndex = value;
-		}
+            set => _selectedIndex = SelectedIndex = value;
+        }
 
-		private void ResetThemeSelectedIndex() => _selectedIndex = _defaultPaletteIndex ?? 30;
+        private void ResetThemeSelectedIndex() => _selectedIndex = _defaultPaletteIndex ?? 30;
 
-		private bool ShouldSerializeThemeSelectedIndex() => _selectedIndex != _defaultPaletteIndex;
+        private bool ShouldSerializeThemeSelectedIndex() => _selectedIndex != _defaultPaletteIndex;
 
-		/// <summary>
-		/// Gets and sets the ThemeSelectedIndex.
-		/// </summary>
-		[Category(@"Visuals")]
-		[Description(@"Custom Theme to use when `Custom` is selected")]
-		[DefaultValue(null)]
-		public KryptonCustomPaletteBase? KryptonCustomPalette { get; set; }
+        /// <summary>
+        /// Gets and sets a KryptonCustomPalette.
+        /// </summary>
+        [Category(@"Visuals")]
+        [Description(@"Custom palette (if set)")]
+        [DefaultValue(null)]
+        public KryptonCustomPaletteBase? KryptonCustomPalette { get; set; }
 
-		[Category(@"Data")]
-		[Description(@"")]
-		[DefaultValue(null)]
-		public KryptonManager? Manager
-		{
-			get => _manager;
+        [Category(@"Data")]
+        [Description(@"")]
+        [DefaultValue(null)]
+        public KryptonManager? Manager
+        {
+            get => _manager;
 
-			set => _manager = value;
-		}
+            set => _manager = value;
+        }
 
-		#endregion
+        #endregion
 
-		#region Identity
+        #region Identity
 
-		/// <summary>Initializes a new instance of the <see cref="KryptonThemeComboBox" /> class.</summary>
-		public KryptonThemeComboBox()
-		{
-			_reportSelectedThemeIndex = false;
+        /// <summary>Initializes a new instance of the <see cref="KryptonThemeComboBox" /> class.</summary>
+        public KryptonThemeComboBox()
+        {
+            _reportSelectedThemeIndex = false;
 
-			_manager = new KryptonManager();
+            _manager = new KryptonManager();
 
-			DropDownStyle = ComboBoxStyle.DropDownList;
-			foreach (var kvp in PaletteModeStrings.SupportedThemesMap)
-			{
-				Items.Add(kvp.Key);
-			}
-			Text = ThemeManager.ReturnPaletteModeAsString(PaletteMode.Microsoft365Blue);
-			_selectedIndex = SelectedIndex = _defaultPaletteIndex ?? GlobalStaticValues.GLOBAL_DEFAULT_THEME_INDEX;
+            DropDownStyle = ComboBoxStyle.DropDownList;
+            foreach (var kvp in PaletteModeStrings.SupportedThemesMap)
+            {
+                Items.Add(kvp.Key);
+            }
+            base.Text = ThemeManager.ReturnPaletteModeAsString(PaletteMode.Microsoft365Blue);
+            _selectedIndex = SelectedIndex = _defaultPaletteIndex ?? GlobalStaticValues.GLOBAL_DEFAULT_THEME_INDEX;
 
-			_defaultPalette = PaletteMode.Microsoft365Blue;
+            _defaultPalette = PaletteMode.Microsoft365Blue;
 
-			Debug.Assert(_selectedIndex == _defaultPaletteIndex, $@"Microsoft365Blue needs to be at the index position of {_defaultPaletteIndex} for backward compatibility");
-		}
-		#endregion
+            Debug.Assert(_selectedIndex == _defaultPaletteIndex, $@"Microsoft365Blue needs to be at the index position of {_defaultPaletteIndex} for backward compatibility");
 
-		#region Implementation
+            HandleCreated += KryptonThemeComboBox_HandleCreated;
+        }
+        #endregion
 
-		private void UpdateDefaultPaletteIndex(PaletteMode mode) => ThemeSelectedIndex = (int)mode + 1;
+        #region Implementation
 
-		/// <summary>Returns the palette mode.</summary>
-		/// <returns>
-		///   <br />
-		/// </returns>
-		public PaletteMode ReturnPaletteMode() => Manager!.GlobalPaletteMode;
+        private void KryptonThemeComboBox_HandleCreated(object sender, EventArgs e)
+        {
+            _handleCreated = true;
+            if (!_pendingPaletteUpdate) return;
 
-		// TODO: Refresh the theme names if the values have been altered
+            _pendingPaletteUpdate = false;
+            DefaultPalette = _pendingPaletteMode;
+        }
 
-		#endregion
+        private void UpdateDefaultPaletteIndex(PaletteMode mode)
+        {
+            if (_isUpdating) return;
+            _isUpdating = true;
 
-		#region Protected Overrides
+            var selectedText = ThemeManager.ReturnPaletteModeAsString(mode);
+            var newIdx = Items.IndexOf(selectedText);
+            if (newIdx >= 0 && newIdx < PaletteModeStrings.SupportedThemesMap.Count)
+            {
+                ThemeSelectedIndex = newIdx;
+            }
 
-		/// <inheritdoc />
-		protected override void OnCreateControl()
-		{
-			base.OnCreateControl();
-			SelectedIndex = _selectedIndex;
-		}
+            _isUpdating = false;
+        }
 
-		/// <inheritdoc />
-		protected override void OnSelectedIndexChanged(EventArgs e)
-		{
-			ThemeManager.ApplyTheme(Text!, Manager!);
+        /// <summary>Returns the palette mode.</summary>
+        /// <returns>
+        ///   <br />
+        /// </returns>
+        public PaletteMode ReturnPaletteMode() => Manager!.GlobalPaletteMode;
 
-			ThemeSelectedIndex = SelectedIndex;
+        // TODO: Refresh the theme names if the values have been altered
 
-			base.OnSelectedIndexChanged(e);
-			if ((ThemeManager.GetThemeManagerMode(Text!) == PaletteMode.Custom)
-				&& (KryptonCustomPalette != null)
-			   )
-			{
-				Manager!.GlobalCustomPalette = KryptonCustomPalette;
-			}
+        #endregion
 
-			if (_reportSelectedThemeIndex)
-			{
-				KryptonMessageBox.Show($@"The index for '{SelectedItem}' is {SelectedIndex}", @"Theme Index", KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.SystemInformation);
-			}
-		}
+        #region Protected Overrides
 
-		#endregion
+        /// <inheritdoc />
+        protected override void OnCreateControl()
+        {
+            base.OnCreateControl();
+            SelectedIndex = _selectedIndex;
+        }
 
-		#region Removed Designer Visibility
-		/// <summary>
-		/// Gets and sets the text associated with the control.
-		/// </summary>
-		[Browsable(false)]
-		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-		[AllowNull]
-		public override string? Text
-		{
-			get => base.Text;
-			set => base.Text = value;
-		}
+        /// <inheritdoc />
+        protected override void OnSelectedIndexChanged(EventArgs e)
+        {
+            ThemeManager.ApplyTheme(Text!, Manager!);
 
-		/// <summary>Gets or sets the format specifier characters that indicate how a value is to be Displayed.</summary>
-		[Browsable(false)]
-		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-		public new string FormatString
-		{
-			get => base.FormatString;
+            ThemeSelectedIndex = SelectedIndex;
 
-			set => base.FormatString = value;
-		}
+            base.OnSelectedIndexChanged(e);
+            if ((ThemeManager.GetThemeManagerMode(Text!) == PaletteMode.Custom)
+                && (KryptonCustomPalette != null)
+               )
+            {
+                Manager!.GlobalCustomPalette = KryptonCustomPalette;
+            }
 
-		/// <summary>
-		/// Gets and sets the appearance and functionality of the KryptonComboBox.
-		/// </summary>
-		[Browsable(false)]
-		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-		public new ComboBoxStyle DropDownStyle
-		{
-			get => base.DropDownStyle;
-			set => base.DropDownStyle = value;
-		}
+            if (_reportSelectedThemeIndex)
+            {
+                KryptonMessageBox.Show($@"The index for '{SelectedItem}' is {SelectedIndex}", @"Theme Index", KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.SystemInformation);
+            }
+        }
 
-		/// <summary>
-		/// Gets or sets the items in the KryptonComboBox.
-		/// </summary>
-		[Browsable(false)]
-		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-		public new ComboBox.ObjectCollection Items => base.Items;
+        #endregion
 
-		/// <summary>Gets or sets the draw mode of the combobox.</summary>
-		/// <value>The draw mode of the combobox.</value>
-		[Browsable(false)]
-		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-		public new DrawMode DrawMode
-		{
-			get => base.DrawMode;
-			set => base.DrawMode = value;
-		}
+        #region Removed Designer Visibility
+        /// <summary>
+        /// Gets and sets the text associated with the control.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [AllowNull]
+        public override string? Text
+        {
+            get => base.Text;
+            set => base.Text = value;
+        }
 
-		/// <summary>
-		/// Gets or sets the StringCollection to use when the AutoCompleteSource property is set to CustomSource.
-		/// </summary>
-		[Browsable(false)]
-		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-		public new AutoCompleteStringCollection AutoCompleteCustomSource
-		{
-			get => base.AutoCompleteCustomSource;
-			set => base.AutoCompleteCustomSource = value;
-		}
+        /// <summary>Gets or sets the format specifier characters that indicate how a value is to be Displayed.</summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public new string FormatString
+        {
+            get => base.FormatString;
 
-		[Browsable(false)]
-		[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-		public new int SelectedIndex { get => base.SelectedIndex; set => base.SelectedIndex = value; }
+            set => base.FormatString = value;
+        }
 
-		#endregion
-	}
+        /// <summary>
+        /// Gets and sets the appearance and functionality of the KryptonComboBox.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public new ComboBoxStyle DropDownStyle
+        {
+            get => base.DropDownStyle;
+            set => base.DropDownStyle = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the items in the KryptonComboBox.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public new ComboBox.ObjectCollection Items => base.Items;
+
+        /// <summary>Gets or sets the draw mode of the combobox.</summary>
+        /// <value>The draw mode of the combobox.</value>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public new DrawMode DrawMode
+        {
+            get => base.DrawMode;
+            set => base.DrawMode = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the StringCollection to use when the AutoCompleteSource property is set to CustomSource.
+        /// </summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public new AutoCompleteStringCollection AutoCompleteCustomSource
+        {
+            get => base.AutoCompleteCustomSource;
+            set => base.AutoCompleteCustomSource = value;
+        }
+
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public new int SelectedIndex { get => base.SelectedIndex; set => base.SelectedIndex = value; }
+
+        #endregion
+    }
 
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
@@ -84,7 +84,6 @@ namespace Krypton.Toolkit
         private int ThemeSelectedIndex
         {
             get => _selectedIndex = _defaultPaletteIndex ?? 30;
-
             set => _selectedIndex = SelectedIndex = value;
         }
 
@@ -106,7 +105,6 @@ namespace Krypton.Toolkit
         public KryptonManager? Manager
         {
             get => _manager;
-
             set => _manager = value;
         }
 
@@ -117,17 +115,26 @@ namespace Krypton.Toolkit
         /// <summary>Initializes a new instance of the <see cref="KryptonThemeComboBox" /> class.</summary>
         public KryptonThemeComboBox()
         {
+            #if DEBUG
+            _reportSelectedThemeIndex = true;
+            #else
             _reportSelectedThemeIndex = false;
-
+            #endif
             _manager = new KryptonManager();
 
+            var defaultThemeName = ThemeManager.ReturnPaletteModeAsString(PaletteMode.Microsoft365Blue);
+            _defaultPaletteIndex = 30; // was 24 which is wrong!
             DropDownStyle = ComboBoxStyle.DropDownList;
             foreach (var kvp in PaletteModeStrings.SupportedThemesMap)
             {
                 Items.Add(kvp.Key);
+                if (kvp.Key == defaultThemeName)
+                {
+                    _defaultPaletteIndex = Items.Count - 1;
+                }
             }
-            base.Text = ThemeManager.ReturnPaletteModeAsString(PaletteMode.Microsoft365Blue);
-            _selectedIndex = SelectedIndex = _defaultPaletteIndex ?? GlobalStaticValues.GLOBAL_DEFAULT_THEME_INDEX;
+            base.Text = defaultThemeName;
+            _selectedIndex = SelectedIndex = (int)_defaultPaletteIndex;
 
             _defaultPalette = PaletteMode.Microsoft365Blue;
 
@@ -164,9 +171,7 @@ namespace Krypton.Toolkit
         }
 
         /// <summary>Returns the palette mode.</summary>
-        /// <returns>
-        ///   <br />
-        /// </returns>
+        /// <returns>PaletteMode of the Manager</returns>
         public PaletteMode ReturnPaletteMode() => Manager!.GlobalPaletteMode;
 
         // TODO: Refresh the theme names if the values have been altered
@@ -179,6 +184,16 @@ namespace Krypton.Toolkit
         protected override void OnCreateControl()
         {
             base.OnCreateControl();
+            // At this point, a potential new Manager is assigned (by Designer file)
+            // If its GlobalPaletteMode is not Custom or Global, set the combo's text:
+            var mgrMode = ReturnPaletteMode();
+            if (mgrMode != PaletteMode.Custom && mgrMode != PaletteMode.Global)
+            {
+                var selectedText = ThemeManager.ReturnPaletteModeAsString(mgrMode);
+                // this triggers below OnSelectedIndexChanged
+                base.Text = selectedText;
+                return;
+            }
             SelectedIndex = _selectedIndex;
         }
 
@@ -199,7 +214,9 @@ namespace Krypton.Toolkit
 
             if (_reportSelectedThemeIndex)
             {
-                KryptonMessageBox.Show($@"The index for '{SelectedItem}' is {SelectedIndex}", @"Theme Index", KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.SystemInformation);
+                //KryptonMessageBox.Show($@"The index for '{SelectedItem}' is {SelectedIndex}",
+                //  @"Theme Index", KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.SystemInformation);
+                Debug.WriteLine($@"The index for '{SelectedItem}' is {SelectedIndex}");
             }
         }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Bases/PaletteMicrosoft365Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Bases/PaletteMicrosoft365Base.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved.
+ *
  */
 #endregion
 
@@ -242,9 +242,9 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Variables
-        private KryptonColorTable365 _table;
+        protected KryptonColorTable365 Table { get; set; }
 
-        private readonly Color[] _ribbonColours;
+        private readonly Color[] _ribbonColors;
 
         private readonly Color[] _trackBarColours;
         private readonly ImageList _checkBoxList;
@@ -252,7 +252,7 @@ namespace Krypton.Toolkit
         private readonly Image?[] _radioButtonArray;
         #endregion
 
-        #region Constructor        
+        #region Constructor
         /// <summary>
         /// Initializes a new instance of the <see cref="PaletteMicrosoft365Base"/> class.
         /// </summary>
@@ -273,7 +273,7 @@ namespace Krypton.Toolkit
 
             if (schemeColours != null)
             {
-                _ribbonColours = schemeColours;
+                _ribbonColors = schemeColours;
             }
 
             if (checkBoxList != null)
@@ -300,7 +300,7 @@ namespace Krypton.Toolkit
         }
         #endregion
 
-        #region Renderer        
+        #region Renderer
         /// <summary>
         /// Gets the renderer to use for this palette.
         /// </summary>
@@ -395,31 +395,31 @@ namespace Krypton.Toolkit
                     return state switch
                     {
                         PaletteState.Disabled => _disabledBack,
-                        PaletteState.Pressed => _ribbonColours[(int)SchemeOfficeColors.GridListPressed1],
-                        PaletteState.CheckedNormal => _ribbonColours[(int)SchemeOfficeColors.GridListSelected],
-                        _ => _ribbonColours[(int)SchemeOfficeColors.GridListNormal1]
+                        PaletteState.Pressed => _ribbonColors[(int)SchemeOfficeColors.GridListPressed1],
+                        PaletteState.CheckedNormal => _ribbonColors[(int)SchemeOfficeColors.GridListSelected],
+                        _ => _ribbonColors[(int)SchemeOfficeColors.GridListNormal1]
                     };
                 case PaletteBackStyle.GridHeaderColumnSheet:
                     return state switch
                     {
                         PaletteState.Disabled => _disabledBack,
-                        PaletteState.Tracking or PaletteState.Pressed => _ribbonColours[(int)SchemeOfficeColors.GridSheetColPressed1],
-                        PaletteState.CheckedNormal => _ribbonColours[(int)SchemeOfficeColors.GridSheetColSelected1],
-                        _ => _ribbonColours[(int)SchemeOfficeColors.GridSheetColNormal1]
+                        PaletteState.Tracking or PaletteState.Pressed => _ribbonColors[(int)SchemeOfficeColors.GridSheetColPressed1],
+                        PaletteState.CheckedNormal => _ribbonColors[(int)SchemeOfficeColors.GridSheetColSelected1],
+                        _ => _ribbonColors[(int)SchemeOfficeColors.GridSheetColNormal1]
                     };
                 case PaletteBackStyle.GridHeaderRowSheet:
                     return state switch
                     {
                         PaletteState.Disabled => _disabledBack,
-                        PaletteState.Tracking or PaletteState.Pressed => _ribbonColours[(int)SchemeOfficeColors.GridSheetRowPressed],
-                        PaletteState.CheckedNormal => _ribbonColours[(int)SchemeOfficeColors.GridSheetRowSelected],
-                        _ => _ribbonColours[(int)SchemeOfficeColors.GridSheetRowNormal]
+                        PaletteState.Tracking or PaletteState.Pressed => _ribbonColors[(int)SchemeOfficeColors.GridSheetRowPressed],
+                        PaletteState.CheckedNormal => _ribbonColors[(int)SchemeOfficeColors.GridSheetRowSelected],
+                        _ => _ribbonColors[(int)SchemeOfficeColors.GridSheetRowNormal]
                     };
                 case PaletteBackStyle.GridDataCellList:
                 case PaletteBackStyle.GridDataCellCustom1:
                 case PaletteBackStyle.GridDataCellCustom2:
                 case PaletteBackStyle.GridDataCellCustom3:
-                    return state == PaletteState.CheckedNormal ? _ribbonColours[(int)SchemeOfficeColors.GridDataCellSelected] : SystemColors.Window;
+                    return state == PaletteState.CheckedNormal ? _ribbonColors[(int)SchemeOfficeColors.GridDataCellSelected] : SystemColors.Window;
 
                 case PaletteBackStyle.GridDataCellSheet:
                     return state == PaletteState.CheckedNormal ? _buttonBackColors[6] : SystemColors.Window;
@@ -483,34 +483,34 @@ namespace Krypton.Toolkit
                     };
                 case PaletteBackStyle.HeaderForm:
                     return state == PaletteState.Disabled
-                        ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive1]
-                        : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive1];
+                        ? _ribbonColors[(int)SchemeOfficeColors.FormBorderHeaderInactive1]
+                        : _ribbonColors[(int)SchemeOfficeColors.FormBorderHeaderActive1];
 
                 case PaletteBackStyle.HeaderCalendar:
                     return state == PaletteState.Disabled
-                        ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                        : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2];
+                        ? _ribbonColors[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                        : _ribbonColors[(int)SchemeOfficeColors.HeaderPrimaryBack2];
 
                 case PaletteBackStyle.HeaderPrimary:
                 case PaletteBackStyle.HeaderCustom1:
                 case PaletteBackStyle.HeaderCustom2:
                 case PaletteBackStyle.HeaderCustom3:
-                    return state == PaletteState.Disabled ? _disabledBack : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1];
+                    return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeOfficeColors.HeaderPrimaryBack1];
 
                 case PaletteBackStyle.HeaderDockInactive:
-                    return state == PaletteState.Disabled ? _disabledBack : _ribbonColours[(int)SchemeOfficeColors.HeaderDockInactiveBack1];
+                    return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeOfficeColors.HeaderDockInactiveBack1];
 
                 case PaletteBackStyle.HeaderDockActive:
                     return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[6];
 
                 case PaletteBackStyle.HeaderSecondary:
-                    return state == PaletteState.Disabled ? _disabledBack : _ribbonColours[(int)SchemeOfficeColors.HeaderSecondaryBack1];
+                    return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeOfficeColors.HeaderSecondaryBack1];
 
                 case PaletteBackStyle.SeparatorHighInternalProfile:
-                    return state == PaletteState.Disabled ? _disabledBack : _ribbonColours[(int)SchemeOfficeColors.SeparatorHighInternalBorder1];
+                    return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeOfficeColors.SeparatorHighInternalBorder1];
 
                 case PaletteBackStyle.SeparatorHighProfile:
-                    return state == PaletteState.Disabled ? _disabledBack : _ribbonColours[(int)SchemeOfficeColors.SeparatorHighBorder1];
+                    return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeOfficeColors.SeparatorHighBorder1];
 
                 case PaletteBackStyle.SeparatorLowProfile:
                 case PaletteBackStyle.SeparatorCustom1:
@@ -526,18 +526,18 @@ namespace Krypton.Toolkit
                 case PaletteBackStyle.GridBackgroundCustom1:
                 case PaletteBackStyle.GridBackgroundCustom2:
                 case PaletteBackStyle.GridBackgroundCustom3:
-                    return _ribbonColours[(int)SchemeOfficeColors.PanelClient];
+                    return _ribbonColors[(int)SchemeOfficeColors.PanelClient];
                 case PaletteBackStyle.PanelAlternate:
-                    return _ribbonColours[(int)SchemeOfficeColors.PanelAlternative];
+                    return _ribbonColors[(int)SchemeOfficeColors.PanelAlternative];
                 case PaletteBackStyle.PanelRibbonInactive:
-                    return _ribbonColours[(int)SchemeOfficeColors.FormBorderInactiveLight];
+                    return _ribbonColors[(int)SchemeOfficeColors.FormBorderInactiveLight];
                 case PaletteBackStyle.FormMain:
                 case PaletteBackStyle.FormCustom1:
                 case PaletteBackStyle.FormCustom2:
                 case PaletteBackStyle.FormCustom3:
                     return state == PaletteState.Disabled
-                        ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactiveLight]
-                        : _ribbonColours[(int)SchemeOfficeColors.FormBorderActiveLight];
+                        ? _ribbonColors[(int)SchemeOfficeColors.FormBorderInactiveLight]
+                        : _ribbonColors[(int)SchemeOfficeColors.FormBorderActiveLight];
 
                 case PaletteBackStyle.ControlClient:
                 case PaletteBackStyle.ControlAlternate:
@@ -552,18 +552,18 @@ namespace Krypton.Toolkit
                 case PaletteBackStyle.InputControlCustom3:
                     if (state == PaletteState.Disabled)
                     {
-                        return _ribbonColours[(int)SchemeOfficeColors.InputControlBackDisabled];
+                        return _ribbonColors[(int)SchemeOfficeColors.InputControlBackDisabled];
                     }
                     else
                     {
                         return (state == PaletteState.Tracking) || (style == PaletteBackStyle.InputControlStandalone)
-                            ? _ribbonColours[(int)SchemeOfficeColors.InputControlBackNormal]
-                            : _ribbonColours[(int)SchemeOfficeColors.InputControlBackInactive];
+                            ? _ribbonColors[(int)SchemeOfficeColors.InputControlBackNormal]
+                            : _ribbonColors[(int)SchemeOfficeColors.InputControlBackInactive];
                     }
                 case PaletteBackStyle.ControlRibbon:
-                    return _ribbonColours[(int)SchemeOfficeColors.RibbonTabSelected4];
+                    return _ribbonColors[(int)SchemeOfficeColors.RibbonTabSelected4];
                 case PaletteBackStyle.ControlRibbonAppMenu:
-                    return _ribbonColours[(int)SchemeOfficeColors.AppButtonBack1];
+                    return _ribbonColors[(int)SchemeOfficeColors.AppButtonBack1];
                 case PaletteBackStyle.ControlToolTip:
                     return _toolTipBack1;
                 case PaletteBackStyle.ContextMenuOuter:
@@ -578,19 +578,19 @@ namespace Krypton.Toolkit
                 case PaletteBackStyle.ContextMenuInner:
                     return _contextMenuBack;
                 case PaletteBackStyle.ContextMenuHeading:
-                    return _ribbonColours[(int)SchemeOfficeColors.ContextMenuHeadingBack];
+                    return _ribbonColors[(int)SchemeOfficeColors.ContextMenuHeadingBack];
                 case PaletteBackStyle.ContextMenuItemImageColumn:
-                    return _ribbonColours[(int)SchemeOfficeColors.ContextMenuImageColumn];
+                    return _ribbonColors[(int)SchemeOfficeColors.ContextMenuImageColumn];
                 case PaletteBackStyle.ContextMenuItemImage:
                     return _contextMenuImageBackChecked;
                 case PaletteBackStyle.ButtonForm:
                     return state switch
                     {
                         PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => Color.Empty,
-                        PaletteState.CheckedNormal => _ribbonColours[(int)SchemeOfficeColors.FormButtonBack1Checked],
-                        PaletteState.Tracking => _ribbonColours[(int)SchemeOfficeColors.FormButtonBack1Track],
-                        PaletteState.CheckedTracking => _ribbonColours[(int)SchemeOfficeColors.FormButtonBack1CheckTrack],
-                        PaletteState.Pressed or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.FormButtonBack1Pressed],
+                        PaletteState.CheckedNormal => _ribbonColors[(int)SchemeOfficeColors.FormButtonBack1Checked],
+                        PaletteState.Tracking => _ribbonColors[(int)SchemeOfficeColors.FormButtonBack1Track],
+                        PaletteState.CheckedTracking => _ribbonColors[(int)SchemeOfficeColors.FormButtonBack1CheckTrack],
+                        PaletteState.Pressed or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeOfficeColors.FormButtonBack1Pressed],
                         _ => throw DebugTools.NotImplemented(state.ToString())
                     };
                 case PaletteBackStyle.ButtonFormClose:
@@ -620,16 +620,16 @@ namespace Krypton.Toolkit
                 case PaletteBackStyle.ContextMenuItemHighlight:
                     return state switch
                     {
-                        PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack1] : _disabledBack,
-                        PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1],
-                        PaletteState.NormalDefaultOverride => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack1],
+                        PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColors[(int)SchemeOfficeColors.RibbonGalleryBack1] : _disabledBack,
+                        PaletteState.Normal => _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBack1],
+                        PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeOfficeColors.ButtonNormalDefaultBack1],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+                                                        ? _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBack1]
                                                         : _buttonBackColors[6],
                         PaletteState.Tracking => _buttonBackColors[2],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
                         PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+                                                        ? _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBack1]
                                                         : _buttonBackColors[8],
                         _ => throw DebugTools.NotImplemented(state.ToString())
                     };
@@ -639,10 +639,10 @@ namespace Krypton.Toolkit
                     return state switch
                     {
                         PaletteState.Disabled => _buttonBackColors[1],
-                        PaletteState.Tracking => _ribbonColours[(int)SchemeOfficeColors.ButtonNavigatorTrack1],
-                        PaletteState.Pressed => _ribbonColours[(int)SchemeOfficeColors.ButtonNavigatorPressed1],
-                        PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.ButtonNavigatorChecked1],
-                        _ => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalNavigatorBack1]
+                        PaletteState.Tracking => _ribbonColors[(int)SchemeOfficeColors.ButtonNavigatorTrack1],
+                        PaletteState.Pressed => _ribbonColors[(int)SchemeOfficeColors.ButtonNavigatorPressed1],
+                        PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeOfficeColors.ButtonNavigatorChecked1],
+                        _ => _ribbonColors[(int)SchemeOfficeColors.ButtonNormalNavigatorBack1]
                     };
                 default:
                     throw DebugTools.NotImplemented(style.ToString());
@@ -676,31 +676,31 @@ namespace Krypton.Toolkit
                     return state switch
                     {
                         PaletteState.Disabled => _disabledBack,
-                        PaletteState.Pressed => _ribbonColours[(int)SchemeOfficeColors.GridListPressed2],
-                        PaletteState.CheckedNormal => _ribbonColours[(int)SchemeOfficeColors.GridListSelected],
-                        _ => _ribbonColours[(int)SchemeOfficeColors.GridListNormal2]
+                        PaletteState.Pressed => _ribbonColors[(int)SchemeOfficeColors.GridListPressed2],
+                        PaletteState.CheckedNormal => _ribbonColors[(int)SchemeOfficeColors.GridListSelected],
+                        _ => _ribbonColors[(int)SchemeOfficeColors.GridListNormal2]
                     };
                 case PaletteBackStyle.GridHeaderColumnSheet:
                     return state switch
                     {
                         PaletteState.Disabled => _disabledBack,
-                        PaletteState.Tracking or PaletteState.Pressed => _ribbonColours[(int)SchemeOfficeColors.GridSheetColPressed2],
-                        PaletteState.CheckedNormal => _ribbonColours[(int)SchemeOfficeColors.GridSheetColSelected2],
-                        _ => _ribbonColours[(int)SchemeOfficeColors.GridSheetColNormal2]
+                        PaletteState.Tracking or PaletteState.Pressed => _ribbonColors[(int)SchemeOfficeColors.GridSheetColPressed2],
+                        PaletteState.CheckedNormal => _ribbonColors[(int)SchemeOfficeColors.GridSheetColSelected2],
+                        _ => _ribbonColors[(int)SchemeOfficeColors.GridSheetColNormal2]
                     };
                 case PaletteBackStyle.GridHeaderRowSheet:
                     return state switch
                     {
                         PaletteState.Disabled => _disabledBack,
-                        PaletteState.Tracking or PaletteState.Pressed => _ribbonColours[(int)SchemeOfficeColors.GridSheetRowPressed],
-                        PaletteState.CheckedNormal => _ribbonColours[(int)SchemeOfficeColors.GridSheetRowSelected],
-                        _ => _ribbonColours[(int)SchemeOfficeColors.GridSheetRowNormal]
+                        PaletteState.Tracking or PaletteState.Pressed => _ribbonColors[(int)SchemeOfficeColors.GridSheetRowPressed],
+                        PaletteState.CheckedNormal => _ribbonColors[(int)SchemeOfficeColors.GridSheetRowSelected],
+                        _ => _ribbonColors[(int)SchemeOfficeColors.GridSheetRowNormal]
                     };
                 case PaletteBackStyle.GridDataCellList:
                 case PaletteBackStyle.GridDataCellCustom1:
                 case PaletteBackStyle.GridDataCellCustom2:
                 case PaletteBackStyle.GridDataCellCustom3:
-                    return state == PaletteState.CheckedNormal ? _ribbonColours[(int)SchemeOfficeColors.GridDataCellSelected] : SystemColors.Window;
+                    return state == PaletteState.CheckedNormal ? _ribbonColors[(int)SchemeOfficeColors.GridDataCellSelected] : SystemColors.Window;
 
                 case PaletteBackStyle.GridDataCellSheet:
                     return state == PaletteState.CheckedNormal ? _buttonBackColors[7] : SystemColors.Window;
@@ -715,7 +715,7 @@ namespace Krypton.Toolkit
                     return state switch
                     {
                         PaletteState.Disabled => style == PaletteBackStyle.TabLowProfile ? Color.Empty : _disabledBack,
-                        PaletteState.Normal => style == PaletteBackStyle.TabLowProfile ? Color.Empty : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2],
+                        PaletteState.Normal => style == PaletteBackStyle.TabLowProfile ? Color.Empty : _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBack2],
                         PaletteState.Tracking or PaletteState.Pressed => style == PaletteBackStyle.TabLowProfile ? Color.Empty : SystemColors.Window,
                         PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => SystemColors.Window,
                         _ => throw DebugTools.NotImplemented(state.ToString())
@@ -724,7 +724,7 @@ namespace Krypton.Toolkit
                     return state switch
                     {
                         PaletteState.Disabled => _disabledBack,
-                        PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.HeaderDockInactiveBack1],
+                        PaletteState.Normal => _ribbonColors[(int)SchemeOfficeColors.HeaderDockInactiveBack1],
                         PaletteState.Tracking or PaletteState.Pressed => _buttonBackColors[4],
                         PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => SystemColors.Window,
                         _ => throw DebugTools.NotImplemented(state.ToString())
@@ -733,40 +733,40 @@ namespace Krypton.Toolkit
                     return state switch
                     {
                         PaletteState.Disabled => _disabledBack,
-                        PaletteState.Normal or PaletteState.CheckedNormal => _ribbonColours[(int)SchemeOfficeColors.HeaderDockInactiveBack1],
+                        PaletteState.Normal or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeOfficeColors.HeaderDockInactiveBack1],
                         PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
                         _ => throw DebugTools.NotImplemented(state.ToString())
                     };
                 case PaletteBackStyle.HeaderForm:
                     return state == PaletteState.Disabled
-                        ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive2]
-                        : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive2];
+                        ? _ribbonColors[(int)SchemeOfficeColors.FormBorderHeaderInactive2]
+                        : _ribbonColors[(int)SchemeOfficeColors.FormBorderHeaderActive2];
 
                 case PaletteBackStyle.HeaderCalendar:
                     return state == PaletteState.Disabled
-                        ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                        : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2];
+                        ? _ribbonColors[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                        : _ribbonColors[(int)SchemeOfficeColors.HeaderPrimaryBack2];
 
                 case PaletteBackStyle.HeaderPrimary:
                 case PaletteBackStyle.HeaderCustom1:
                 case PaletteBackStyle.HeaderCustom2:
                 case PaletteBackStyle.HeaderCustom3:
-                    return state == PaletteState.Disabled ? _disabledBack : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2];
+                    return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeOfficeColors.HeaderPrimaryBack2];
 
                 case PaletteBackStyle.HeaderDockInactive:
-                    return state == PaletteState.Disabled ? _disabledBack : _ribbonColours[(int)SchemeOfficeColors.HeaderDockInactiveBack2];
+                    return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeOfficeColors.HeaderDockInactiveBack2];
 
                 case PaletteBackStyle.HeaderDockActive:
                     return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[7];
 
                 case PaletteBackStyle.HeaderSecondary:
-                    return state == PaletteState.Disabled ? _disabledBack : _ribbonColours[(int)SchemeOfficeColors.HeaderSecondaryBack2];
+                    return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeOfficeColors.HeaderSecondaryBack2];
 
                 case PaletteBackStyle.SeparatorHighInternalProfile:
-                    return state == PaletteState.Disabled ? _disabledBack : _ribbonColours[(int)SchemeOfficeColors.SeparatorHighInternalBorder2];
+                    return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeOfficeColors.SeparatorHighInternalBorder2];
 
                 case PaletteBackStyle.SeparatorHighProfile:
-                    return state == PaletteState.Disabled ? _disabledBack : _ribbonColours[(int)SchemeOfficeColors.SeparatorHighBorder2];
+                    return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeOfficeColors.SeparatorHighBorder2];
 
                 case PaletteBackStyle.SeparatorLowProfile:
                 case PaletteBackStyle.SeparatorCustom1:
@@ -782,18 +782,18 @@ namespace Krypton.Toolkit
                 case PaletteBackStyle.GridBackgroundCustom1:
                 case PaletteBackStyle.GridBackgroundCustom2:
                 case PaletteBackStyle.GridBackgroundCustom3:
-                    return _ribbonColours[(int)SchemeOfficeColors.PanelClient];
+                    return _ribbonColors[(int)SchemeOfficeColors.PanelClient];
                 case PaletteBackStyle.PanelAlternate:
-                    return _ribbonColours[(int)SchemeOfficeColors.PanelAlternative];
+                    return _ribbonColors[(int)SchemeOfficeColors.PanelAlternative];
                 case PaletteBackStyle.PanelRibbonInactive:
-                    return _ribbonColours[(int)SchemeOfficeColors.FormBorderInactiveDark];
+                    return _ribbonColors[(int)SchemeOfficeColors.FormBorderInactiveDark];
                 case PaletteBackStyle.FormMain:
                 case PaletteBackStyle.FormCustom1:
                 case PaletteBackStyle.FormCustom2:
                 case PaletteBackStyle.FormCustom3:
                     return state == PaletteState.Disabled
-                        ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactiveDark]
-                        : _ribbonColours[(int)SchemeOfficeColors.FormBorderActiveDark];
+                        ? _ribbonColors[(int)SchemeOfficeColors.FormBorderInactiveDark]
+                        : _ribbonColors[(int)SchemeOfficeColors.FormBorderActiveDark];
 
                 case PaletteBackStyle.ControlClient:
                 case PaletteBackStyle.ControlAlternate:
@@ -808,20 +808,20 @@ namespace Krypton.Toolkit
                 case PaletteBackStyle.InputControlCustom3:
                     if (state == PaletteState.Disabled)
                     {
-                        return _ribbonColours[(int)SchemeOfficeColors.InputControlBackDisabled];
+                        return _ribbonColors[(int)SchemeOfficeColors.InputControlBackDisabled];
                     }
                     else
                     {
                         return (state == PaletteState.Tracking) || (style == PaletteBackStyle.InputControlStandalone)
-                            ? _ribbonColours[(int)SchemeOfficeColors.InputControlBackNormal]
-                            : _ribbonColours[(int)SchemeOfficeColors.InputControlBackInactive];
+                            ? _ribbonColors[(int)SchemeOfficeColors.InputControlBackNormal]
+                            : _ribbonColors[(int)SchemeOfficeColors.InputControlBackInactive];
                     }
                 case PaletteBackStyle.ControlRibbon:
-                    return _ribbonColours[(int)SchemeOfficeColors.RibbonTabSelected4];
+                    return _ribbonColors[(int)SchemeOfficeColors.RibbonTabSelected4];
                 case PaletteBackStyle.ControlRibbonAppMenu:
-                    return _ribbonColours[(int)SchemeOfficeColors.AppButtonBack2];
+                    return _ribbonColors[(int)SchemeOfficeColors.AppButtonBack2];
                 case PaletteBackStyle.ControlToolTip:
-                    return _ribbonColours[(int)SchemeOfficeColors.ToolTipBottom];
+                    return _ribbonColors[(int)SchemeOfficeColors.ToolTipBottom];
                 case PaletteBackStyle.ContextMenuOuter:
                     return _contextMenuBack;
                 case PaletteBackStyle.ContextMenuSeparator:
@@ -834,19 +834,19 @@ namespace Krypton.Toolkit
                 case PaletteBackStyle.ContextMenuInner:
                     return _contextMenuBack;
                 case PaletteBackStyle.ContextMenuHeading:
-                    return _ribbonColours[(int)SchemeOfficeColors.ContextMenuHeadingBack];
+                    return _ribbonColors[(int)SchemeOfficeColors.ContextMenuHeadingBack];
                 case PaletteBackStyle.ContextMenuItemImageColumn:
-                    return _ribbonColours[(int)SchemeOfficeColors.ContextMenuImageColumn];
+                    return _ribbonColors[(int)SchemeOfficeColors.ContextMenuImageColumn];
                 case PaletteBackStyle.ContextMenuItemImage:
                     return _contextMenuImageBackChecked;
                 case PaletteBackStyle.ButtonForm:
                     return state switch
                     {
                         PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => Color.Empty,
-                        PaletteState.CheckedNormal => _ribbonColours[(int)SchemeOfficeColors.FormButtonBack2Checked],
-                        PaletteState.Tracking => _ribbonColours[(int)SchemeOfficeColors.FormButtonBack2Track],
-                        PaletteState.CheckedTracking => _ribbonColours[(int)SchemeOfficeColors.FormButtonBack2CheckTrack],
-                        PaletteState.Pressed or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.FormButtonBack2Pressed],
+                        PaletteState.CheckedNormal => _ribbonColors[(int)SchemeOfficeColors.FormButtonBack2Checked],
+                        PaletteState.Tracking => _ribbonColors[(int)SchemeOfficeColors.FormButtonBack2Track],
+                        PaletteState.CheckedTracking => _ribbonColors[(int)SchemeOfficeColors.FormButtonBack2CheckTrack],
+                        PaletteState.Pressed or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeOfficeColors.FormButtonBack2Pressed],
                         _ => throw DebugTools.NotImplemented(state.ToString())
                     };
                 case PaletteBackStyle.ButtonFormClose:
@@ -876,18 +876,18 @@ namespace Krypton.Toolkit
                 case PaletteBackStyle.ContextMenuItemHighlight:
                     return state switch
                     {
-                        PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack1] : _buttonBackColors[1],
-                        PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2],
+                        PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColors[(int)SchemeOfficeColors.RibbonGalleryBack1] : _buttonBackColors[1],
+                        PaletteState.Normal => _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBack2],
                         PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
                                                                 ? Color.Empty
-                                                                : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
+                                                                : _ribbonColors[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2]
+                                                        ? _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBack2]
                                                         : _buttonBackColors[7],
                         PaletteState.Tracking => _buttonBackColors[3],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
                         PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
-                                                            ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+                                                            ? _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBack1]
                                                             : _buttonBackColors[9],
                         _ => throw DebugTools.NotImplemented(state.ToString())
                     };
@@ -897,10 +897,10 @@ namespace Krypton.Toolkit
                     return state switch
                     {
                         PaletteState.Disabled => _buttonBackColors[1],
-                        PaletteState.Tracking => _ribbonColours[(int)SchemeOfficeColors.ButtonNavigatorTrack2],
-                        PaletteState.Pressed => _ribbonColours[(int)SchemeOfficeColors.ButtonNavigatorPressed2],
-                        PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.ButtonNavigatorChecked2],
-                        _ => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalNavigatorBack2]
+                        PaletteState.Tracking => _ribbonColors[(int)SchemeOfficeColors.ButtonNavigatorTrack2],
+                        PaletteState.Pressed => _ribbonColors[(int)SchemeOfficeColors.ButtonNavigatorPressed2],
+                        PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeOfficeColors.ButtonNavigatorChecked2],
+                        _ => _ribbonColors[(int)SchemeOfficeColors.ButtonNormalNavigatorBack2]
                     };
                 default:
                     throw DebugTools.NotImplemented(style.ToString());
@@ -1219,32 +1219,32 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.TabHighProfile or PaletteBorderStyle.TabStandardProfile or PaletteBorderStyle.TabLowProfile or PaletteBorderStyle.TabOneNote or PaletteBorderStyle.TabCustom1 or PaletteBorderStyle.TabCustom2 or PaletteBorderStyle.TabCustom3 => state switch
                 {
                     PaletteState.Disabled => style == PaletteBorderStyle.TabLowProfile ? Color.Empty : _disabledBorder,
-                    PaletteState.Normal or PaletteState.Tracking or PaletteState.Pressed => style == PaletteBorderStyle.TabLowProfile ? Color.Empty : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
-                    PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
+                    PaletteState.Normal or PaletteState.Tracking or PaletteState.Pressed => style == PaletteBorderStyle.TabLowProfile ? Color.Empty : _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBorder],
+                    PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeOfficeColors.ControlBorder],
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.TabDock => state switch
                 {
                     PaletteState.Disabled => _disabledBorder,
-                    PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
+                    PaletteState.Normal => _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
-                    PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
+                    PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeOfficeColors.ControlBorder],
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.TabDockAutoHidden => state switch
                 {
                     PaletteState.Disabled => _disabledBorder,
-                    PaletteState.Normal or PaletteState.CheckedNormal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
+                    PaletteState.Normal or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                        : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                        ? _ribbonColors[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                        : _ribbonColors[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
-                                                ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
-                                                : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
-                PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
+                                                ? _ribbonColors[(int)SchemeOfficeColors.FormBorderHeaderInactive]
+                                                : _ribbonColors[(int)SchemeOfficeColors.FormBorderHeaderActive],
+                PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColors[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -1254,23 +1254,23 @@ namespace Krypton.Toolkit
                 },
                 PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
                 PaletteBorderStyle.InputControlStandalone or PaletteBorderStyle.InputControlRibbon or PaletteBorderStyle.InputControlCustom1 or PaletteBorderStyle.InputControlCustom2 or PaletteBorderStyle.InputControlCustom3 => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.InputControlBorderDisabled]
-: _ribbonColours[(int)SchemeOfficeColors.InputControlBorderNormal],
-                PaletteBorderStyle.GridDataCellList or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1 or PaletteBorderStyle.GridDataCellCustom2 or PaletteBorderStyle.GridDataCellCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.GridDataCellBorder],
-                PaletteBorderStyle.ControlRibbon => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.RibbonGroupsArea1],
-                PaletteBorderStyle.ControlRibbonAppMenu => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.AppButtonBorder],
+? _ribbonColors[(int)SchemeOfficeColors.InputControlBorderDisabled]
+: _ribbonColors[(int)SchemeOfficeColors.InputControlBorderNormal],
+                PaletteBorderStyle.GridDataCellList or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1 or PaletteBorderStyle.GridDataCellCustom2 or PaletteBorderStyle.GridDataCellCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColors[(int)SchemeOfficeColors.GridDataCellBorder],
+                PaletteBorderStyle.ControlRibbon => state == PaletteState.Disabled ? _disabledBorder : _ribbonColors[(int)SchemeOfficeColors.RibbonGroupsArea1],
+                PaletteBorderStyle.ControlRibbonAppMenu => state == PaletteState.Disabled ? _disabledBorder : _ribbonColors[(int)SchemeOfficeColors.AppButtonBorder],
                 PaletteBorderStyle.ContextMenuOuter => _contextMenuBorder,
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+                                    ? _ribbonColors[(int)SchemeOfficeColors.FormBorderInactive]
+                                    : _ribbonColors[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => Color.Empty,
-                    PaletteState.CheckedNormal => _ribbonColours[(int)SchemeOfficeColors.FormButtonBorderCheck],
-                    PaletteState.Tracking or PaletteState.CheckedTracking => _ribbonColours[(int)SchemeOfficeColors.FormButtonBorderTrack],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.FormButtonBorderPressed],
+                    PaletteState.CheckedNormal => _ribbonColors[(int)SchemeOfficeColors.FormButtonBorderCheck],
+                    PaletteState.Tracking or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeOfficeColors.FormButtonBorderTrack],
+                    PaletteState.Pressed or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeOfficeColors.FormButtonBorderPressed],
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.ButtonFormClose => state switch
@@ -1284,12 +1284,12 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
+                                                   ? _ribbonColors[(int)SchemeOfficeColors.RibbonGalleryBack2]
                                                    : _buttonBorderColors[0],
-                    PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
+                    PaletteState.Normal => _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
                                                         ? Color.Empty
-                                                        : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+                                                        : _ribbonColors[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
@@ -1299,7 +1299,7 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ButtonInputControl => state switch
                 {
                     PaletteState.Disabled => _buttonBorderColors[0],
-                    PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
+                    PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
                     _ => throw DebugTools.NotImplemented(state.ToString())
@@ -1307,15 +1307,15 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Disabled => _disabledBack,
-                    PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1],
-                    PaletteState.NormalDefaultOverride => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack1],
+                    PaletteState.Normal => _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBack1],
+                    PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeOfficeColors.ButtonNormalDefaultBack1],
                     PaletteState.CheckedNormal => _buttonBackColors[6],
                     PaletteState.Tracking => _buttonBackColors[2],
                     PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
                     PaletteState.CheckedTracking => _buttonBackColors[8],
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
-                PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => _ribbonColours[(int)SchemeOfficeColors.ButtonNavigatorBorder],
+                PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => _ribbonColors[(int)SchemeOfficeColors.ButtonNavigatorBorder],
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -1347,32 +1347,32 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.TabHighProfile or PaletteBorderStyle.TabStandardProfile or PaletteBorderStyle.TabLowProfile or PaletteBorderStyle.TabOneNote or PaletteBorderStyle.TabCustom1 or PaletteBorderStyle.TabCustom2 or PaletteBorderStyle.TabCustom3 => state switch
                 {
                     PaletteState.Disabled => style == PaletteBorderStyle.TabLowProfile ? Color.Empty : _disabledBorder,
-                    PaletteState.Normal or PaletteState.Tracking or PaletteState.Pressed => style == PaletteBorderStyle.TabLowProfile ? Color.Empty : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
-                    PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
+                    PaletteState.Normal or PaletteState.Tracking or PaletteState.Pressed => style == PaletteBorderStyle.TabLowProfile ? Color.Empty : _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBorder],
+                    PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeOfficeColors.ControlBorder],
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.TabDock => state switch
                 {
                     PaletteState.Disabled => _disabledBorder,
-                    PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
+                    PaletteState.Normal => _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
-                    PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
+                    PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeOfficeColors.ControlBorder],
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.TabDockAutoHidden => state switch
                 {
                     PaletteState.Disabled => _disabledBorder,
-                    PaletteState.Normal or PaletteState.CheckedNormal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
+                    PaletteState.Normal or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
-                                                ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
-                                                : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
-                PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
+                                                ? _ribbonColors[(int)SchemeOfficeColors.FormBorderHeaderInactive]
+                                                : _ribbonColors[(int)SchemeOfficeColors.FormBorderHeaderActive],
+                PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColors[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                        : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                        ? _ribbonColors[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                        : _ribbonColors[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -1382,23 +1382,23 @@ namespace Krypton.Toolkit
                 },
                 PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
                 PaletteBorderStyle.InputControlStandalone or PaletteBorderStyle.InputControlRibbon or PaletteBorderStyle.InputControlCustom1 or PaletteBorderStyle.InputControlCustom2 or PaletteBorderStyle.InputControlCustom3 => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.InputControlBorderDisabled]
-: _ribbonColours[(int)SchemeOfficeColors.InputControlBorderNormal],
-                PaletteBorderStyle.GridDataCellList or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1 or PaletteBorderStyle.GridDataCellCustom2 or PaletteBorderStyle.GridDataCellCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.GridDataCellBorder],
-                PaletteBorderStyle.ControlRibbon => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.RibbonGroupsArea1],
-                PaletteBorderStyle.ControlRibbonAppMenu => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.AppButtonBorder],
+? _ribbonColors[(int)SchemeOfficeColors.InputControlBorderDisabled]
+: _ribbonColors[(int)SchemeOfficeColors.InputControlBorderNormal],
+                PaletteBorderStyle.GridDataCellList or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1 or PaletteBorderStyle.GridDataCellCustom2 or PaletteBorderStyle.GridDataCellCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColors[(int)SchemeOfficeColors.GridDataCellBorder],
+                PaletteBorderStyle.ControlRibbon => state == PaletteState.Disabled ? _disabledBorder : _ribbonColors[(int)SchemeOfficeColors.RibbonGroupsArea1],
+                PaletteBorderStyle.ControlRibbonAppMenu => state == PaletteState.Disabled ? _disabledBorder : _ribbonColors[(int)SchemeOfficeColors.AppButtonBorder],
                 PaletteBorderStyle.ContextMenuOuter => _contextMenuBorder,
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+                                                    ? _ribbonColors[(int)SchemeOfficeColors.FormBorderInactive]
+                                                    : _ribbonColors[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => Color.Empty,
-                    PaletteState.CheckedNormal => _ribbonColours[(int)SchemeOfficeColors.FormButtonBorderCheck],
-                    PaletteState.Tracking or PaletteState.CheckedTracking => _ribbonColours[(int)SchemeOfficeColors.FormButtonBorderTrack],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.FormButtonBorderPressed],
+                    PaletteState.CheckedNormal => _ribbonColors[(int)SchemeOfficeColors.FormButtonBorderCheck],
+                    PaletteState.Tracking or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeOfficeColors.FormButtonBorderTrack],
+                    PaletteState.Pressed or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeOfficeColors.FormButtonBorderPressed],
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.ButtonFormClose => state switch
@@ -1412,10 +1412,10 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
+                                                   ? _ribbonColors[(int)SchemeOfficeColors.RibbonGalleryBack2]
                                                    : _buttonBorderColors[0],
-                    PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
-                    PaletteState.NormalDefaultOverride => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+                    PaletteState.Normal => _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBorder],
+                    PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[6],
                     PaletteState.Tracking => _buttonBorderColors[2],
                     PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
@@ -1425,7 +1425,7 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ButtonInputControl => state switch
                 {
                     PaletteState.Disabled => _buttonBorderColors[0],
-                    PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
+                    PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.Tracking => _buttonBorderColors[2],
                     PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
                     _ => throw DebugTools.NotImplemented(state.ToString())
@@ -1433,15 +1433,15 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Disabled => _disabledBack,
-                    PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1],
-                    PaletteState.NormalDefaultOverride => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack1],
+                    PaletteState.Normal => _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBack1],
+                    PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeOfficeColors.ButtonNormalDefaultBack1],
                     PaletteState.CheckedNormal => _buttonBackColors[6],
                     PaletteState.Tracking => _buttonBackColors[2],
                     PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
                     PaletteState.CheckedTracking => _buttonBackColors[8],
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
-                PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => _ribbonColours[(int)SchemeOfficeColors.ButtonNavigatorBorder],
+                PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => _ribbonColors[(int)SchemeOfficeColors.ButtonNavigatorBorder],
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -2089,21 +2089,21 @@ namespace Krypton.Toolkit
                 {
                     PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl => state switch
                     {
-                        PaletteState.LinkNotVisitedOverride => _ribbonColours[
+                        PaletteState.LinkNotVisitedOverride => _ribbonColors[
                             (int)SchemeOfficeColors.LinkNotVisitedOverrideControl],
-                        PaletteState.LinkVisitedOverride => _ribbonColours[
+                        PaletteState.LinkVisitedOverride => _ribbonColors[
                             (int)SchemeOfficeColors.LinkVisitedOverrideControl],
-                        PaletteState.LinkPressedOverride => _ribbonColours[
+                        PaletteState.LinkPressedOverride => _ribbonColors[
                             (int)SchemeOfficeColors.LinkPressedOverrideControl],
                         _ => Color.Empty
                     },
                     PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelGroupBoxCaption => state switch
                     {
-                        PaletteState.LinkNotVisitedOverride => _ribbonColours[
+                        PaletteState.LinkNotVisitedOverride => _ribbonColors[
                             (int)SchemeOfficeColors.LinkNotVisitedOverridePanel],
-                        PaletteState.LinkVisitedOverride => _ribbonColours[
+                        PaletteState.LinkVisitedOverride => _ribbonColors[
                             (int)SchemeOfficeColors.LinkVisitedOverridePanel],
-                        PaletteState.LinkPressedOverride => _ribbonColours[
+                        PaletteState.LinkPressedOverride => _ribbonColors[
                             (int)SchemeOfficeColors.LinkPressedOverridePanel],
                         _ => Color.Empty
                     },
@@ -2115,8 +2115,8 @@ namespace Krypton.Toolkit
             {
                 case PaletteContentStyle.HeaderForm:
                     return state == PaletteState.Disabled
-                        ? _ribbonColours[(int)SchemeOfficeColors.FormHeaderShortInactive]
-                        : _ribbonColours[(int)SchemeOfficeColors.FormHeaderShortActive];
+                        ? _ribbonColors[(int)SchemeOfficeColors.FormHeaderShortInactive]
+                        : _ribbonColors[(int)SchemeOfficeColors.FormHeaderShortActive];
             }
 
             if ((state == PaletteState.Disabled) &&
@@ -2137,40 +2137,40 @@ namespace Krypton.Toolkit
             return style switch
             {
                 PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 or PaletteContentStyle.HeaderCalendar => _gridTextColor,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderSecondary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _ribbonColours[(int)SchemeOfficeColors.HeaderText],
+                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderSecondary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _ribbonColors[(int)SchemeOfficeColors.HeaderText],
                 PaletteContentStyle.HeaderDockActive => Color.Black,
                 PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.InputControlTextDisabled]
-: _ribbonColours[(int)SchemeOfficeColors.InputControlTextNormal],
-                PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelGroupBoxCaption => _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 or PaletteContentStyle.ContextMenuItemImage or PaletteContentStyle.ContextMenuItemTextStandard or PaletteContentStyle.ContextMenuItemShortcutText or PaletteContentStyle.ContextMenuItemTextAlternate => _ribbonColours[(int)SchemeOfficeColors.TextLabelControl],
+? _ribbonColors[(int)SchemeOfficeColors.InputControlTextDisabled]
+: _ribbonColors[(int)SchemeOfficeColors.InputControlTextNormal],
+                PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelGroupBoxCaption => _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
+                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 or PaletteContentStyle.ContextMenuItemImage or PaletteContentStyle.ContextMenuItemTextStandard or PaletteContentStyle.ContextMenuItemShortcutText or PaletteContentStyle.ContextMenuItemTextAlternate => _ribbonColors[(int)SchemeOfficeColors.TextLabelControl],
                 PaletteContentStyle.LabelToolTip or PaletteContentStyle.LabelSuperTip or PaletteContentStyle.LabelKeyTip => _toolTipText,
-                PaletteContentStyle.ContextMenuHeading => _ribbonColours[(int)SchemeOfficeColors.ContextMenuHeadingText],
+                PaletteContentStyle.ContextMenuHeading => _ribbonColors[(int)SchemeOfficeColors.ContextMenuHeadingText],
                 PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabDock or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 or PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonGallery or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => state != PaletteState.Normal
-? _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked]
-: _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal],
-                PaletteContentStyle.TabDockAutoHidden => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal],
+? _ribbonColors[(int)SchemeOfficeColors.TextButtonChecked]
+: _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal],
+                PaletteContentStyle.TabDockAutoHidden => _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal],
                 PaletteContentStyle.ButtonCalendarDay => state == PaletteState.Disabled ? _disabledText2 : Color.Black,
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
-                    PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
-                    _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
+                                                   ? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
+                    PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeOfficeColors.TextButtonChecked],
+                    _ => _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal]
                 },
                 PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => state switch
                 {
-                    PaletteState.Tracking or PaletteState.CheckedTracking => _ribbonColours[(int)SchemeOfficeColors.TextButtonFormTracking],
-                    PaletteState.Pressed or PaletteState.CheckedPressed or PaletteState.CheckedNormal => _ribbonColours[(int)SchemeOfficeColors.TextButtonFormPressed],
-                    _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonFormNormal]
+                    PaletteState.Tracking or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeOfficeColors.TextButtonFormTracking],
+                    PaletteState.Pressed or PaletteState.CheckedPressed or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeOfficeColors.TextButtonFormPressed],
+                    _ => _ribbonColors[(int)SchemeOfficeColors.TextButtonFormNormal]
                 },
                 PaletteContentStyle.ButtonInputControl => state != PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.InputDropDownNormal1]
-: _ribbonColours[(int)SchemeOfficeColors.InputDropDownDisabled1],
+? _ribbonColors[(int)SchemeOfficeColors.InputDropDownNormal1]
+: _ribbonColors[(int)SchemeOfficeColors.InputDropDownDisabled1],
                 PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => state != PaletteState.Normal
-? _ribbonColours[(int)SchemeOfficeColors.ButtonNavigatorText]
-: _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal],
+? _ribbonColors[(int)SchemeOfficeColors.ButtonNavigatorText]
+: _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal],
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -2193,8 +2193,8 @@ namespace Krypton.Toolkit
             {
                 case PaletteContentStyle.HeaderForm:
                     return state == PaletteState.Disabled
-                        ? _ribbonColours[(int)SchemeOfficeColors.FormHeaderShortInactive]
-                        : _ribbonColours[(int)SchemeOfficeColors.FormHeaderShortActive];
+                        ? _ribbonColors[(int)SchemeOfficeColors.FormHeaderShortInactive]
+                        : _ribbonColors[(int)SchemeOfficeColors.FormHeaderShortActive];
             }
 
             if ((state == PaletteState.Disabled) &&
@@ -2215,40 +2215,40 @@ namespace Krypton.Toolkit
             return style switch
             {
                 PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 or PaletteContentStyle.HeaderCalendar => _gridTextColor,
-                PaletteContentStyle.HeaderSecondary or PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _ribbonColours[(int)SchemeOfficeColors.HeaderText],
+                PaletteContentStyle.HeaderSecondary or PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _ribbonColors[(int)SchemeOfficeColors.HeaderText],
                 PaletteContentStyle.HeaderDockActive => Color.Black,
                 PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.InputControlTextDisabled]
-: _ribbonColours[(int)SchemeOfficeColors.InputControlTextNormal],
-                PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelGroupBoxCaption => _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 or PaletteContentStyle.ContextMenuItemImage or PaletteContentStyle.ContextMenuItemTextStandard or PaletteContentStyle.ContextMenuItemTextAlternate or PaletteContentStyle.ContextMenuItemShortcutText => _ribbonColours[(int)SchemeOfficeColors.TextLabelControl],
+? _ribbonColors[(int)SchemeOfficeColors.InputControlTextDisabled]
+: _ribbonColors[(int)SchemeOfficeColors.InputControlTextNormal],
+                PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelGroupBoxCaption => _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
+                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 or PaletteContentStyle.ContextMenuItemImage or PaletteContentStyle.ContextMenuItemTextStandard or PaletteContentStyle.ContextMenuItemTextAlternate or PaletteContentStyle.ContextMenuItemShortcutText => _ribbonColors[(int)SchemeOfficeColors.TextLabelControl],
                 PaletteContentStyle.LabelToolTip or PaletteContentStyle.LabelSuperTip or PaletteContentStyle.LabelKeyTip => _toolTipText,
-                PaletteContentStyle.ContextMenuHeading => _ribbonColours[(int)SchemeOfficeColors.ContextMenuHeadingText],
+                PaletteContentStyle.ContextMenuHeading => _ribbonColors[(int)SchemeOfficeColors.ContextMenuHeadingText],
                 PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabDock or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 or PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonGallery or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => state != PaletteState.Normal
-? _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked]
-: _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal],
-                PaletteContentStyle.TabDockAutoHidden => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal],
+? _ribbonColors[(int)SchemeOfficeColors.TextButtonChecked]
+: _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal],
+                PaletteContentStyle.TabDockAutoHidden => _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal],
                 PaletteContentStyle.ButtonCalendarDay => state == PaletteState.Disabled ? _disabledText2 : Color.Black,
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
-                    PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
-                    _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
+                                                   ? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
+                    PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeOfficeColors.TextButtonChecked],
+                    _ => _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal]
                 },
                 PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => state switch
                 {
-                    PaletteState.Tracking or PaletteState.CheckedTracking => _ribbonColours[(int)SchemeOfficeColors.TextButtonFormTracking],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonFormPressed],
-                    _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonFormNormal]
+                    PaletteState.Tracking or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeOfficeColors.TextButtonFormTracking],
+                    PaletteState.Pressed or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeOfficeColors.TextButtonFormPressed],
+                    _ => _ribbonColors[(int)SchemeOfficeColors.TextButtonFormNormal]
                 },
                 PaletteContentStyle.ButtonInputControl => state != PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.InputDropDownNormal2]
-: _ribbonColours[(int)SchemeOfficeColors.InputDropDownDisabled2],
+? _ribbonColors[(int)SchemeOfficeColors.InputDropDownNormal2]
+: _ribbonColors[(int)SchemeOfficeColors.InputDropDownDisabled2],
                 PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => state != PaletteState.Normal
-? _ribbonColours[(int)SchemeOfficeColors.ButtonNavigatorText]
-: _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal],
+? _ribbonColors[(int)SchemeOfficeColors.ButtonNavigatorText]
+: _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal],
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -2594,8 +2594,8 @@ namespace Krypton.Toolkit
             {
                 case PaletteContentStyle.HeaderForm:
                     return state == PaletteState.Disabled
-                        ? _ribbonColours[(int)SchemeOfficeColors.FormHeaderLongInactive]
-                        : _ribbonColours[(int)SchemeOfficeColors.FormHeaderLongActive];
+                        ? _ribbonColors[(int)SchemeOfficeColors.FormHeaderLongInactive]
+                        : _ribbonColors[(int)SchemeOfficeColors.FormHeaderLongActive];
             }
 
             if ((state == PaletteState.Disabled) &&
@@ -2615,39 +2615,39 @@ namespace Krypton.Toolkit
             return style switch
             {
                 PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 or PaletteContentStyle.HeaderCalendar => _gridTextColor,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderSecondary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _ribbonColours[(int)SchemeOfficeColors.HeaderText],
+                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderSecondary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _ribbonColors[(int)SchemeOfficeColors.HeaderText],
                 PaletteContentStyle.HeaderDockActive => Color.Black,
                 PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.InputControlTextDisabled]
-: _ribbonColours[(int)SchemeOfficeColors.InputControlTextNormal],
-                PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelGroupBoxCaption => _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 or PaletteContentStyle.ContextMenuItemImage or PaletteContentStyle.ContextMenuItemTextStandard or PaletteContentStyle.ContextMenuItemShortcutText or PaletteContentStyle.ContextMenuItemTextAlternate => _ribbonColours[(int)SchemeOfficeColors.TextLabelControl],
+? _ribbonColors[(int)SchemeOfficeColors.InputControlTextDisabled]
+: _ribbonColors[(int)SchemeOfficeColors.InputControlTextNormal],
+                PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelGroupBoxCaption => _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
+                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 or PaletteContentStyle.ContextMenuItemImage or PaletteContentStyle.ContextMenuItemTextStandard or PaletteContentStyle.ContextMenuItemShortcutText or PaletteContentStyle.ContextMenuItemTextAlternate => _ribbonColors[(int)SchemeOfficeColors.TextLabelControl],
                 PaletteContentStyle.LabelToolTip or PaletteContentStyle.LabelSuperTip or PaletteContentStyle.LabelKeyTip => _toolTipText,
-                PaletteContentStyle.ContextMenuHeading => _ribbonColours[(int)SchemeOfficeColors.ContextMenuHeadingText],
+                PaletteContentStyle.ContextMenuHeading => _ribbonColors[(int)SchemeOfficeColors.ContextMenuHeadingText],
                 PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabDock or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 or PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonGallery or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => state != PaletteState.Normal
-? _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked]
-: _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal],
-                PaletteContentStyle.TabDockAutoHidden => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal],
+? _ribbonColors[(int)SchemeOfficeColors.TextButtonChecked]
+: _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal],
+                PaletteContentStyle.TabDockAutoHidden => _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal],
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
-                    PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
-                    _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
+                                                   ? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
+                    PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeOfficeColors.TextButtonChecked],
+                    _ => _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal]
                 },
                 PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => state switch
                 {
-                    PaletteState.Tracking or PaletteState.CheckedTracking => _ribbonColours[(int)SchemeOfficeColors.TextButtonFormTracking],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonFormPressed],
-                    _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonFormNormal]
+                    PaletteState.Tracking or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeOfficeColors.TextButtonFormTracking],
+                    PaletteState.Pressed or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeOfficeColors.TextButtonFormPressed],
+                    _ => _ribbonColors[(int)SchemeOfficeColors.TextButtonFormNormal]
                 },
                 PaletteContentStyle.ButtonInputControl => state != PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.InputDropDownNormal1]
-: _ribbonColours[(int)SchemeOfficeColors.InputDropDownDisabled1],
+? _ribbonColors[(int)SchemeOfficeColors.InputDropDownNormal1]
+: _ribbonColors[(int)SchemeOfficeColors.InputDropDownDisabled1],
                 PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => state != PaletteState.Normal
-? _ribbonColours[(int)SchemeOfficeColors.ButtonNavigatorText]
-: _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal],
+? _ribbonColors[(int)SchemeOfficeColors.ButtonNavigatorText]
+: _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal],
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -2670,8 +2670,8 @@ namespace Krypton.Toolkit
             {
                 case PaletteContentStyle.HeaderForm:
                     return state == PaletteState.Disabled
-                        ? _ribbonColours[(int)SchemeOfficeColors.FormHeaderLongInactive]
-                        : _ribbonColours[(int)SchemeOfficeColors.FormHeaderLongActive];
+                        ? _ribbonColors[(int)SchemeOfficeColors.FormHeaderLongInactive]
+                        : _ribbonColors[(int)SchemeOfficeColors.FormHeaderLongActive];
             }
 
             if ((state == PaletteState.Disabled) &&
@@ -2691,39 +2691,39 @@ namespace Krypton.Toolkit
             return style switch
             {
                 PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 or PaletteContentStyle.HeaderCalendar => _gridTextColor,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderSecondary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _ribbonColours[(int)SchemeOfficeColors.HeaderText],
+                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderSecondary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _ribbonColors[(int)SchemeOfficeColors.HeaderText],
                 PaletteContentStyle.HeaderDockActive => Color.Black,
                 PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.InputControlTextDisabled]
-: _ribbonColours[(int)SchemeOfficeColors.InputControlTextNormal],
-                PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelGroupBoxCaption => _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 or PaletteContentStyle.ContextMenuItemImage or PaletteContentStyle.ContextMenuItemTextStandard or PaletteContentStyle.ContextMenuItemTextAlternate or PaletteContentStyle.ContextMenuItemShortcutText => _ribbonColours[(int)SchemeOfficeColors.TextLabelControl],
+? _ribbonColors[(int)SchemeOfficeColors.InputControlTextDisabled]
+: _ribbonColors[(int)SchemeOfficeColors.InputControlTextNormal],
+                PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelGroupBoxCaption => _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
+                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 or PaletteContentStyle.ContextMenuItemImage or PaletteContentStyle.ContextMenuItemTextStandard or PaletteContentStyle.ContextMenuItemTextAlternate or PaletteContentStyle.ContextMenuItemShortcutText => _ribbonColors[(int)SchemeOfficeColors.TextLabelControl],
                 PaletteContentStyle.LabelToolTip or PaletteContentStyle.LabelSuperTip or PaletteContentStyle.LabelKeyTip => _toolTipText,
-                PaletteContentStyle.ContextMenuHeading => _ribbonColours[(int)SchemeOfficeColors.ContextMenuHeadingText],
+                PaletteContentStyle.ContextMenuHeading => _ribbonColors[(int)SchemeOfficeColors.ContextMenuHeadingText],
                 PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabDock or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 or PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonGallery or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => state != PaletteState.Normal
-? _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked]
-: _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal],
-                PaletteContentStyle.TabDockAutoHidden => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal],
+? _ribbonColors[(int)SchemeOfficeColors.TextButtonChecked]
+: _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal],
+                PaletteContentStyle.TabDockAutoHidden => _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal],
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
-                    PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
-                    _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
+                                                   ? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
+                    PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeOfficeColors.TextButtonChecked],
+                    _ => _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal]
                 },
                 PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => state switch
                 {
-                    PaletteState.Tracking or PaletteState.CheckedTracking => _ribbonColours[(int)SchemeOfficeColors.TextButtonFormTracking],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonFormPressed],
-                    _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonFormNormal]
+                    PaletteState.Tracking or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeOfficeColors.TextButtonFormTracking],
+                    PaletteState.Pressed or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeOfficeColors.TextButtonFormPressed],
+                    _ => _ribbonColors[(int)SchemeOfficeColors.TextButtonFormNormal]
                 },
                 PaletteContentStyle.ButtonInputControl => state != PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.InputDropDownNormal2]
-: _ribbonColours[(int)SchemeOfficeColors.InputDropDownDisabled2],
+? _ribbonColors[(int)SchemeOfficeColors.InputDropDownNormal2]
+: _ribbonColors[(int)SchemeOfficeColors.InputDropDownDisabled2],
                 PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => state != PaletteState.Normal
-? _ribbonColours[(int)SchemeOfficeColors.ButtonNavigatorText]
-: _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal],
+? _ribbonColors[(int)SchemeOfficeColors.ButtonNavigatorText]
+: _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal],
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -3329,63 +3329,63 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public override Color GetRibbonDropArrowLight(PaletteState state) => _ribbonColours[(int)SchemeOfficeColors.RibbonDropArrowLight];
+        public override Color GetRibbonDropArrowLight(PaletteState state) => _ribbonColors[(int)SchemeOfficeColors.RibbonDropArrowLight];
 
         /// <summary>
         /// Gets the color for the drop arrow dark.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public override Color GetRibbonDropArrowDark(PaletteState state) => _ribbonColours[(int)SchemeOfficeColors.RibbonDropArrowDark];
+        public override Color GetRibbonDropArrowDark(PaletteState state) => _ribbonColors[(int)SchemeOfficeColors.RibbonDropArrowDark];
 
         /// <summary>
         /// Gets the color for the dialog launcher dark.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public override Color GetRibbonGroupDialogDark(PaletteState state) => _ribbonColours[(int)SchemeOfficeColors.RibbonGroupDialogDark];
+        public override Color GetRibbonGroupDialogDark(PaletteState state) => _ribbonColors[(int)SchemeOfficeColors.RibbonGroupDialogDark];
 
         /// <summary>
         /// Gets the color for the dialog launcher light.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public override Color GetRibbonGroupDialogLight(PaletteState state) => _ribbonColours[(int)SchemeOfficeColors.RibbonGroupDialogLight];
+        public override Color GetRibbonGroupDialogLight(PaletteState state) => _ribbonColors[(int)SchemeOfficeColors.RibbonGroupDialogLight];
 
         /// <summary>
         /// Gets the color for the group separator dark.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public override Color GetRibbonGroupSeparatorDark(PaletteState state) => _ribbonColours[(int)SchemeOfficeColors.RibbonGroupSeparatorDark];
+        public override Color GetRibbonGroupSeparatorDark(PaletteState state) => _ribbonColors[(int)SchemeOfficeColors.RibbonGroupSeparatorDark];
 
         /// <summary>
         /// Gets the color for the group separator light.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public override Color GetRibbonGroupSeparatorLight(PaletteState state) => _ribbonColours[(int)SchemeOfficeColors.RibbonGroupSeparatorLight];
+        public override Color GetRibbonGroupSeparatorLight(PaletteState state) => _ribbonColors[(int)SchemeOfficeColors.RibbonGroupSeparatorLight];
 
         /// <summary>
         /// Gets the color for the minimize bar dark.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public override Color GetRibbonMinimizeBarDark(PaletteState state) => _ribbonColours[(int)SchemeOfficeColors.RibbonMinimizeBarDark];
+        public override Color GetRibbonMinimizeBarDark(PaletteState state) => _ribbonColors[(int)SchemeOfficeColors.RibbonMinimizeBarDark];
 
         /// <summary>
         /// Gets the color for the minimize bar light.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public override Color GetRibbonMinimizeBarLight(PaletteState state) => _ribbonColours[(int)SchemeOfficeColors.RibbonMinimizeBarLight];
+        public override Color GetRibbonMinimizeBarLight(PaletteState state) => _ribbonColors[(int)SchemeOfficeColors.RibbonMinimizeBarLight];
 
         /// <summary>
         /// Gets the color for the tab separator.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public override Color GetRibbonTabSeparatorColor(PaletteState state) => _ribbonColours[(int)SchemeOfficeColors.RibbonTabSeparatorColor];
+        public override Color GetRibbonTabSeparatorColor(PaletteState state) => _ribbonColors[(int)SchemeOfficeColors.RibbonTabSeparatorColor];
 
         /// <summary>
         /// Gets the color for the tab context separators.
@@ -3413,14 +3413,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public override Color GetRibbonQATButtonDark(PaletteState state) => _ribbonColours[(int)SchemeOfficeColors.RibbonQATButtonDark];
+        public override Color GetRibbonQATButtonDark(PaletteState state) => _ribbonColors[(int)SchemeOfficeColors.RibbonQATButtonDark];
 
         /// <summary>
         /// Gets the color for the extra QAT button light content color.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public override Color GetRibbonQATButtonLight(PaletteState state) => _ribbonColours[(int)SchemeOfficeColors.RibbonQATButtonLight];
+        public override Color GetRibbonQATButtonLight(PaletteState state) => _ribbonColors[(int)SchemeOfficeColors.RibbonQATButtonLight];
 
         #endregion
 
@@ -3548,34 +3548,34 @@ namespace Krypton.Toolkit
                     return state switch
                     {
                         PaletteState.Disabled => _disabledBack,
-                        PaletteState.Tracking => _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBackTracking],
-                        _ => _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBackNormal]
+                        PaletteState.Tracking => _ribbonColors[(int)SchemeOfficeColors.RibbonGalleryBackTracking],
+                        _ => _ribbonColors[(int)SchemeOfficeColors.RibbonGalleryBackNormal]
                     };
                 case PaletteRibbonBackStyle.RibbonGalleryBorder:
                     return state switch
                     {
                         PaletteState.Disabled => _disabledBorder,
-                        _ => _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBorder]
+                        _ => _ribbonColors[(int)SchemeOfficeColors.RibbonGalleryBorder]
                     };
                 case PaletteRibbonBackStyle.RibbonAppMenuDocs:
-                    return _ribbonColours[(int)SchemeOfficeColors.AppButtonMenuDocsBack];
+                    return _ribbonColors[(int)SchemeOfficeColors.AppButtonMenuDocsBack];
                 case PaletteRibbonBackStyle.RibbonAppMenuInner:
-                    return _ribbonColours[(int)SchemeOfficeColors.AppButtonInner1];
+                    return _ribbonColors[(int)SchemeOfficeColors.AppButtonInner1];
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
-                    return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter1];
+                    return _ribbonColors[(int)SchemeOfficeColors.AppButtonOuter1];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
                     return state == PaletteState.Normal
-                        ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini1]
-                        : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini1I];
+                        ? _ribbonColors[(int)SchemeOfficeColors.RibbonQATMini1]
+                        : _ribbonColors[(int)SchemeOfficeColors.RibbonQATMini1I];
 
                 case PaletteRibbonBackStyle.RibbonQATFullbar:
-                    return _ribbonColours[(int)SchemeOfficeColors.RibbonQATFullbar1];
+                    return _ribbonColors[(int)SchemeOfficeColors.RibbonQATFullbar1];
                 case PaletteRibbonBackStyle.RibbonQATOverflow:
-                    return _ribbonColours[(int)SchemeOfficeColors.RibbonQATOverflow1];
+                    return _ribbonColors[(int)SchemeOfficeColors.RibbonQATOverflow1];
                 case PaletteRibbonBackStyle.RibbonGroupCollapsedFrameBorder:
-                    return _ribbonColours[(int)SchemeOfficeColors.RibbonGroupFrameBorder1];
+                    return _ribbonColors[(int)SchemeOfficeColors.RibbonGroupFrameBorder1];
                 case PaletteRibbonBackStyle.RibbonGroupCollapsedFrameBack:
-                    return _ribbonColours[(int)SchemeOfficeColors.RibbonGroupFrameInside1];
+                    return _ribbonColors[(int)SchemeOfficeColors.RibbonGroupFrameInside1];
                 case PaletteRibbonBackStyle.RibbonGroupNormalTitle:
                 case PaletteRibbonBackStyle.RibbonGroupCollapsedBack:
                     return Color.Empty;
@@ -3589,7 +3589,7 @@ namespace Krypton.Toolkit
                         case PaletteState.ContextNormal:
                         case PaletteState.ContextTracking:
                         case PaletteState.ContextPressed:
-                            return _ribbonColours[(int)SchemeOfficeColors.RibbonGroupBorder1];
+                            return _ribbonColors[(int)SchemeOfficeColors.RibbonGroupBorder1];
                         default:
                             // Should never happen!
                             Debug.Assert(false);
@@ -3614,7 +3614,7 @@ namespace Krypton.Toolkit
                     }
                     break;
                 case PaletteRibbonBackStyle.RibbonGroupArea:
-                    return state == PaletteState.ContextCheckedNormal ? Color.Empty : _ribbonColours[(int)SchemeOfficeColors.RibbonGroupsArea1];
+                    return state == PaletteState.ContextCheckedNormal ? Color.Empty : _ribbonColors[(int)SchemeOfficeColors.RibbonGroupsArea1];
 
                 case PaletteRibbonBackStyle.RibbonTab:
                     switch (state)
@@ -3622,13 +3622,13 @@ namespace Krypton.Toolkit
                         case PaletteState.Tracking:
                         case PaletteState.Pressed:
                         case PaletteState.ContextTracking:
-                            return _ribbonColours[(int)SchemeOfficeColors.RibbonTabTracking1];
+                            return _ribbonColors[(int)SchemeOfficeColors.RibbonTabTracking1];
                         case PaletteState.CheckedNormal:
                         case PaletteState.CheckedTracking:
                         case PaletteState.CheckedPressed:
                         case PaletteState.ContextCheckedNormal:
                         case PaletteState.ContextCheckedTracking:
-                            return _ribbonColours[(int)SchemeOfficeColors.RibbonTabSelected1];
+                            return _ribbonColors[(int)SchemeOfficeColors.RibbonTabSelected1];
                         case PaletteState.FocusOverride:
                             return _contextCheckedTabBorder1;
                         case PaletteState.Normal:
@@ -3661,32 +3661,32 @@ namespace Krypton.Toolkit
             switch (style)
             {
                 case PaletteRibbonBackStyle.RibbonAppMenuInner:
-                    return _ribbonColours[(int)SchemeOfficeColors.AppButtonInner2];
+                    return _ribbonColors[(int)SchemeOfficeColors.AppButtonInner2];
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
-                    return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter2];
+                    return _ribbonColors[(int)SchemeOfficeColors.AppButtonOuter2];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
                     return state == PaletteState.Normal
-                        ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini2]
-                        : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini2I];
+                        ? _ribbonColors[(int)SchemeOfficeColors.RibbonQATMini2]
+                        : _ribbonColors[(int)SchemeOfficeColors.RibbonQATMini2I];
 
                 case PaletteRibbonBackStyle.RibbonQATFullbar:
-                    return _ribbonColours[(int)SchemeOfficeColors.RibbonQATFullbar2];
+                    return _ribbonColors[(int)SchemeOfficeColors.RibbonQATFullbar2];
                 case PaletteRibbonBackStyle.RibbonQATOverflow:
-                    return _ribbonColours[(int)SchemeOfficeColors.RibbonQATOverflow2];
+                    return _ribbonColors[(int)SchemeOfficeColors.RibbonQATOverflow2];
                 case PaletteRibbonBackStyle.RibbonGroupCollapsedFrameBorder:
-                    return _ribbonColours[(int)SchemeOfficeColors.RibbonGroupFrameBorder2];
+                    return _ribbonColors[(int)SchemeOfficeColors.RibbonGroupFrameBorder2];
                 case PaletteRibbonBackStyle.RibbonGroupCollapsedFrameBack:
-                    return _ribbonColours[(int)SchemeOfficeColors.RibbonGroupFrameInside2];
+                    return _ribbonColors[(int)SchemeOfficeColors.RibbonGroupFrameInside2];
                 case PaletteRibbonBackStyle.RibbonGroupNormalTitle:
                     switch (state)
                     {
                         case PaletteState.Normal:
-                            return _ribbonColours[(int)SchemeOfficeColors.RibbonGroupTitle2];
+                            return _ribbonColors[(int)SchemeOfficeColors.RibbonGroupTitle2];
                         case PaletteState.ContextNormal:
-                            return _ribbonColours[(int)SchemeOfficeColors.RibbonGroupTitleContext2];
+                            return _ribbonColors[(int)SchemeOfficeColors.RibbonGroupTitleContext2];
                         case PaletteState.Tracking:
                         case PaletteState.ContextTracking:
-                            return _ribbonColours[(int)SchemeOfficeColors.RibbonGroupTitleTracking2];
+                            return _ribbonColors[(int)SchemeOfficeColors.RibbonGroupTitleTracking2];
                         default:
                             // Should never happen!
                             Debug.Assert(false);
@@ -3704,7 +3704,7 @@ namespace Krypton.Toolkit
                         case PaletteState.ContextNormal:
                         case PaletteState.ContextTracking:
                         case PaletteState.ContextPressed:
-                            return _ribbonColours[(int)SchemeOfficeColors.RibbonGroupBorder2];
+                            return _ribbonColors[(int)SchemeOfficeColors.RibbonGroupBorder2];
                         default:
                             // Should never happen!
                             Debug.Assert(false);
@@ -3729,20 +3729,20 @@ namespace Krypton.Toolkit
                     }
                     break;
                 case PaletteRibbonBackStyle.RibbonGroupArea:
-                    return _ribbonColours[(int)SchemeOfficeColors.RibbonGroupsArea2];
+                    return _ribbonColors[(int)SchemeOfficeColors.RibbonGroupsArea2];
                 case PaletteRibbonBackStyle.RibbonTab:
                     switch (state)
                     {
                         case PaletteState.Tracking:
                         case PaletteState.Pressed:
                         case PaletteState.ContextTracking:
-                            return _ribbonColours[(int)SchemeOfficeColors.RibbonTabTracking2];
+                            return _ribbonColors[(int)SchemeOfficeColors.RibbonTabTracking2];
                         case PaletteState.CheckedNormal:
                         case PaletteState.CheckedTracking:
                         case PaletteState.CheckedPressed:
                         case PaletteState.ContextCheckedTracking:
                         case PaletteState.ContextCheckedNormal:
-                            return _ribbonColours[(int)SchemeOfficeColors.RibbonTabSelected2];
+                            return _ribbonColors[(int)SchemeOfficeColors.RibbonTabSelected2];
                         case PaletteState.FocusOverride:
                             return _contextCheckedTabBorder2;
                         case PaletteState.Normal:
@@ -3780,17 +3780,17 @@ namespace Krypton.Toolkit
             switch (style)
             {
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
-                    return _ribbonColours[(int)SchemeOfficeColors.AppButtonOuter3];
+                    return _ribbonColors[(int)SchemeOfficeColors.AppButtonOuter3];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
                     return state == PaletteState.Normal
-                        ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini3]
-                        : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini3I];
+                        ? _ribbonColors[(int)SchemeOfficeColors.RibbonQATMini3]
+                        : _ribbonColors[(int)SchemeOfficeColors.RibbonQATMini3I];
 
                 case PaletteRibbonBackStyle.RibbonQATFullbar:
-                    return _ribbonColours[(int)SchemeOfficeColors.RibbonQATFullbar3];
+                    return _ribbonColors[(int)SchemeOfficeColors.RibbonQATFullbar3];
                 case PaletteRibbonBackStyle.RibbonGroupNormalBorder:
                 case PaletteRibbonBackStyle.RibbonGroupCollapsedBorder:
-                    return _ribbonColours[(int)SchemeOfficeColors.RibbonGroupBorder3];
+                    return _ribbonColors[(int)SchemeOfficeColors.RibbonGroupBorder3];
                 case PaletteRibbonBackStyle.RibbonAppMenuDocs:
                 case PaletteRibbonBackStyle.RibbonAppMenuInner:
                 case PaletteRibbonBackStyle.RibbonQATOverflow:
@@ -3818,20 +3818,20 @@ namespace Krypton.Toolkit
                     }
                     break;
                 case PaletteRibbonBackStyle.RibbonGroupArea:
-                    return _ribbonColours[(int)SchemeOfficeColors.RibbonGroupsArea3];
+                    return _ribbonColors[(int)SchemeOfficeColors.RibbonGroupsArea3];
                 case PaletteRibbonBackStyle.RibbonTab:
                     switch (state)
                     {
                         case PaletteState.Tracking:
                         case PaletteState.Pressed:
                         case PaletteState.ContextTracking:
-                            return _ribbonColours[(int)SchemeOfficeColors.RibbonTabTracking3];
+                            return _ribbonColors[(int)SchemeOfficeColors.RibbonTabTracking3];
                         case PaletteState.CheckedNormal:
                         case PaletteState.CheckedTracking:
                         case PaletteState.CheckedPressed:
                         case PaletteState.ContextCheckedNormal:
                         case PaletteState.ContextCheckedTracking:
-                            return _ribbonColours[(int)SchemeOfficeColors.RibbonTabSelected3];
+                            return _ribbonColors[(int)SchemeOfficeColors.RibbonTabSelected3];
                         case PaletteState.FocusOverride:
                             return _contextCheckedTabBorder3;
                         case PaletteState.Normal:
@@ -3865,12 +3865,12 @@ namespace Krypton.Toolkit
             {
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
                     return state == PaletteState.Normal
-                        ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini4]
-                        : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini4I];
+                        ? _ribbonColors[(int)SchemeOfficeColors.RibbonQATMini4]
+                        : _ribbonColors[(int)SchemeOfficeColors.RibbonQATMini4I];
 
                 case PaletteRibbonBackStyle.RibbonGroupNormalBorder:
                 case PaletteRibbonBackStyle.RibbonGroupCollapsedBorder:
-                    return _ribbonColours[(int)SchemeOfficeColors.RibbonGroupBorder4];
+                    return _ribbonColors[(int)SchemeOfficeColors.RibbonGroupBorder4];
                 case PaletteRibbonBackStyle.RibbonAppMenuDocs:
                 case PaletteRibbonBackStyle.RibbonAppMenuInner:
                 case PaletteRibbonBackStyle.RibbonAppMenuOuter:
@@ -3900,20 +3900,20 @@ namespace Krypton.Toolkit
                     }
                     break;
                 case PaletteRibbonBackStyle.RibbonGroupArea:
-                    return _ribbonColours[(int)SchemeOfficeColors.RibbonGroupsArea4];
+                    return _ribbonColors[(int)SchemeOfficeColors.RibbonGroupsArea4];
                 case PaletteRibbonBackStyle.RibbonTab:
                     switch (state)
                     {
                         case PaletteState.Tracking:
                         case PaletteState.Pressed:
                         case PaletteState.ContextTracking:
-                            return _ribbonColours[(int)SchemeOfficeColors.RibbonTabTracking4];
+                            return _ribbonColors[(int)SchemeOfficeColors.RibbonTabTracking4];
                         case PaletteState.CheckedNormal:
                         case PaletteState.CheckedTracking:
                         case PaletteState.CheckedPressed:
                         case PaletteState.ContextCheckedNormal:
                         case PaletteState.ContextCheckedTracking:
-                            return _ribbonColours[(int)SchemeOfficeColors.RibbonTabSelected4];
+                            return _ribbonColors[(int)SchemeOfficeColors.RibbonTabSelected4];
                         case PaletteState.FocusOverride:
                             return _contextCheckedTabBorder4;
                         case PaletteState.Normal:
@@ -3959,11 +3959,11 @@ namespace Krypton.Toolkit
                     return Color.Empty;
                 case PaletteRibbonBackStyle.RibbonGroupNormalBorder:
                 case PaletteRibbonBackStyle.RibbonGroupCollapsedBorder:
-                    return _ribbonColours[(int)SchemeOfficeColors.RibbonGroupBorder5];
+                    return _ribbonColors[(int)SchemeOfficeColors.RibbonGroupBorder5];
                 case PaletteRibbonBackStyle.RibbonQATMinibar:
                     return state == PaletteState.Normal
-                        ? _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini5]
-                        : _ribbonColours[(int)SchemeOfficeColors.RibbonQATMini5I];
+                        ? _ribbonColors[(int)SchemeOfficeColors.RibbonQATMini5]
+                        : _ribbonColors[(int)SchemeOfficeColors.RibbonQATMini5I];
 
                 case PaletteRibbonBackStyle.RibbonAppButton:
                     switch (state)
@@ -3982,14 +3982,14 @@ namespace Krypton.Toolkit
                     }
                     break;
                 case PaletteRibbonBackStyle.RibbonGroupArea:
-                    return _ribbonColours[(int)SchemeOfficeColors.RibbonGroupsArea5];
+                    return _ribbonColors[(int)SchemeOfficeColors.RibbonGroupsArea5];
                 case PaletteRibbonBackStyle.RibbonTab:
                     switch (state)
                     {
                         case PaletteState.Disabled:
                             return _disabledText;
                         case PaletteState.Pressed:
-                            return _ribbonColours[(int)SchemeOfficeColors.RibbonTabTracking2];
+                            return _ribbonColors[(int)SchemeOfficeColors.RibbonTabTracking2];
                         case PaletteState.Tracking:
                         case PaletteState.CheckedNormal:
                         case PaletteState.CheckedTracking:
@@ -4031,27 +4031,27 @@ namespace Krypton.Toolkit
             {
                 case PaletteRibbonTextStyle.RibbonAppMenuDocsTitle:
                 case PaletteRibbonTextStyle.RibbonAppMenuDocsEntry:
-                    return _ribbonColours[(int)SchemeOfficeColors.AppButtonMenuDocsText];
+                    return _ribbonColors[(int)SchemeOfficeColors.AppButtonMenuDocsText];
                 case PaletteRibbonTextStyle.RibbonGroupNormalTitle:
                     return state switch
                     {
                         PaletteState.Disabled => _disabledText,
-                        _ => _ribbonColours[(int)SchemeOfficeColors.RibbonGroupTitleText]
+                        _ => _ribbonColors[(int)SchemeOfficeColors.RibbonGroupTitleText]
                     };
                 case PaletteRibbonTextStyle.RibbonTab:
                     return state switch
                     {
                         PaletteState.Disabled => _disabledText,
-                        PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking or PaletteState.ContextCheckedNormal or PaletteState.ContextCheckedTracking or PaletteState.FocusOverride => _ribbonColours[(int)SchemeOfficeColors.RibbonTabTextChecked],
-                        _ => _ribbonColours[(int)SchemeOfficeColors.RibbonTabTextNormal]
+                        PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking or PaletteState.ContextCheckedNormal or PaletteState.ContextCheckedTracking or PaletteState.FocusOverride => _ribbonColors[(int)SchemeOfficeColors.RibbonTabTextChecked],
+                        _ => _ribbonColors[(int)SchemeOfficeColors.RibbonTabTextNormal]
                     };
                 case PaletteRibbonTextStyle.RibbonGroupCollapsedText:
-                    return _ribbonColours[(int)SchemeOfficeColors.RibbonGroupCollapsedText];
+                    return _ribbonColors[(int)SchemeOfficeColors.RibbonGroupCollapsedText];
                 case PaletteRibbonTextStyle.RibbonGroupButtonText:
                 case PaletteRibbonTextStyle.RibbonGroupLabelText:
                 case PaletteRibbonTextStyle.RibbonGroupCheckBoxText:
                 case PaletteRibbonTextStyle.RibbonGroupRadioButtonText:
-                    return state == PaletteState.Disabled ? _disabledText : _ribbonColours[(int)SchemeOfficeColors.RibbonGroupCollapsedText];
+                    return state == PaletteState.Disabled ? _disabledText : _ribbonColors[(int)SchemeOfficeColors.RibbonGroupCollapsedText];
 
                 default:
                     // Should never happen!
@@ -4123,8 +4123,8 @@ namespace Krypton.Toolkit
                 case PaletteElement.TrackBarPosition:
                     return state switch
                     {
-                        PaletteState.Disabled => ControlPaint.Light(_ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder]),
-                        PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
+                        PaletteState.Disabled => ControlPaint.Light(_ribbonColors[(int)SchemeOfficeColors.ButtonNormalBorder]),
+                        PaletteState.Normal => _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBorder],
                         PaletteState.Tracking or PaletteState.FocusOverride => _buttonBorderColors[1],
                         PaletteState.Pressed => _buttonBorderColors[3],
                         _ => throw DebugTools.NotImplemented(state.ToString())
@@ -4162,9 +4162,9 @@ namespace Krypton.Toolkit
                     return state switch
                     {
                         PaletteState.Disabled => ControlPaint.LightLight(
-                            _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]),
+                            _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBack1]),
                         PaletteState.Normal => ControlPaint.Light(
-                            _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]),
+                            _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBack1]),
                         PaletteState.Tracking => ControlPaint.Light(_buttonBackColors[2]),
                         PaletteState.Pressed => ControlPaint.Light(_buttonBackColors[4]),
                         _ => throw DebugTools.NotImplemented(state.ToString())
@@ -4212,8 +4212,8 @@ namespace Krypton.Toolkit
 
                     return state switch
                     {
-                        PaletteState.Disabled => ControlPaint.LightLight(_ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]),
-                        PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1],
+                        PaletteState.Disabled => ControlPaint.LightLight(_ribbonColors[(int)SchemeOfficeColors.ButtonNormalBack1]),
+                        PaletteState.Normal => _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBack1],
                         PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[2],
                         PaletteState.Pressed => _buttonBackColors[4],
                         _ => throw DebugTools.NotImplemented(state.ToString())
@@ -4260,8 +4260,8 @@ namespace Krypton.Toolkit
 
                     return state switch
                     {
-                        PaletteState.Disabled => ControlPaint.LightLight(_ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]),
-                        PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2],
+                        PaletteState.Disabled => ControlPaint.LightLight(_ribbonColors[(int)SchemeOfficeColors.ButtonNormalBack1]),
+                        PaletteState.Normal => _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBack2],
                         PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[3],
                         PaletteState.Pressed => _buttonBackColors[5],
                         _ => throw DebugTools.NotImplemented(state.ToString())
@@ -4282,15 +4282,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the color table instance.
         /// </summary>
-        public override KryptonColorTable ColorTable
-        {
-            get
-            {
-                _table ??= new KryptonColorTable365(_ribbonColours, InheritBool.True, this);
-
-                return _table;
-            }
-        }
+        public override KryptonColorTable ColorTable => Table ??= new KryptonColorTable365(_ribbonColors, InheritBool.True, this);
         #endregion
 
         #region OnUserPreferenceChanged
@@ -4302,7 +4294,7 @@ namespace Krypton.Toolkit
         protected override void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e)
         {
             // Remove the current table, so it gets regenerated when next requested
-            _table = null;
+            Table = null;
 
             // Update fonts to reflect any change in system settings
             DefineFonts();

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Black.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Black.cs
@@ -12,12 +12,14 @@
 
 namespace Krypton.Toolkit
 {
-    /// <summary></summary>
+    /// <summary>
+    /// Gets the single instance of the PaletteMicrosoft365Black palette.
+    /// </summary>
     public class PaletteMicrosoft365Black : PaletteMicrosoft365Base
     {
         #region Static Fields
 
-        #region ImageLists
+        #region Image Lists
 
         private static readonly ImageList _checkBoxList;
         private static readonly ImageList _galleryButtonList;
@@ -125,7 +127,6 @@ namespace Krypton.Toolkit
 
         #region Colour Arrays
 
-        //private static readonly Color _disabledRibbonText = Color.White; // Color.FromArgb(205, 205, 205);
         private static readonly Color[] _trackBarColors =
         [
             Color.FromArgb(17, 17, 17), // Tick marks
@@ -156,7 +157,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(172, 172, 172), // SeparatorHighBorder1
             Color.FromArgb(111, 111, 111), // SeparatorHighBorder2
             Color.FromArgb(139, 139, 139), // HeaderPrimaryBack1
-            Color.FromArgb(72, 72, 72), // HeaderPrimaryBack2
+            Color.FromArgb(72, 72, 72),    // HeaderPrimaryBack2
             Color.FromArgb(190, 190, 190), // HeaderSecondaryBack1
             Color.FromArgb(145, 145, 145), // HeaderSecondaryBack2
             Color.Black, // HeaderText
@@ -212,14 +213,14 @@ namespace Krypton.Toolkit
             //Color.FromArgb(226, 226, 226),    // RibbonTabTextNormal
             Color.White, // RibbonTabTextNormal
             Color.Black, // RibbonTabTextChecked
-            Color.FromArgb(32, 32, 32), // RibbonTabSelected1
+            Color.FromArgb(32, 32, 32),    // RibbonTabSelected1
             Color.FromArgb(201, 201, 201), // RibbonTabSelected2
             Color.FromArgb(192, 192, 192), // RibbonTabSelected3
             Color.FromArgb(192, 192, 192), // RibbonTabSelected4
             Color.FromArgb(192, 192, 192), // RibbonTabSelected5
-            Color.FromArgb(32, 32, 32), // RibbonTabTracking1
+            Color.FromArgb(32, 32, 32),    // RibbonTabTracking1
             Color.FromArgb(183, 183, 183), // RibbonTabTracking2
-            Color.FromArgb(32, 32, 32), // RibbonTabHighlight1
+            Color.FromArgb(32, 32, 32),    // RibbonTabHighlight1
             Color.FromArgb(201, 201, 201), // RibbonTabHighlight2
             Color.FromArgb(192, 192, 192), // RibbonTabHighlight3
             Color.FromArgb(192, 192, 192), // RibbonTabHighlight4
@@ -293,18 +294,12 @@ namespace Krypton.Toolkit
             Color.FromArgb(174, 174, 175), // RibbonQATButtonLight                                                      
             Color.FromArgb(161, 161, 161), // RibbonQATOverflow1                                                      
             Color.FromArgb(68, 68, 68), // RibbonQATOverflow2                                                      
-            Color.FromArgb(82, 82,
-                82), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(190, 190,
-                190), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(210, 217,
-                219), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(214, 222,
-                223), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(179, 188,
-                191), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(145, 156,
-                159), // ButtonClusterButtonBorder2                                                      
+            Color.FromArgb(82, 82, 82), // RibbonGroupSeparatorDark                                                      
+            Color.FromArgb(190, 190, 190), // RibbonGroupSeparatorLight                                                      
+            Color.FromArgb(210, 217, 219), // ButtonClusterButtonBack1                                                      
+            Color.FromArgb(214, 222, 223), // ButtonClusterButtonBack2                                                      
+            Color.FromArgb(179, 188, 191), // ButtonClusterButtonBorder1                                                      
+            Color.FromArgb(145, 156, 159), // ButtonClusterButtonBorder2                                                      
             Color.FromArgb(235, 235, 235), // NavigatorMiniBackColor                                                    
             Color.FromArgb(205, 205, 205), // GridListNormal1                                                    
             Color.FromArgb(166, 166, 166), // GridListNormal2                                                    
@@ -375,7 +370,6 @@ namespace Krypton.Toolkit
         ];
 
         #endregion
-
         #endregion
 
         #region Constructors
@@ -581,7 +575,7 @@ namespace Krypton.Toolkit
     #region Class: PaletteMicrosoft365BlackThemeBase
 
     /// <summary>
-    /// Provides a base for Office 365 palettes.
+    /// Provides a base for Office 365 Black palettes.
     /// </summary>
     /// <seealso cref="PaletteBase" />
     public abstract class PaletteMicrosoft365BlackThemeBase : PaletteBase
@@ -685,52 +679,52 @@ namespace Krypton.Toolkit
         private static readonly Color[] _appButtonNormal =
         [
             Color.FromArgb(243, 245, 248),
-                                                             Color.FromArgb(214, 220, 231),
-                                                             Color.FromArgb(188, 198, 211),
-                                                             Color.FromArgb(254, 254, 255),
-                                                             Color.FromArgb(206, 213, 225)
+            Color.FromArgb(214, 220, 231),
+            Color.FromArgb(188, 198, 211),
+            Color.FromArgb(254, 254, 255),
+            Color.FromArgb(206, 213, 225)
         ];
 
         private static readonly Color[] _appButtonTrack =
         [
             Color.FromArgb(255, 251, 230),
-                                                            Color.FromArgb(248, 230, 143),
-                                                            Color.FromArgb(238, 213, 126),
-                                                            Color.FromArgb(254, 247, 129),
-                                                            Color.FromArgb(240, 201, 41)
+            Color.FromArgb(248, 230, 143),
+            Color.FromArgb(238, 213, 126),
+            Color.FromArgb(254, 247, 129),
+            Color.FromArgb(240, 201, 41)
         ];
 
         private static readonly Color[] _appButtonPressed =
         [
             Color.FromArgb(235, 227, 196),
-                                                              Color.FromArgb(228, 198, 149),
-                                                              Color.FromArgb(166, 97, 7),
-                                                              Color.FromArgb(242, 155, 57),
-                                                              Color.FromArgb(236, 136, 9)
+            Color.FromArgb(228, 198, 149),
+            Color.FromArgb(166, 97, 7),
+            Color.FromArgb(242, 155, 57),
+            Color.FromArgb(236, 136, 9)
         ];
 
         private static readonly Color[] _buttonBorderColors =
         [
             Color.FromArgb(180, 180, 180), // Button, Disabled, Border
-                                                                Color.FromArgb(237, 201, 88),  // Button, Tracking, Border 1
-                                                                Color.FromArgb(243, 213, 73),  // Button, Tracking, Border 2
-                                                                Color.FromArgb(194, 118, 43),  // Button, Pressed, Border 1
-                                                                Color.FromArgb(194, 158, 71),  // Button, Pressed, Border 2
-                                                                Color.FromArgb(194, 138, 48),  // Button, Checked, Border 1
-                                                                           Color.FromArgb(194, 164, 77)   // Button, Checked, Border 2
+            Color.FromArgb(237, 201, 88),  // Button, Tracking, Border 1
+            Color.FromArgb(243, 213, 73),  // Button, Tracking, Border 2
+            Color.FromArgb(194, 118, 43),  // Button, Pressed, Border 1
+            Color.FromArgb(194, 158, 71),  // Button, Pressed, Border 2
+            Color.FromArgb(194, 138, 48),  // Button, Checked, Border 1
+            Color.FromArgb(194, 164, 77)   // Button, Checked, Border 2
         ];
         private static readonly Color[] _buttonBackColors =
         [
             Color.FromArgb(250, 250, 250), // Button, Disabled, Back 1
-                                                                         Color.FromArgb(250, 250, 250), // Button, Disabled, Back 2
-                                                                         Color.FromArgb(248, 225, 135), // Button, Tracking, Back 1
-                                                                         Color.FromArgb(251, 248, 224), // Button, Tracking, Back 2
-                                                                         Color.FromArgb(255, 228, 138), // Button, Pressed, Back 1
-                                                                         Color.FromArgb(194, 118, 43),  // Button, Pressed, Back 2
-                                                                         Color.FromArgb(255, 216, 108), // Button, Checked, Back 1
-                                                                         Color.FromArgb(255, 244, 128), // Button, Checked, Back 2
-                                                                         Color.FromArgb(255, 225, 104), // Button, Checked Tracking, Back 1
-                                                                         Color.FromArgb(255, 249, 196)  // Button, Checked Tracking, Back 2
+            Color.FromArgb(250, 250, 250), // Button, Disabled, Back 2
+            Color.FromArgb(248, 225, 135), // Button, Tracking, Back 1
+            Color.FromArgb(251, 248, 224), // Button, Tracking, Back 2
+            Color.FromArgb(255, 228, 138), // Button, Pressed, Back 1
+            Color.FromArgb(194, 118, 43),  // Button, Pressed, Back 2
+            Color.FromArgb(255, 216, 108), // Button, Checked, Back 1
+            Color.FromArgb(255, 244, 128), // Button, Checked, Back 2
+            Color.FromArgb(255, 225, 104), // Button, Checked Tracking, Back 1
+            Color.FromArgb(255, 249, 196)  // Button, Checked Tracking, Back 2
         ];
         /*private static readonly Color[] _appButtonNormal = new Color[] { Color.FromArgb(243, 245, 248), Color.FromArgb(214, 220, 231), Color.FromArgb(188, 198, 211), Color.FromArgb(254, 254, 255), Color.FromArgb(206, 213, 225) };
         private static readonly Color[] _appButtonTrack = new Color[] { Color.FromArgb(255, 251, 230), Color.FromArgb(248, 230, 143), Color.FromArgb(238, 213, 126), Color.FromArgb(254, 247, 129), Color.FromArgb(240, 201, 41) };

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365White.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365White.cs
@@ -1,19 +1,19 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved.
+ *
  */
 #endregion
 
 namespace Krypton.Toolkit
 {
     /// <summary>
-    /// Gets the single instance of the ### palette.
+    /// Gets the single instance of the PaletteMicrosoft365White palette.
     /// </summary>
     public class PaletteMicrosoft365White : PaletteMicrosoft365Base
     {
@@ -119,7 +119,7 @@ namespace Krypton.Toolkit
 
         #endregion
 
-        #region Colour Arrays
+        #region Color Arrays
 
         private static readonly Color[] _trackBarColors =
         [
@@ -184,9 +184,9 @@ namespace Krypton.Toolkit
             Color.FromArgb(228, 230, 232), // FormBorderHeaderActive2
             Color.FromArgb(248, 247, 247), // FormBorderHeaderInctive1
             Color.FromArgb(248, 247, 247), // FormBorderHeaderInctive2
-            Color.FromArgb(59, 59, 59), // FormHeaderShortActive
+            Color.FromArgb(59, 59, 59),    // FormHeaderShortActive
             Color.FromArgb(138, 138, 138), // FormHeaderShortInactive
-            Color.FromArgb(59, 59, 59), // FormHeaderLongActive
+            Color.FromArgb(59, 59, 59),    // FormHeaderLongActive
             Color.FromArgb(138, 138, 138), // FormHeaderLongInactive
             Color.FromArgb(166, 172, 179), // FormButtonBorderTrack
             Color.FromArgb(255, 255, 255), // FormButtonBack1Track
@@ -260,7 +260,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(254, 254, 254), // RibbonGroupFrameInside2
             Color.Empty, // RibbonGroupFrameInside3
             Color.Empty, // RibbonGroupFrameInside4
-            Color.FromArgb(59, 59, 59), // RibbonGroupCollapsedText         
+            Color.FromArgb(59, 59, 59), // RibbonGroupCollapsedText
             Color.FromArgb(179, 185, 195), // AlternatePressedBack1
             Color.FromArgb(216, 224, 224), // AlternatePressedBack2
             Color.FromArgb(125, 125, 125), // AlternatePressedBorder1
@@ -274,44 +274,38 @@ namespace Krypton.Toolkit
             Color.FromArgb(210, 215, 221), // RibbonQATMini2
             Color.FromArgb(195, 200, 206), // RibbonQATMini3
             Color.FromArgb(10, Color.White), // RibbonQATMini4
-            Color.FromArgb(32, Color.White), // RibbonQATMini5                                                       
+            Color.FromArgb(32, Color.White), // RibbonQATMini5
             Color.FromArgb(200, 200, 200), // RibbonQATMini1I
             Color.FromArgb(233, 234, 238), // RibbonQATMini2I
             Color.FromArgb(223, 224, 228), // RibbonQATMini3I
             Color.FromArgb(10, Color.White), // RibbonQATMini4I
-            Color.FromArgb(32, Color.White), // RibbonQATMini5I                                                       
-            Color.FromArgb(223, 227, 234), // RibbonQATFullbar1                                                      
-            Color.FromArgb(213, 217, 222), // RibbonQATFullbar2                                                      
-            Color.FromArgb(135, 140, 146), // RibbonQATFullbar3                                                      
-            Color.FromArgb(90, 90, 90), // RibbonQATButtonDark                                                      
-            Color.FromArgb(210, 212, 215), // RibbonQATButtonLight                                                      
-            Color.FromArgb(233, 237, 241), // RibbonQATOverflow1                                                      
-            Color.FromArgb(138, 144, 150), // RibbonQATOverflow2                                                      
-            Color.FromArgb(191, 195,
-                199), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(255, 255,
-                255), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(231, 234,
-                238), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(241, 243,
-                243), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(197, 198,
-                199), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(157, 158,
-                159), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor                                                    
-            Color.White, // GridListNormal1                                                    
-            Color.White, // GridListNormal2                                                    
-            Color.FromArgb(203, 207, 212), // GridListPressed1                                                    
-            Color.White, // GridListPressed2                                                    
-            Color.FromArgb(186, 189, 194), // GridListSelected                                                    
-            Color.FromArgb(238, 241, 247), // GridSheetColNormal1                                                    
-            Color.FromArgb(218, 222, 227), // GridSheetColNormal2                                                    
-            Color.FromArgb(255, 223, 107), // GridSheetColPressed1                                                    
-            Color.FromArgb(255, 252, 230), // GridSheetColPressed2                                                    
+            Color.FromArgb(32, Color.White), // RibbonQATMini5I
+            Color.FromArgb(223, 227, 234), // RibbonQATFullbar1
+            Color.FromArgb(213, 217, 222), // RibbonQATFullbar2
+            Color.FromArgb(135, 140, 146), // RibbonQATFullbar3
+            Color.FromArgb(90, 90, 90), // RibbonQATButtonDark
+            Color.FromArgb(210, 212, 215), // RibbonQATButtonLight
+            Color.FromArgb(233, 237, 241), // RibbonQATOverflow1
+            Color.FromArgb(138, 144, 150), // RibbonQATOverflow2
+            Color.FromArgb(191, 195, 199), // RibbonGroupSeparatorDark
+            Color.FromArgb(255, 255, 255), // RibbonGroupSeparatorLight
+            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1
+            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2
+            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1
+            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2
+            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor
+            Color.White, // GridListNormal1
+            Color.White, // GridListNormal2
+            Color.FromArgb(203, 207, 212), // GridListPressed1
+            Color.White, // GridListPressed2
+            Color.FromArgb(186, 189, 194), // GridListSelected
+            Color.FromArgb(238, 241, 247), // GridSheetColNormal1
+            Color.FromArgb(218, 222, 227), // GridSheetColNormal2
+            Color.FromArgb(255, 223, 107), // GridSheetColPressed1
+            Color.FromArgb(255, 252, 230), // GridSheetColPressed2
             Color.FromArgb(255, 211, 89), // GridSheetColSelected1
             Color.FromArgb(255, 239, 113), // GridSheetColSelected2
-            Color.FromArgb(223, 227, 232), // GridSheetRowNormal                                                   
+            Color.FromArgb(223, 227, 232), // GridSheetRowNormal
             Color.FromArgb(255, 223, 107), // GridSheetRowPressed
             Color.FromArgb(245, 210, 87), // GridSheetRowSelected
             Color.FromArgb(218, 220, 221), // GridDataCellBorder
@@ -346,8 +340,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(255, 255, 255), // RibbonGalleryBackNormal
             Color.FromArgb(255, 255, 255), // RibbonGalleryBackTracking
             Color.FromArgb(250, 250, 250), // RibbonGalleryBack1
-            Color.FromArgb(228, 231,
-                235), // RibbonGalleryBack2                                                                                                                                      Color.FromArgb(177, 181, 186),    // RibbonTabTracking1
+            Color.FromArgb(228, 231, 235), // RibbonGalleryBack2                        //Color.FromArgb(177, 181, 186), // RibbonTabTracking1
             Color.FromArgb(229, 231, 235), // RibbonTabTracking3
             Color.FromArgb(231, 233, 235), // RibbonTabTracking4
             Color.FromArgb(176, 182, 188), // RibbonGroupBorder3
@@ -366,8 +359,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(225, 226, 230), // ButtonNavigatorPressed2
             Color.FromArgb(222, 227, 234), // ButtonNavigatorChecked1
             Color.FromArgb(206, 214, 221), // ButtonNavigatorChecked2
-            Color.FromArgb(221, 221,
-                221) // ToolTipBottom                                                                      
+            Color.FromArgb(221, 221, 221) // ToolTipBottom
         ];
 
         #endregion
@@ -562,5 +554,13 @@ namespace Krypton.Toolkit
                                                      _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
+
+        #region ColorTable
+        /// <summary>
+        /// Gets access to the color table instance.
+        /// </summary>
+        public override KryptonColorTable ColorTable => Table ??= new KryptonColorTable365White(_schemeOfficeColors, InheritBool.True, this);
+        #endregion
+
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Bases/PaletteOffice2010Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Bases/PaletteOffice2010Base.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved.
+ *
  */
 #endregion
 
@@ -136,7 +136,7 @@ namespace Krypton.Toolkit
         private static readonly Color _contextTabSeparator = Color.White;
         private static readonly Color _contextTextColor = Color.White;
         private static readonly Color _todayBorder = Color.FromArgb(187, 85, 3);
-        private static readonly Color _toolTipBack1 = Color.FromArgb(255, 255, 255);
+        private static readonly Color _toolTipBack1 = Color.White;
         private static readonly Color _toolTipBack2 = Color.FromArgb(201, 217, 239);
         private static readonly Color _toolTipBorder = Color.FromArgb(118, 118, 118);
         private static readonly Color _toolTipText = Color.FromArgb(76, 76, 76);
@@ -221,7 +221,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Instance Fields
-        private KryptonColorTable2010 _table;
+        protected KryptonColorTable2010 Table { get; set; }
         private readonly Color[] _ribbonColors;
         private readonly Color[] _trackBarColors;
         private readonly ImageList _checkBoxList;
@@ -239,10 +239,10 @@ namespace Krypton.Toolkit
         /// <param name="radioButtonArray">Array of images for radio button.</param>
         /// <param name="trackBarColors">Array of track bar specific colors.</param>
         protected PaletteOffice2010Base([DisallowNull] Color[] schemeColors,
-                                     [DisallowNull] ImageList checkBoxList,
-                                     [DisallowNull] ImageList galleryButtonList,
-                                     [DisallowNull] Image?[] radioButtonArray,
-                                     Color[] trackBarColors)
+                                        [DisallowNull] ImageList checkBoxList,
+                                        [DisallowNull] ImageList galleryButtonList,
+                                        [DisallowNull] Image?[] radioButtonArray,
+                                        Color[] trackBarColors)
         {
             Debug.Assert(schemeColors != null);
             Debug.Assert(checkBoxList != null);
@@ -276,6 +276,14 @@ namespace Krypton.Toolkit
             // Get the font settings from the system
             DefineFonts();
         }
+        #endregion
+
+        #region ColorTable
+        /// <summary>
+        /// Gets access to the color table instance.
+        /// </summary>
+        public override KryptonColorTable ColorTable => Table ??= new KryptonColorTable2010(_ribbonColors, InheritBool.True, this);
+
         #endregion
 
         #region Renderer
@@ -338,10 +346,39 @@ namespace Krypton.Toolkit
 
             return style switch
             {
-                PaletteBackStyle.TabHighProfile or PaletteBackStyle.TabStandardProfile or PaletteBackStyle.TabLowProfile or PaletteBackStyle.TabOneNote or PaletteBackStyle.TabDock or PaletteBackStyle.TabDockAutoHidden or PaletteBackStyle.TabCustom1 or PaletteBackStyle.TabCustom2 or PaletteBackStyle.TabCustom3 or PaletteBackStyle.PanelClient or PaletteBackStyle.PanelRibbonInactive or PaletteBackStyle.PanelAlternate or PaletteBackStyle.PanelCustom1 or PaletteBackStyle.PanelCustom2 or PaletteBackStyle.PanelCustom3 or PaletteBackStyle.SeparatorHighInternalProfile or PaletteBackStyle.SeparatorHighProfile or PaletteBackStyle.SeparatorLowProfile or PaletteBackStyle.SeparatorCustom1 or PaletteBackStyle.SeparatorCustom2 or PaletteBackStyle.SeparatorCustom3 or PaletteBackStyle.ControlClient or PaletteBackStyle.ControlAlternate or PaletteBackStyle.ControlGroupBox or PaletteBackStyle.ControlToolTip or PaletteBackStyle.ControlRibbon or PaletteBackStyle.ControlRibbonAppMenu or PaletteBackStyle.ControlCustom1 or PaletteBackStyle.ControlCustom2 or PaletteBackStyle.ControlCustom3 or PaletteBackStyle.ContextMenuOuter or PaletteBackStyle.ContextMenuInner or PaletteBackStyle.ContextMenuHeading or PaletteBackStyle.ContextMenuSeparator or PaletteBackStyle.ContextMenuItemSplit or PaletteBackStyle.ContextMenuItemImageColumn or PaletteBackStyle.ContextMenuItemImage or PaletteBackStyle.ContextMenuItemHighlight or PaletteBackStyle.InputControlStandalone or PaletteBackStyle.InputControlRibbon or PaletteBackStyle.InputControlCustom1 or PaletteBackStyle.InputControlCustom2 or PaletteBackStyle.InputControlCustom3 or PaletteBackStyle.FormMain or PaletteBackStyle.FormCustom1 or PaletteBackStyle.FormCustom2 or PaletteBackStyle.FormCustom3 or PaletteBackStyle.HeaderPrimary or PaletteBackStyle.HeaderDockInactive or PaletteBackStyle.HeaderDockActive or PaletteBackStyle.HeaderSecondary or PaletteBackStyle.HeaderForm or PaletteBackStyle.HeaderCalendar or PaletteBackStyle.HeaderCustom1 or PaletteBackStyle.HeaderCustom2 or PaletteBackStyle.HeaderCustom3 or PaletteBackStyle.ButtonStandalone or PaletteBackStyle.ButtonGallery or PaletteBackStyle.ButtonAlternate or PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonCalendarDay or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ButtonCluster or PaletteBackStyle.ButtonNavigatorStack or PaletteBackStyle.ButtonNavigatorOverflow or PaletteBackStyle.ButtonNavigatorMini or PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose or PaletteBackStyle.ButtonCustom1 or PaletteBackStyle.ButtonCustom2 or PaletteBackStyle.ButtonCustom3 or PaletteBackStyle.ButtonInputControl or PaletteBackStyle.GridBackgroundList or PaletteBackStyle.GridBackgroundSheet or PaletteBackStyle.GridBackgroundCustom1
-                    or PaletteBackStyle.GridBackgroundCustom2
-                    or PaletteBackStyle.GridBackgroundCustom3
- or PaletteBackStyle.GridHeaderColumnList or PaletteBackStyle.GridHeaderColumnSheet or PaletteBackStyle.GridHeaderColumnCustom1 or PaletteBackStyle.GridHeaderColumnCustom2 or PaletteBackStyle.GridHeaderColumnCustom3 or PaletteBackStyle.GridHeaderRowList or PaletteBackStyle.GridHeaderRowSheet or PaletteBackStyle.GridHeaderRowCustom1 or PaletteBackStyle.GridHeaderRowCustom2 or PaletteBackStyle.GridHeaderRowCustom3 or PaletteBackStyle.GridDataCellList or PaletteBackStyle.GridDataCellSheet or PaletteBackStyle.GridDataCellCustom1 or PaletteBackStyle.GridDataCellCustom2 or PaletteBackStyle.GridDataCellCustom3 => PaletteGraphicsHint.None,
+                PaletteBackStyle.TabHighProfile or PaletteBackStyle.TabStandardProfile or PaletteBackStyle.TabLowProfile or
+                    PaletteBackStyle.TabOneNote or PaletteBackStyle.TabDock or PaletteBackStyle.TabDockAutoHidden or
+                    PaletteBackStyle.TabCustom1 or PaletteBackStyle.TabCustom2 or PaletteBackStyle.TabCustom3 or
+                    PaletteBackStyle.PanelClient or PaletteBackStyle.PanelRibbonInactive or PaletteBackStyle.PanelAlternate or
+                    PaletteBackStyle.PanelCustom1 or PaletteBackStyle.PanelCustom2 or PaletteBackStyle.PanelCustom3 or
+                    PaletteBackStyle.SeparatorHighInternalProfile or PaletteBackStyle.SeparatorHighProfile or
+                    PaletteBackStyle.SeparatorLowProfile or PaletteBackStyle.SeparatorCustom1 or PaletteBackStyle.SeparatorCustom2 or
+                    PaletteBackStyle.SeparatorCustom3 or PaletteBackStyle.ControlClient or PaletteBackStyle.ControlAlternate or
+                    PaletteBackStyle.ControlGroupBox or PaletteBackStyle.ControlToolTip or PaletteBackStyle.ControlRibbon or
+                    PaletteBackStyle.ControlRibbonAppMenu or PaletteBackStyle.ControlCustom1 or PaletteBackStyle.ControlCustom2 or
+                    PaletteBackStyle.ControlCustom3 or PaletteBackStyle.ContextMenuOuter or PaletteBackStyle.ContextMenuInner or
+                    PaletteBackStyle.ContextMenuHeading or PaletteBackStyle.ContextMenuSeparator or PaletteBackStyle.ContextMenuItemSplit or
+                    PaletteBackStyle.ContextMenuItemImageColumn or PaletteBackStyle.ContextMenuItemImage or
+                    PaletteBackStyle.ContextMenuItemHighlight or PaletteBackStyle.InputControlStandalone or
+                    PaletteBackStyle.InputControlRibbon or PaletteBackStyle.InputControlCustom1 or PaletteBackStyle.InputControlCustom2 or
+                    PaletteBackStyle.InputControlCustom3 or PaletteBackStyle.FormMain or PaletteBackStyle.FormCustom1 or
+                    PaletteBackStyle.FormCustom2 or PaletteBackStyle.FormCustom3 or PaletteBackStyle.HeaderPrimary or
+                    PaletteBackStyle.HeaderDockInactive or PaletteBackStyle.HeaderDockActive or PaletteBackStyle.HeaderSecondary or
+                    PaletteBackStyle.HeaderForm or PaletteBackStyle.HeaderCalendar or PaletteBackStyle.HeaderCustom1 or
+                    PaletteBackStyle.HeaderCustom2 or PaletteBackStyle.HeaderCustom3 or PaletteBackStyle.ButtonStandalone or
+                    PaletteBackStyle.ButtonGallery or PaletteBackStyle.ButtonAlternate or PaletteBackStyle.ButtonLowProfile or
+                    PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or
+                    PaletteBackStyle.ButtonCalendarDay or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ButtonCluster or
+                    PaletteBackStyle.ButtonNavigatorStack or PaletteBackStyle.ButtonNavigatorOverflow or PaletteBackStyle.ButtonNavigatorMini or
+                    PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose or PaletteBackStyle.ButtonCustom1 or
+                    PaletteBackStyle.ButtonCustom2 or PaletteBackStyle.ButtonCustom3 or PaletteBackStyle.ButtonInputControl or
+                    PaletteBackStyle.GridBackgroundList or PaletteBackStyle.GridBackgroundSheet or PaletteBackStyle.GridBackgroundCustom1 or
+                    PaletteBackStyle.GridBackgroundCustom2 or PaletteBackStyle.GridBackgroundCustom3 or PaletteBackStyle.GridHeaderColumnList or
+                    PaletteBackStyle.GridHeaderColumnSheet or PaletteBackStyle.GridHeaderColumnCustom1 or PaletteBackStyle.GridHeaderColumnCustom2 or
+                    PaletteBackStyle.GridHeaderColumnCustom3 or PaletteBackStyle.GridHeaderRowList or PaletteBackStyle.GridHeaderRowSheet or
+                    PaletteBackStyle.GridHeaderRowCustom1 or PaletteBackStyle.GridHeaderRowCustom2 or PaletteBackStyle.GridHeaderRowCustom3 or
+                    PaletteBackStyle.GridDataCellList or PaletteBackStyle.GridDataCellSheet or PaletteBackStyle.GridDataCellCustom1 or
+                    PaletteBackStyle.GridDataCellCustom2 or PaletteBackStyle.GridDataCellCustom3 => PaletteGraphicsHint.None,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -2064,26 +2101,31 @@ namespace Krypton.Toolkit
             {
                 return style switch
                 {
-                    PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl => state switch
-                    {
-                        PaletteState.LinkNotVisitedOverride => _ribbonColors[
-                            (int)SchemeOfficeColors.LinkNotVisitedOverrideControl],
-                        PaletteState.LinkVisitedOverride => _ribbonColors[
-                            (int)SchemeOfficeColors.LinkVisitedOverrideControl],
-                        PaletteState.LinkPressedOverride => _ribbonColors[
-                            (int)SchemeOfficeColors.LinkPressedOverrideControl],
-                        _ => Color.Empty
-                    },
-                    PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelGroupBoxCaption => state switch
-                    {
-                        PaletteState.LinkNotVisitedOverride => _ribbonColors[
-                            (int)SchemeOfficeColors.LinkNotVisitedOverridePanel],
-                        PaletteState.LinkVisitedOverride => _ribbonColors[
-                            (int)SchemeOfficeColors.LinkVisitedOverridePanel],
-                        PaletteState.LinkPressedOverride => _ribbonColors[
-                            (int)SchemeOfficeColors.LinkPressedOverridePanel],
-                        _ => Color.Empty
-                    },
+                    PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or
+                        PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl
+                        => state switch
+                        {
+                            PaletteState.LinkNotVisitedOverride => _ribbonColors[
+                                (int)SchemeOfficeColors.LinkNotVisitedOverrideControl],
+                            PaletteState.LinkVisitedOverride => _ribbonColors[
+                                (int)SchemeOfficeColors.LinkVisitedOverrideControl],
+                            PaletteState.LinkPressedOverride => _ribbonColors[
+                                (int)SchemeOfficeColors.LinkPressedOverrideControl],
+                            _ => Color.Empty
+                        },
+                    PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or
+                        PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or
+                        PaletteContentStyle.LabelGroupBoxCaption
+                        => state switch
+                        {
+                            PaletteState.LinkNotVisitedOverride => _ribbonColors[
+                                (int)SchemeOfficeColors.LinkNotVisitedOverridePanel],
+                            PaletteState.LinkVisitedOverride => _ribbonColors[
+                                (int)SchemeOfficeColors.LinkVisitedOverridePanel],
+                            PaletteState.LinkPressedOverride => _ribbonColors[
+                                (int)SchemeOfficeColors.LinkPressedOverridePanel],
+                            _ => Color.Empty
+                        },
                     _ => Color.Empty
                 };
             }
@@ -2113,41 +2155,67 @@ namespace Krypton.Toolkit
 
             return style switch
             {
-                PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 or PaletteContentStyle.HeaderCalendar => _gridTextColor,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderSecondary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _ribbonColors[(int)SchemeOfficeColors.HeaderText],
-                PaletteContentStyle.HeaderDockActive => Color.Black,
-                PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => state == PaletteState.Disabled
-? _ribbonColors[(int)SchemeOfficeColors.InputControlTextDisabled]
-: _ribbonColors[(int)SchemeOfficeColors.InputControlTextNormal],
-                PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelGroupBoxCaption => _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 or PaletteContentStyle.ContextMenuItemImage or PaletteContentStyle.ContextMenuItemTextStandard or PaletteContentStyle.ContextMenuItemShortcutText or PaletteContentStyle.ContextMenuItemTextAlternate => _ribbonColors[(int)SchemeOfficeColors.TextLabelControl],
-                PaletteContentStyle.LabelToolTip or PaletteContentStyle.LabelSuperTip or PaletteContentStyle.LabelKeyTip => _toolTipText,
+                PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1
+                    or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList
+                    or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2
+                    or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet
+                    or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3
+                    or PaletteContentStyle.HeaderCalendar => _gridTextColor,
+                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderSecondary
+                    or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3
+                    => _ribbonColors[(int)SchemeOfficeColors.HeaderText],
+                PaletteContentStyle.HeaderDockActive
+                    => Color.Black,
+                PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or
+                    PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or
+                    PaletteContentStyle.InputControlCustom3
+                    => state == PaletteState.Disabled
+                        ? _ribbonColors[(int)SchemeOfficeColors.InputControlTextDisabled]
+                        : _ribbonColors[(int)SchemeOfficeColors.InputControlTextNormal],
+                PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or
+                    PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelGroupBoxCaption => _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
+                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or
+                    PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or
+                    PaletteContentStyle.LabelCustom3 or PaletteContentStyle.ContextMenuItemImage or PaletteContentStyle.ContextMenuItemTextStandard or
+                    PaletteContentStyle.ContextMenuItemShortcutText or PaletteContentStyle.ContextMenuItemTextAlternate
+                        => _ribbonColors[(int)SchemeOfficeColors.TextLabelControl],
+                PaletteContentStyle.LabelToolTip or PaletteContentStyle.LabelSuperTip or PaletteContentStyle.LabelKeyTip
+                        => _toolTipText,
                 PaletteContentStyle.ContextMenuHeading => _ribbonColors[(int)SchemeOfficeColors.ContextMenuHeadingText],
-                PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabDock or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 or PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonGallery or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => state != PaletteState.Normal
-? _ribbonColors[(int)SchemeOfficeColors.TextButtonChecked]
-: _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal],
+                PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or
+                    PaletteContentStyle.TabOneNote or PaletteContentStyle.TabDock or PaletteContentStyle.TabCustom1 or
+                    PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 or PaletteContentStyle.ButtonStandalone or
+                    PaletteContentStyle.ButtonGallery or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonCluster or
+                    PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3
+                        => state != PaletteState.Normal
+                            ? _ribbonColors[(int)SchemeOfficeColors.TextButtonChecked]
+                            : _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal],
                 PaletteContentStyle.TabDockAutoHidden => _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal],
                 PaletteContentStyle.ButtonCalendarDay => state == PaletteState.Disabled ? _disabledText2 : Color.Black,
-                PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
+                PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or
+                    PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
-                    PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeOfficeColors.TextButtonChecked],
+                       ? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
+                       : _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
+                    PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed
+                        => _ribbonColors[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal]
                 },
                 PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => state switch
                 {
                     PaletteState.Tracking or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeOfficeColors.TextButtonFormTracking],
-                    PaletteState.Pressed or PaletteState.CheckedPressed or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeOfficeColors.TextButtonFormPressed],
+                    PaletteState.Pressed or PaletteState.CheckedPressed or PaletteState.CheckedNormal
+                        => _ribbonColors[(int)SchemeOfficeColors.TextButtonFormPressed],
                     _ => _ribbonColors[(int)SchemeOfficeColors.TextButtonFormNormal]
                 },
                 PaletteContentStyle.ButtonInputControl => state != PaletteState.Disabled
-? _ribbonColors[(int)SchemeOfficeColors.InputDropDownNormal1]
-: _ribbonColors[(int)SchemeOfficeColors.InputDropDownDisabled1],
-                PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => state != PaletteState.Normal
-? _ribbonColors[(int)SchemeOfficeColors.ButtonNavigatorText]
-: _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal],
+                    ? _ribbonColors[(int)SchemeOfficeColors.InputDropDownNormal1]
+                    : _ribbonColors[(int)SchemeOfficeColors.InputDropDownDisabled1],
+                PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonNavigatorStack or
+                    PaletteContentStyle.ButtonNavigatorOverflow => state != PaletteState.Normal
+                        ? _ribbonColors[(int)SchemeOfficeColors.ButtonNavigatorText]
+                        : _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal],
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -4252,14 +4320,6 @@ namespace Krypton.Toolkit
         }
         #endregion
 
-        #region ColorTable
-        /// <summary>
-        /// Gets access to the color table instance.
-        /// </summary>
-        public override KryptonColorTable ColorTable => _table ??= new KryptonColorTable2010(_ribbonColors, InheritBool.True, this);
-
-        #endregion
-
         #region OnUserPreferenceChanged
         /// <summary>
         /// Handle a change in the user preferences.
@@ -4269,7 +4329,7 @@ namespace Krypton.Toolkit
         protected override void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e)
         {
             // Remove the current table, so it gets regenerated when next requested
-            _table = null;
+            Table = null;
 
             // Update fonts to reflect any change in system settings
             DefineFonts();

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Non Official Themes/PaletteOffice2010White.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Non Official Themes/PaletteOffice2010White.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved.
+ *
  */
 #endregion
 
@@ -46,240 +46,240 @@ namespace Krypton.Toolkit
         private static readonly Color[] _trackBarColors =
         [
             Color.Red,      // Tick marks
-                                                                        Color.FromArgb(166, 170, 175),      // Top track
-                                                                        Color.FromArgb(226, 220, 235),      // Bottom track
-                                                                        Color.FromArgb(206, 200, 215),      // Fill track
-                                                                        Color.FromArgb(64, Color.White),    // Outside position
-                                                                        Color.FromArgb(80, 81, 82)          // Border (normal) position
+            Color.FromArgb(166, 170, 175),      // Top track
+            Color.FromArgb(226, 220, 235),      // Bottom track
+            Color.FromArgb(206, 200, 215),      // Fill track
+            Color.FromArgb(64, Color.White),    // Outside position
+            Color.FromArgb(80, 81, 82)          // Border (normal) position
         ];
         private static readonly Color[] _schemeOfficeColors =
         [
-            Color.FromArgb( 59,  59,  59),    // TextLabelControl
-                                                                      Color.FromArgb( 59,  59,  59),    // TextButtonNormal
-                                                                      Color.Black,                      // TextButtonChecked
-                                                                      Color.FromArgb(170, 170, 170),    // ButtonNormalBorder1 -n
-                                                                      Color.FromArgb(170, 170, 170),    // ButtonNormalDefaultBorder -n
-                                                                      Color.FromArgb(253, 253, 253),    // ButtonNormalBack1 -n
-                                                                      Color.FromArgb(253, 253, 253),    // ButtonNormalBack2 -n
-                                                                      Color.FromArgb(235, 235, 235),    // ButtonNormalDefaultBack1
-                                                                      Color.FromArgb(195, 195, 195),    // ButtonNormalDefaultBack2
-                                                                      Color.FromArgb(207, 212, 218),    // ButtonNormalNavigatorBack1
-                                                                      Color.FromArgb(207, 212, 218),    // ButtonNormalNavigatorBack2
-                                                                      Color.White                  ,    // PanelClient -n
-                                                                      Color.FromArgb(207, 212, 218),    // PanelAlternative
-                                                                      Color.FromArgb(213, 213, 213),    // ControlBorder -n
-                                                                      Color.FromArgb(250, 253, 255),    // SeparatorHighBorder1
-                                                                      Color.FromArgb(227, 232, 237),    // SeparatorHighBorder2
-                                                                      Color.FromArgb(255, 255, 255),    // HeaderPrimaryBack1 -n
-                                                                      Color.FromArgb(255, 255, 255),    // HeaderPrimaryBack2 -n
-                                                                      Color.FromArgb(255, 255, 255),    // HeaderSecondaryBack1
-                                                                      Color.FromArgb(255, 255, 255),    // HeaderSecondaryBack2-n
-                                                                      Color.FromArgb( 59,  59,  59),    // HeaderText
-                                                                      Color.FromArgb(255, 255, 255),    // StatusStripText
-                                                                      Color.FromArgb(236, 199,  87),    // ButtonBorder
-                                                                      Color.FromArgb(247, 250, 252),    // SeparatorLight
-                                                                      Color.FromArgb(119, 123, 127),    // SeparatorDark
-                                                                      Color.FromArgb(191, 191, 191),    // GripLight
-                                                                      Color.FromArgb(191, 191, 191),    // GripDark
-                                                                      Color.FromArgb(227, 230, 232),    // ToolStripBack
-                                                                      Color.FromArgb(0  , 114, 198),    // StatusStripLight
-                                                                      Color.FromArgb(0  , 114, 198),    // StatusStripDark
-                                                                      Color.White,                      // ImageMargin
-                                                                      Color.FromArgb( 25,  71, 138),    // ToolStripBegin
-                                                                      Color.FromArgb( 25,  71, 138),    // ToolStripMiddle
-                                                                      Color.FromArgb( 25,  71, 138),    // ToolStripEnd
-                                                                      Color.FromArgb(147, 154, 163),    // OverflowBegin
-                                                                      Color.FromArgb(147, 154, 163),    // OverflowMiddle
-                                                                      Color.FromArgb(147, 154, 163),    // OverflowEnd
-                                                                      Color.FromArgb(147, 154, 163),    // ToolStripBorder
-                                                                      Color.FromArgb(0  , 114, 198),    // FormBorderActive -n
-                                                                      Color.FromArgb(134, 139, 145),    // FormBorderInactive
-                                                                      Color.FromArgb(228, 230, 232),    // FormBorderActiveLight
-                                                                      Color.FromArgb(255, 255, 255),    // FormBorderActiveDark
-                                                                      Color.FromArgb(248, 247, 247),    // FormBorderInactiveLight
-                                                                      Color.FromArgb(248, 247, 247),    // FormBorderInactiveDark
-                                                                      Color.FromArgb(101, 109, 117),    // FormBorderHeaderActive
-                                                                      Color.FromArgb(134, 139, 145),    // FormBorderHeaderInactive
-                                                                      Color.FromArgb(235, 237, 240),    // FormBorderHeaderActive1
-                                                                      Color.FromArgb(228, 230, 232),    // FormBorderHeaderActive2
-                                                                      Color.FromArgb(248, 247, 247),    // FormBorderHeaderInctive1
-                                                                      Color.FromArgb(248, 247, 247),    // FormBorderHeaderInctive2
-                                                                      Color.FromArgb( 59,  59,  59),    // FormHeaderShortActive
-                                                                      Color.FromArgb(138, 138, 138),    // FormHeaderShortInactive
-                                                                      Color.FromArgb( 59,  59,  59),    // FormHeaderLongActive
-                                                                      Color.FromArgb(138, 138, 138),    // FormHeaderLongInactive
-                                                                      Color.FromArgb(166, 172, 179),    // FormButtonBorderTrack
-                                                                      Color.FromArgb(255, 255, 255),    // FormButtonBack1Track
-                                                                      Color.FromArgb(228, 228, 229),    // FormButtonBack2Track
-                                                                      Color.FromArgb(166, 172, 179),    // FormButtonBorderPressed
-                                                                      Color.FromArgb(223, 228, 235),    // FormButtonBack1Pressed
-                                                                      Color.FromArgb(188, 193, 200),    // FormButtonBack2Pressed
-                                                                      Color.Black,                      // TextButtonFormNormal
-                                                                      Color.Black,                      // TextButtonFormTracking
-                                                                      Color.Black,                      // TextButtonFormPressed
-                                                                      Color.Blue,                       // LinkNotVisitedOverrideControl
-                                                                      Color.Purple,                     // LinkVisitedOverrideControl
-                                                                      Color.Red,                        // LinkPressedOverrideControl
-                                                                      Color.Blue,                       // LinkNotVisitedOverridePanel
-                                                                      Color.Purple,                     // LinkVisitedOverridePanel
-                                                                      Color.Red,                        // LinkPressedOverridePanel
-                                                                      Color.FromArgb( 59,  59,  59),    // TextLabelPanel
-                                                                      Color.FromArgb(102, 102, 102),    // RibbonTabTextNormal -n
-                                                                      Color.FromArgb(  0, 114, 198),    // RibbonTabTextChecked -n
-                                                                      Color.FromArgb(182, 186, 191),    // RibbonTabSelected1
-                                                                      Color.White,                      // RibbonTabSelected2
-                                                                      Color.White,                      // RibbonTabSelected3
-                                                                      Color.White,                      // RibbonTabSelected4
-                                                                      Color.White,                      // RibbonTabSelected5
-                                                                      Color.FromArgb(177, 181, 186),    // RibbonTabTracking1
-                                                                      Color.FromArgb(248, 249, 249),    // RibbonTabTracking2
-                                                                      Color.FromArgb(182, 186, 191),    // RibbonTabHighlight1
-                                                                      Color.White,                      // RibbonTabHighlight2
-                                                                      Color.White,                      // RibbonTabHighlight3
-                                                                      Color.White,                      // RibbonTabHighlight4
-                                                                      Color.White,                      // RibbonTabHighlight5
-                                                                      Color.FromArgb(182, 186, 191),    // RibbonTabSeparatorColor
-                                                                      Color.FromArgb(212, 212, 212),    // RibbonGroupsArea1 -n
-                                                                      Color.FromArgb(212, 212, 212),    // RibbonGroupsArea2 -n
-                                                                      Color.White,                      // RibbonGroupsArea3 -n
-                                                                      Color.White,                      // RibbonGroupsArea4 -n
-                                                                      Color.White,                      // RibbonGroupsArea5 -n
-                                                                      Color.Empty,                      // RibbonGroupBorder1 -n
-                                                                      Color.Empty,                      // RibbonGroupBorder2 -n
-                                                                      Color.Empty,                      // RibbonGroupTitle1
-                                                                      Color.Empty,                      // RibbonGroupTitle2
-                                                                      Color.Empty,                      // RibbonGroupBorderContext1
-                                                                      Color.Empty,                      // RibbonGroupBorderContext2
-                                                                      Color.Empty,                      // RibbonGroupTitleContext1
-                                                                      Color.Empty,                      // RibbonGroupTitleContext2
-                                                                      Color.FromArgb(148, 149, 152),    // RibbonGroupDialogDark
-                                                                      Color.FromArgb(180, 182, 183),    // RibbonGroupDialogLight
-                                                                      Color.Empty,                      // RibbonGroupTitleTracking1
-                                                                      Color.Empty,                      // RibbonGroupTitleTracking2
-                                                                      Color.FromArgb(139, 144, 151),    // RibbonMinimizeBarDark
-                                                                      Color.FromArgb(205, 209, 214),    // RibbonMinimizeBarLight
-                                                                      Color.Empty,                      // RibbonGroupCollapsedBorder1
-                                                                      Color.Empty,                      // RibbonGroupCollapsedBorder2
-                                                                      Color.Empty,                      // RibbonGroupCollapsedBorder3
-                                                                      Color.Empty,                      // RibbonGroupCollapsedBorder4
-                                                                      Color.Empty,                      // RibbonGroupCollapsedBack1
-                                                                      Color.Empty,                      // RibbonGroupCollapsedBack2
-                                                                      Color.Empty,                      // RibbonGroupCollapsedBack3
-                                                                      Color.Empty,                      // RibbonGroupCollapsedBack4
-                                                                      Color.Empty,                      // RibbonGroupCollapsedBorderT1
-                                                                      Color.Empty,                      // RibbonGroupCollapsedBorderT2
-                                                                      Color.Empty,                      // RibbonGroupCollapsedBorderT3
-                                                                      Color.Empty,                      // RibbonGroupCollapsedBorderT4
-                                                                      Color.Empty,                      // RibbonGroupCollapsedBackT1
-                                                                      Color.FromArgb(242, 244, 247),    // RibbonGroupCollapsedBackT2
-                                                                      Color.FromArgb(238, 241, 245),    // RibbonGroupCollapsedBackT3
-                                                                      Color.FromArgb(234, 235, 235),    // RibbonGroupCollapsedBackT4
-                                                                      Color.FromArgb(208, 212, 217),    // RibbonGroupFrameBorder1
-                                                                      Color.FromArgb(208, 212, 217),    // RibbonGroupFrameBorder2
-                                                                      Color.FromArgb(254, 254, 254),    // RibbonGroupFrameInside1
-                                                                      Color.FromArgb(254, 254, 254),    // RibbonGroupFrameInside2
-                                                                      Color.Empty,                      // RibbonGroupFrameInside3
-                                                                      Color.Empty,                      // RibbonGroupFrameInside4
-                                                                      Color.FromArgb( 59,  59,  59),    // RibbonGroupCollapsedText         
-                                                                      Color.FromArgb(179, 185, 195),    // AlternatePressedBack1
-                                                                      Color.FromArgb(216, 224, 224),    // AlternatePressedBack2
-                                                                      Color.FromArgb(125, 125, 125),    // AlternatePressedBorder1
-                                                                      Color.FromArgb(186, 186, 186),    // AlternatePressedBorder2
-                                                                      Color.FromArgb(157, 166, 174),    // FormButtonBack1Checked
-                                                                      Color.FromArgb(222, 230, 242),    // FormButtonBack2Checked
-                                                                      Color.FromArgb(149, 154, 160),    // FormButtonBorderCheck
-                                                                      Color.FromArgb(147, 156, 164),    // FormButtonBack1CheckTrack
-                                                                      Color.FromArgb(237, 245, 250),    // FormButtonBack2CheckTrack
-                                                                      Color.FromArgb(180, 180, 180),    // RibbonQATMini1
-                                                                      Color.FromArgb(210, 215, 221),    // RibbonQATMini2
-                                                                      Color.FromArgb(195, 200, 206),    // RibbonQATMini3
-                                                                      Color.FromArgb(10, Color.White),  // RibbonQATMini4
-                                                                      Color.FromArgb(32, Color.White),  // RibbonQATMini5                                                       
-                                                                      Color.FromArgb(200, 200, 200),    // RibbonQATMini1I
-                                                                      Color.FromArgb(233, 234, 238),    // RibbonQATMini2I
-                                                                      Color.FromArgb(223, 224, 228),    // RibbonQATMini3I
-                                                                      Color.FromArgb(10, Color.White),  // RibbonQATMini4I
-                                                                      Color.FromArgb(32, Color.White),  // RibbonQATMini5I                                                       
-                                                                      Color.FromArgb(223, 227, 234),    // RibbonQATFullbar1                                                      
-                                                                      Color.FromArgb(213, 217, 222),    // RibbonQATFullbar2                                                      
-                                                                      Color.FromArgb(135, 140, 146),    // RibbonQATFullbar3                                                      
-                                                                      Color.FromArgb( 90,  90,  90),    // RibbonQATButtonDark                                                      
-                                                                      Color.FromArgb(210, 212, 215),    // RibbonQATButtonLight                                                      
-                                                                      Color.FromArgb(233, 237, 241),    // RibbonQATOverflow1                                                      
-                                                                      Color.FromArgb(138, 144, 150),    // RibbonQATOverflow2                                                      
-                                                                      Color.FromArgb(191, 195, 199),    // RibbonGroupSeparatorDark                                                      
-                                                                      Color.FromArgb(255, 255, 255),    // RibbonGroupSeparatorLight                                                      
-                                                                      Color.FromArgb(231, 234, 238),    // ButtonClusterButtonBack1                                                      
-                                                                      Color.FromArgb(241, 243, 243),    // ButtonClusterButtonBack2                                                      
-                                                                      Color.FromArgb(197, 198, 199),    // ButtonClusterButtonBorder1                                                      
-                                                                      Color.FromArgb(157, 158, 159),    // ButtonClusterButtonBorder2                                                      
-                                                                      Color.FromArgb(238, 238, 244),    // NavigatorMiniBackColor                                                    
-                                                                      Color.White,    // GridListNormal1                                                    
-                                                                      Color.White,    // GridListNormal2                                                    
-                                                                      Color.FromArgb(203, 207, 212),    // GridListPressed1                                                    
-                                                                      Color.White,                      // GridListPressed2                                                    
-                                                                      Color.FromArgb(186, 189, 194),    // GridListSelected                                                    
-                                                                      Color.FromArgb(238, 241, 247),    // GridSheetColNormal1                                                    
-                                                                      Color.FromArgb(218, 222, 227),    // GridSheetColNormal2                                                    
-                                                                      Color.FromArgb(255, 223, 107),    // GridSheetColPressed1                                                    
-                                                                      Color.FromArgb(255, 252, 230),    // GridSheetColPressed2                                                    
-                                                                      Color.FromArgb(255, 211,  89),    // GridSheetColSelected1
-                                                                      Color.FromArgb(255, 239, 113),    // GridSheetColSelected2
-                                                                      Color.FromArgb(223, 227, 232),    // GridSheetRowNormal                                                   
-                                                                      Color.FromArgb(255, 223, 107),    // GridSheetRowPressed
-                                                                      Color.FromArgb(245, 210,  87),    // GridSheetRowSelected
-                                                                      Color.FromArgb(218, 220, 221),    // GridDataCellBorder
-                                                                      Color.FromArgb(183, 219, 255),    // GridDataCellSelected
-                                                                      Color.Black,                      // InputControlTextNormal
-                                                                      Color.FromArgb(168, 168, 168),    // InputControlTextDisabled
-                                                                      Color.FromArgb(212, 214, 217),    // InputControlBorderNormal
-                                                                      Color.FromArgb(187, 187, 187),    // InputControlBorderDisabled
-                                                                      Color.FromArgb(255, 255, 255),    // InputControlBackNormal
-                                                                      Color.FromArgb(240, 240, 240),    // InputControlBackDisabled
-                                                                      Color.FromArgb(247, 247, 247),    // InputControlBackInactive
-                                                                      Color.Black,                      // InputDropDownNormal1
-                                                                      Color.Transparent,                // InputDropDownNormal2
-                                                                      Color.FromArgb(172, 168, 153),    // InputDropDownDisabled1
-                                                                      Color.Transparent,                // InputDropDownDisabled2
-                                                                      Color.FromArgb(240, 242, 245),    // ContextMenuHeadingBack
-                                                                      Color.FromArgb( 59,  59,  59),    // ContextMenuHeadingText
-                                                                      Color.White,                      // ContextMenuImageColumn
-                                                                      Color.FromArgb(224, 227, 231),    // AppButtonBack1
-                                                                      Color.FromArgb(224, 227, 231),    // AppButtonBack2
-                                                                      Color.FromArgb(135, 140, 146),    // AppButtonBorder
-                                                                      Color.FromArgb(224, 227, 231),    // AppButtonOuter1
-                                                                      Color.FromArgb(224, 227, 231),    // AppButtonOuter2
-                                                                      Color.FromArgb(224, 227, 231),    // AppButtonOuter3
-                                                                      Color.Empty,                      // AppButtonInner1
-                                                                      Color.FromArgb(135, 140, 146),    // AppButtonInner2
-                                                                      Color.White,                      // AppButtonMenuDocs
-                                                                      Color.Black,                      // AppButtonMenuDocsText
-                                                                      Color.FromArgb(250, 253, 255),    // SeparatorHighInternalBorder1
-                                                                      Color.FromArgb(227, 232, 237),    // SeparatorHighInternalBorder2
-                                                                      Color.FromArgb(198, 202, 205),    // RibbonGalleryBorder
-                                                                      Color.FromArgb(255, 255, 255),    // RibbonGalleryBackNormal
-                                                                      Color.FromArgb(255, 255, 255),    // RibbonGalleryBackTracking
-                                                                      Color.FromArgb(250, 250, 250),    // RibbonGalleryBack1
-                                                                      Color.FromArgb(228, 231, 235),    // RibbonGalleryBack2                                                                                                                                      Color.FromArgb(177, 181, 186),    // RibbonTabTracking1
-                                                                      Color.FromArgb(229, 231, 235),    // RibbonTabTracking3
-                                                                      Color.FromArgb(231, 233, 235),    // RibbonTabTracking4
-                                                                      Color.FromArgb(176, 182, 188),    // RibbonGroupBorder3
-                                                                      Color.FromArgb(246, 247, 248),    // RibbonGroupBorder4
-                                                                      Color.FromArgb(249, 250, 250),    // RibbonGroupBorder5
-                                                                      Color.FromArgb(102, 109, 124),    // RibbonGroupTitleText
-                                                                      Color.FromArgb(151, 156, 163),    // RibbonDropArrowLight
-                                                                      Color.FromArgb( 39,  49,  60),    // RibbonDropArrowDark
-                                                                      Color.FromArgb(237, 242, 248),    // HeaderDockInactiveBack1
-                                                                      Color.FromArgb(207, 213, 220),    // HeaderDockInactiveBack2
-                                                                      Color.FromArgb(161, 169, 179),    // ButtonNavigatorBorder
-                                                                      Color.Black,                      // ButtonNavigatorText
-                                                                      Color.FromArgb(207, 213, 220),    // ButtonNavigatorTrack1
-                                                                      Color.FromArgb(232, 234, 238),    // ButtonNavigatorTrack2
-                                                                      Color.FromArgb(191, 196, 202),    // ButtonNavigatorPressed1
-                                                                      Color.FromArgb(225, 226, 230),    // ButtonNavigatorPressed2
-                                                                      Color.FromArgb(222, 227, 234),    // ButtonNavigatorChecked1
-                                                                      Color.FromArgb(206, 214, 221),    // ButtonNavigatorChecked2
-                                                                      Color.FromArgb(221, 221, 221) // ToolTipBottom                                                                      
+              Color.FromArgb( 59,  59,  59),    // TextLabelControl
+              Color.FromArgb( 59,  59,  59),    // TextButtonNormal
+              Color.Black,                      // TextButtonChecked
+              Color.FromArgb(170, 170, 170),    // ButtonNormalBorder1 -n
+              Color.FromArgb(170, 170, 170),    // ButtonNormalDefaultBorder -n
+              Color.FromArgb(253, 253, 253),    // ButtonNormalBack1 -n
+              Color.FromArgb(253, 253, 253),    // ButtonNormalBack2 -n
+              Color.FromArgb(235, 235, 235),    // ButtonNormalDefaultBack1
+              Color.FromArgb(195, 195, 195),    // ButtonNormalDefaultBack2
+              Color.FromArgb(207, 212, 218),    // ButtonNormalNavigatorBack1
+              Color.FromArgb(207, 212, 218),    // ButtonNormalNavigatorBack2
+              Color.White                  ,    // PanelClient -n
+              Color.FromArgb(207, 212, 218),    // PanelAlternative
+              Color.FromArgb(213, 213, 213),    // ControlBorder -n
+              Color.FromArgb(250, 253, 255),    // SeparatorHighBorder1
+              Color.FromArgb(227, 232, 237),    // SeparatorHighBorder2
+              Color.FromArgb(255, 255, 255),    // HeaderPrimaryBack1 -n
+              Color.FromArgb(255, 255, 255),    // HeaderPrimaryBack2 -n
+              Color.FromArgb(255, 255, 255),    // HeaderSecondaryBack1
+              Color.FromArgb(255, 255, 255),    // HeaderSecondaryBack2-n
+              Color.FromArgb( 59,  59,  59),    // HeaderText
+              Color.FromArgb(255, 255, 255),    // StatusStripText
+              Color.FromArgb(236, 199,  87),    // ButtonBorder
+              Color.FromArgb(247, 250, 252),    // SeparatorLight
+              Color.FromArgb(119, 123, 127),    // SeparatorDark
+              Color.FromArgb(191, 191, 191),    // GripLight
+              Color.FromArgb(191, 191, 191),    // GripDark
+              Color.FromArgb(227, 230, 232),    // ToolStripBack
+              Color.FromArgb(0  , 114, 198),    // StatusStripLight
+              Color.FromArgb(0  , 114, 198),    // StatusStripDark
+              Color.White,                      // ImageMargin
+              Color.FromArgb( 25,  71, 138),    // ToolStripBegin
+              Color.FromArgb( 25,  71, 138),    // ToolStripMiddle
+              Color.FromArgb( 25,  71, 138),    // ToolStripEnd
+              Color.FromArgb(147, 154, 163),    // OverflowBegin
+              Color.FromArgb(147, 154, 163),    // OverflowMiddle
+              Color.FromArgb(147, 154, 163),    // OverflowEnd
+              Color.FromArgb(147, 154, 163),    // ToolStripBorder
+              Color.FromArgb(0  , 114, 198),    // FormBorderActive -n
+              Color.FromArgb(134, 139, 145),    // FormBorderInactive
+              Color.FromArgb(228, 230, 232),    // FormBorderActiveLight
+              Color.FromArgb(255, 255, 255),    // FormBorderActiveDark
+              Color.FromArgb(248, 247, 247),    // FormBorderInactiveLight
+              Color.FromArgb(248, 247, 247),    // FormBorderInactiveDark
+              Color.FromArgb(101, 109, 117),    // FormBorderHeaderActive
+              Color.FromArgb(134, 139, 145),    // FormBorderHeaderInactive
+              Color.FromArgb(235, 237, 240),    // FormBorderHeaderActive1
+              Color.FromArgb(228, 230, 232),    // FormBorderHeaderActive2
+              Color.FromArgb(248, 247, 247),    // FormBorderHeaderInctive1
+              Color.FromArgb(248, 247, 247),    // FormBorderHeaderInctive2
+              Color.FromArgb( 59,  59,  59),    // FormHeaderShortActive
+              Color.FromArgb(138, 138, 138),    // FormHeaderShortInactive
+              Color.FromArgb( 59,  59,  59),    // FormHeaderLongActive
+              Color.FromArgb(138, 138, 138),    // FormHeaderLongInactive
+              Color.FromArgb(166, 172, 179),    // FormButtonBorderTrack
+              Color.FromArgb(255, 255, 255),    // FormButtonBack1Track
+              Color.FromArgb(228, 228, 229),    // FormButtonBack2Track
+              Color.FromArgb(166, 172, 179),    // FormButtonBorderPressed
+              Color.FromArgb(223, 228, 235),    // FormButtonBack1Pressed
+              Color.FromArgb(188, 193, 200),    // FormButtonBack2Pressed
+              Color.Black,                      // TextButtonFormNormal
+              Color.Black,                      // TextButtonFormTracking
+              Color.Black,                      // TextButtonFormPressed
+              Color.Blue,                       // LinkNotVisitedOverrideControl
+              Color.Purple,                     // LinkVisitedOverrideControl
+              Color.Red,                        // LinkPressedOverrideControl
+              Color.Blue,                       // LinkNotVisitedOverridePanel
+              Color.Purple,                     // LinkVisitedOverridePanel
+              Color.Red,                        // LinkPressedOverridePanel
+              Color.FromArgb( 59,  59,  59),    // TextLabelPanel
+              Color.FromArgb(102, 102, 102),    // RibbonTabTextNormal -n
+              Color.FromArgb(  0, 114, 198),    // RibbonTabTextChecked -n
+              Color.FromArgb(182, 186, 191),    // RibbonTabSelected1
+              Color.White,                      // RibbonTabSelected2
+              Color.White,                      // RibbonTabSelected3
+              Color.White,                      // RibbonTabSelected4
+              Color.White,                      // RibbonTabSelected5
+              Color.FromArgb(177, 181, 186),    // RibbonTabTracking1
+              Color.FromArgb(248, 249, 249),    // RibbonTabTracking2
+              Color.FromArgb(182, 186, 191),    // RibbonTabHighlight1
+              Color.White,                      // RibbonTabHighlight2
+              Color.White,                      // RibbonTabHighlight3
+              Color.White,                      // RibbonTabHighlight4
+              Color.White,                      // RibbonTabHighlight5
+              Color.FromArgb(182, 186, 191),    // RibbonTabSeparatorColor
+              Color.FromArgb(212, 212, 212),    // RibbonGroupsArea1 -n
+              Color.FromArgb(212, 212, 212),    // RibbonGroupsArea2 -n
+              Color.White,                      // RibbonGroupsArea3 -n
+              Color.White,                      // RibbonGroupsArea4 -n
+              Color.White,                      // RibbonGroupsArea5 -n
+              Color.Empty,                      // RibbonGroupBorder1 -n
+              Color.Empty,                      // RibbonGroupBorder2 -n
+              Color.Empty,                      // RibbonGroupTitle1
+              Color.Empty,                      // RibbonGroupTitle2
+              Color.Empty,                      // RibbonGroupBorderContext1
+              Color.Empty,                      // RibbonGroupBorderContext2
+              Color.Empty,                      // RibbonGroupTitleContext1
+              Color.Empty,                      // RibbonGroupTitleContext2
+              Color.FromArgb(148, 149, 152),    // RibbonGroupDialogDark
+              Color.FromArgb(180, 182, 183),    // RibbonGroupDialogLight
+              Color.Empty,                      // RibbonGroupTitleTracking1
+              Color.Empty,                      // RibbonGroupTitleTracking2
+              Color.FromArgb(139, 144, 151),    // RibbonMinimizeBarDark
+              Color.FromArgb(205, 209, 214),    // RibbonMinimizeBarLight
+              Color.Empty,                      // RibbonGroupCollapsedBorder1
+              Color.Empty,                      // RibbonGroupCollapsedBorder2
+              Color.Empty,                      // RibbonGroupCollapsedBorder3
+              Color.Empty,                      // RibbonGroupCollapsedBorder4
+              Color.Empty,                      // RibbonGroupCollapsedBack1
+              Color.Empty,                      // RibbonGroupCollapsedBack2
+              Color.Empty,                      // RibbonGroupCollapsedBack3
+              Color.Empty,                      // RibbonGroupCollapsedBack4
+              Color.Empty,                      // RibbonGroupCollapsedBorderT1
+              Color.Empty,                      // RibbonGroupCollapsedBorderT2
+              Color.Empty,                      // RibbonGroupCollapsedBorderT3
+              Color.Empty,                      // RibbonGroupCollapsedBorderT4
+              Color.Empty,                      // RibbonGroupCollapsedBackT1
+              Color.FromArgb(242, 244, 247),    // RibbonGroupCollapsedBackT2
+              Color.FromArgb(238, 241, 245),    // RibbonGroupCollapsedBackT3
+              Color.FromArgb(234, 235, 235),    // RibbonGroupCollapsedBackT4
+              Color.FromArgb(208, 212, 217),    // RibbonGroupFrameBorder1
+              Color.FromArgb(208, 212, 217),    // RibbonGroupFrameBorder2
+              Color.FromArgb(254, 254, 254),    // RibbonGroupFrameInside1
+              Color.FromArgb(254, 254, 254),    // RibbonGroupFrameInside2
+              Color.Empty,                      // RibbonGroupFrameInside3
+              Color.Empty,                      // RibbonGroupFrameInside4
+              Color.FromArgb( 59,  59,  59),    // RibbonGroupCollapsedText
+              Color.FromArgb(179, 185, 195),    // AlternatePressedBack1
+              Color.FromArgb(216, 224, 224),    // AlternatePressedBack2
+              Color.FromArgb(125, 125, 125),    // AlternatePressedBorder1
+              Color.FromArgb(186, 186, 186),    // AlternatePressedBorder2
+              Color.FromArgb(157, 166, 174),    // FormButtonBack1Checked
+              Color.FromArgb(222, 230, 242),    // FormButtonBack2Checked
+              Color.FromArgb(149, 154, 160),    // FormButtonBorderCheck
+              Color.FromArgb(147, 156, 164),    // FormButtonBack1CheckTrack
+              Color.FromArgb(237, 245, 250),    // FormButtonBack2CheckTrack
+              Color.FromArgb(180, 180, 180),    // RibbonQATMini1
+              Color.FromArgb(210, 215, 221),    // RibbonQATMini2
+              Color.FromArgb(195, 200, 206),    // RibbonQATMini3
+              Color.FromArgb(10, Color.White),  // RibbonQATMini4
+              Color.FromArgb(32, Color.White),  // RibbonQATMini5
+              Color.FromArgb(200, 200, 200),    // RibbonQATMini1I
+              Color.FromArgb(233, 234, 238),    // RibbonQATMini2I
+              Color.FromArgb(223, 224, 228),    // RibbonQATMini3I
+              Color.FromArgb(10, Color.White),  // RibbonQATMini4I
+              Color.FromArgb(32, Color.White),  // RibbonQATMini5I
+              Color.FromArgb(223, 227, 234),    // RibbonQATFullbar1
+              Color.FromArgb(213, 217, 222),    // RibbonQATFullbar2
+              Color.FromArgb(135, 140, 146),    // RibbonQATFullbar3
+              Color.FromArgb( 90,  90,  90),    // RibbonQATButtonDark
+              Color.FromArgb(210, 212, 215),    // RibbonQATButtonLight
+              Color.FromArgb(233, 237, 241),    // RibbonQATOverflow1
+              Color.FromArgb(138, 144, 150),    // RibbonQATOverflow2
+              Color.FromArgb(191, 195, 199),    // RibbonGroupSeparatorDark
+              Color.FromArgb(255, 255, 255),    // RibbonGroupSeparatorLight
+              Color.FromArgb(231, 234, 238),    // ButtonClusterButtonBack1
+              Color.FromArgb(241, 243, 243),    // ButtonClusterButtonBack2
+              Color.FromArgb(197, 198, 199),    // ButtonClusterButtonBorder1
+              Color.FromArgb(157, 158, 159),    // ButtonClusterButtonBorder2
+              Color.FromArgb(238, 238, 244),    // NavigatorMiniBackColor
+              Color.White,    // GridListNormal1
+              Color.White,    // GridListNormal2
+              Color.FromArgb(203, 207, 212),    // GridListPressed1
+              Color.White,                      // GridListPressed2
+              Color.FromArgb(186, 189, 194),    // GridListSelected
+              Color.FromArgb(238, 241, 247),    // GridSheetColNormal1
+              Color.FromArgb(218, 222, 227),    // GridSheetColNormal2
+              Color.FromArgb(255, 223, 107),    // GridSheetColPressed1
+              Color.FromArgb(255, 252, 230),    // GridSheetColPressed2
+              Color.FromArgb(255, 211,  89),    // GridSheetColSelected1
+              Color.FromArgb(255, 239, 113),    // GridSheetColSelected2
+              Color.FromArgb(223, 227, 232),    // GridSheetRowNormal
+              Color.FromArgb(255, 223, 107),    // GridSheetRowPressed
+              Color.FromArgb(245, 210,  87),    // GridSheetRowSelected
+              Color.FromArgb(218, 220, 221),    // GridDataCellBorder
+              Color.FromArgb(183, 219, 255),    // GridDataCellSelected
+              Color.Black,                      // InputControlTextNormal
+              Color.FromArgb(168, 168, 168),    // InputControlTextDisabled
+              Color.FromArgb(212, 214, 217),    // InputControlBorderNormal
+              Color.FromArgb(187, 187, 187),    // InputControlBorderDisabled
+              Color.FromArgb(255, 255, 255),    // InputControlBackNormal
+              Color.FromArgb(240, 240, 240),    // InputControlBackDisabled
+              Color.FromArgb(247, 247, 247),    // InputControlBackInactive
+              Color.Black,                      // InputDropDownNormal1
+              Color.Transparent,                // InputDropDownNormal2
+              Color.FromArgb(172, 168, 153),    // InputDropDownDisabled1
+              Color.Transparent,                // InputDropDownDisabled2
+              Color.FromArgb(240, 242, 245),    // ContextMenuHeadingBack
+              Color.FromArgb( 59,  59,  59),    // ContextMenuHeadingText
+              Color.White,                      // ContextMenuImageColumn
+              Color.FromArgb(224, 227, 231),    // AppButtonBack1
+              Color.FromArgb(224, 227, 231),    // AppButtonBack2
+              Color.FromArgb(135, 140, 146),    // AppButtonBorder
+              Color.FromArgb(224, 227, 231),    // AppButtonOuter1
+              Color.FromArgb(224, 227, 231),    // AppButtonOuter2
+              Color.FromArgb(224, 227, 231),    // AppButtonOuter3
+              Color.Empty,                        // AppButtonInner1
+              Color.FromArgb(135, 140, 146),    // AppButtonInner2
+              Color.White,                      // AppButtonMenuDocs
+              Color.Black,                      // AppButtonMenuDocsText
+              Color.FromArgb(250, 253, 255),    // SeparatorHighInternalBorder1
+              Color.FromArgb(227, 232, 237),    // SeparatorHighInternalBorder2
+              Color.FromArgb(198, 202, 205),    // RibbonGalleryBorder
+              Color.FromArgb(255, 255, 255),    // RibbonGalleryBackNormal
+              Color.FromArgb(255, 255, 255),    // RibbonGalleryBackTracking
+              Color.FromArgb(250, 250, 250),    // RibbonGalleryBack1
+              Color.FromArgb(228, 231, 235),    // RibbonGalleryBack2           // Color.FromArgb(177, 181, 186),    // RibbonTabTracking1
+              Color.FromArgb(229, 231, 235),    // RibbonTabTracking3
+              Color.FromArgb(231, 233, 235),    // RibbonTabTracking4
+              Color.FromArgb(176, 182, 188),    // RibbonGroupBorder3
+              Color.FromArgb(246, 247, 248),    // RibbonGroupBorder4
+              Color.FromArgb(249, 250, 250),    // RibbonGroupBorder5
+              Color.FromArgb(102, 109, 124),    // RibbonGroupTitleText
+              Color.FromArgb(151, 156, 163),    // RibbonDropArrowLight
+              Color.FromArgb( 39,  49,  60),    // RibbonDropArrowDark
+              Color.FromArgb(237, 242, 248),    // HeaderDockInactiveBack1
+              Color.FromArgb(207, 213, 220),    // HeaderDockInactiveBack2
+              Color.FromArgb(161, 169, 179),    // ButtonNavigatorBorder
+              Color.Black,                      // ButtonNavigatorText
+              Color.FromArgb(207, 213, 220),    // ButtonNavigatorTrack1
+              Color.FromArgb(232, 234, 238),    // ButtonNavigatorTrack2
+              Color.FromArgb(191, 196, 202),    // ButtonNavigatorPressed1
+              Color.FromArgb(225, 226, 230),    // ButtonNavigatorPressed2
+              Color.FromArgb(222, 227, 234),    // ButtonNavigatorChecked1
+              Color.FromArgb(206, 214, 221),    // ButtonNavigatorChecked2
+              Color.FromArgb(221, 221, 221)     // ToolTipBottom
         ];
         #endregion
 
@@ -313,7 +313,7 @@ namespace Krypton.Toolkit
         }
 
         /// <summary>
-        /// Initialize a new instance of the PaletteOffice2010Silver class.
+        /// Initialize a new instance of the PaletteOffice2010White class.
         /// </summary>
         public PaletteOffice2010White()
             : base(_schemeOfficeColors,
@@ -340,53 +340,60 @@ namespace Krypton.Toolkit
 
         #endregion
 
-        #region ButtonSpec
+         #region ButtonSpec
+         /// <summary>
+         /// Gets the image to display for the button.
+         /// </summary>
+         /// <param name="style">Style of button spec.</param>
+         /// <param name="state">State for which image is required.</param>
+         /// <returns>Image value.</returns>
+         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style, PaletteState state) => style switch
+         {
+            PaletteButtonSpecStyle.FormClose => state switch
+            {
+                 PaletteState.Tracking => _formCloseActive,
+                 PaletteState.Normal => _formCloseNormal,
+                 PaletteState.Pressed => _formClosePressed,
+                 _ => _formCloseDisabled
+            },
+            PaletteButtonSpecStyle.FormMin => state switch
+            {
+                 PaletteState.Normal => _formMinimiseNormal,
+                 PaletteState.Tracking => _formMinimiseActive,
+                 PaletteState.Pressed => _formMinimisePressed,
+                 _ => _formMinimiseDisabled
+            },
+            PaletteButtonSpecStyle.FormMax => state switch
+            {
+                 PaletteState.Normal => _formMaximiseNormal,
+                 PaletteState.Tracking => _formMaximiseActive,
+                 PaletteState.Pressed => _formMaximisePressed,
+                 _ => _formMaximiseDisabled
+            },
+            PaletteButtonSpecStyle.FormRestore => state switch
+            {
+                 PaletteState.Normal => _formRestoreNormal,
+                 PaletteState.Tracking => _formRestoreActive,
+                 PaletteState.Pressed => _formRestorePressed,
+                 _ => _formRestoreDisabled
+            },
+            PaletteButtonSpecStyle.FormHelp => state switch
+            {
+                 PaletteState.Tracking => _formHelpActive,
+                 PaletteState.Pressed => _formHelpPressed,
+                 PaletteState.Normal => _formHelpNormal,
+                 _ => _formHelpDisabled
+            },
+            _ => base.GetButtonSpecImage(style, state)
+        };
+        #endregion
+
+        #region ColorTable
         /// <summary>
-        /// Gets the image to display for the button.
+        /// Gets access to the color table instance.
         /// </summary>
-        /// <param name="style">Style of button spec.</param>
-        /// <param name="state">State for which image is required.</param>
-        /// <returns>Image value.</returns>
-        public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
-                                                 PaletteState state) => style switch
-                                                 {
-                                                     PaletteButtonSpecStyle.FormClose => state switch
-                                                     {
-                                                         PaletteState.Tracking => _formCloseActive,
-                                                         PaletteState.Normal => _formCloseNormal,
-                                                         PaletteState.Pressed => _formClosePressed,
-                                                         _ => _formCloseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMin => state switch
-                                                     {
-                                                         PaletteState.Normal => _formMinimiseNormal,
-                                                         PaletteState.Tracking => _formMinimiseActive,
-                                                         PaletteState.Pressed => _formMinimisePressed,
-                                                         _ => _formMinimiseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMax => state switch
-                                                     {
-                                                         PaletteState.Normal => _formMaximiseNormal,
-                                                         PaletteState.Tracking => _formMaximiseActive,
-                                                         PaletteState.Pressed => _formMaximisePressed,
-                                                         _ => _formMaximiseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormRestore => state switch
-                                                     {
-                                                         PaletteState.Normal => _formRestoreNormal,
-                                                         PaletteState.Tracking => _formRestoreActive,
-                                                         PaletteState.Pressed => _formRestorePressed,
-                                                         _ => _formRestoreDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormHelp => state switch
-                                                     {
-                                                         PaletteState.Tracking => _formHelpActive,
-                                                         PaletteState.Pressed => _formHelpPressed,
-                                                         PaletteState.Normal => _formHelpNormal,
-                                                         _ => _formHelpDisabled
-                                                     },
-                                                     _ => base.GetButtonSpecImage(style, state)
-                                                 };
+        public override KryptonColorTable ColorTable => Table ??= new KryptonColorTable2010White(_schemeOfficeColors, InheritBool.True, this);
+
         #endregion
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Bases/PaletteOffice2013Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Bases/PaletteOffice2013Base.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved.
+ *
  */
 #endregion
 
@@ -136,7 +136,7 @@ namespace Krypton.Toolkit
         private static readonly Color _contextTabSeparator = Color.White;
         private static readonly Color _contextTextColor = Color.White;
         private static readonly Color _todayBorder = Color.FromArgb(187, 85, 3);
-        private static readonly Color _toolTipBack1 = Color.FromArgb(255, 255, 255);
+        private static readonly Color _toolTipBack1 = Color.White;
         private static readonly Color _toolTipBack2 = Color.FromArgb(201, 217, 239);
         private static readonly Color _toolTipBorder = Color.FromArgb(118, 118, 118);
         private static readonly Color _toolTipText = Color.FromArgb(76, 76, 76);
@@ -240,7 +240,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Instance Fields
-        private KryptonColorTable2013? _table;
+        protected KryptonColorTable2013? Table { get; set; }
         private readonly Color[] _ribbonColors;
         private readonly Color[]? _trackBarColors;
         private readonly ImageList _checkBoxList;
@@ -261,10 +261,10 @@ namespace Krypton.Toolkit
         /// <param name="radioButtonArray">Array of images for radio button.</param>
         /// <param name="trackBarColors">Array of track bar specific colors.</param>
         protected PaletteOffice2013Base([DisallowNull] Color[] schemeColors,
-                                     [DisallowNull] ImageList checkBoxList,
-                                     [DisallowNull] ImageList galleryButtonList,
-                                     [DisallowNull] Image?[] radioButtonArray,
-                                     Color[] trackBarColors)
+                                        [DisallowNull] ImageList checkBoxList,
+                                        [DisallowNull] ImageList galleryButtonList,
+                                        [DisallowNull] Image?[] radioButtonArray,
+                                        Color[] trackBarColors)
         {
             Debug.Assert(schemeColors != null);
             Debug.Assert(checkBoxList != null);
@@ -360,10 +360,43 @@ namespace Krypton.Toolkit
 
             return style switch
             {
-                PaletteBackStyle.TabHighProfile or PaletteBackStyle.TabStandardProfile or PaletteBackStyle.TabLowProfile or PaletteBackStyle.TabOneNote or PaletteBackStyle.TabDock or PaletteBackStyle.TabDockAutoHidden or PaletteBackStyle.TabCustom1 or PaletteBackStyle.TabCustom2 or PaletteBackStyle.TabCustom3 or PaletteBackStyle.PanelClient or PaletteBackStyle.PanelRibbonInactive or PaletteBackStyle.PanelAlternate or PaletteBackStyle.PanelCustom1 or PaletteBackStyle.PanelCustom2 or PaletteBackStyle.PanelCustom3 or PaletteBackStyle.SeparatorHighInternalProfile or PaletteBackStyle.SeparatorHighProfile or PaletteBackStyle.SeparatorLowProfile or PaletteBackStyle.SeparatorCustom1 or PaletteBackStyle.SeparatorCustom2 or PaletteBackStyle.SeparatorCustom3 or PaletteBackStyle.ControlClient or PaletteBackStyle.ControlAlternate or PaletteBackStyle.ControlGroupBox or PaletteBackStyle.ControlToolTip or PaletteBackStyle.ControlRibbon or PaletteBackStyle.ControlRibbonAppMenu or PaletteBackStyle.ControlCustom1 or PaletteBackStyle.ControlCustom2 or PaletteBackStyle.ControlCustom3 or PaletteBackStyle.ContextMenuOuter or PaletteBackStyle.ContextMenuInner or PaletteBackStyle.ContextMenuHeading or PaletteBackStyle.ContextMenuSeparator or PaletteBackStyle.ContextMenuItemSplit or PaletteBackStyle.ContextMenuItemImageColumn or PaletteBackStyle.ContextMenuItemImage or PaletteBackStyle.ContextMenuItemHighlight or PaletteBackStyle.InputControlStandalone or PaletteBackStyle.InputControlRibbon or PaletteBackStyle.InputControlCustom1 or PaletteBackStyle.InputControlCustom2 or PaletteBackStyle.InputControlCustom3 or PaletteBackStyle.FormMain or PaletteBackStyle.FormCustom1 or PaletteBackStyle.FormCustom2 or PaletteBackStyle.FormCustom3 or PaletteBackStyle.HeaderPrimary or PaletteBackStyle.HeaderDockInactive or PaletteBackStyle.HeaderDockActive or PaletteBackStyle.HeaderSecondary or PaletteBackStyle.HeaderForm or PaletteBackStyle.HeaderCalendar or PaletteBackStyle.HeaderCustom1 or PaletteBackStyle.HeaderCustom2 or PaletteBackStyle.HeaderCustom3 or PaletteBackStyle.ButtonStandalone or PaletteBackStyle.ButtonGallery or PaletteBackStyle.ButtonAlternate or PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonCalendarDay or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ButtonCluster or PaletteBackStyle.ButtonNavigatorStack or PaletteBackStyle.ButtonNavigatorOverflow or PaletteBackStyle.ButtonNavigatorMini or PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose or PaletteBackStyle.ButtonCustom1 or PaletteBackStyle.ButtonCustom2 or PaletteBackStyle.ButtonCustom3 or PaletteBackStyle.ButtonInputControl or PaletteBackStyle.GridBackgroundList or PaletteBackStyle.GridBackgroundSheet or PaletteBackStyle.GridBackgroundCustom1
-                    or PaletteBackStyle.GridBackgroundCustom2
-                    or PaletteBackStyle.GridBackgroundCustom3
- or PaletteBackStyle.GridHeaderColumnList or PaletteBackStyle.GridHeaderColumnSheet or PaletteBackStyle.GridHeaderColumnCustom1 or PaletteBackStyle.GridHeaderColumnCustom2 or PaletteBackStyle.GridHeaderColumnCustom3 or PaletteBackStyle.GridHeaderRowList or PaletteBackStyle.GridHeaderRowSheet or PaletteBackStyle.GridHeaderRowCustom1 or PaletteBackStyle.GridHeaderRowCustom2 or PaletteBackStyle.GridHeaderRowCustom3 or PaletteBackStyle.GridDataCellList or PaletteBackStyle.GridDataCellSheet or PaletteBackStyle.GridDataCellCustom1 or PaletteBackStyle.GridDataCellCustom2 or PaletteBackStyle.GridDataCellCustom3 => PaletteGraphicsHint.None,
+                PaletteBackStyle.TabHighProfile or PaletteBackStyle.TabStandardProfile or PaletteBackStyle.TabLowProfile or
+                    PaletteBackStyle.TabOneNote or PaletteBackStyle.TabDock or PaletteBackStyle.TabDockAutoHidden or
+                    PaletteBackStyle.TabCustom1 or PaletteBackStyle.TabCustom2 or PaletteBackStyle.TabCustom3 or
+                    PaletteBackStyle.PanelClient or PaletteBackStyle.PanelRibbonInactive or PaletteBackStyle.PanelAlternate or
+                    PaletteBackStyle.PanelCustom1 or PaletteBackStyle.PanelCustom2 or PaletteBackStyle.PanelCustom3 or
+                    PaletteBackStyle.SeparatorHighInternalProfile or PaletteBackStyle.SeparatorHighProfile or
+                    PaletteBackStyle.SeparatorLowProfile or PaletteBackStyle.SeparatorCustom1 or PaletteBackStyle.SeparatorCustom2 or
+                    PaletteBackStyle.SeparatorCustom3 or PaletteBackStyle.ControlClient or PaletteBackStyle.ControlAlternate or
+                    PaletteBackStyle.ControlGroupBox or PaletteBackStyle.ControlToolTip or PaletteBackStyle.ControlRibbon or
+                    PaletteBackStyle.ControlRibbonAppMenu or PaletteBackStyle.ControlCustom1 or PaletteBackStyle.ControlCustom2 or
+                    PaletteBackStyle.ControlCustom3 or PaletteBackStyle.ContextMenuOuter or PaletteBackStyle.ContextMenuInner or
+                    PaletteBackStyle.ContextMenuHeading or PaletteBackStyle.ContextMenuSeparator or PaletteBackStyle.ContextMenuItemSplit or
+                    PaletteBackStyle.ContextMenuItemImageColumn or PaletteBackStyle.ContextMenuItemImage or
+                    PaletteBackStyle.ContextMenuItemHighlight or PaletteBackStyle.InputControlStandalone or
+                    PaletteBackStyle.InputControlRibbon or PaletteBackStyle.InputControlCustom1 or
+                    PaletteBackStyle.InputControlCustom2 or PaletteBackStyle.InputControlCustom3 or
+                    PaletteBackStyle.FormMain or PaletteBackStyle.FormCustom1 or PaletteBackStyle.FormCustom2 or
+                    PaletteBackStyle.FormCustom3 or PaletteBackStyle.HeaderPrimary or PaletteBackStyle.HeaderDockInactive or
+                    PaletteBackStyle.HeaderDockActive or PaletteBackStyle.HeaderSecondary or PaletteBackStyle.HeaderForm or
+                    PaletteBackStyle.HeaderCalendar or PaletteBackStyle.HeaderCustom1 or PaletteBackStyle.HeaderCustom2 or
+                    PaletteBackStyle.HeaderCustom3 or PaletteBackStyle.ButtonStandalone or PaletteBackStyle.ButtonGallery or
+                    PaletteBackStyle.ButtonAlternate or PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or
+                    PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonCalendarDay or
+                    PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ButtonCluster or PaletteBackStyle.ButtonNavigatorStack or
+                    PaletteBackStyle.ButtonNavigatorOverflow or PaletteBackStyle.ButtonNavigatorMini or PaletteBackStyle.ButtonForm or
+                    PaletteBackStyle.ButtonFormClose or PaletteBackStyle.ButtonCustom1 or PaletteBackStyle.ButtonCustom2 or
+                    PaletteBackStyle.ButtonCustom3 or PaletteBackStyle.ButtonInputControl or PaletteBackStyle.GridBackgroundList or
+                    PaletteBackStyle.GridBackgroundSheet or PaletteBackStyle.GridBackgroundCustom1 or PaletteBackStyle.GridBackgroundCustom2 or
+                    PaletteBackStyle.GridBackgroundCustom3 or PaletteBackStyle.GridHeaderColumnList or
+                    PaletteBackStyle.GridHeaderColumnSheet or PaletteBackStyle.GridHeaderColumnCustom1 or
+                    PaletteBackStyle.GridHeaderColumnCustom2 or PaletteBackStyle.GridHeaderColumnCustom3 or
+                    PaletteBackStyle.GridHeaderRowList or PaletteBackStyle.GridHeaderRowSheet or
+                    PaletteBackStyle.GridHeaderRowCustom1 or PaletteBackStyle.GridHeaderRowCustom2 or
+                    PaletteBackStyle.GridHeaderRowCustom3 or PaletteBackStyle.GridDataCellList or
+                    PaletteBackStyle.GridDataCellSheet or PaletteBackStyle.GridDataCellCustom1 or
+                    PaletteBackStyle.GridDataCellCustom2 or PaletteBackStyle.GridDataCellCustom3
+                    => PaletteGraphicsHint.None,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -4202,15 +4235,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the color table instance.
         /// </summary>
-        public override KryptonColorTable ColorTable
-        {
-            get
-            {
-                _table ??= new KryptonColorTable2013(_ribbonColors, InheritBool.True, this);
-
-                return _table;
-            }
-        }
+        public override KryptonColorTable ColorTable => Table ??= new KryptonColorTable2013(_ribbonColors, InheritBool.True, this);
         #endregion
 
         #region OnUserPreferenceChanged
@@ -4222,7 +4247,7 @@ namespace Krypton.Toolkit
         protected override void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e)
         {
             // Remove the current table, so it gets regenerated when next requested
-            _table = null;
+            Table = null;
 
             // Update fonts to reflect any change in system settings
             DefineFonts();

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013White.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013White.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved.
+ *
  */
 #endregion
 
@@ -59,7 +59,7 @@ namespace Krypton.Toolkit
 
         #endregion
 
-        #region Colour Arrays
+        #region Color Arrays
 
         private static readonly Color[] _trackBarColors =
         [
@@ -199,7 +199,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(254, 254, 254), // RibbonGroupFrameInside2
             Color.Empty, // RibbonGroupFrameInside3
             Color.Empty, // RibbonGroupFrameInside4
-            Color.FromArgb(59, 59, 59), // RibbonGroupCollapsedText         
+            Color.FromArgb(59, 59, 59), // RibbonGroupCollapsedText
             Color.FromArgb(179, 185, 195), // AlternatePressedBack1
             Color.FromArgb(216, 224, 224), // AlternatePressedBack2
             Color.FromArgb(125, 125, 125), // AlternatePressedBorder1
@@ -213,44 +213,38 @@ namespace Krypton.Toolkit
             Color.FromArgb(210, 215, 221), // RibbonQATMini2
             Color.FromArgb(195, 200, 206), // RibbonQATMini3
             Color.FromArgb(10, Color.White), // RibbonQATMini4
-            Color.FromArgb(32, Color.White), // RibbonQATMini5                                                       
+            Color.FromArgb(32, Color.White), // RibbonQATMini5
             Color.FromArgb(200, 200, 200), // RibbonQATMini1I
             Color.FromArgb(233, 234, 238), // RibbonQATMini2I
             Color.FromArgb(223, 224, 228), // RibbonQATMini3I
             Color.FromArgb(10, Color.White), // RibbonQATMini4I
-            Color.FromArgb(32, Color.White), // RibbonQATMini5I                                                       
-            Color.FromArgb(223, 227, 234), // RibbonQATFullbar1                                                      
-            Color.FromArgb(213, 217, 222), // RibbonQATFullbar2                                                      
-            Color.FromArgb(135, 140, 146), // RibbonQATFullbar3                                                      
-            Color.FromArgb(90, 90, 90), // RibbonQATButtonDark                                                      
-            Color.FromArgb(210, 212, 215), // RibbonQATButtonLight                                                      
-            Color.FromArgb(233, 237, 241), // RibbonQATOverflow1                                                      
-            Color.FromArgb(138, 144, 150), // RibbonQATOverflow2                                                      
-            Color.FromArgb(191, 195,
-                199), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(255, 255,
-                255), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(231, 234,
-                238), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(241, 243,
-                243), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(197, 198,
-                199), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(157, 158,
-                159), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor                                                    
-            Color.White, // GridListNormal1                                                    
-            Color.White, // GridListNormal2                                                    
-            Color.FromArgb(203, 207, 212), // GridListPressed1                                                    
-            Color.White, // GridListPressed2                                                    
-            Color.FromArgb(186, 189, 194), // GridListSelected                                                    
-            Color.FromArgb(238, 241, 247), // GridSheetColNormal1                                                    
-            Color.FromArgb(218, 222, 227), // GridSheetColNormal2                                                    
-            Color.FromArgb(255, 223, 107), // GridSheetColPressed1                                                    
-            Color.FromArgb(255, 252, 230), // GridSheetColPressed2                                                    
+            Color.FromArgb(32, Color.White), // RibbonQATMini5I
+            Color.FromArgb(223, 227, 234), // RibbonQATFullbar1
+            Color.FromArgb(213, 217, 222), // RibbonQATFullbar2
+            Color.FromArgb(135, 140, 146), // RibbonQATFullbar3
+            Color.FromArgb(90, 90, 90), // RibbonQATButtonDark
+            Color.FromArgb(210, 212, 215), // RibbonQATButtonLight
+            Color.FromArgb(233, 237, 241), // RibbonQATOverflow1
+            Color.FromArgb(138, 144, 150), // RibbonQATOverflow2
+            Color.FromArgb(191, 195, 199), // RibbonGroupSeparatorDark
+            Color.FromArgb(255, 255, 255), // RibbonGroupSeparatorLight
+            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1
+            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2
+            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1
+            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2
+            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor
+            Color.White, // GridListNormal1
+            Color.White, // GridListNormal2
+            Color.FromArgb(203, 207, 212), // GridListPressed1
+            Color.White, // GridListPressed2
+            Color.FromArgb(186, 189, 194), // GridListSelected
+            Color.FromArgb(238, 241, 247), // GridSheetColNormal1
+            Color.FromArgb(218, 222, 227), // GridSheetColNormal2
+            Color.FromArgb(255, 223, 107), // GridSheetColPressed1
+            Color.FromArgb(255, 252, 230), // GridSheetColPressed2
             Color.FromArgb(255, 211, 89), // GridSheetColSelected1
             Color.FromArgb(255, 239, 113), // GridSheetColSelected2
-            Color.FromArgb(223, 227, 232), // GridSheetRowNormal                                                   
+            Color.FromArgb(223, 227, 232), // GridSheetRowNormal
             Color.FromArgb(255, 223, 107), // GridSheetRowPressed
             Color.FromArgb(245, 210, 87), // GridSheetRowSelected
             Color.FromArgb(218, 220, 221), // GridDataCellBorder
@@ -285,7 +279,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(255, 255, 255), // RibbonGalleryBackNormal
             Color.FromArgb(255, 255, 255), // RibbonGalleryBackTracking
             Color.FromArgb(250, 250, 250), // RibbonGalleryBack1
-            Color.FromArgb(228, 231, 235), // RibbonGalleryBack2                                                                                                                                      Color.FromArgb(177, 181, 186),    // RibbonTabTracking1
+            Color.FromArgb(228, 231, 235), // RibbonGalleryBack2                      // Color.FromArgb(177, 181, 186),    // RibbonTabTracking1
             Color.FromArgb(229, 231, 235), // RibbonTabTracking3
             Color.FromArgb(231, 233, 235), // RibbonTabTracking4
             Color.FromArgb(176, 182, 188), // RibbonGroupBorder3
@@ -304,7 +298,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(225, 226, 230), // ButtonNavigatorPressed2
             Color.FromArgb(222, 227, 234), // ButtonNavigatorChecked1
             Color.FromArgb(206, 214, 221), // ButtonNavigatorChecked2
-            Color.FromArgb(221, 221, 221) // ToolTipBottom                                                                      
+            Color.FromArgb(221, 221, 221) // ToolTipBottom
         ];
 
         #endregion
@@ -375,53 +369,52 @@ namespace Krypton.Toolkit
         /// <param name="style">Style of button spec.</param>
         /// <param name="state">State for which image is required.</param>
         /// <returns>Image value.</returns>
-        public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
-                                                 PaletteState state) => style switch
-                                                 {
-                                                     PaletteButtonSpecStyle.FormClose => state switch
-                                                     {
-                                                         PaletteState.Tracking => _formCloseActive,
-                                                         PaletteState.Normal => _formCloseNormal,
-                                                         PaletteState.Pressed => _formClosePressed,
-                                                         _ => _formCloseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMin => state switch
-                                                     {
-                                                         PaletteState.Normal => _formMinimiseNormal,
-                                                         PaletteState.Tracking => _formMinimiseActive,
-                                                         PaletteState.Pressed => _formMinimisePressed,
-                                                         _ => _formMinimiseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMax => state switch
-                                                     {
-                                                         PaletteState.Normal => _formMaximiseNormal,
-                                                         PaletteState.Tracking => _formMaximiseActive,
-                                                         PaletteState.Pressed => _formMaximisePressed,
-                                                         _ => _formMaximiseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormRestore => state switch
-                                                     {
-                                                         PaletteState.Normal => _formRestoreNormal,
-                                                         PaletteState.Tracking => _formRestoreActive,
-                                                         PaletteState.Pressed => _formRestorePressed,
-                                                         _ => _formRestoreDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormHelp => state switch
-                                                     {
-                                                         PaletteState.Tracking => _formHelpActive,
-                                                         PaletteState.Pressed => _formHelpPressed,
-                                                         PaletteState.Normal => _formHelpNormal,
-                                                         _ => _formHelpDisabled
-                                                     },
-                                                     _ => base.GetButtonSpecImage(style, state)
-                                                 };
+        public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style, PaletteState state) => style switch
+         {
+             PaletteButtonSpecStyle.FormClose => state switch
+             {
+                 PaletteState.Tracking => _formCloseActive,
+                 PaletteState.Normal => _formCloseNormal,
+                 PaletteState.Pressed => _formClosePressed,
+                 _ => _formCloseDisabled
+             },
+             PaletteButtonSpecStyle.FormMin => state switch
+             {
+                 PaletteState.Normal => _formMinimiseNormal,
+                 PaletteState.Tracking => _formMinimiseActive,
+                 PaletteState.Pressed => _formMinimisePressed,
+                 _ => _formMinimiseDisabled
+             },
+             PaletteButtonSpecStyle.FormMax => state switch
+             {
+                 PaletteState.Normal => _formMaximiseNormal,
+                 PaletteState.Tracking => _formMaximiseActive,
+                 PaletteState.Pressed => _formMaximisePressed,
+                 _ => _formMaximiseDisabled
+             },
+             PaletteButtonSpecStyle.FormRestore => state switch
+             {
+                 PaletteState.Normal => _formRestoreNormal,
+                 PaletteState.Tracking => _formRestoreActive,
+                 PaletteState.Pressed => _formRestorePressed,
+                 _ => _formRestoreDisabled
+             },
+             PaletteButtonSpecStyle.FormHelp => state switch
+             {
+                 PaletteState.Tracking => _formHelpActive,
+                 PaletteState.Pressed => _formHelpPressed,
+                 PaletteState.Normal => _formHelpNormal,
+                 _ => _formHelpDisabled
+             },
+             _ => base.GetButtonSpecImage(style, state)
+         };
         #endregion
     }
 
     #region Class: PaletteOffice2013WhiteBase
 
     /// <summary>
-    /// Gets the single instance of the ### palette.
+    /// Gets the single instance of the PaletteOffice2013WhiteBase palette.
     /// </summary>
     public abstract class PaletteOffice2013WhiteBase : PaletteBase
     {
@@ -528,7 +521,7 @@ namespace Krypton.Toolkit
 
         #endregion
 
-        #region Colours
+        #region Colors
 
         private static readonly Color _gridTextColor = Color.Black;
         private static readonly Color _disabledText2 = Color.FromArgb(128, 128, 128);
@@ -625,7 +618,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Instance Fields
-        private KryptonColorTable2013? _table;
+        protected KryptonColorTable2013White? Table { get; set; }
         private readonly Color[] _ribbonColors;
         private readonly Color[] _trackBarColors;
         private readonly ImageList _checkBoxList;
@@ -646,10 +639,10 @@ namespace Krypton.Toolkit
         /// <param name="radioButtonArray">Array of images for radio button.</param>
         /// <param name="trackBarColors">Array of track bar specific colors.</param>
         protected PaletteOffice2013WhiteBase([DisallowNull] Color[] schemeColors,
-                                     [DisallowNull] ImageList checkBoxList,
-                                     [DisallowNull] ImageList galleryButtonList,
-                                     [DisallowNull] Image?[] radioButtonArray,
-                                     Color[] trackBarColors)
+                                             [DisallowNull] ImageList checkBoxList,
+                                             [DisallowNull] ImageList galleryButtonList,
+                                             [DisallowNull] Image?[] radioButtonArray,
+                                             Color[] trackBarColors)
         {
             Debug.Assert(schemeColors != null);
             Debug.Assert(checkBoxList != null);
@@ -3493,8 +3486,7 @@ namespace Krypton.Toolkit
         /// <param name="style">Style of button spec.</param>
         /// <param name="state">State for which image is required.</param>
         /// <returns>Image value.</returns>
-        public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
-                                                 PaletteState state)
+        public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style, PaletteState state)
         {
             switch (style)
             {
@@ -4571,15 +4563,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the color table instance.
         /// </summary>
-        public override KryptonColorTable ColorTable
-        {
-            get
-            {
-                _table ??= new KryptonColorTable2013(_ribbonColors, InheritBool.True, this);
-
-                return _table;
-            }
-        }
+        public override KryptonColorTable ColorTable => Table ??= new KryptonColorTable2013White(_ribbonColors, InheritBool.True, this);
         #endregion
 
         #region OnUserPreferenceChanged
@@ -4591,7 +4575,7 @@ namespace Krypton.Toolkit
         protected override void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e)
         {
             // Remove the current table, so it gets regenerated when next requested
-            _table = null;
+            Table = null;
 
             // Update fonts to reflect any change in system settings
             DefineFonts();

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonInternalKCT.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonInternalKCT.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved.
+ *
  */
 #endregion
 
@@ -782,17 +782,26 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the color used to draw text on a menu strip.
         /// </summary>
-        public override Color MenuStripText =>
-            _colors[(int)PaletteColorIndex.MenuStripText] == Color.Empty
-                ? BaseKCT.MenuStripText
-                : _colors[(int)PaletteColorIndex.MenuStripText];
+        public override Color MenuStripText
+        {
+            get
+            {
+                if (_colors.Length > (int)PaletteColorIndex.MenuStripText)
+                {
+                    return _colors[(int)PaletteColorIndex.MenuStripText] == Color.Empty
+                        ? BaseKCT.MenuStripText
+                        : _colors[(int)PaletteColorIndex.MenuStripText];
+                }
+                return BaseKCT.MenuStripText;
+            }
+        }
 
         /// <summary>
         /// Sets and sets the internal MenuStripText value.
         /// </summary>
         public Color InternalMenuStripText
         {
-            get => _colors[(int)PaletteColorIndex.MenuStripText];
+            get => _colors.Length > (int)PaletteColorIndex.MenuStripText ? _colors [(int)PaletteColorIndex.MenuStripText] : BaseKCT.MenuStripText;
             set => _colors[(int)PaletteColorIndex.MenuStripText] = value;
         }
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTable2010.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTable2010.cs
@@ -1,17 +1,55 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved.
+ *
  */
 #endregion
 
+using System.Drawing.Imaging;
+
 namespace Krypton.Toolkit
 {
+    /// <summary>
+    /// Provide KryptonColorTable2010 values using an array of Color values as the source.
+    /// </summary>
+    public class KryptonColorTable2010White : KryptonColorTable2010
+    {
+        #region Identity
+        static KryptonColorTable2010White()
+        {
+            // Get the font settings from the system
+            DefineFonts();
+
+            // We need to notice when system color settings change
+            SystemEvents.UserPreferenceChanged += OnUserPreferenceChanged;
+        }
+
+        /// <summary>
+        /// Initialize a new instance of the KryptonColorTable2010White class.
+        /// </summary>
+        /// <param name="colors">Source of </param>
+        /// <param name="roundedEdges">Should have rounded edges.</param>
+        /// <param name="palette">Associated palette instance.</param>
+        public KryptonColorTable2010White([DisallowNull] Color[] colors,
+                                     InheritBool roundedEdges,
+        PaletteBase palette)
+            : base(colors, roundedEdges, palette)
+        {
+            Debug.Assert(colors != null);
+        }
+        #endregion
+
+        /// <summary>
+        /// MenuStripText
+        /// </summary>
+        public override Color MenuStripText => Color.FromArgb(255, 30, 30, 30);// Colors[(int)SchemeOfficeColors.StatusStripText];
+    }
+
     /// <summary>
     /// Provide KryptonColorTable2010 values using an array of Color values as the source.
     /// </summary>
@@ -611,7 +649,9 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private static void DefineFonts()
+
+        /// <summary>DefineFonts</summary>
+        protected static void DefineFonts()
         {
             // Create new font using system information
             // TODO: Should be using base font
@@ -619,7 +659,10 @@ namespace Krypton.Toolkit
             _statusFont = new Font(@"Segoe UI", SystemFonts.StatusFont.SizeInPoints, FontStyle.Regular);
         }
 
-        private static void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e) =>
+        /// <summary>OnUserPreferenceChanged</summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        protected static void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e) =>
             // Update fonts to reflect any change in system settings
             DefineFonts();
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTable2013.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTable2013.cs
@@ -1,17 +1,53 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved.
+ *
  */
 #endregion
 
 namespace Krypton.Toolkit
 {
+    /// <summary>
+    /// Provide KryptonColorTable2013White values using an array of Color values as the source.
+    /// </summary>
+    public class KryptonColorTable2013White : KryptonColorTable2013
+    {
+        #region Identity
+        static KryptonColorTable2013White()
+        {
+            // Get the font settings from the system
+            DefineFonts();
+
+            // We need to notice when system color settings change
+            SystemEvents.UserPreferenceChanged += OnUserPreferenceChanged;
+        }
+
+        /// <summary>
+        /// Initialize a new instance of the KryptonColorTable2013White class.
+        /// </summary>
+        /// <param name="colors">Source of </param>
+        /// <param name="roundedEdges">Should have rounded edges.</param>
+        /// <param name="palette">Associated palette instance.</param>
+        public KryptonColorTable2013White([DisallowNull] Color[] colors,
+                                          InheritBool roundedEdges,
+                                          PaletteBase palette)
+            : base(colors, roundedEdges, palette)
+        {
+            Debug.Assert(colors != null);
+        }
+        #endregion
+
+        /// <summary>
+        /// MenuStripText
+        /// </summary>
+        public override Color MenuStripText => Color.FromArgb(255, 30, 30, 30);
+    }
+
     /// <summary>
     /// Provide KryptonColorTable2013 values using an array of Color values as the source.
     /// </summary>
@@ -617,7 +653,8 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private static void DefineFonts()
+        /// <summary>DefineFonts</summary>
+        protected static void DefineFonts()
         {
             // Create new font using system information
             // TODO: Should be using base font
@@ -625,7 +662,10 @@ namespace Krypton.Toolkit
             _statusFont = new Font(@"Segoe UI", SystemFonts.StatusFont.SizeInPoints, FontStyle.Regular);
         }
 
-        private static void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e) =>
+        /// <summary>OnUserPreferenceChanged</summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        protected static void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e) =>
             // Update fonts to reflect any change in system settings
             DefineFonts();
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTable365.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/KryptonColorTable365.cs
@@ -1,17 +1,54 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved.
+ *
  */
 #endregion
 
 namespace Krypton.Toolkit
 {
+
+    /// <summary>
+    /// Provide KryptonColorTable2013White values using an array of Color values as the source.
+    /// </summary>
+    public class KryptonColorTable365White : KryptonColorTable365
+    {
+        #region Identity
+        static KryptonColorTable365White()
+        {
+            // Get the font settings from the system
+            DefineFonts();
+
+            // We need to notice when system color settings change
+            SystemEvents.UserPreferenceChanged += OnUserPreferenceChanged;
+        }
+
+        /// <summary>
+        /// Initialize a new instance of the KryptonColorTable365White class.
+        /// </summary>
+        /// <param name="colors">Source of </param>
+        /// <param name="roundedEdges">Should have rounded edges.</param>
+        /// <param name="palette">Associated palette instance.</param>
+        public KryptonColorTable365White([DisallowNull] Color[] colors,
+                                          InheritBool roundedEdges,
+                                          PaletteBase palette)
+            : base(colors, roundedEdges, palette)
+        {
+            Debug.Assert(colors != null);
+        }
+        #endregion
+
+        /// <summary>
+        /// MenuStripText
+        /// </summary>
+        public override Color MenuStripText => Color.FromArgb(255, 30, 30, 30);
+    }
+
     /// <summary>
     /// Provide KryptonColorTable365 values using an array of Color values as the source.
     /// </summary>
@@ -55,8 +92,9 @@ namespace Krypton.Toolkit
         /// <param name="colors">Source of </param>
         /// <param name="roundedEdges">Should have rounded edges.</param>
         /// <param name="palette">Associated palette instance.</param>
-        public KryptonColorTable365([DisallowNull] Color[] colors, 
-            InheritBool roundedEdges, PaletteBase palette) 
+        public KryptonColorTable365([DisallowNull] Color[] colors,
+                                    InheritBool roundedEdges,
+                                    PaletteBase palette)
             : base(palette)
         {
             Debug.Assert(colors != null);
@@ -616,7 +654,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private static void DefineFonts()
+        protected static void DefineFonts()
         {
             // Create new font using system information
             // TODO: Should be using base font
@@ -624,7 +662,7 @@ namespace Krypton.Toolkit
             _statusFont = new Font(@"Segoe UI", SystemFonts.StatusFont.SizeInPoints, FontStyle.Regular);
         }
 
-        private static void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e) =>
+        protected static void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e) =>
             // Update fonts to reflect any change in system settings
             DefineFonts();
 

--- a/Source/Krypton Components/TestForm/StartScreen.Designer.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace TestForm
+﻿using Krypton.Toolkit;
+
+namespace TestForm
 {
     partial class StartScreen
     {
@@ -31,6 +33,8 @@
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(StartScreen));
             this.kryptonPanel1 = new Krypton.Toolkit.KryptonPanel();
+            this.kryptonThemeComboBox1 = new Krypton.Toolkit.KryptonThemeComboBox();
+            this.kryptonManager1 = new Krypton.Toolkit.KryptonManager(this.components);
             this.kbtnOutlookGrid = new Krypton.Toolkit.KryptonButton();
             this.kbtnTreeView = new Krypton.Toolkit.KryptonButton();
             this.kbtnExit = new Krypton.Toolkit.KryptonButton();
@@ -48,15 +52,13 @@
             this.kbtnFadeForm = new Krypton.Toolkit.KryptonButton();
             this.kbtnCommandLinkButtons = new Krypton.Toolkit.KryptonButton();
             this.kbtnBreadCrumb = new Krypton.Toolkit.KryptonButton();
-            this.kryptonManager1 = new Krypton.Toolkit.KryptonManager(this.components);
-            this.kryptonThemeComboBox1 = new Krypton.Toolkit.KryptonThemeComboBox();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).BeginInit();
             this.kryptonPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonThemeComboBox1)).BeginInit();
             this.SuspendLayout();
-            // 
+            //
             // kryptonPanel1
-            // 
+            //
             this.kryptonPanel1.Controls.Add(this.kryptonThemeComboBox1);
             this.kryptonPanel1.Controls.Add(this.kbtnOutlookGrid);
             this.kryptonPanel1.Controls.Add(this.kbtnTreeView);
@@ -77,187 +79,210 @@
             this.kryptonPanel1.Controls.Add(this.kbtnBreadCrumb);
             this.kryptonPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonPanel1.Location = new System.Drawing.Point(0, 0);
+            this.kryptonPanel1.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonPanel1.Name = "kryptonPanel1";
-            this.kryptonPanel1.Size = new System.Drawing.Size(437, 359);
+            this.kryptonPanel1.Size = new System.Drawing.Size(619, 425);
             this.kryptonPanel1.TabIndex = 0;
-            // 
+            //
+            // kryptonThemeComboBox1
+            //
+            this.kryptonThemeComboBox1.DefaultPalette = Krypton.Toolkit.PaletteMode.Office365Blue;
+            this.kryptonThemeComboBox1.DropDownWidth = 552;
+            this.kryptonThemeComboBox1.IntegralHeight = false;
+            this.kryptonThemeComboBox1.Location = new System.Drawing.Point(17, 16);
+            this.kryptonThemeComboBox1.Manager = this.kryptonManager1;
+            this.kryptonThemeComboBox1.Margin = new System.Windows.Forms.Padding(4);
+            this.kryptonThemeComboBox1.Name = "kryptonThemeComboBox1";
+            this.kryptonThemeComboBox1.ReportSelectedThemeIndex = false;
+            this.kryptonThemeComboBox1.Size = new System.Drawing.Size(552, 25);
+            this.kryptonThemeComboBox1.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
+            this.kryptonThemeComboBox1.TabIndex = 18;
+            //
+            // kryptonManager1
+            //
+            this.kryptonManager1.BaseFont = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2010White;
+            //
             // kbtnOutlookGrid
-            // 
-            this.kbtnOutlookGrid.Location = new System.Drawing.Point(223, 164);
+            //
+            this.kbtnOutlookGrid.Location = new System.Drawing.Point(297, 202);
+            this.kbtnOutlookGrid.Margin = new System.Windows.Forms.Padding(4);
             this.kbtnOutlookGrid.Name = "kbtnOutlookGrid";
-            this.kbtnOutlookGrid.Size = new System.Drawing.Size(204, 25);
+            this.kbtnOutlookGrid.Size = new System.Drawing.Size(272, 31);
             this.kbtnOutlookGrid.TabIndex = 17;
             this.kbtnOutlookGrid.Values.Text = "Outlook Grid";
             this.kbtnOutlookGrid.Click += new System.EventHandler(this.kbtnOutlookGrid_Click);
-            // 
+            //
             // kbtnTreeView
-            // 
-            this.kbtnTreeView.Location = new System.Drawing.Point(223, 257);
+            //
+            this.kbtnTreeView.Location = new System.Drawing.Point(297, 316);
+            this.kbtnTreeView.Margin = new System.Windows.Forms.Padding(4);
             this.kbtnTreeView.Name = "kbtnTreeView";
-            this.kbtnTreeView.Size = new System.Drawing.Size(204, 25);
+            this.kbtnTreeView.Size = new System.Drawing.Size(272, 31);
             this.kbtnTreeView.TabIndex = 16;
             this.kbtnTreeView.Values.Text = "TreeView";
             this.kbtnTreeView.Click += new System.EventHandler(this.kbtnTreeView_Click);
-            // 
+            //
             // kbtnExit
-            // 
+            //
             this.kbtnExit.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.kbtnExit.Location = new System.Drawing.Point(13, 288);
+            this.kbtnExit.Location = new System.Drawing.Point(17, 354);
+            this.kbtnExit.Margin = new System.Windows.Forms.Padding(4);
             this.kbtnExit.Name = "kbtnExit";
-            this.kbtnExit.Size = new System.Drawing.Size(204, 25);
+            this.kbtnExit.Size = new System.Drawing.Size(272, 31);
             this.kbtnExit.TabIndex = 15;
             this.kbtnExit.Values.Text = "Exit";
             this.kbtnExit.Click += new System.EventHandler(this.kbtnExit_Click);
-            // 
+            //
             // kbtnFormBorder
-            // 
-            this.kbtnFormBorder.Location = new System.Drawing.Point(223, 102);
+            //
+            this.kbtnFormBorder.Location = new System.Drawing.Point(297, 126);
+            this.kbtnFormBorder.Margin = new System.Windows.Forms.Padding(4);
             this.kbtnFormBorder.Name = "kbtnFormBorder";
-            this.kbtnFormBorder.Size = new System.Drawing.Size(204, 25);
+            this.kbtnFormBorder.Size = new System.Drawing.Size(272, 31);
             this.kbtnFormBorder.TabIndex = 14;
             this.kbtnFormBorder.Values.Text = "Form Border";
             this.kbtnFormBorder.Click += new System.EventHandler(this.kbtnFormBorder_Click);
-            // 
+            //
             // kbtnToast
-            // 
-            this.kbtnToast.Location = new System.Drawing.Point(13, 257);
+            //
+            this.kbtnToast.Location = new System.Drawing.Point(17, 316);
+            this.kbtnToast.Margin = new System.Windows.Forms.Padding(4);
             this.kbtnToast.Name = "kbtnToast";
-            this.kbtnToast.Size = new System.Drawing.Size(204, 25);
+            this.kbtnToast.Size = new System.Drawing.Size(272, 31);
             this.kbtnToast.TabIndex = 13;
             this.kbtnToast.Values.Text = "Toast";
             this.kbtnToast.Click += new System.EventHandler(this.kbtnToast_Click);
-            // 
+            //
             // kbtnTheme
-            // 
-            this.kbtnTheme.Location = new System.Drawing.Point(223, 226);
+            //
+            this.kbtnTheme.Location = new System.Drawing.Point(297, 278);
+            this.kbtnTheme.Margin = new System.Windows.Forms.Padding(4);
             this.kbtnTheme.Name = "kbtnTheme";
-            this.kbtnTheme.Size = new System.Drawing.Size(204, 25);
+            this.kbtnTheme.Size = new System.Drawing.Size(272, 31);
             this.kbtnTheme.TabIndex = 12;
             this.kbtnTheme.Values.Text = "Theme";
             this.kbtnTheme.Click += new System.EventHandler(this.kbtnTheme_Click);
-            // 
+            //
             // kbtnTextBox
-            // 
-            this.kbtnTextBox.Location = new System.Drawing.Point(13, 226);
+            //
+            this.kbtnTextBox.Location = new System.Drawing.Point(17, 278);
+            this.kbtnTextBox.Margin = new System.Windows.Forms.Padding(4);
             this.kbtnTextBox.Name = "kbtnTextBox";
-            this.kbtnTextBox.Size = new System.Drawing.Size(204, 25);
+            this.kbtnTextBox.Size = new System.Drawing.Size(272, 31);
             this.kbtnTextBox.TabIndex = 11;
             this.kbtnTextBox.Values.Text = "TextBox";
             this.kbtnTextBox.Click += new System.EventHandler(this.kbtnTextBox_Click);
-            // 
+            //
             // kbtnRibbon
-            // 
-            this.kbtnRibbon.Location = new System.Drawing.Point(223, 195);
+            //
+            this.kbtnRibbon.Location = new System.Drawing.Point(297, 240);
+            this.kbtnRibbon.Margin = new System.Windows.Forms.Padding(4);
             this.kbtnRibbon.Name = "kbtnRibbon";
-            this.kbtnRibbon.Size = new System.Drawing.Size(204, 25);
+            this.kbtnRibbon.Size = new System.Drawing.Size(272, 31);
             this.kbtnRibbon.TabIndex = 10;
             this.kbtnRibbon.Values.Text = "Ribbon";
             this.kbtnRibbon.Click += new System.EventHandler(this.kbtnRibbon_Click);
-            // 
+            //
             // kbtnProgressBar
-            // 
-            this.kbtnProgressBar.Location = new System.Drawing.Point(13, 195);
+            //
+            this.kbtnProgressBar.Location = new System.Drawing.Point(17, 240);
+            this.kbtnProgressBar.Margin = new System.Windows.Forms.Padding(4);
             this.kbtnProgressBar.Name = "kbtnProgressBar";
-            this.kbtnProgressBar.Size = new System.Drawing.Size(204, 25);
+            this.kbtnProgressBar.Size = new System.Drawing.Size(272, 31);
             this.kbtnProgressBar.TabIndex = 9;
             this.kbtnProgressBar.Values.Text = "ProgressBar";
             this.kbtnProgressBar.Click += new System.EventHandler(this.kbtnProgressBar_Click);
-            // 
+            //
             // kbtnButtons
-            // 
-            this.kbtnButtons.Location = new System.Drawing.Point(13, 71);
+            //
+            this.kbtnButtons.Location = new System.Drawing.Point(17, 87);
+            this.kbtnButtons.Margin = new System.Windows.Forms.Padding(4);
             this.kbtnButtons.Name = "kbtnButtons";
-            this.kbtnButtons.Size = new System.Drawing.Size(204, 25);
+            this.kbtnButtons.Size = new System.Drawing.Size(272, 31);
             this.kbtnButtons.TabIndex = 8;
             this.kbtnButtons.Values.Text = "Buttons";
             this.kbtnButtons.Click += new System.EventHandler(this.kbtnButtons_Click);
-            // 
+            //
             // kbtnAboutBox
-            // 
-            this.kbtnAboutBox.Location = new System.Drawing.Point(13, 40);
+            //
+            this.kbtnAboutBox.Location = new System.Drawing.Point(17, 49);
+            this.kbtnAboutBox.Margin = new System.Windows.Forms.Padding(4);
             this.kbtnAboutBox.Name = "kbtnAboutBox";
-            this.kbtnAboutBox.Size = new System.Drawing.Size(204, 25);
+            this.kbtnAboutBox.Size = new System.Drawing.Size(272, 31);
             this.kbtnAboutBox.TabIndex = 7;
             this.kbtnAboutBox.Values.Text = "About Box";
             this.kbtnAboutBox.Click += new System.EventHandler(this.kbtnAboutBox_Click);
-            // 
+            //
             // kbtnMessageBox
-            // 
-            this.kbtnMessageBox.Location = new System.Drawing.Point(13, 164);
+            //
+            this.kbtnMessageBox.Location = new System.Drawing.Point(17, 202);
+            this.kbtnMessageBox.Margin = new System.Windows.Forms.Padding(4);
             this.kbtnMessageBox.Name = "kbtnMessageBox";
-            this.kbtnMessageBox.Size = new System.Drawing.Size(204, 25);
+            this.kbtnMessageBox.Size = new System.Drawing.Size(272, 31);
             this.kbtnMessageBox.TabIndex = 6;
             this.kbtnMessageBox.Values.Text = "MessageBox";
             this.kbtnMessageBox.Click += new System.EventHandler(this.kbtnMessageBox_Click);
-            // 
+            //
             // kbtnMenuToolStatusStrips
-            // 
-            this.kbtnMenuToolStatusStrips.Location = new System.Drawing.Point(223, 133);
+            //
+            this.kbtnMenuToolStatusStrips.Location = new System.Drawing.Point(297, 164);
+            this.kbtnMenuToolStatusStrips.Margin = new System.Windows.Forms.Padding(4);
             this.kbtnMenuToolStatusStrips.Name = "kbtnMenuToolStatusStrips";
-            this.kbtnMenuToolStatusStrips.Size = new System.Drawing.Size(204, 25);
+            this.kbtnMenuToolStatusStrips.Size = new System.Drawing.Size(272, 31);
             this.kbtnMenuToolStatusStrips.TabIndex = 5;
             this.kbtnMenuToolStatusStrips.Values.Text = "Menu/Tool/Status Strips";
             this.kbtnMenuToolStatusStrips.Click += new System.EventHandler(this.kbtnMenuToolStatusStrips_Click);
-            // 
+            //
             // kbtnGroupBox
-            // 
-            this.kbtnGroupBox.Location = new System.Drawing.Point(13, 133);
+            //
+            this.kbtnGroupBox.Location = new System.Drawing.Point(17, 164);
+            this.kbtnGroupBox.Margin = new System.Windows.Forms.Padding(4);
             this.kbtnGroupBox.Name = "kbtnGroupBox";
-            this.kbtnGroupBox.Size = new System.Drawing.Size(204, 25);
+            this.kbtnGroupBox.Size = new System.Drawing.Size(272, 31);
             this.kbtnGroupBox.TabIndex = 4;
             this.kbtnGroupBox.Values.Text = "GroupBox";
             this.kbtnGroupBox.Click += new System.EventHandler(this.kbtnGroupBox_Click);
-            // 
+            //
             // kbtnFadeForm
-            // 
-            this.kbtnFadeForm.Location = new System.Drawing.Point(13, 102);
+            //
+            this.kbtnFadeForm.Location = new System.Drawing.Point(17, 126);
+            this.kbtnFadeForm.Margin = new System.Windows.Forms.Padding(4);
             this.kbtnFadeForm.Name = "kbtnFadeForm";
-            this.kbtnFadeForm.Size = new System.Drawing.Size(204, 25);
+            this.kbtnFadeForm.Size = new System.Drawing.Size(272, 31);
             this.kbtnFadeForm.TabIndex = 3;
             this.kbtnFadeForm.Values.Text = "Fade Form";
             this.kbtnFadeForm.Click += new System.EventHandler(this.kbtnFadeForm_Click);
-            // 
+            //
             // kbtnCommandLinkButtons
-            // 
-            this.kbtnCommandLinkButtons.Location = new System.Drawing.Point(223, 71);
+            //
+            this.kbtnCommandLinkButtons.Location = new System.Drawing.Point(297, 87);
+            this.kbtnCommandLinkButtons.Margin = new System.Windows.Forms.Padding(4);
             this.kbtnCommandLinkButtons.Name = "kbtnCommandLinkButtons";
-            this.kbtnCommandLinkButtons.Size = new System.Drawing.Size(204, 25);
+            this.kbtnCommandLinkButtons.Size = new System.Drawing.Size(272, 31);
             this.kbtnCommandLinkButtons.TabIndex = 2;
             this.kbtnCommandLinkButtons.Values.Text = "CommandLink Buttons";
             this.kbtnCommandLinkButtons.Click += new System.EventHandler(this.kbtnCommandLinkButtons_Click);
-            // 
+            //
             // kbtnBreadCrumb
-            // 
-            this.kbtnBreadCrumb.Location = new System.Drawing.Point(223, 40);
+            //
+            this.kbtnBreadCrumb.Location = new System.Drawing.Point(297, 49);
+            this.kbtnBreadCrumb.Margin = new System.Windows.Forms.Padding(4);
             this.kbtnBreadCrumb.Name = "kbtnBreadCrumb";
-            this.kbtnBreadCrumb.Size = new System.Drawing.Size(204, 25);
+            this.kbtnBreadCrumb.Size = new System.Drawing.Size(272, 31);
             this.kbtnBreadCrumb.TabIndex = 1;
             this.kbtnBreadCrumb.Values.Text = "BreadCrumb";
             this.kbtnBreadCrumb.Click += new System.EventHandler(this.kbtnBreadCrumb_Click);
-            // 
-            // kryptonManager1
-            // 
-            this.kryptonManager1.BaseFont = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2010SilverLightMode;
-            // 
-            // kryptonThemeComboBox1
-            // 
-            this.kryptonThemeComboBox1.DropDownWidth = 121;
-            this.kryptonThemeComboBox1.IntegralHeight = false;
-            this.kryptonThemeComboBox1.Location = new System.Drawing.Point(13, 13);
-            this.kryptonThemeComboBox1.Name = "kryptonThemeComboBox1";
-            this.kryptonThemeComboBox1.Size = new System.Drawing.Size(414, 21);
-            this.kryptonThemeComboBox1.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
-            this.kryptonThemeComboBox1.TabIndex = 18;
-            // 
+            //
             // StartScreen
-            // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            //
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.kbtnExit;
-            this.ClientSize = new System.Drawing.Size(437, 359);
+            this.ClientSize = new System.Drawing.Size(619, 425);
             this.Controls.Add(this.kryptonPanel1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.Margin = new System.Windows.Forms.Padding(4);
             this.MaximizeBox = false;
             this.Name = "StartScreen";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;

--- a/Source/Krypton Components/TestForm/StartScreen.Designer.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.Designer.cs
@@ -86,7 +86,6 @@ namespace TestForm
             //
             // kryptonThemeComboBox1
             //
-            this.kryptonThemeComboBox1.DefaultPalette = Krypton.Toolkit.PaletteMode.Office365Blue;
             this.kryptonThemeComboBox1.DropDownWidth = 552;
             this.kryptonThemeComboBox1.IntegralHeight = false;
             this.kryptonThemeComboBox1.Location = new System.Drawing.Point(17, 16);
@@ -101,7 +100,7 @@ namespace TestForm
             // kryptonManager1
             //
             this.kryptonManager1.BaseFont = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2010White;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Microsoft365Blue;
             //
             // kbtnOutlookGrid
             //

--- a/Source/Krypton Components/TestForm/ThemeTest.Designer.cs
+++ b/Source/Krypton Components/TestForm/ThemeTest.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace TestForm
+﻿using System.Drawing;
+
+namespace TestForm
 {
     partial class ThemeTest
     {
@@ -116,9 +118,9 @@
             this.kryptonPanel2.SuspendLayout();
             this.statusStrip1.SuspendLayout();
             this.SuspendLayout();
-            // 
+            //
             // kryptonPanel1
-            // 
+            //
             this.kryptonPanel1.Controls.Add(this.kryptonRichTextBox1);
             this.kryptonPanel1.Controls.Add(this.kryptonThemeComboBox1);
             this.kryptonPanel1.Controls.Add(this.ktrkProgressValues);
@@ -128,82 +130,93 @@
             this.kryptonPanel1.Controls.Add(this.menuStrip1);
             this.kryptonPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonPanel1.Location = new System.Drawing.Point(0, 0);
+            this.kryptonPanel1.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonPanel1.Name = "kryptonPanel1";
-            this.kryptonPanel1.Size = new System.Drawing.Size(760, 332);
+            this.kryptonPanel1.Size = new System.Drawing.Size(1211, 433);
             this.kryptonPanel1.TabIndex = 0;
-            // 
+            //
             // kryptonRichTextBox1
-            // 
-            this.kryptonRichTextBox1.Location = new System.Drawing.Point(13, 162);
+            //
+            this.kryptonRichTextBox1.Location = new System.Drawing.Point(15, 211);
+            this.kryptonRichTextBox1.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonRichTextBox1.Name = "kryptonRichTextBox1";
-            this.kryptonRichTextBox1.Size = new System.Drawing.Size(388, 96);
+            this.kryptonRichTextBox1.Size = new System.Drawing.Size(452, 125);
             this.kryptonRichTextBox1.TabIndex = 13;
             this.kryptonRichTextBox1.Text = "kryptonRichTextBox1";
-            // 
+            //
             // kryptonThemeComboBox1
-            // 
-            this.kryptonThemeComboBox1.DropDownWidth = 201;
+            //
+            this.kryptonThemeComboBox1.DefaultPalette = Krypton.Toolkit.PaletteMode.Office2010Black;
+            this.kryptonThemeComboBox1.DropDownWidth = 452;
             this.kryptonThemeComboBox1.IntegralHeight = false;
-            this.kryptonThemeComboBox1.Location = new System.Drawing.Point(13, 135);
+            this.kryptonThemeComboBox1.Location = new System.Drawing.Point(15, 176);
+            this.kryptonThemeComboBox1.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonThemeComboBox1.Name = "kryptonThemeComboBox1";
             this.kryptonThemeComboBox1.ReportSelectedThemeIndex = false;
-            this.kryptonThemeComboBox1.Size = new System.Drawing.Size(201, 20);
+            this.kryptonThemeComboBox1.Size = new System.Drawing.Size(452, 26);
             this.kryptonThemeComboBox1.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
             this.kryptonThemeComboBox1.TabIndex = 12;
-            // 
+            //
             // ktrkProgressValues
-            // 
-            this.ktrkProgressValues.Location = new System.Drawing.Point(13, 333);
+            //
+            this.ktrkProgressValues.Location = new System.Drawing.Point(15, 436);
+            this.ktrkProgressValues.Margin = new System.Windows.Forms.Padding(4);
             this.ktrkProgressValues.Maximum = 100;
             this.ktrkProgressValues.Name = "ktrkProgressValues";
-            this.ktrkProgressValues.Size = new System.Drawing.Size(388, 33);
+            this.ktrkProgressValues.Size = new System.Drawing.Size(452, 33);
             this.ktrkProgressValues.TabIndex = 11;
             this.ktrkProgressValues.TickStyle = System.Windows.Forms.TickStyle.Both;
             this.ktrkProgressValues.ValueChanged += new System.EventHandler(this.ktrkProgressValues_ValueChanged);
-            // 
+            //
             // kbtnKMBTest
-            // 
-            this.kbtnKMBTest.Location = new System.Drawing.Point(13, 103);
+            //
+            this.kbtnKMBTest.Location = new System.Drawing.Point(15, 135);
+            this.kbtnKMBTest.Margin = new System.Windows.Forms.Padding(4);
             this.kbtnKMBTest.Name = "kbtnKMBTest";
-            this.kbtnKMBTest.Size = new System.Drawing.Size(201, 25);
+            this.kbtnKMBTest.Size = new System.Drawing.Size(234, 33);
             this.kbtnKMBTest.TabIndex = 4;
             this.kbtnKMBTest.Values.Text = "MessageBox Test";
             this.kbtnKMBTest.Click += new System.EventHandler(this.kbtnKMBTest_Click);
-            // 
+            //
             // kryptonLabel1
-            // 
-            this.kryptonLabel1.Location = new System.Drawing.Point(13, 63);
+            //
+            this.kryptonLabel1.Location = new System.Drawing.Point(15, 83);
+            this.kryptonLabel1.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonLabel1.Name = "kryptonLabel1";
-            this.kryptonLabel1.Size = new System.Drawing.Size(127, 19);
+            this.kryptonLabel1.Size = new System.Drawing.Size(135, 25);
             this.kryptonLabel1.TabIndex = 3;
             this.kryptonLabel1.Values.Text = "kryptonLabel1";
-            // 
+            //
             // kryptonPropertyGrid1
-            // 
-            this.kryptonPropertyGrid1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(10)))), ((int)(((byte)(10)))), ((int)(((byte)(10)))));
-            this.kryptonPropertyGrid1.CategoryForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(10)))), ((int)(((byte)(10)))), ((int)(((byte)(10)))));
-            this.kryptonPropertyGrid1.CommandsBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(10)))), ((int)(((byte)(10)))), ((int)(((byte)(10)))));
-            this.kryptonPropertyGrid1.CommandsForeColor = System.Drawing.Color.White;
+            //
+            this.kryptonPropertyGrid1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.kryptonPropertyGrid1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(134)))), ((int)(((byte)(179)))), ((int)(((byte)(236)))));
+            this.kryptonPropertyGrid1.CategoryForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(134)))), ((int)(((byte)(179)))), ((int)(((byte)(236)))));
+            this.kryptonPropertyGrid1.CommandsBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(134)))), ((int)(((byte)(179)))), ((int)(((byte)(236)))));
+            this.kryptonPropertyGrid1.CommandsForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(21)))), ((int)(((byte)(66)))), ((int)(((byte)(139)))));
             this.kryptonPropertyGrid1.DisabledItemForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(127)))), ((int)(((byte)(30)))), ((int)(((byte)(57)))), ((int)(((byte)(91)))));
-            this.kryptonPropertyGrid1.Font = new System.Drawing.Font("Lucida Console", 10.8F);
-            this.kryptonPropertyGrid1.HelpBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(10)))), ((int)(((byte)(10)))), ((int)(((byte)(10)))));
-            this.kryptonPropertyGrid1.HelpForeColor = System.Drawing.Color.White;
-            this.kryptonPropertyGrid1.LineColor = System.Drawing.Color.FromArgb(((int)(((byte)(33)))), ((int)(((byte)(33)))), ((int)(((byte)(33)))));
-            this.kryptonPropertyGrid1.Location = new System.Drawing.Point(455, 27);
+            this.kryptonPropertyGrid1.Font = new System.Drawing.Font("Segoe UI", 10F);
+            this.kryptonPropertyGrid1.HelpBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(63)))), ((int)(((byte)(122)))), ((int)(((byte)(197)))));
+            this.kryptonPropertyGrid1.HelpForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(21)))), ((int)(((byte)(66)))), ((int)(((byte)(139)))));
+            this.kryptonPropertyGrid1.LineColor = System.Drawing.Color.FromArgb(((int)(((byte)(222)))), ((int)(((byte)(236)))), ((int)(((byte)(255)))));
+            this.kryptonPropertyGrid1.Location = new System.Drawing.Point(531, 35);
+            this.kryptonPropertyGrid1.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonPropertyGrid1.Name = "kryptonPropertyGrid1";
             this.kryptonPropertyGrid1.SelectedObject = this.kryptonManager1;
-            this.kryptonPropertyGrid1.Size = new System.Drawing.Size(333, 345);
+            this.kryptonPropertyGrid1.Size = new System.Drawing.Size(671, 383);
             this.kryptonPropertyGrid1.TabIndex = 2;
-            this.kryptonPropertyGrid1.ViewBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(10)))), ((int)(((byte)(10)))), ((int)(((byte)(10)))));
-            this.kryptonPropertyGrid1.ViewForeColor = System.Drawing.Color.White;
-            // 
+            this.kryptonPropertyGrid1.ViewBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(134)))), ((int)(((byte)(179)))), ((int)(((byte)(236)))));
+            this.kryptonPropertyGrid1.ViewForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(21)))), ((int)(((byte)(66)))), ((int)(((byte)(139)))));
+            //
             // kryptonManager1
-            // 
-            this.kryptonManager1.BaseFont = new System.Drawing.Font("Lucida Console", 10.8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Microsoft365BlackDarkMode;
-            // 
+            //
+            this.kryptonManager1.BaseFont = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2010Black;
+            //
             // menuStrip1
-            // 
+            //
             this.menuStrip1.Font = new System.Drawing.Font("Segoe UI", 9F);
             this.menuStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -214,12 +227,12 @@
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
             this.menuStrip1.Padding = new System.Windows.Forms.Padding(4, 2, 0, 2);
-            this.menuStrip1.Size = new System.Drawing.Size(760, 24);
+            this.menuStrip1.Size = new System.Drawing.Size(1211, 28);
             this.menuStrip1.TabIndex = 1;
             this.menuStrip1.Text = "menuStrip1";
-            // 
+            //
             // fileToolStripMenuItem
-            // 
+            //
             this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.newToolStripMenuItem,
             this.openToolStripMenuItem,
@@ -232,82 +245,82 @@
             this.toolStripSeparator2,
             this.exitToolStripMenuItem});
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(46, 24);
             this.fileToolStripMenuItem.Text = "&File";
-            // 
+            //
             // newToolStripMenuItem
-            // 
+            //
             this.newToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("newToolStripMenuItem.Image")));
             this.newToolStripMenuItem.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.newToolStripMenuItem.Name = "newToolStripMenuItem";
             this.newToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.N)));
-            this.newToolStripMenuItem.Size = new System.Drawing.Size(150, 26);
+            this.newToolStripMenuItem.Size = new System.Drawing.Size(181, 26);
             this.newToolStripMenuItem.Text = "&New";
-            // 
+            //
             // openToolStripMenuItem
-            // 
+            //
             this.openToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("openToolStripMenuItem.Image")));
             this.openToolStripMenuItem.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.openToolStripMenuItem.Name = "openToolStripMenuItem";
             this.openToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
-            this.openToolStripMenuItem.Size = new System.Drawing.Size(150, 26);
+            this.openToolStripMenuItem.Size = new System.Drawing.Size(181, 26);
             this.openToolStripMenuItem.Text = "&Open";
-            // 
+            //
             // toolStripSeparator
-            // 
+            //
             this.toolStripSeparator.Name = "toolStripSeparator";
-            this.toolStripSeparator.Size = new System.Drawing.Size(147, 6);
-            // 
+            this.toolStripSeparator.Size = new System.Drawing.Size(178, 6);
+            //
             // saveToolStripMenuItem
-            // 
+            //
             this.saveToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("saveToolStripMenuItem.Image")));
             this.saveToolStripMenuItem.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
             this.saveToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
-            this.saveToolStripMenuItem.Size = new System.Drawing.Size(150, 26);
+            this.saveToolStripMenuItem.Size = new System.Drawing.Size(181, 26);
             this.saveToolStripMenuItem.Text = "&Save";
-            // 
+            //
             // saveAsToolStripMenuItem
-            // 
+            //
             this.saveAsToolStripMenuItem.Name = "saveAsToolStripMenuItem";
-            this.saveAsToolStripMenuItem.Size = new System.Drawing.Size(150, 26);
+            this.saveAsToolStripMenuItem.Size = new System.Drawing.Size(181, 26);
             this.saveAsToolStripMenuItem.Text = "Save &As";
-            // 
+            //
             // toolStripSeparator1
-            // 
+            //
             this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(147, 6);
-            // 
+            this.toolStripSeparator1.Size = new System.Drawing.Size(178, 6);
+            //
             // printToolStripMenuItem
-            // 
+            //
             this.printToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("printToolStripMenuItem.Image")));
             this.printToolStripMenuItem.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.printToolStripMenuItem.Name = "printToolStripMenuItem";
             this.printToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.P)));
-            this.printToolStripMenuItem.Size = new System.Drawing.Size(150, 26);
+            this.printToolStripMenuItem.Size = new System.Drawing.Size(181, 26);
             this.printToolStripMenuItem.Text = "&Print";
-            // 
+            //
             // printPreviewToolStripMenuItem
-            // 
+            //
             this.printPreviewToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("printPreviewToolStripMenuItem.Image")));
             this.printPreviewToolStripMenuItem.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.printPreviewToolStripMenuItem.Name = "printPreviewToolStripMenuItem";
-            this.printPreviewToolStripMenuItem.Size = new System.Drawing.Size(150, 26);
+            this.printPreviewToolStripMenuItem.Size = new System.Drawing.Size(181, 26);
             this.printPreviewToolStripMenuItem.Text = "Print Pre&view";
-            // 
+            //
             // toolStripSeparator2
-            // 
+            //
             this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(147, 6);
-            // 
+            this.toolStripSeparator2.Size = new System.Drawing.Size(178, 6);
+            //
             // exitToolStripMenuItem
-            // 
+            //
             this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
-            this.exitToolStripMenuItem.Size = new System.Drawing.Size(150, 26);
+            this.exitToolStripMenuItem.Size = new System.Drawing.Size(181, 26);
             this.exitToolStripMenuItem.Text = "E&xit";
-            // 
+            //
             // editToolStripMenuItem
-            // 
+            //
             this.editToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.undoToolStripMenuItem,
             this.redoToolStripMenuItem,
@@ -318,114 +331,114 @@
             this.toolStripSeparator4,
             this.selectAllToolStripMenuItem});
             this.editToolStripMenuItem.Name = "editToolStripMenuItem";
-            this.editToolStripMenuItem.Size = new System.Drawing.Size(39, 20);
+            this.editToolStripMenuItem.Size = new System.Drawing.Size(49, 24);
             this.editToolStripMenuItem.Text = "&Edit";
-            // 
+            //
             // undoToolStripMenuItem
-            // 
+            //
             this.undoToolStripMenuItem.Name = "undoToolStripMenuItem";
             this.undoToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Z)));
-            this.undoToolStripMenuItem.Size = new System.Drawing.Size(148, 26);
+            this.undoToolStripMenuItem.Size = new System.Drawing.Size(179, 26);
             this.undoToolStripMenuItem.Text = "&Undo";
-            // 
+            //
             // redoToolStripMenuItem
-            // 
+            //
             this.redoToolStripMenuItem.Name = "redoToolStripMenuItem";
             this.redoToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Y)));
-            this.redoToolStripMenuItem.Size = new System.Drawing.Size(148, 26);
+            this.redoToolStripMenuItem.Size = new System.Drawing.Size(179, 26);
             this.redoToolStripMenuItem.Text = "&Redo";
-            // 
+            //
             // toolStripSeparator3
-            // 
+            //
             this.toolStripSeparator3.Name = "toolStripSeparator3";
-            this.toolStripSeparator3.Size = new System.Drawing.Size(145, 6);
-            // 
+            this.toolStripSeparator3.Size = new System.Drawing.Size(176, 6);
+            //
             // cutToolStripMenuItem
-            // 
+            //
             this.cutToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("cutToolStripMenuItem.Image")));
             this.cutToolStripMenuItem.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.cutToolStripMenuItem.Name = "cutToolStripMenuItem";
             this.cutToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.X)));
-            this.cutToolStripMenuItem.Size = new System.Drawing.Size(148, 26);
+            this.cutToolStripMenuItem.Size = new System.Drawing.Size(179, 26);
             this.cutToolStripMenuItem.Text = "Cu&t";
-            // 
+            //
             // copyToolStripMenuItem
-            // 
+            //
             this.copyToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("copyToolStripMenuItem.Image")));
             this.copyToolStripMenuItem.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.copyToolStripMenuItem.Name = "copyToolStripMenuItem";
             this.copyToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
-            this.copyToolStripMenuItem.Size = new System.Drawing.Size(148, 26);
+            this.copyToolStripMenuItem.Size = new System.Drawing.Size(179, 26);
             this.copyToolStripMenuItem.Text = "&Copy";
-            // 
+            //
             // pasteToolStripMenuItem
-            // 
+            //
             this.pasteToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("pasteToolStripMenuItem.Image")));
             this.pasteToolStripMenuItem.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.pasteToolStripMenuItem.Name = "pasteToolStripMenuItem";
             this.pasteToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.V)));
-            this.pasteToolStripMenuItem.Size = new System.Drawing.Size(148, 26);
+            this.pasteToolStripMenuItem.Size = new System.Drawing.Size(179, 26);
             this.pasteToolStripMenuItem.Text = "&Paste";
-            // 
+            //
             // toolStripSeparator4
-            // 
+            //
             this.toolStripSeparator4.Name = "toolStripSeparator4";
-            this.toolStripSeparator4.Size = new System.Drawing.Size(145, 6);
-            // 
+            this.toolStripSeparator4.Size = new System.Drawing.Size(176, 6);
+            //
             // selectAllToolStripMenuItem
-            // 
+            //
             this.selectAllToolStripMenuItem.Name = "selectAllToolStripMenuItem";
-            this.selectAllToolStripMenuItem.Size = new System.Drawing.Size(148, 26);
+            this.selectAllToolStripMenuItem.Size = new System.Drawing.Size(179, 26);
             this.selectAllToolStripMenuItem.Text = "Select &All";
-            // 
+            //
             // toolsToolStripMenuItem
-            // 
+            //
             this.toolsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.customizeToolStripMenuItem,
             this.optionsToolStripMenuItem});
             this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
-            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(46, 20);
+            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(58, 24);
             this.toolsToolStripMenuItem.Text = "&Tools";
-            // 
+            //
             // customizeToolStripMenuItem
-            // 
+            //
             this.customizeToolStripMenuItem.Name = "customizeToolStripMenuItem";
-            this.customizeToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.customizeToolStripMenuItem.Size = new System.Drawing.Size(161, 26);
             this.customizeToolStripMenuItem.Text = "&Customize";
-            // 
+            //
             // optionsToolStripMenuItem
-            // 
+            //
             this.optionsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.themeBrowserToolStripMenuItem});
             this.optionsToolStripMenuItem.Name = "optionsToolStripMenuItem";
-            this.optionsToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.optionsToolStripMenuItem.Size = new System.Drawing.Size(161, 26);
             this.optionsToolStripMenuItem.Text = "&Options";
-            // 
+            //
             // themeBrowserToolStripMenuItem
-            // 
+            //
             this.themeBrowserToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.leftToRightToolStripMenuItem,
             this.rightToLeftToolStripMenuItem});
             this.themeBrowserToolStripMenuItem.Name = "themeBrowserToolStripMenuItem";
-            this.themeBrowserToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.themeBrowserToolStripMenuItem.Size = new System.Drawing.Size(194, 26);
             this.themeBrowserToolStripMenuItem.Text = "Theme Browser";
-            // 
+            //
             // leftToRightToolStripMenuItem
-            // 
+            //
             this.leftToRightToolStripMenuItem.Name = "leftToRightToolStripMenuItem";
-            this.leftToRightToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.leftToRightToolStripMenuItem.Size = new System.Drawing.Size(174, 26);
             this.leftToRightToolStripMenuItem.Text = "Left to Right";
             this.leftToRightToolStripMenuItem.Click += new System.EventHandler(this.leftToRightToolStripMenuItem_Click);
-            // 
+            //
             // rightToLeftToolStripMenuItem
-            // 
+            //
             this.rightToLeftToolStripMenuItem.Name = "rightToLeftToolStripMenuItem";
-            this.rightToLeftToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.rightToLeftToolStripMenuItem.Size = new System.Drawing.Size(174, 26);
             this.rightToLeftToolStripMenuItem.Text = "Right to Left";
             this.rightToLeftToolStripMenuItem.Click += new System.EventHandler(this.rightToLeftToolStripMenuItem_Click);
-            // 
+            //
             // helpToolStripMenuItem
-            // 
+            //
             this.helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.contentsToolStripMenuItem,
             this.indexToolStripMenuItem,
@@ -433,285 +446,291 @@
             this.toolStripSeparator5,
             this.aboutToolStripMenuItem});
             this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
-            this.helpToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
+            this.helpToolStripMenuItem.Size = new System.Drawing.Size(55, 24);
             this.helpToolStripMenuItem.Text = "&Help";
-            // 
+            //
             // contentsToolStripMenuItem
-            // 
+            //
             this.contentsToolStripMenuItem.Name = "contentsToolStripMenuItem";
-            this.contentsToolStripMenuItem.Size = new System.Drawing.Size(122, 22);
+            this.contentsToolStripMenuItem.Size = new System.Drawing.Size(150, 26);
             this.contentsToolStripMenuItem.Text = "&Contents";
-            // 
+            //
             // indexToolStripMenuItem
-            // 
+            //
             this.indexToolStripMenuItem.Name = "indexToolStripMenuItem";
-            this.indexToolStripMenuItem.Size = new System.Drawing.Size(122, 22);
+            this.indexToolStripMenuItem.Size = new System.Drawing.Size(150, 26);
             this.indexToolStripMenuItem.Text = "&Index";
-            // 
+            //
             // searchToolStripMenuItem
-            // 
+            //
             this.searchToolStripMenuItem.Name = "searchToolStripMenuItem";
-            this.searchToolStripMenuItem.Size = new System.Drawing.Size(122, 22);
+            this.searchToolStripMenuItem.Size = new System.Drawing.Size(150, 26);
             this.searchToolStripMenuItem.Text = "&Search";
-            // 
+            //
             // toolStripSeparator5
-            // 
+            //
             this.toolStripSeparator5.Name = "toolStripSeparator5";
-            this.toolStripSeparator5.Size = new System.Drawing.Size(119, 6);
-            // 
+            this.toolStripSeparator5.Size = new System.Drawing.Size(147, 6);
+            //
             // aboutToolStripMenuItem
-            // 
+            //
             this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
-            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(122, 22);
+            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(150, 26);
             this.aboutToolStripMenuItem.Text = "&About...";
-            // 
+            //
             // kryptonButton1
-            // 
-            this.kryptonButton1.Location = new System.Drawing.Point(698, 15);
+            //
+            this.kryptonButton1.Location = new System.Drawing.Point(815, 19);
+            this.kryptonButton1.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonButton1.Name = "kryptonButton1";
-            this.kryptonButton1.Size = new System.Drawing.Size(90, 25);
+            this.kryptonButton1.Size = new System.Drawing.Size(105, 33);
             this.kryptonButton1.TabIndex = 0;
             this.kryptonButton1.ToolTipValues.ToolTipStyle = Krypton.Toolkit.LabelStyle.ToolTip;
             this.kryptonButton1.Values.Text = "kryptonButton1";
-            // 
+            //
             // kryptonPanel2
-            // 
+            //
             this.kryptonPanel2.Controls.Add(this.kryptonLabel2);
             this.kryptonPanel2.Controls.Add(this.kryptonButton1);
             this.kryptonPanel2.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.kryptonPanel2.Location = new System.Drawing.Point(0, 332);
+            this.kryptonPanel2.Location = new System.Drawing.Point(0, 433);
+            this.kryptonPanel2.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonPanel2.Name = "kryptonPanel2";
             this.kryptonPanel2.PanelBackStyle = Krypton.Toolkit.PaletteBackStyle.PanelAlternate;
-            this.kryptonPanel2.Size = new System.Drawing.Size(760, 50);
+            this.kryptonPanel2.Size = new System.Drawing.Size(1211, 66);
             this.kryptonPanel2.TabIndex = 1;
-            // 
+            //
             // kryptonLabel2
-            // 
-            this.kryptonLabel2.Location = new System.Drawing.Point(13, 15);
+            //
+            this.kryptonLabel2.Location = new System.Drawing.Point(15, 19);
+            this.kryptonLabel2.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonLabel2.Name = "kryptonLabel2";
-            this.kryptonLabel2.Size = new System.Drawing.Size(127, 19);
+            this.kryptonLabel2.Size = new System.Drawing.Size(135, 25);
             this.kryptonLabel2.TabIndex = 1;
             this.kryptonLabel2.Values.Text = "kryptonLabel2";
-            // 
+            //
             // statusStrip1
-            // 
+            //
             this.statusStrip1.Font = new System.Drawing.Font("Segoe UI", 9F);
             this.statusStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripStatusLabel1,
             this.kryptonProgressBarToolStripItem1,
             this.toolStripProgressBar1});
-            this.statusStrip1.Location = new System.Drawing.Point(0, 382);
+            this.statusStrip1.Location = new System.Drawing.Point(0, 499);
             this.statusStrip1.Name = "statusStrip1";
+            this.statusStrip1.Padding = new System.Windows.Forms.Padding(1, 0, 17, 0);
             this.statusStrip1.RenderMode = System.Windows.Forms.ToolStripRenderMode.ManagerRenderMode;
-            this.statusStrip1.Size = new System.Drawing.Size(760, 28);
+            this.statusStrip1.Size = new System.Drawing.Size(1211, 36);
             this.statusStrip1.TabIndex = 2;
             this.statusStrip1.Text = "statusStrip1";
-            // 
+            //
             // toolStripStatusLabel1
-            // 
+            //
+            this.toolStripStatusLabel1.Font = new System.Drawing.Font("Segoe UI", 9F);
             this.toolStripStatusLabel1.Name = "toolStripStatusLabel1";
-            this.toolStripStatusLabel1.Size = new System.Drawing.Size(118, 23);
+            this.toolStripStatusLabel1.Size = new System.Drawing.Size(167, 30);
             this.toolStripStatusLabel1.Text = "toolStripStatusLabel1";
-            // 
+            //
             // kryptonProgressBarToolStripItem1
-            // 
+            //
+            this.kryptonProgressBarToolStripItem1.Font = new System.Drawing.Font("Segoe UI", 9F);
             this.kryptonProgressBarToolStripItem1.Name = "kryptonProgressBarToolStripItem1";
-            this.kryptonProgressBarToolStripItem1.Size = new System.Drawing.Size(100, 26);
+            this.kryptonProgressBarToolStripItem1.Size = new System.Drawing.Size(116, 34);
             this.kryptonProgressBarToolStripItem1.StateCommon.Back.Color1 = System.Drawing.Color.Green;
             this.kryptonProgressBarToolStripItem1.StateDisabled.Back.ColorStyle = Krypton.Toolkit.PaletteColorStyle.OneNote;
             this.kryptonProgressBarToolStripItem1.StateNormal.Back.ColorStyle = Krypton.Toolkit.PaletteColorStyle.OneNote;
             this.kryptonProgressBarToolStripItem1.Text = "0%";
             this.kryptonProgressBarToolStripItem1.UseValueAsText = true;
             this.kryptonProgressBarToolStripItem1.Values.Text = "0%";
-            // 
+            //
             // toolStripProgressBar1
-            // 
+            //
+            this.toolStripProgressBar1.Font = new System.Drawing.Font("Segoe UI", 9F);
             this.toolStripProgressBar1.Name = "toolStripProgressBar1";
-            this.toolStripProgressBar1.Size = new System.Drawing.Size(100, 22);
-            // 
+            this.toolStripProgressBar1.Size = new System.Drawing.Size(116, 28);
+            //
             // buttonSpecAny1
-            // 
+            //
             this.buttonSpecAny1.Enabled = Krypton.Toolkit.ButtonEnabled.True;
             this.buttonSpecAny1.KryptonCommand = this.kryptonCommand1;
             this.buttonSpecAny1.UniqueName = "f605d0a8865e404f8bfe158508b3a4de";
-            // 
+            //
             // kryptonCommand1
-            // 
+            //
             this.kryptonCommand1.AssignedButtonSpec = this.buttonSpecAny1;
             this.kryptonCommand1.CommandType = Krypton.Toolkit.KryptonCommandType.IntegratedToolBarNewCommand;
             this.kryptonCommand1.ImageSmall = ((System.Drawing.Image)(resources.GetObject("kryptonCommand1.ImageSmall")));
-            // 
+            //
             // buttonSpecAny2
-            // 
+            //
             this.buttonSpecAny2.Enabled = Krypton.Toolkit.ButtonEnabled.True;
             this.buttonSpecAny2.KryptonCommand = this.kryptonCommand2;
             this.buttonSpecAny2.UniqueName = "1ff2817dc9fc40da882c6b5f99e326fd";
-            // 
+            //
             // kryptonCommand2
-            // 
+            //
             this.kryptonCommand2.AssignedButtonSpec = this.buttonSpecAny2;
             this.kryptonCommand2.CommandType = Krypton.Toolkit.KryptonCommandType.IntegratedToolBarOpenCommand;
             this.kryptonCommand2.ImageSmall = ((System.Drawing.Image)(resources.GetObject("kryptonCommand2.ImageSmall")));
-            // 
+            //
             // buttonSpecAny3
-            // 
+            //
             this.buttonSpecAny3.Enabled = Krypton.Toolkit.ButtonEnabled.True;
             this.buttonSpecAny3.KryptonCommand = this.kryptonCommand3;
             this.buttonSpecAny3.UniqueName = "c2ee7f9823c9495393353da22e5e33b4";
-            // 
+            //
             // kryptonCommand3
-            // 
+            //
             this.kryptonCommand3.AssignedButtonSpec = this.buttonSpecAny3;
             this.kryptonCommand3.CommandType = Krypton.Toolkit.KryptonCommandType.IntegratedToolBarSaveCommand;
             this.kryptonCommand3.ImageSmall = ((System.Drawing.Image)(resources.GetObject("kryptonCommand3.ImageSmall")));
-            // 
+            //
             // buttonSpecAny4
-            // 
+            //
             this.buttonSpecAny4.Enabled = Krypton.Toolkit.ButtonEnabled.True;
             this.buttonSpecAny4.KryptonCommand = this.kryptonCommand4;
             this.buttonSpecAny4.UniqueName = "c524f280d6f04baaafd5e8e9495fd09d";
-            // 
+            //
             // kryptonCommand4
-            // 
+            //
             this.kryptonCommand4.AssignedButtonSpec = this.buttonSpecAny4;
             this.kryptonCommand4.CommandType = Krypton.Toolkit.KryptonCommandType.IntegratedToolBarSaveAllCommand;
             this.kryptonCommand4.ImageSmall = ((System.Drawing.Image)(resources.GetObject("kryptonCommand4.ImageSmall")));
-            // 
+            //
             // buttonSpecAny5
-            // 
+            //
             this.buttonSpecAny5.Enabled = Krypton.Toolkit.ButtonEnabled.True;
             this.buttonSpecAny5.KryptonCommand = this.kryptonCommand5;
             this.buttonSpecAny5.UniqueName = "8ef2facb6eda4780b0646c9101a41a55";
-            // 
+            //
             // kryptonCommand5
-            // 
+            //
             this.kryptonCommand5.AssignedButtonSpec = this.buttonSpecAny5;
             this.kryptonCommand5.CommandType = Krypton.Toolkit.KryptonCommandType.IntegratedToolBarSaveAsCommand;
             this.kryptonCommand5.ImageSmall = ((System.Drawing.Image)(resources.GetObject("kryptonCommand5.ImageSmall")));
-            // 
+            //
             // buttonSpecAny6
-            // 
+            //
             this.buttonSpecAny6.Enabled = Krypton.Toolkit.ButtonEnabled.True;
             this.buttonSpecAny6.KryptonCommand = this.kryptonCommand6;
             this.buttonSpecAny6.UniqueName = "21524c805767427193d30d8593526f93";
-            // 
+            //
             // kryptonCommand6
-            // 
+            //
             this.kryptonCommand6.AssignedButtonSpec = this.buttonSpecAny6;
             this.kryptonCommand6.CommandType = Krypton.Toolkit.KryptonCommandType.IntegratedToolBarCutCommand;
             this.kryptonCommand6.ImageSmall = ((System.Drawing.Image)(resources.GetObject("kryptonCommand6.ImageSmall")));
-            // 
+            //
             // buttonSpecAny7
-            // 
+            //
             this.buttonSpecAny7.Enabled = Krypton.Toolkit.ButtonEnabled.True;
             this.buttonSpecAny7.KryptonCommand = this.kryptonCommand7;
             this.buttonSpecAny7.UniqueName = "88f66da3c04f4b47a620df157cef2e70";
-            // 
+            //
             // kryptonCommand7
-            // 
+            //
             this.kryptonCommand7.AssignedButtonSpec = this.buttonSpecAny7;
             this.kryptonCommand7.CommandType = Krypton.Toolkit.KryptonCommandType.IntegratedToolBarCopyCommand;
             this.kryptonCommand7.ImageSmall = ((System.Drawing.Image)(resources.GetObject("kryptonCommand7.ImageSmall")));
-            // 
+            //
             // buttonSpecAny8
-            // 
+            //
             this.buttonSpecAny8.Enabled = Krypton.Toolkit.ButtonEnabled.True;
             this.buttonSpecAny8.KryptonCommand = this.kryptonCommand8;
             this.buttonSpecAny8.UniqueName = "0b34a05f7f864d05aba8e89529d152e0";
-            // 
+            //
             // kryptonCommand8
-            // 
+            //
             this.kryptonCommand8.AssignedButtonSpec = this.buttonSpecAny8;
             this.kryptonCommand8.CommandType = Krypton.Toolkit.KryptonCommandType.IntegratedToolBarPasteCommand;
             this.kryptonCommand8.ImageSmall = ((System.Drawing.Image)(resources.GetObject("kryptonCommand8.ImageSmall")));
-            // 
+            //
             // buttonSpecAny9
-            // 
+            //
             this.buttonSpecAny9.Enabled = Krypton.Toolkit.ButtonEnabled.True;
             this.buttonSpecAny9.KryptonCommand = this.kryptonCommand9;
             this.buttonSpecAny9.UniqueName = "9694cb140466450db01fa4319a373fe7";
-            // 
+            //
             // kryptonCommand9
-            // 
+            //
             this.kryptonCommand9.AssignedButtonSpec = this.buttonSpecAny9;
             this.kryptonCommand9.CommandType = Krypton.Toolkit.KryptonCommandType.IntegratedToolBarUndoCommand;
             this.kryptonCommand9.ImageSmall = ((System.Drawing.Image)(resources.GetObject("kryptonCommand9.ImageSmall")));
-            // 
+            //
             // buttonSpecAny10
-            // 
+            //
             this.buttonSpecAny10.Enabled = Krypton.Toolkit.ButtonEnabled.True;
             this.buttonSpecAny10.KryptonCommand = this.kryptonCommand10;
             this.buttonSpecAny10.UniqueName = "6642cbcd7389428dba083557733d1033";
-            // 
+            //
             // kryptonCommand10
-            // 
+            //
             this.kryptonCommand10.AssignedButtonSpec = this.buttonSpecAny10;
             this.kryptonCommand10.CommandType = Krypton.Toolkit.KryptonCommandType.IntegratedToolBarRedoCommand;
             this.kryptonCommand10.ImageSmall = ((System.Drawing.Image)(resources.GetObject("kryptonCommand10.ImageSmall")));
-            // 
+            //
             // buttonSpecAny11
-            // 
+            //
             this.buttonSpecAny11.Enabled = Krypton.Toolkit.ButtonEnabled.True;
             this.buttonSpecAny11.KryptonCommand = this.kryptonCommand11;
             this.buttonSpecAny11.UniqueName = "74db3c2b6178400c8ec6ed14a0a394c0";
-            // 
+            //
             // kryptonCommand11
-            // 
+            //
             this.kryptonCommand11.AssignedButtonSpec = this.buttonSpecAny11;
             this.kryptonCommand11.CommandType = Krypton.Toolkit.KryptonCommandType.IntegratedToolBarPageSetupCommand;
             this.kryptonCommand11.ImageSmall = ((System.Drawing.Image)(resources.GetObject("kryptonCommand11.ImageSmall")));
-            // 
+            //
             // buttonSpecAny12
-            // 
+            //
             this.buttonSpecAny12.Enabled = Krypton.Toolkit.ButtonEnabled.True;
             this.buttonSpecAny12.KryptonCommand = this.kryptonCommand12;
             this.buttonSpecAny12.UniqueName = "50ac1cab058249d4a3dd90ff75c757e0";
-            // 
+            //
             // kryptonCommand12
-            // 
+            //
             this.kryptonCommand12.AssignedButtonSpec = this.buttonSpecAny12;
             this.kryptonCommand12.CommandType = Krypton.Toolkit.KryptonCommandType.IntegratedToolBarPrintPreviewCommand;
             this.kryptonCommand12.ImageSmall = ((System.Drawing.Image)(resources.GetObject("kryptonCommand12.ImageSmall")));
-            // 
+            //
             // buttonSpecAny13
-            // 
+            //
             this.buttonSpecAny13.Enabled = Krypton.Toolkit.ButtonEnabled.True;
             this.buttonSpecAny13.KryptonCommand = this.kryptonCommand13;
             this.buttonSpecAny13.UniqueName = "546c7b4153cf4bf49e900f02acbddf57";
-            // 
+            //
             // kryptonCommand13
-            // 
+            //
             this.kryptonCommand13.AssignedButtonSpec = this.buttonSpecAny13;
             this.kryptonCommand13.CommandType = Krypton.Toolkit.KryptonCommandType.IntegratedToolBarPrintCommand;
             this.kryptonCommand13.ImageSmall = ((System.Drawing.Image)(resources.GetObject("kryptonCommand13.ImageSmall")));
-            // 
+            //
             // buttonSpecAny14
-            // 
+            //
             this.buttonSpecAny14.Enabled = Krypton.Toolkit.ButtonEnabled.True;
             this.buttonSpecAny14.KryptonCommand = this.kryptonCommand14;
             this.buttonSpecAny14.UniqueName = "7156d4510a29499cb0eb26ea230e36b9";
-            // 
+            //
             // kryptonCommand14
-            // 
+            //
             this.kryptonCommand14.AssignedButtonSpec = this.buttonSpecAny14;
             this.kryptonCommand14.CommandType = Krypton.Toolkit.KryptonCommandType.IntegratedToolBarQuickPrintCommand;
             this.kryptonCommand14.ImageSmall = ((System.Drawing.Image)(resources.GetObject("kryptonCommand14.ImageSmall")));
-            // 
+            //
             // buttonSpecAny15
-            // 
+            //
             this.buttonSpecAny15.Enabled = Krypton.Toolkit.ButtonEnabled.True;
             this.buttonSpecAny15.KryptonCommand = this.kryptonCommand15;
             this.buttonSpecAny15.UniqueName = "21201fe41a0d4bbb91c1fc22053d1724";
-            // 
+            //
             // kryptonCommand15
-            // 
+            //
             this.kryptonCommand15.AssignedButtonSpec = this.buttonSpecAny15;
-            // 
+            //
             // ThemeTest
-            // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            //
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
             this.ButtonSpecs.Add(this.buttonSpecAny1);
             this.ButtonSpecs.Add(this.buttonSpecAny2);
             this.ButtonSpecs.Add(this.buttonSpecAny3);
@@ -727,10 +746,12 @@
             this.ButtonSpecs.Add(this.buttonSpecAny13);
             this.ButtonSpecs.Add(this.buttonSpecAny14);
             this.ButtonSpecs.Add(this.buttonSpecAny15);
-            this.ClientSize = new System.Drawing.Size(760, 410);
+            this.ClientSize = new System.Drawing.Size(1211, 535);
             this.Controls.Add(this.kryptonPanel1);
             this.Controls.Add(this.kryptonPanel2);
             this.Controls.Add(this.statusStrip1);
+            this.Font = new System.Drawing.Font("Segoe UI", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.Margin = new System.Windows.Forms.Padding(4);
             this.Name = "ThemeTest";
             this.Text = "Form5";
             this.UseThemeFormChromeBorderWidth = false;


### PR DESCRIPTION
Hey @Wagnerp @Smurf-IV 
please forgive some code reformattings in between, mostly indentations.
This should fix 3 issues:
- White themes (2010, 2013, 365) had white menu text. This was a bit tricky as I had to change the color table "_table" to become protected to be able to override the method for menu item text color in new derived classes for the white themes to use.
- The PropertyGrid showed white-on-white/unreadable color combos in several themes. Adapated to use for the given background a contrast color as per method from another class. It's either black or white font and I tested it with all builtin palettes and they now all show readable content.
- Revised the ThemeComboBox' handling of the DefaultPalette as the index was operating on 2 disjunct sources and thus causing a mismatch. Also made it UI safer to wait for handle to exist.
- See the TestForm's "Theme" dialog for above: once you open it the themes correctly synchronize across the 2 forms as they should and the property grid shows up fine in all themes, too.