### PR TITLE
- `[Browsable(false)]`  //  Hides the property from the Property Grid in the Visual Studio designer

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
+* Resolved [#1337](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1337), ViewManager is visible in the designer as a readonly field, when it should be invisible !
 * Resolved [#1322](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1322), Exception at design time When Assigning CustomPalette to PropertyGrid / TreeGrid
 * Resolved [#1340](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1340), `KryptonPropertyGrid` Category header text colours
 * Resolved [#1331](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1331), Fix white menu text in White themes (2010, 2013, 365); fixes to `KryptonPropertyGrid` and `KryptonThemeComboBox` with regard to theme switching

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualControlBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualControlBase.cs
@@ -514,8 +514,9 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the ViewManager instance.
         /// </summary>
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Browsable(false)]  //  Hides the property from the Property Grid in the Visual Studio designer
+        [EditorBrowsable(EditorBrowsableState.Never)]   // Hides the property from IntelliSense and code completion. 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] //  Prevents the property from being serialized into the designer code.
         public ViewManager? ViewManager
         {
             [DebuggerStepThrough]


### PR DESCRIPTION
- `[Browsable(false)]`  //  Hides the property from the Property Grid in the Visual Studio designer
- `[EditorBrowsable(EditorBrowsableState.Never)]`   // Hides the property from IntelliSense and code completion.
- `[DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]` //  Prevents the property from being serialized into the designer code.

#1337

![image](https://github.com/Krypton-Suite/Standard-Toolkit/assets/2418812/efd60d4f-ff5a-458d-b79a-0e242a75b7c9)
