### PR TITLE
- Detect if the Reflection returned a null and attempt to get the net core `-Options` instead

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,10 +3,11 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
+* Resolved [#1351](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1351),  KryptonFolderBrowserDialog display and runtime errors
 * Resolved [#1337](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1337), ViewManager is visible in the designer as a readonly field, when it should be invisible !
 * Resolved [#1244](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1244), Should `IsDefault` set to be `internal`
 * Resolved [#1322](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1322), Exception at design time When Assigning CustomPalette to PropertyGrid / TreeGrid
-  * Resolved [#1340](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1340), `KryptonPropertyGrid` Category header text colours
+* Resolved [#1340](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1340), `KryptonPropertyGrid` Category header text colours
 * Resolved [#1331](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1331), Fix white menu text in White themes (2010, 2013, 365); fixes to `KryptonPropertyGrid` and `KryptonThemeComboBox` with regard to theme switching
 * Resolved [#1313](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1313), White background in tabs area
 * Implement [#1309](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1309), Is it time to bring over `KryptonOutlookGrid`

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -119,6 +119,8 @@ namespace Krypton.Toolkit
             _recreateButtons = true;
             _firstCheckView = true;
             _lastNotNormal = false;
+            // Yes, we want to be drawn double buffered by default
+            base.DoubleBuffered = true;
 
             // Create storage objects
             ButtonSpecs = new FormButtonSpecCollection(this);
@@ -528,7 +530,7 @@ namespace Krypton.Toolkit
                 else
                 {
                     // Just add to the docking edge requested
-                    _drawHeading.Add(element, style);
+                    _drawHeading.Add(element!, style);
                 }
             }
         }
@@ -1292,7 +1294,7 @@ namespace Krypton.Toolkit
                     if (_headerStyle != _headerStylePrev)
                     {
                         // Ensure the header style matches the form border style
-                        SetHeaderStyle(_drawHeading, StateCommon.Header, _headerStyle);
+                        SetHeaderStyle(_drawHeading, StateCommon!.Header, _headerStyle);
 
                         // Remember last header style set
                         _headerStylePrev = _headerStyle;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/CommonDialogHandler.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/CommonDialogHandler.cs
@@ -424,6 +424,7 @@ namespace Krypton.Toolkit
                 Padding = new Padding(0),
                 TopMost = true
             };
+
             if (ShowIcon)
             {
                 _wrapperForm.FormBorderStyle = _isResizable ? FormBorderStyle.Sizable : FormBorderStyle.Fixed3D;
@@ -497,7 +498,9 @@ namespace Krypton.Toolkit
                 if (_wrapperForm != null)
                 {
                     var clientSize = _wrapperForm.ClientSize;
-                    PI.MoveWindow(_resizeHandle, 0, 0, clientSize.Width, clientSize.Height, false);
+                    _wrapperForm.SuspendLayout();
+                    PI.MoveWindow(_resizeHandle, 0, 0, clientSize.Width, clientSize.Height, true);
+                    _wrapperForm.ResumeLayout(false);
                 }
             }
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
@@ -137,7 +137,6 @@ namespace Krypton.Toolkit
             UpdateDpiFactors();
         }
 
-
         /// <summary>
         /// Releases all resources used by the Control. 
         /// </summary>
@@ -1035,7 +1034,7 @@ namespace Krypton.Toolkit
             }
 
             // Do we need to override message processing?
-            if (/*ApplyCustomChrome &&*/ !IsDisposed && !Disposing)
+            if (!IsDisposed && !Disposing)
             {
                 switch (m.Msg)
                 {

--- a/Source/Krypton Components/Krypton.Toolkit/ShellDialogs/ShellBrowserDialogTFM.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ShellDialogs/ShellBrowserDialogTFM.cs
@@ -52,14 +52,19 @@ namespace Krypton.Toolkit
             _internalOpenFileDialog.AddExtension = false;
             _internalOpenFileDialog.CheckFileExists = false;
             _internalOpenFileDialog.DereferenceLinks = true;
-            _internalOpenFileDialog.Filter = @"folders|\n";
+            _internalOpenFileDialog.Filter = "folders|\n";
             _internalOpenFileDialog.Multiselect = false;
             _internalOpenFileDialog.ValidateNames = false;
             _internalOpenFileDialog.CheckPathExists = true;
             _internalOpenFileDialog.FileName = "Folder Selection.";
             var options = _ofd.GetField(@"options", BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic);
-            var value = (int)options?.GetValue(_internalOpenFileDialog)!;
-            options.SetValue(_internalOpenFileDialog, value | (int)(FOS_.FORCEFILESYSTEM | FOS_.PICKFOLDERS));
+            // Check null: if this is running on core !!
+            options ??= _ofd.GetField(@"_options", BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic);
+            if (options != null)
+            {
+                var value = (int)options.GetValue(_internalOpenFileDialog)!;
+                options.SetValue(_internalOpenFileDialog, value | (int)(FOS_.FORCEFILESYSTEM | FOS_.PICKFOLDERS));
+            }
 
             return _internalOpenFileDialog.ShowDialog(owner);
         }
@@ -70,7 +75,6 @@ namespace Krypton.Toolkit
 
             if (e.message == PI.WM_.INITDIALOG)
             {
-                // TODO: Also Disable the Combo filter drop down 
                 var button = _commonDialogHandler.Controls.FirstOrDefault(static ctl => ctl.DlgCtrlId == 1);
                 if (button?.Button != null)
                 {
@@ -80,6 +84,16 @@ namespace Krypton.Toolkit
                         panel.Left -= (int)(30 * _scaleFactor);
                         panel.Width += (int)(30 * _scaleFactor);
                     }
+                }
+                // Also Hide the Combo filter drop down 
+                var filterCombo = _commonDialogHandler.Controls.FirstOrDefault(static ctl => ctl.DlgCtrlId == 0x470);
+                if (filterCombo != null)
+                {
+                    var fileNameCombo = _commonDialogHandler.Controls.First(static ctl => ctl.DlgCtrlId == 0x47C);
+                    PI.ShowWindow(fileNameCombo.hWnd, PI.ShowWindowCommands.SW_HIDE);
+                    var fileNameText = _commonDialogHandler.Controls.First(static ctl => ctl.DlgCtrlId == 0x442);
+                    PI.ShowWindow(fileNameText.hWnd, PI.ShowWindowCommands.SW_HIDE);
+                    PI.ShowWindow(filterCombo.hWnd, PI.ShowWindowCommands.SW_HIDE);
                 }
             }
         }

--- a/Source/Krypton Components/Krypton.Toolkit/ShellDialogs/ShellDialogWrapper.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ShellDialogs/ShellDialogWrapper.cs
@@ -106,8 +106,13 @@ namespace Krypton.Toolkit
 
         private protected virtual void FormResize(object sender, EventArgs e)
         {
+            if (_commonDialogHandler._wrapperForm == null)
+            {
+                return;
+            }
+            _commonDialogHandler._wrapperForm.SuspendLayout();
             // Align the button underneath the drop down
-            var clientSize = _commonDialogHandler._wrapperForm!.ClientSize;
+            var clientSize = _commonDialogHandler._wrapperForm.ClientSize;
             foreach (var button in _commonDialogHandler.Controls.Where(static ctl => ctl.Button != null))
             {
                 if (button.Button?.Parent is Panel panel)
@@ -118,17 +123,20 @@ namespace Krypton.Toolkit
                         case 1: // @"&Save"
                                 // case @"&Open":
                                 // case @"Select Folder":
-                            panel.Location = new Point((int)(clientSize.Width - 116 * _scaleFactor - button.Button.Width * 1.1),
+                            panel.Location = new Point(
+                                (int)(clientSize.Width - 116 * _scaleFactor - button.Button.Width * 1.1),
                                 (int)(clientSize.Height - 12 * _scaleFactor - button.Button.Height));
                             break;
                         case 2:
                             //case @"Cancel":
-                            panel.Location = new Point((int)(clientSize.Width - 30 * _scaleFactor - button.Button.Width),
+                            panel.Location = new Point(
+                                (int)(clientSize.Width - 30 * _scaleFactor - button.Button.Width),
                                 (int)(clientSize.Height - 12 * _scaleFactor - button.Button.Height));
                             break;
                     }
                 }
             }
+            _commonDialogHandler._wrapperForm.ResumeLayout(false);
         }
 
         private void WndCreated(object sender, CbtEventArgs e)


### PR DESCRIPTION
- Detect if the Reflection returned a null and attempt to get the net core `-Options` instead
- Hide the Unused fields in the Folder browsing experience
- Attempt to reduce flickering (Some not all !)

![image](https://github.com/Krypton-Suite/Standard-Toolkit/assets/2418812/30e9584e-6754-4f61-9425-d209c79178b0)

#1351

![image](https://github.com/Krypton-Suite/Standard-Toolkit/assets/2418812/2f9a3aed-9292-4244-8e9c-a8f407945f95)
