### PR TITLE
- Sort out access to the correct named static fields that have been renamed in `netCore`

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,13 +3,14 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
-* Resolved [#1362](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1362), Using todays Alpha and todays alpha Demos: cannot open Outlook Mail Clone Form in the designer
-* Tested [#1188](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1188), Duplicate window titles when window maximized
+* Resolved [#1314](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1314), **[Regression]** CheckedListBox CheckedIndices NullRef
+* Resolved [#1362](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1362), **[Regression]** Using todays Alpha and todays alpha Demos: cannot open Outlook Mail Clone Form in the designer
+* Tested [#1188](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1188), **[Regression]** Duplicate window titles when window maximized
 * Resolved [#1361](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1361), Opening an existing (Or creating a new) RibbonBar creates incorrect designer code for new `ToolBarImages` object(s)
 * Implemented [#1355](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1355), Ability to merge `KryptonRibbon`s
     - **Note:** This feature is activated via the `KryptonRibbonMerger` API
 * Resolved issue whereby `CustomFormatMinimumColorButtonText` was assigned `null`, therefore flagging `KryptonOutlookGridStrings` as 'modified'
-* Resolved [#1351](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1351),  KryptonFolderBrowserDialog display and runtime errors
+* Resolved [#1351](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1351), **[Regression]** KryptonFolderBrowserDialog display and runtime errors
 * Implemented [#1343](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1343), Extend palette to accept `AppButton` colours
 * Resolved [#1337](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1337), ViewManager is visible in the designer as a readonly field, when it should be invisible !
 * Resolved [#1244](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1244), Should `IsDefault` set to be `internal`

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckedListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckedListBox.cs
@@ -150,9 +150,17 @@ namespace Krypton.Toolkit
 
             private object InnerArrayGetEntryObject(int index, int stateMask) => _internalListBox.InnerArrayGetEntryObject(index, stateMask);
 
-            private int InnerArrayIndexOfIdentifier(object? identifier, int stateMask) => _internalListBox.InnerArrayIndexOfIdentifier(identifier, stateMask);
+            private int InnerArrayIndexOfIdentifier(object? identifier, int stateMask)
+            {
+#if NET6_0_OR_GREATER
+// https://github.com/dotnet/winforms/commit/1f4a593a6de32e75ff0f5fa97d35191c1facbc93#diff-c4db2c84a2a605af84487ad4386f94c42193826e71b7cf8d297c610c034245f9
+                return _internalListBox.InnerArrayIndexOf(identifier, stateMask);
+#else
+                return _internalListBox.InnerArrayIndexOfIdentifier(identifier, stateMask);
+#endif
+            }
 
-            #endregion
+#endregion
         }
 
         /// <summary>
@@ -936,7 +944,7 @@ namespace Krypton.Toolkit
             #endregion
         }
 
-        #endregion
+#endregion
 
         #region Instance Fields
 
@@ -1871,7 +1879,7 @@ namespace Krypton.Toolkit
         /// Sets input focus to the control.
         /// </summary>
         /// <returns>true if the input focus request was successful; otherwise, false.</returns>
-        public new bool Focus() => ListBox.Focus() == true;
+        public new bool Focus() => ListBox.Focus();
 
         /// <summary>
         /// Activates the control.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewButtonCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewButtonCell.cs
@@ -18,9 +18,9 @@ namespace Krypton.Toolkit
     public class KryptonDataGridViewButtonCell : DataGridViewButtonCell
     {
         #region Static Fields
-        private static PropertyInfo _piButtonState;
-        private static PropertyInfo _piMouseEnteredCellAddress;
-        private static FieldInfo _fiMouseInContentBounds;
+        private static PropertyInfo? _piButtonState;
+        private static PropertyInfo? _piMouseEnteredCellAddress;
+        private static FieldInfo? _fiMouseInContentBounds;
         #endregion
 
         #region Instance Fields
@@ -352,11 +352,10 @@ namespace Krypton.Toolkit
                     _piButtonState = typeof(DataGridViewButtonCell).GetProperty(nameof(ButtonState), BindingFlags.Instance |
                                                                                                BindingFlags.NonPublic |
                                                                                                BindingFlags.GetField);
-
                 }
 
                 // Grab the internal property implemented by base class
-                return (ButtonState)_piButtonState.GetValue(this, null);
+                return _piButtonState != null ? (ButtonState)(_piButtonState.GetValue(this, null) ?? ButtonState.Normal) : ButtonState.Normal;
             }
         }
 
@@ -371,10 +370,18 @@ namespace Krypton.Toolkit
                     _fiMouseInContentBounds = typeof(DataGridViewButtonCell).GetField(@"mouseInContentBounds", BindingFlags.Static |
                                                                                                               BindingFlags.NonPublic |
                                                                                                               BindingFlags.GetField);
+                    if (_fiMouseInContentBounds == null)
+                    {
+                        // https://github.com/dotnet/winforms/commit/27e010d21c78457113f5be67eeea842499ab5f74#diff-bb5ad249080118c559367691ad27b9a93f8d5324b814f65113ff2e4bd15c9b39
+                        // This was changed in netCore8 P1 but when running netcore7 it still wants this new name ??
+                        _fiMouseInContentBounds = typeof(DataGridViewButtonCell).GetField(@"s_mouseInContentBounds", BindingFlags.Static |
+                            BindingFlags.NonPublic |
+                            BindingFlags.GetField);
+                    }
                 }
 
                 // Grab the internal property implemented by base class
-                return (bool)_fiMouseInContentBounds.GetValue(this);
+                return _fiMouseInContentBounds != null && (bool)(_fiMouseInContentBounds.GetValue(this) ?? false);
             }
         }
 
@@ -389,12 +396,11 @@ namespace Krypton.Toolkit
                     _piMouseEnteredCellAddress = typeof(DataGridView).GetProperty(@"MouseEnteredCellAddress", BindingFlags.Instance |
                                                                                                              BindingFlags.NonPublic |
                                                                                                              BindingFlags.GetField);
-
                 }
 
                 // Grab the internal property implemented by base class
                 // ReSharper disable RedundantBaseQualifier
-                return (Point)_piMouseEnteredCellAddress.GetValue(base.DataGridView, null);
+                return _piMouseEnteredCellAddress != null ? (Point)(_piMouseEnteredCellAddress.GetValue(base.DataGridView, null) ?? Point.Empty) : Point.Empty;
                 // ReSharper restore RedundantBaseQualifier
             }
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewCheckBoxCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewCheckBoxCell.cs
@@ -18,9 +18,9 @@ namespace Krypton.Toolkit
     public class KryptonDataGridViewCheckBoxCell : DataGridViewCheckBoxCell
     {
         #region Static Fields
-        private static PropertyInfo _piButtonState;
-        private static PropertyInfo _piMouseEnteredCellAddress;
-        private static FieldInfo _fiMouseInContentBounds;
+        private static PropertyInfo? _piButtonState;
+        private static PropertyInfo? _piMouseEnteredCellAddress;
+        private static FieldInfo? _fiMouseInContentBounds;
         #endregion
 
         #region Instance Fields
@@ -265,7 +265,7 @@ namespace Krypton.Toolkit
                 }
 
                 // Grab the internal property implemented by base class
-                return (ButtonState)_piButtonState.GetValue(this, null);
+                return _piButtonState != null ? (ButtonState)_piButtonState.GetValue(this, null) : ButtonState.Normal;
             }
         }
 
@@ -280,6 +280,14 @@ namespace Krypton.Toolkit
                     _fiMouseInContentBounds = typeof(DataGridViewCheckBoxCell).GetField(@"mouseInContentBounds", BindingFlags.Static |
                                                                                                                 BindingFlags.NonPublic |
                                                                                                                 BindingFlags.GetField);
+                    if (_fiMouseInContentBounds == null)
+                    {
+                        // https://github.com/dotnet/winforms/commit/7ab46c6e6ae1c39143a7638d694fb6e130ab4edc#diff-2684515ec95bea4ec16a0bf7c9e6ff09dc33d31aafabd2c35f016994c800fc84
+                        // This was changed in netCore8 P1 but when running netcore7 it still wants this new name ??
+                        _fiMouseInContentBounds = typeof(DataGridViewCheckBoxCell).GetField(@"s_mouseInContentBounds", BindingFlags.Static |
+                            BindingFlags.NonPublic |
+                            BindingFlags.GetField);
+                    }
                 }
 
                 // Grab the internal property implemented by base class

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonFolderBrowserDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonFolderBrowserDialog.cs
@@ -20,7 +20,7 @@ namespace Krypton.Toolkit
     [ToolboxItem(true)]
     public class KryptonFolderBrowserDialog : ShellDialogWrapper, IDisposable
     {
-#if NET60_OR_GREATER
+#if NET6_0_OR_GREATER
         private readonly FolderBrowserDialog _internalOpenFileDialog = new();// { AutoUpgradeEnabled = true };
 #else
         private readonly ShellBrowserDialogTFM _internalOpenFileDialog = new ShellBrowserDialogTFM();
@@ -45,7 +45,7 @@ namespace Krypton.Toolkit
         //    return true;
         //}
 
-#if NET60_OR_GREATER
+#if NET6_0_OR_GREATER
         /// <inheritdoc />
         public override Guid? ClientGuid 
         { 
@@ -70,13 +70,13 @@ namespace Krypton.Toolkit
             set => _internalOpenFileDialog.SelectedPath = value;
         }
 
-#if NET60_OR_GREATER
+#if NET6_0_OR_GREATER
         /// <summary>
         ///  Gets or sets the initial directory displayed by the folder browser dialog.
         /// </summary>
         [Category(@"FolderBrowsing")]
         [DefaultValue("")]
-        [Editor(typeof(InitialDirectoryEditor), typeof(UITypeEditor))]
+        [Editor(typeof(KryptonInitialDirectoryEditor), typeof(UITypeEditor))]
         [Description(@"Gets or sets the initial directory displayed by the folder browser dialog")]
         [AllowNull]
         public string InitialDirectory

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonOpenFileDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonOpenFileDialog.cs
@@ -86,7 +86,7 @@ namespace Krypton.Toolkit
             set => _internalOpenFileDialog.CheckPathExists = value;
         }
 
-#if NET60_OR_GREATER
+#if NET6_0_OR_GREATER
         /// <inheritdoc />
         public override Guid? ClientGuid
         { 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonSaveFileDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonSaveFileDialog.cs
@@ -25,7 +25,7 @@ namespace Krypton.Toolkit
         /// <inheritdoc />
         protected override DialogResult ShowActualDialog(IWin32Window? owner) => _internalSaveFileDialog.ShowDialog(owner);
 
-#if NET7_0 || NET8_0
+#if NET7_0 || NET8_0_OR_GREATER
         /// <summary>
         ///  Gets or sets a value indicating whether the dialog box verifies if the creation of the specified file will be successful.
         ///  If this flag is not set, the calling application must handle errors, such as denial of access, discovered when the item is created.
@@ -104,7 +104,7 @@ namespace Krypton.Toolkit
             set => _internalSaveFileDialog.CheckPathExists = value;
         }
 
-#if NET60_OR_GREATER
+#if NET6_0_OR_GREATER
         /// <inheritdoc />
         public override Guid? ClientGuid
         { 

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Editors/KryptonInitialDirectoryEditor.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Editors/KryptonInitialDirectoryEditor.cs
@@ -1,0 +1,14 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Windows.Forms.Design;
+
+internal class KryptonInitialDirectoryEditor : FolderNameEditor
+{
+    protected override void InitializeDialog(FolderBrowser folderBrowser)
+    {
+        folderBrowser.Description = //SR.InitialDirectoryEditorLabel;
+            @"Select the directory that will initially be opened in the dialog.";
+    }
+}

--- a/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
@@ -1950,8 +1950,8 @@ namespace Krypton.Toolkit
         /// <summary>
         ///  Specifies that the message box contains Cancel, Try Again, and Continue buttons.
         /// </summary>
-#if NET60_OR_GREATER
-            CancelTryContinue = MessageBoxButtons.CancelTryContinue
+#if NET6_0_OR_GREATER
+        CancelTryContinue = MessageBoxButtons.CancelTryContinue
 #else
         CancelTryContinue = 0x00000006
 #endif

--- a/Source/Krypton Components/Krypton.Toolkit/Krypton.Toolkit 2022.csproj
+++ b/Source/Krypton Components/Krypton.Toolkit/Krypton.Toolkit 2022.csproj
@@ -1,886 +1,885 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<Choose>
-		<When Condition="'$(Configuration)' == 'Nightly'">
-			<PropertyGroup>
-				<TargetFrameworks>net462;net47;net471;net472;net48;net481;net6.0-windows;net7.0-windows;net8.0-windows;net9.0-windows</TargetFrameworks>
-			</PropertyGroup>
-		</When>
-		<Otherwise>
-			<Choose>
-				<When Condition="'$(Configuration)' == 'Canary'">
-					<PropertyGroup>
-						<TargetFrameworks>net462;net47;net471;net472;net48;net481;net6.0-windows;net7.0-windows;net8.0-windows;net9.0-windows</TargetFrameworks>
-					</PropertyGroup>
-				</When>
-				<Otherwise>
-					<PropertyGroup>
-						<TargetFrameworks>net48;net481;net6.0-windows;net8.0-windows;net9.0-windows</TargetFrameworks>
+    <Choose>
+        <When Condition="'$(Configuration)' == 'Nightly'">
+            <PropertyGroup>
+                <TargetFrameworks>net462;net47;net471;net472;net48;net481;net6.0-windows;net7.0-windows;net8.0-windows;net9.0-windows</TargetFrameworks>
+            </PropertyGroup>
+        </When>
+        <Otherwise>
+            <Choose>
+                <When Condition="'$(Configuration)' == 'Canary'">
+                    <PropertyGroup>
+                        <TargetFrameworks>net462;net47;net471;net472;net48;net481;net6.0-windows;net7.0-windows;net8.0-windows;net9.0-windows</TargetFrameworks>
+                    </PropertyGroup>
+                </When>
+                <Otherwise>
+                    <PropertyGroup>
+                        <TargetFrameworks>net48;net481;net6.0-windows;net8.0-windows;net9.0-windows</TargetFrameworks>
 
-						<TargetFrameworks Condition="'$(TFMs)' == 'all'">net462;net47;net471;net472;net48;net481;net6.0-windows;net7.0-windows;net8.0-windows</TargetFrameworks>
-					</PropertyGroup>
-				</Otherwise>
-			</Choose>
-		</Otherwise>
-	</Choose>
+                        <TargetFrameworks Condition="'$(TFMs)' == 'all'">net462;net47;net471;net472;net48;net481;net6.0-windows;net7.0-windows;net8.0-windows</TargetFrameworks>
+                    </PropertyGroup>
+                </Otherwise>
+            </Choose>
+        </Otherwise>
+    </Choose>
 
-	<PropertyGroup>
-		<OutputType>Library</OutputType>
-		<RootNamespace>Krypton.Toolkit</RootNamespace>
-		<AssemblyName>Krypton.Toolkit</AssemblyName>
-		<!-- Set the CheckEolTargetFramework property to false to fix the warning -->
-		<CheckEolTargetFramework>false</CheckEolTargetFramework>
-		<SignAssembly>True</SignAssembly>
-		<AssemblyOriginatorKeyFile>StrongKrypton.snk</AssemblyOriginatorKeyFile>
-		<ApplicationIcon>Krypton.ico</ApplicationIcon>
-		<DelaySign>false</DelaySign>
-		<UseWindowsForms>true</UseWindowsForms>
-		<PlatformTarget>AnyCPU</PlatformTarget>
-		<EnableNETAnalyzers>true</EnableNETAnalyzers>
-		<NeutralLanguage>en</NeutralLanguage>
-		<DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
-		<NoWarn>1701;1702</NoWarn>
-		<Configurations>Debug;Release;Installer;Nightly;Canary</Configurations>
-		<DocumentationFile>..\..\..\Bin\$(Configuration)\Krypton.Toolkit.xml</DocumentationFile>
-		<OutputPath>..\..\..\Bin\$(Configuration)\</OutputPath>
-		<LangVersion>preview</LangVersion>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-		<LangVersion>preview</LangVersion>
-		<Nullable>enable</Nullable>
-		<WarningLevel>6</WarningLevel>
-		<AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
-	</PropertyGroup>
+    <PropertyGroup>
+        <OutputType>Library</OutputType>
+        <RootNamespace>Krypton.Toolkit</RootNamespace>
+        <AssemblyName>Krypton.Toolkit</AssemblyName>
+        <!-- Set the CheckEolTargetFramework property to false to fix the warning -->
+        <CheckEolTargetFramework>false</CheckEolTargetFramework>
+        <SignAssembly>True</SignAssembly>
+        <AssemblyOriginatorKeyFile>StrongKrypton.snk</AssemblyOriginatorKeyFile>
+        <ApplicationIcon>Krypton.ico</ApplicationIcon>
+        <DelaySign>false</DelaySign>
+        <UseWindowsForms>true</UseWindowsForms>
+        <PlatformTarget>AnyCPU</PlatformTarget>
+        <EnableNETAnalyzers>true</EnableNETAnalyzers>
+        <NeutralLanguage>en</NeutralLanguage>
+        <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
+        <NoWarn>1701;1702</NoWarn>
+        <Configurations>Debug;Release;Installer;Nightly;Canary</Configurations>
+        <DocumentationFile>..\..\..\Bin\$(Configuration)\Krypton.Toolkit.xml</DocumentationFile>
+        <OutputPath>..\..\..\Bin\$(Configuration)\</OutputPath>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <LangVersion>preview</LangVersion>
+        <Nullable>enable</Nullable>
+        <WarningLevel>6</WarningLevel>
+        <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
+    </PropertyGroup>
 
-	<ItemGroup>
-		<Reference Include="System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="$(TargetFramework.StartsWith('net4'))">
-			<SpecificVersion>True</SpecificVersion>
-			<Version>4.0.0.0</Version>
-			<!-- Designers for the `TFMs != net4` are "Pulled in" via Visual studios ".nuget\packages\microsoft.windowsdesktop.app.ref" -->
-		</Reference>
-	</ItemGroup>
+    <ItemGroup>
+        <Reference Include="System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="$(TargetFramework.StartsWith('net4'))">
+            <SpecificVersion>True</SpecificVersion>
+            <Version>4.0.0.0</Version>
+            <!-- Designers for the `TFMs != net4` are "Pulled in" via Visual studios ".nuget\packages\microsoft.windowsdesktop.app.ref" -->
+        </Reference>
+    </ItemGroup>
 
-	<PropertyGroup>
-		<PackageId>Krypton.Toolkit</PackageId>
-		<Description>This is the core toolkit module.</Description>
-	</PropertyGroup>
+    <PropertyGroup>
+        <PackageId>Krypton.Toolkit</PackageId>
+        <Description>This is the core toolkit module.</Description>
+    </PropertyGroup>
 
-	<ItemGroup>
-		<Compile Update="ButtonSpec\ButtonSpecFormFixed.cs">
-			<SubType>Component</SubType>
-		</Compile>
-		<Compile Update="ButtonSpec\ButtonSpecFormWindowClose.cs">
-			<SubType>Component</SubType>
-		</Compile>
-		<Compile Update="ButtonSpec\ButtonSpecFormWindowMin.cs">
-			<SubType>Component</SubType>
-		</Compile>
-		<Compile Update="ButtonSpec\ButtonSpecFormWindowMax.cs">
-			<SubType>Component</SubType>
-		</Compile>
-		<Compile Update="ButtonSpec\ButtonSpecCalendar.cs">
-			<SubType>Component</SubType>
-		</Compile>
-		<Compile Update="Controls Toolkit\KryptonColorDialog.cs" />
-		<Compile Update="Controls Toolkit\KryptonPrintDialog.cs" />
-		<Compile Update="Designers\Other\PaletteDrawBordersSelector.cs" />
-		<Compile Update="Controls Toolkit\KryptonBreadCrumbItem.cs">
-			<SubType>Component</SubType>
-		</Compile>
-		<Compile Update="Controls Toolkit\KryptonListItem.cs">
-			<SubType>Component</SubType>
-		</Compile>
-		<Compile Update="ContextMenu\KryptonContextMenuItemBase.cs" />
-		<Compile Update="ButtonSpec\ButtonSpecAny.cs">
-			<SubType>Component</SubType>
-		</Compile>
-		<Compile Update="ButtonSpec\ButtonSpec.cs">
-			<SubType>Component</SubType>
-		</Compile>
-		<Compile Update="Palette Builtin\Office 2007\Non Official Themes\PaletteOffice2007White.cs" />
-		<Compile Update="Palette Builtin\Office 2010\Non Official Themes\PaletteOffice2010White.cs" />
-		<Compile Update="Palette Builtin\Office 2013\Non Official Themes\PaletteOffice2013AccessLegacy.cs">
-			<SubType>Component</SubType>
-		</Compile>
-		<Compile Update="Palette Builtin\Office 2013\Bases\PaletteOffice2013Base.cs" />
-		<Compile Update="Palette Builtin\Office 2013\Official Themes\PaletteOffice2013White.cs" />
-		<Compile Update="Palette Builtin\Microsoft 365\Bases\PaletteMicrosoft365Base.cs" />
-		<Compile Update="Palette Builtin\Office 365\Non Official Themes\PaletteOffice365AccessLegacy.cs">
-			<SubType>Component</SubType>
-		</Compile>
-		<Compile Update="Palette Builtin\Microsoft 365\Non Official Themes\PaletteOffice365Blue.cs" />
-		<Compile Update="Palette Builtin\Microsoft 365\Official Themes\PaletteMicrosoft365Black.cs" />
-		<Compile Update="Palette Builtin\Microsoft 365\Official Themes\PaletteOffice365Silver.cs" />
-		<Compile Update="Palette Builtin\Microsoft 365\Official Themes\PaletteOffice365White.cs" />
-		<Compile Update="Palette Builtin\PaletteVisualStudio2020Base.cs">
-			<SubType>Component</SubType>
-		</Compile>
-		<Compile Update="Palette Builtin\Office 2010\Official Themes\PaletteOffice2010Black.cs" />
-		<Compile Update="Palette Builtin\Office 2010\Official Themes\PaletteOffice2010Blue.cs" />
-		<Compile Update="Palette Builtin\Office 2010\Official Themes\PaletteOffice2010Silver.cs" />
-		<Compile Update="Palette Builtin\Office 2010\Bases\PaletteOffice2010Base.cs" />
-		<Compile Update="Palette Builtin\Sparkle\Official Themes\PaletteSparklePurple.cs" />
-		<Compile Update="Palette Builtin\Sparkle\Base\PaletteSparkleBase.cs" />
-		<Compile Update="Palette Builtin\Sparkle\Official Themes\PaletteSparkleOrange.cs" />
-		<Compile Update="Palette Builtin\Sparkle\Official Themes\PaletteSparkleBlue.cs" />
-		<Compile Update="Palette Builtin\Office 2007\Official Themes\PaletteOffice2007Black.cs" />
-		<Compile Update="Palette Builtin\Office 2007\Official Themes\PaletteOffice2007Silver.cs" />
-		<Compile Update="Palette Builtin\Office 2007\Official Themes\PaletteOffice2007Blue.cs" />
-		<Compile Update="Palette Builtin\Office 2007\Bases\PaletteOffice2007Base.cs" />
-		<Compile Update="Properties\Resources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>Resources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="Rendering\RenderOffice2013.cs">
-			<SubType>Component</SubType>
-		</Compile>
-		<Compile Update="Rendering\RenderMicrosoft365.cs">
-			<SubType>Component</SubType>
-		</Compile>
-		<Compile Update="Rendering\RenderOffice2007.cs">
-			<SubType>Component</SubType>
-		</Compile>
-		<Compile Update="Rendering\RenderSparkle.cs">
-			<SubType>Component</SubType>
-		</Compile>
-		<Compile Update="ButtonSpec\ButtonSpecHeaderGroup.cs">
-			<SubType>Component</SubType>
-		</Compile>
-		<Compile Update="Controls Toolkit\KryptonManager.cs">
-			<SubType>Component</SubType>
-		</Compile>
-		<Compile Update="Palette Builtin\Professional\PaletteProfessionalSystem.cs" />
-		<Compile Update="Palette Builtin\Base\PaletteBase.cs" />
-		<Compile Update="Rendering\RenderOffice2010.cs">
-			<SubType>Component</SubType>
-		</Compile>
-		<Compile Update="Rendering\RenderProfessional.cs">
-			<SubType>Component</SubType>
-		</Compile>
-		<Compile Update="Palette Builtin\Professional\PaletteProfessionalOffice2003.cs" />
-		<Compile Update="Rendering\RenderBase.cs">
-			<SubType>Component</SubType>
-		</Compile>
-		<Compile Update="Rendering\RenderStandard.cs">
-			<SubType>Component</SubType>
-		</Compile>
-		<Compile Update="ResourceFiles\AboutToolkit\AboutToolkitImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>AboutToolkitImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\Arrows\BlueArrowResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>BlueArrowResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\Arrows\Office2010ArrowResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>Office2010ArrowResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\Arrows\RibbonArrowImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>RibbonArrowImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\Arrows\SortArrowImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>SortArrowImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\ButtonSpecs\ProfessionalButtonSpecResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>ProfessionalButtonSpecResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\CheckBoxes\CheckBoxStripResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>CheckBoxStripResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\ColourScales\ColourScaleImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>ColourScaleImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\CommandLink\CommandLinkImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>CommandLinkImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\ControlBox\Microsoft365ControlBoxResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>Microsoft365ControlBoxResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\ControlBox\Office2003ControlBoxResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>Office2003ControlBoxResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\ControlBox\Office2007ControlBoxResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>Office2007ControlBoxResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\ControlBox\Office2010ControlBoxResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>Office2010ControlBoxResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\ControlBox\Office2013ControlBoxResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>Office2013ControlBoxResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\ControlBox\ProfessionalControlBoxResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>ProfessionalControlBoxResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\ControlBox\SparkleControlBoxResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>SparkleControlBoxResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\Cursors\CursorResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>CursorResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\DataBars\DataBarImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>DataBarImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\Dialogs\DialogImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>DialogImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\DropDown\DropDownArrowImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>DropDownArrowImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\Elements\ElementsImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>ElementsImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\Gallery\GalleryImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>GalleryImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\Generic\GenericImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>GenericImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\Generic\GenericKryptonImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>GenericKryptonImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\Generic\GenericOffice2007ImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>GenericOffice2007ImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\Generic\GenericProfessionalImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>GenericProfessionalImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\Generic\GenericSparkleImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>GenericSparkleImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\Generic\GenericWhiteImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>GenericWhiteImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\Grid\GridImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>GridImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\Logos\ToolkitLogoImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>ToolkitLogoImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\MDI\GenericMDIImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>GenericMDIImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\MDI\Office2010MDIImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>Office2010MDIImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\MessageBox\MessageBoxImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>MessageBoxImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\OutlookGrid\OutlookGridImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>OutlookGridImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\OutlookGrid\Strings\OutlookGridStringResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>OutlookGridStringResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\PaletteSchemas\PaletteSchemaResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>PaletteSchemaResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\Pendants\ProfessionalPendantImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>ProfessionalPendantImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\Pin\ProfessionalPinImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>ProfessionalPinImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\RadioButtons\Office2007RadioButtonImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>Office2007RadioButtonImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\RadioButtons\Office2010RadioButtonImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>Office2010RadioButtonImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\RadioButtons\SparkleRadioButtonImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>SparkleRadioButtonImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\RadioButtons\VisualStudioRadioButtonImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>VisualStudioRadioButtonImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\SizeGripStyles\SizeGripStyleResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>SizeGripStyleResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\Sort\SortingImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>SortingImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\Stars\StarImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>StarImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\TaskDialog\TaskDialogImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>TaskDialogImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\ToastNotification\ToastNotificationImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>ToastNotificationImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\Toolbars\GenericToolbarImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>GenericToolbarImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\Toolbars\Microsoft365ToolbarImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>Microsoft365ToolbarImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\Toolbars\Office2003ToolbarImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>Office2003ToolbarImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\Toolbars\Office2007ToolbarImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>Office2007ToolbarImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\Toolbars\Office2010ToolbarImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>Office2010ToolbarImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\Toolbars\Office2013ToolbarImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>Office2013ToolbarImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\Toolbars\Office2016ToolbarImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>Office2016ToolbarImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\Toolbars\Office2019ToolbarImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>Office2019ToolbarImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\Toolbars\SystemToolbarImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>SystemToolbarImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\Toolbars\VisualStudioToolbarImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>VisualStudioToolbarImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\TreeItems\TreeItemImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>TreeItemImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\UAC\UACShieldIconResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>UACShieldIconResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="ResourceFiles\VisualStudio\VisualStudioImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>VisualStudioImageResources.resx</DependentUpon>
-		</Compile>
-		<Compile Update="View Base\ViewControl.cs" />
-	</ItemGroup>
-	<ItemGroup>
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonButton.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonTreeView.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonInputBox.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonTaskDialogCommand.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonTaskDialog.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonMessageBox.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonTrackBar.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonManager.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonHeaderGroup.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonGroup.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonHeader.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonPanel.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonLabel.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonPalette.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonSplitContainer.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonCheckButton.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonCheckSet.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonBorderEdge.bmp" />
-		<Content Include="Krypton.ico" Pack="false" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonGroupBox.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonWrapLabel.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonSeparator.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonDateTimePicker.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonMonthCalendar.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonBreadCrumbItem.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonDomainUpDown.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonBreadCrumb.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonNumericUpDown.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonContextMenuImageSelect.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonCommand.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonCheckedListBox.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonListBox.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonColorButton.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonDropButton.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonContextMenuColorColumns.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonMaskedTextBox.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonContextMenuItem.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonContextMenuItems.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonContextMenuSeparator.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonContextMenuHeading.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonContextMenu.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonRichTextBox.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonComboBox.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonTextBox.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonDataGridView.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonRadioButton.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonCheckBox.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonButtonSpec.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonGroupPanel.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonForm.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonLinkLabel.bmp" />
-	</ItemGroup>
-	<ItemGroup>
-		<Compile Remove="Controls Toolkit\KryptonByteViewer.cs" />
-		<Compile Remove="Controls Toolkit\KryptonDataGridViewBinaryCell.cs" />
-		<Compile Remove="Controls Toolkit\KryptonDataGridViewBinaryColumn.cs" />
-		<Compile Remove="Controls Toolkit\KryptonInputBoxNew.cs" />
-		<Compile Remove="Toolkit\KryptonBorderEdgeActionList.cs" />
-		<Compile Remove="Toolkit\KryptonBorderEdgeDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonBreadCrumbActionList.cs" />
-		<Compile Remove="Toolkit\KryptonBreadCrumbDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonBreadCrumbItemDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonBreadCrumbItemsEditor.cs" />
-		<Compile Remove="Toolkit\KryptonButtonActionList.cs" />
-		<Compile Remove="Toolkit\KryptonButtonDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonCheckBoxActionList.cs" />
-		<Compile Remove="Toolkit\KryptonCheckBoxDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonCheckButtonActionList.cs" />
-		<Compile Remove="Toolkit\KryptonCheckButtonCollectionEditor.cs" />
-		<Compile Remove="Toolkit\KryptonCheckButtonCollectionForm.cs" />
-		<Compile Remove="Toolkit\KryptonCheckButtonCollectionForm.Designer.cs" />
-		<Compile Remove="Toolkit\KryptonCheckButtonDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonCheckedListBoxActionList.cs" />
-		<Compile Remove="Toolkit\KryptonCheckedListBoxDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonCheckSetActionList.cs" />
-		<Compile Remove="Toolkit\KryptonCheckSetDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonColorButtonActionList.cs" />
-		<Compile Remove="Toolkit\KryptonColorButtonDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonComboBoxActionList.cs" />
-		<Compile Remove="Toolkit\KryptonComboBoxColumnDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonComboBoxDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonCommandActionList.cs" />
-		<Compile Remove="Toolkit\KryptonCommandDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonContextMenuActionList.cs" />
-		<Compile Remove="Toolkit\KryptonContextMenuCollectionEditor.cs" />
-		<Compile Remove="Toolkit\KryptonContextMenuDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonContextMenuItemCollectionEditor.cs" />
-		<Compile Remove="Toolkit\KryptonContextMenuItemDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonContextMenuItemsDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonDataGridViewDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonDateTimePickerActionList.cs" />
-		<Compile Remove="Toolkit\KryptonDateTimePickerColumnDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonDateTimePickerDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonDesignerActionItem.cs" />
-		<Compile Remove="Toolkit\KryptonDomainUpDownActionList.cs" />
-		<Compile Remove="Toolkit\KryptonDomainUpDownColumnDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonDomainUpDownDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonDropButtonActionList.cs" />
-		<Compile Remove="Toolkit\KryptonDropButtonDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonGroupActionList.cs" />
-		<Compile Remove="Toolkit\KryptonGroupBoxActionList.cs" />
-		<Compile Remove="Toolkit\KryptonGroupBoxDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonGroupDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonGroupPanelDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonHeaderActionList.cs" />
-		<Compile Remove="Toolkit\KryptonHeaderDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonHeaderGroupActionList.cs" />
-		<Compile Remove="Toolkit\KryptonHeaderGroupDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonLabelActionList.cs" />
-		<Compile Remove="Toolkit\KryptonLabelDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonLinkLabelActionList.cs" />
-		<Compile Remove="Toolkit\KryptonLinkLabelDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonListBoxActionList.cs" />
-		<Compile Remove="Toolkit\KryptonListBoxDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonManagerActionList.cs" />
-		<Compile Remove="Toolkit\KryptonManagerDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonMaskedTextBoxActionList.cs" />
-		<Compile Remove="Toolkit\KryptonMaskedTextBoxColumnDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonMaskedTextBoxDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonMonthCalendarActionList.cs" />
-		<Compile Remove="Toolkit\KryptonMonthCalendarDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonNumericUpDownActionList.cs" />
-		<Compile Remove="Toolkit\KryptonNumericUpDownColumnDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonNumericUpDownDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonPaletteActionList.cs" />
-		<Compile Remove="Toolkit\KryptonPaletteDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonPanelActionList.cs" />
-		<Compile Remove="Toolkit\KryptonPanelDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonRadioButtonActionList.cs" />
-		<Compile Remove="Toolkit\KryptonRadioButtonDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonRichTextBoxActionList.cs" />
-		<Compile Remove="Toolkit\KryptonRichTextBoxDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonSeparatorActionList.cs" />
-		<Compile Remove="Toolkit\KryptonSeparatorDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonSplitContainerActionList.cs" />
-		<Compile Remove="Toolkit\KryptonSplitContainerBehavior.cs" />
-		<Compile Remove="Toolkit\KryptonSplitContainerDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonSplitContainerGlyph.cs" />
-		<Compile Remove="Toolkit\KryptonSplitterPanelDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonTextBoxActionList.cs" />
-		<Compile Remove="Toolkit\KryptonTextBoxColumnDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonTextBoxDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonTrackBarActionList.cs" />
-		<Compile Remove="Toolkit\KryptonTrackBarDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonTreeViewActionList.cs" />
-		<Compile Remove="Toolkit\KryptonTreeViewDesigner.cs" />
-		<Compile Remove="Toolkit\KryptonWrapLabelActionList.cs" />
-		<Compile Remove="Toolkit\KryptonWrapLabelDesigner.cs" />
-		<Compile Remove="Toolkit\PaletteDrawBordersEditor.cs" />
-		<Compile Remove="Toolkit\PaletteDrawBordersSelector.cs" />
-		<Compile Remove="Toolkit\PaletteDrawBordersSelector.Designer.cs" />
-		<EmbeddedResource Remove="Controls Toolkit\KryptonInputBoxNew.resx" />
-		<EmbeddedResource Remove="Toolkit\KryptonCheckButtonCollectionForm.resx" />
-		<EmbeddedResource Remove="Toolkit\PaletteDrawBordersSelector.resx" />
-	</ItemGroup>
-	<ItemGroup>
-		<None Remove="Controls Toolkit\KryptonButton.bmp" />
-		<None Remove="ToolboxBitmaps\KryptonButton.bmp" />
-	</ItemGroup>
-	<ItemGroup>
-		<EmbeddedResource Update="Properties\Resources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>Resources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\AboutToolkit\AboutToolkitImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>AboutToolkitImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\Arrows\BlueArrowResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>BlueArrowResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\Arrows\Office2010ArrowResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>Office2010ArrowResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\Arrows\RibbonArrowImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>RibbonArrowImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\Arrows\SortArrowImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>SortArrowImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\ButtonSpecs\ProfessionalButtonSpecResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>ProfessionalButtonSpecResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\CheckBoxes\CheckBoxStripResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>CheckBoxStripResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\ColourScales\ColourScaleImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>ColourScaleImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\CommandLink\CommandLinkImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>CommandLinkImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\ControlBox\Microsoft365ControlBoxResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>Microsoft365ControlBoxResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\ControlBox\Office2003ControlBoxResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>Office2003ControlBoxResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\ControlBox\Office2007ControlBoxResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>Office2007ControlBoxResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\ControlBox\Office2010ControlBoxResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>Office2010ControlBoxResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\ControlBox\Office2013ControlBoxResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>Office2013ControlBoxResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\ControlBox\ProfessionalControlBoxResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>ProfessionalControlBoxResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\ControlBox\SparkleControlBoxResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>SparkleControlBoxResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\Cursors\CursorResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>CursorResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\DataBars\DataBarImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>DataBarImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\Dialogs\DialogImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>DialogImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\DropDown\DropDownArrowImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>DropDownArrowImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\Elements\ElementsImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>ElementsImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\Gallery\GalleryImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>GalleryImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\Generic\GenericImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>GenericImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\Generic\GenericKryptonImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>GenericKryptonImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\Generic\GenericOffice2007ImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>GenericOffice2007ImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\Generic\GenericProfessionalImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>GenericProfessionalImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\Generic\GenericSparkleImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>GenericSparkleImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\Generic\GenericWhiteImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>GenericWhiteImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\Grid\GridImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>GridImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\Logos\ToolkitLogoImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>ToolkitLogoImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\MDI\GenericMDIImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>GenericMDIImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\MDI\Office2010MDIImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>Office2010MDIImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\MessageBox\MessageBoxImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>MessageBoxImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\OutlookGrid\OutlookGridImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>OutlookGridImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\OutlookGrid\Strings\OutlookGridStringResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>OutlookGridStringResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\PaletteSchemas\PaletteSchemaResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>PaletteSchemaResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\Pendants\ProfessionalPendantImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>ProfessionalPendantImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\Pin\ProfessionalPinImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>ProfessionalPinImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\RadioButtons\Office2007RadioButtonImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>Office2007RadioButtonImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\RadioButtons\Office2010RadioButtonImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>Office2010RadioButtonImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\RadioButtons\SparkleRadioButtonImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>SparkleRadioButtonImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\RadioButtons\VisualStudioRadioButtonImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>VisualStudioRadioButtonImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\SizeGripStyles\SizeGripStyleResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>SizeGripStyleResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\Sort\SortingImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>SortingImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\Stars\StarImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>StarImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\TaskDialog\TaskDialogImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>TaskDialogImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\ToastNotification\ToastNotificationImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>ToastNotificationImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\Toolbars\GenericToolbarImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>GenericToolbarImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\Toolbars\Microsoft365ToolbarImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>Microsoft365ToolbarImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\Toolbars\Office2003ToolbarImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>Office2003ToolbarImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\Toolbars\Office2007ToolbarImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>Office2007ToolbarImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\Toolbars\Office2010ToolbarImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>Office2010ToolbarImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\Toolbars\Office2013ToolbarImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>Office2013ToolbarImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\Toolbars\Office2016ToolbarImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>Office2016ToolbarImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\Toolbars\Office2019ToolbarImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>Office2019ToolbarImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\Toolbars\SystemToolbarImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>SystemToolbarImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\Toolbars\VisualStudioToolbarImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>VisualStudioToolbarImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\TreeItems\TreeItemImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>TreeItemImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\UAC\UACShieldIconResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>UACShieldIconResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-		<EmbeddedResource Update="ResourceFiles\VisualStudio\VisualStudioImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>VisualStudioImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-	</ItemGroup>
-	<ItemGroup>
-		<None Update="../../../Assets/PNG/NuGet Package Icons/Krypton Stable.png" Link="Krypton Stable.png" />
-	</ItemGroup>
-	<ItemGroup>
-		<Folder Include="Storage\Images\Generic\" />
-	</ItemGroup>
+    <ItemGroup>
+        <Compile Update="ButtonSpec\ButtonSpecFormFixed.cs">
+            <SubType>Component</SubType>
+        </Compile>
+        <Compile Update="ButtonSpec\ButtonSpecFormWindowClose.cs">
+            <SubType>Component</SubType>
+        </Compile>
+        <Compile Update="ButtonSpec\ButtonSpecFormWindowMin.cs">
+            <SubType>Component</SubType>
+        </Compile>
+        <Compile Update="ButtonSpec\ButtonSpecFormWindowMax.cs">
+            <SubType>Component</SubType>
+        </Compile>
+        <Compile Update="ButtonSpec\ButtonSpecCalendar.cs">
+            <SubType>Component</SubType>
+        </Compile>
+        <Compile Update="Controls Toolkit\KryptonColorDialog.cs" />
+        <Compile Update="Controls Toolkit\KryptonPrintDialog.cs" />
+        <Compile Update="Designers\Other\PaletteDrawBordersSelector.cs" />
+        <Compile Update="Controls Toolkit\KryptonBreadCrumbItem.cs">
+            <SubType>Component</SubType>
+        </Compile>
+        <Compile Update="Controls Toolkit\KryptonListItem.cs">
+            <SubType>Component</SubType>
+        </Compile>
+        <Compile Update="ContextMenu\KryptonContextMenuItemBase.cs" />
+        <Compile Update="ButtonSpec\ButtonSpecAny.cs">
+            <SubType>Component</SubType>
+        </Compile>
+        <Compile Update="ButtonSpec\ButtonSpec.cs">
+            <SubType>Component</SubType>
+        </Compile>
+        <Compile Update="Palette Builtin\Office 2007\Non Official Themes\PaletteOffice2007White.cs" />
+        <Compile Update="Palette Builtin\Office 2010\Non Official Themes\PaletteOffice2010White.cs" />
+        <Compile Update="Palette Builtin\Office 2013\Non Official Themes\PaletteOffice2013AccessLegacy.cs">
+            <SubType>Component</SubType>
+        </Compile>
+        <Compile Update="Palette Builtin\Office 2013\Bases\PaletteOffice2013Base.cs" />
+        <Compile Update="Palette Builtin\Office 2013\Official Themes\PaletteOffice2013White.cs" />
+        <Compile Update="Palette Builtin\Microsoft 365\Bases\PaletteMicrosoft365Base.cs" />
+        <Compile Update="Palette Builtin\Office 365\Non Official Themes\PaletteOffice365AccessLegacy.cs">
+            <SubType>Component</SubType>
+        </Compile>
+        <Compile Update="Palette Builtin\Microsoft 365\Non Official Themes\PaletteOffice365Blue.cs" />
+        <Compile Update="Palette Builtin\Microsoft 365\Official Themes\PaletteMicrosoft365Black.cs" />
+        <Compile Update="Palette Builtin\Microsoft 365\Official Themes\PaletteOffice365Silver.cs" />
+        <Compile Update="Palette Builtin\Microsoft 365\Official Themes\PaletteOffice365White.cs" />
+        <Compile Update="Palette Builtin\PaletteVisualStudio2020Base.cs">
+            <SubType>Component</SubType>
+        </Compile>
+        <Compile Update="Palette Builtin\Office 2010\Official Themes\PaletteOffice2010Black.cs" />
+        <Compile Update="Palette Builtin\Office 2010\Official Themes\PaletteOffice2010Blue.cs" />
+        <Compile Update="Palette Builtin\Office 2010\Official Themes\PaletteOffice2010Silver.cs" />
+        <Compile Update="Palette Builtin\Office 2010\Bases\PaletteOffice2010Base.cs" />
+        <Compile Update="Palette Builtin\Sparkle\Official Themes\PaletteSparklePurple.cs" />
+        <Compile Update="Palette Builtin\Sparkle\Base\PaletteSparkleBase.cs" />
+        <Compile Update="Palette Builtin\Sparkle\Official Themes\PaletteSparkleOrange.cs" />
+        <Compile Update="Palette Builtin\Sparkle\Official Themes\PaletteSparkleBlue.cs" />
+        <Compile Update="Palette Builtin\Office 2007\Official Themes\PaletteOffice2007Black.cs" />
+        <Compile Update="Palette Builtin\Office 2007\Official Themes\PaletteOffice2007Silver.cs" />
+        <Compile Update="Palette Builtin\Office 2007\Official Themes\PaletteOffice2007Blue.cs" />
+        <Compile Update="Palette Builtin\Office 2007\Bases\PaletteOffice2007Base.cs" />
+        <Compile Update="Properties\Resources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>Resources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="Rendering\RenderOffice2013.cs">
+            <SubType>Component</SubType>
+        </Compile>
+        <Compile Update="Rendering\RenderMicrosoft365.cs">
+            <SubType>Component</SubType>
+        </Compile>
+        <Compile Update="Rendering\RenderOffice2007.cs">
+            <SubType>Component</SubType>
+        </Compile>
+        <Compile Update="Rendering\RenderSparkle.cs">
+            <SubType>Component</SubType>
+        </Compile>
+        <Compile Update="ButtonSpec\ButtonSpecHeaderGroup.cs">
+            <SubType>Component</SubType>
+        </Compile>
+        <Compile Update="Controls Toolkit\KryptonManager.cs">
+            <SubType>Component</SubType>
+        </Compile>
+        <Compile Update="Palette Builtin\Professional\PaletteProfessionalSystem.cs" />
+        <Compile Update="Palette Builtin\Base\PaletteBase.cs" />
+        <Compile Update="Rendering\RenderOffice2010.cs">
+            <SubType>Component</SubType>
+        </Compile>
+        <Compile Update="Rendering\RenderProfessional.cs">
+            <SubType>Component</SubType>
+        </Compile>
+        <Compile Update="Palette Builtin\Professional\PaletteProfessionalOffice2003.cs" />
+        <Compile Update="Rendering\RenderBase.cs">
+            <SubType>Component</SubType>
+        </Compile>
+        <Compile Update="Rendering\RenderStandard.cs">
+            <SubType>Component</SubType>
+        </Compile>
+        <Compile Update="ResourceFiles\AboutToolkit\AboutToolkitImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>AboutToolkitImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\Arrows\BlueArrowResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>BlueArrowResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\Arrows\Office2010ArrowResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>Office2010ArrowResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\Arrows\RibbonArrowImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>RibbonArrowImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\Arrows\SortArrowImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>SortArrowImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\ButtonSpecs\ProfessionalButtonSpecResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>ProfessionalButtonSpecResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\CheckBoxes\CheckBoxStripResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>CheckBoxStripResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\ColourScales\ColourScaleImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>ColourScaleImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\CommandLink\CommandLinkImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>CommandLinkImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\ControlBox\Microsoft365ControlBoxResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>Microsoft365ControlBoxResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\ControlBox\Office2003ControlBoxResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>Office2003ControlBoxResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\ControlBox\Office2007ControlBoxResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>Office2007ControlBoxResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\ControlBox\Office2010ControlBoxResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>Office2010ControlBoxResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\ControlBox\Office2013ControlBoxResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>Office2013ControlBoxResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\ControlBox\ProfessionalControlBoxResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>ProfessionalControlBoxResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\ControlBox\SparkleControlBoxResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>SparkleControlBoxResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\Cursors\CursorResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>CursorResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\DataBars\DataBarImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>DataBarImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\Dialogs\DialogImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>DialogImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\DropDown\DropDownArrowImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>DropDownArrowImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\Elements\ElementsImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>ElementsImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\Gallery\GalleryImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>GalleryImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\Generic\GenericImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>GenericImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\Generic\GenericKryptonImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>GenericKryptonImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\Generic\GenericOffice2007ImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>GenericOffice2007ImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\Generic\GenericProfessionalImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>GenericProfessionalImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\Generic\GenericSparkleImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>GenericSparkleImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\Generic\GenericWhiteImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>GenericWhiteImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\Grid\GridImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>GridImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\Logos\ToolkitLogoImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>ToolkitLogoImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\MDI\GenericMDIImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>GenericMDIImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\MDI\Office2010MDIImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>Office2010MDIImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\MessageBox\MessageBoxImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>MessageBoxImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\OutlookGrid\OutlookGridImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>OutlookGridImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\OutlookGrid\Strings\OutlookGridStringResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>OutlookGridStringResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\PaletteSchemas\PaletteSchemaResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>PaletteSchemaResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\Pendants\ProfessionalPendantImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>ProfessionalPendantImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\Pin\ProfessionalPinImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>ProfessionalPinImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\RadioButtons\Office2007RadioButtonImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>Office2007RadioButtonImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\RadioButtons\Office2010RadioButtonImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>Office2010RadioButtonImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\RadioButtons\SparkleRadioButtonImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>SparkleRadioButtonImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\RadioButtons\VisualStudioRadioButtonImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>VisualStudioRadioButtonImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\SizeGripStyles\SizeGripStyleResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>SizeGripStyleResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\Sort\SortingImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>SortingImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\Stars\StarImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>StarImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\TaskDialog\TaskDialogImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>TaskDialogImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\ToastNotification\ToastNotificationImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>ToastNotificationImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\Toolbars\GenericToolbarImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>GenericToolbarImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\Toolbars\Microsoft365ToolbarImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>Microsoft365ToolbarImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\Toolbars\Office2003ToolbarImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>Office2003ToolbarImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\Toolbars\Office2007ToolbarImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>Office2007ToolbarImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\Toolbars\Office2010ToolbarImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>Office2010ToolbarImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\Toolbars\Office2013ToolbarImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>Office2013ToolbarImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\Toolbars\Office2016ToolbarImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>Office2016ToolbarImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\Toolbars\Office2019ToolbarImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>Office2019ToolbarImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\Toolbars\SystemToolbarImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>SystemToolbarImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\Toolbars\VisualStudioToolbarImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>VisualStudioToolbarImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\TreeItems\TreeItemImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>TreeItemImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\UAC\UACShieldIconResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>UACShieldIconResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="ResourceFiles\VisualStudio\VisualStudioImageResources.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>VisualStudioImageResources.resx</DependentUpon>
+        </Compile>
+        <Compile Update="View Base\ViewControl.cs" />
+    </ItemGroup>
+    <ItemGroup>
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonButton.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonTreeView.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonInputBox.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonTaskDialogCommand.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonTaskDialog.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonMessageBox.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonTrackBar.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonManager.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonHeaderGroup.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonGroup.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonHeader.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonPanel.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonLabel.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonPalette.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonSplitContainer.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonCheckButton.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonCheckSet.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonBorderEdge.bmp" />
+        <Content Include="Krypton.ico" Pack="false" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonGroupBox.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonWrapLabel.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonSeparator.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonDateTimePicker.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonMonthCalendar.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonBreadCrumbItem.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonDomainUpDown.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonBreadCrumb.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonNumericUpDown.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonContextMenuImageSelect.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonCommand.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonCheckedListBox.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonListBox.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonColorButton.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonDropButton.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonContextMenuColorColumns.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonMaskedTextBox.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonContextMenuItem.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonContextMenuItems.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonContextMenuSeparator.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonContextMenuHeading.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonContextMenu.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonRichTextBox.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonComboBox.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonTextBox.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonDataGridView.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonRadioButton.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonCheckBox.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonButtonSpec.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonGroupPanel.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonForm.bmp" />
+        <EmbeddedResource Include="ToolboxBitmaps\KryptonLinkLabel.bmp" />
+    </ItemGroup>
+    <ItemGroup>
+        <Compile Remove="Controls Toolkit\KryptonByteViewer.cs" />
+        <Compile Remove="Controls Toolkit\KryptonDataGridViewBinaryCell.cs" />
+        <Compile Remove="Controls Toolkit\KryptonDataGridViewBinaryColumn.cs" />
+        <Compile Remove="Controls Toolkit\KryptonInputBoxNew.cs" />
+        <Compile Remove="Toolkit\KryptonBorderEdgeActionList.cs" />
+        <Compile Remove="Toolkit\KryptonBorderEdgeDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonBreadCrumbActionList.cs" />
+        <Compile Remove="Toolkit\KryptonBreadCrumbDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonBreadCrumbItemDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonBreadCrumbItemsEditor.cs" />
+        <Compile Remove="Toolkit\KryptonButtonActionList.cs" />
+        <Compile Remove="Toolkit\KryptonButtonDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonCheckBoxActionList.cs" />
+        <Compile Remove="Toolkit\KryptonCheckBoxDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonCheckButtonActionList.cs" />
+        <Compile Remove="Toolkit\KryptonCheckButtonCollectionEditor.cs" />
+        <Compile Remove="Toolkit\KryptonCheckButtonCollectionForm.cs" />
+        <Compile Remove="Toolkit\KryptonCheckButtonCollectionForm.Designer.cs" />
+        <Compile Remove="Toolkit\KryptonCheckButtonDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonCheckedListBoxActionList.cs" />
+        <Compile Remove="Toolkit\KryptonCheckedListBoxDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonCheckSetActionList.cs" />
+        <Compile Remove="Toolkit\KryptonCheckSetDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonColorButtonActionList.cs" />
+        <Compile Remove="Toolkit\KryptonColorButtonDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonComboBoxActionList.cs" />
+        <Compile Remove="Toolkit\KryptonComboBoxColumnDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonComboBoxDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonCommandActionList.cs" />
+        <Compile Remove="Toolkit\KryptonCommandDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonContextMenuActionList.cs" />
+        <Compile Remove="Toolkit\KryptonContextMenuCollectionEditor.cs" />
+        <Compile Remove="Toolkit\KryptonContextMenuDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonContextMenuItemCollectionEditor.cs" />
+        <Compile Remove="Toolkit\KryptonContextMenuItemDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonContextMenuItemsDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonDataGridViewDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonDateTimePickerActionList.cs" />
+        <Compile Remove="Toolkit\KryptonDateTimePickerColumnDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonDateTimePickerDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonDesignerActionItem.cs" />
+        <Compile Remove="Toolkit\KryptonDomainUpDownActionList.cs" />
+        <Compile Remove="Toolkit\KryptonDomainUpDownColumnDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonDomainUpDownDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonDropButtonActionList.cs" />
+        <Compile Remove="Toolkit\KryptonDropButtonDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonGroupActionList.cs" />
+        <Compile Remove="Toolkit\KryptonGroupBoxActionList.cs" />
+        <Compile Remove="Toolkit\KryptonGroupBoxDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonGroupDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonGroupPanelDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonHeaderActionList.cs" />
+        <Compile Remove="Toolkit\KryptonHeaderDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonHeaderGroupActionList.cs" />
+        <Compile Remove="Toolkit\KryptonHeaderGroupDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonLabelActionList.cs" />
+        <Compile Remove="Toolkit\KryptonLabelDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonLinkLabelActionList.cs" />
+        <Compile Remove="Toolkit\KryptonLinkLabelDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonListBoxActionList.cs" />
+        <Compile Remove="Toolkit\KryptonListBoxDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonManagerActionList.cs" />
+        <Compile Remove="Toolkit\KryptonManagerDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonMaskedTextBoxActionList.cs" />
+        <Compile Remove="Toolkit\KryptonMaskedTextBoxColumnDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonMaskedTextBoxDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonMonthCalendarActionList.cs" />
+        <Compile Remove="Toolkit\KryptonMonthCalendarDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonNumericUpDownActionList.cs" />
+        <Compile Remove="Toolkit\KryptonNumericUpDownColumnDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonNumericUpDownDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonPaletteActionList.cs" />
+        <Compile Remove="Toolkit\KryptonPaletteDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonPanelActionList.cs" />
+        <Compile Remove="Toolkit\KryptonPanelDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonRadioButtonActionList.cs" />
+        <Compile Remove="Toolkit\KryptonRadioButtonDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonRichTextBoxActionList.cs" />
+        <Compile Remove="Toolkit\KryptonRichTextBoxDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonSeparatorActionList.cs" />
+        <Compile Remove="Toolkit\KryptonSeparatorDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonSplitContainerActionList.cs" />
+        <Compile Remove="Toolkit\KryptonSplitContainerBehavior.cs" />
+        <Compile Remove="Toolkit\KryptonSplitContainerDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonSplitContainerGlyph.cs" />
+        <Compile Remove="Toolkit\KryptonSplitterPanelDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonTextBoxActionList.cs" />
+        <Compile Remove="Toolkit\KryptonTextBoxColumnDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonTextBoxDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonTrackBarActionList.cs" />
+        <Compile Remove="Toolkit\KryptonTrackBarDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonTreeViewActionList.cs" />
+        <Compile Remove="Toolkit\KryptonTreeViewDesigner.cs" />
+        <Compile Remove="Toolkit\KryptonWrapLabelActionList.cs" />
+        <Compile Remove="Toolkit\KryptonWrapLabelDesigner.cs" />
+        <Compile Remove="Toolkit\PaletteDrawBordersEditor.cs" />
+        <Compile Remove="Toolkit\PaletteDrawBordersSelector.cs" />
+        <Compile Remove="Toolkit\PaletteDrawBordersSelector.Designer.cs" />
+        <EmbeddedResource Remove="Controls Toolkit\KryptonInputBoxNew.resx" />
+        <EmbeddedResource Remove="Toolkit\KryptonCheckButtonCollectionForm.resx" />
+        <EmbeddedResource Remove="Toolkit\PaletteDrawBordersSelector.resx" />
+    </ItemGroup>
+    <ItemGroup>
+        <None Remove="Controls Toolkit\KryptonButton.bmp" />
+        <None Remove="ToolboxBitmaps\KryptonButton.bmp" />
+    </ItemGroup>
+    <ItemGroup>
+        <EmbeddedResource Update="Properties\Resources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\AboutToolkit\AboutToolkitImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>AboutToolkitImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\Arrows\BlueArrowResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>BlueArrowResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\Arrows\Office2010ArrowResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>Office2010ArrowResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\Arrows\RibbonArrowImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>RibbonArrowImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\Arrows\SortArrowImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>SortArrowImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\ButtonSpecs\ProfessionalButtonSpecResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>ProfessionalButtonSpecResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\CheckBoxes\CheckBoxStripResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>CheckBoxStripResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\ColourScales\ColourScaleImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>ColourScaleImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\CommandLink\CommandLinkImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>CommandLinkImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\ControlBox\Microsoft365ControlBoxResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>Microsoft365ControlBoxResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\ControlBox\Office2003ControlBoxResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>Office2003ControlBoxResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\ControlBox\Office2007ControlBoxResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>Office2007ControlBoxResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\ControlBox\Office2010ControlBoxResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>Office2010ControlBoxResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\ControlBox\Office2013ControlBoxResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>Office2013ControlBoxResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\ControlBox\ProfessionalControlBoxResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>ProfessionalControlBoxResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\ControlBox\SparkleControlBoxResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>SparkleControlBoxResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\Cursors\CursorResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>CursorResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\DataBars\DataBarImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>DataBarImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\Dialogs\DialogImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>DialogImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\DropDown\DropDownArrowImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>DropDownArrowImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\Elements\ElementsImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>ElementsImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\Gallery\GalleryImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>GalleryImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\Generic\GenericImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>GenericImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\Generic\GenericKryptonImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>GenericKryptonImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\Generic\GenericOffice2007ImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>GenericOffice2007ImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\Generic\GenericProfessionalImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>GenericProfessionalImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\Generic\GenericSparkleImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>GenericSparkleImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\Generic\GenericWhiteImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>GenericWhiteImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\Grid\GridImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>GridImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\Logos\ToolkitLogoImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>ToolkitLogoImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\MDI\GenericMDIImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>GenericMDIImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\MDI\Office2010MDIImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>Office2010MDIImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\MessageBox\MessageBoxImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>MessageBoxImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\OutlookGrid\OutlookGridImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>OutlookGridImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\OutlookGrid\Strings\OutlookGridStringResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>OutlookGridStringResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\PaletteSchemas\PaletteSchemaResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>PaletteSchemaResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\Pendants\ProfessionalPendantImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>ProfessionalPendantImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\Pin\ProfessionalPinImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>ProfessionalPinImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\RadioButtons\Office2007RadioButtonImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>Office2007RadioButtonImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\RadioButtons\Office2010RadioButtonImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>Office2010RadioButtonImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\RadioButtons\SparkleRadioButtonImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>SparkleRadioButtonImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\RadioButtons\VisualStudioRadioButtonImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>VisualStudioRadioButtonImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\SizeGripStyles\SizeGripStyleResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>SizeGripStyleResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\Sort\SortingImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>SortingImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\Stars\StarImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>StarImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\TaskDialog\TaskDialogImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>TaskDialogImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\ToastNotification\ToastNotificationImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>ToastNotificationImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\Toolbars\GenericToolbarImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>GenericToolbarImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\Toolbars\Microsoft365ToolbarImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>Microsoft365ToolbarImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\Toolbars\Office2003ToolbarImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>Office2003ToolbarImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\Toolbars\Office2007ToolbarImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>Office2007ToolbarImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\Toolbars\Office2010ToolbarImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>Office2010ToolbarImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\Toolbars\Office2013ToolbarImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>Office2013ToolbarImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\Toolbars\Office2016ToolbarImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>Office2016ToolbarImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\Toolbars\Office2019ToolbarImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>Office2019ToolbarImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\Toolbars\SystemToolbarImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>SystemToolbarImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\Toolbars\VisualStudioToolbarImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>VisualStudioToolbarImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\TreeItems\TreeItemImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>TreeItemImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\UAC\UACShieldIconResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>UACShieldIconResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <EmbeddedResource Update="ResourceFiles\VisualStudio\VisualStudioImageResources.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>VisualStudioImageResources.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+    </ItemGroup>
+    <ItemGroup>
+        <None Update="../../../Assets/PNG/NuGet Package Icons/Krypton Stable.png" Link="Krypton Stable.png" />
+    </ItemGroup>
+    <ItemGroup>
+        <Folder Include="Storage\Images\Generic\" />
+    </ItemGroup>
 
-	<PropertyGroup Condition="'$(Configuration)'!='Debug'">
-		<Optimize>True</Optimize>
-	</PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)'!='Debug'">
+        <Optimize>True</Optimize>
+    </PropertyGroup>
 
 </Project>

--- a/Source/Krypton Components/Krypton.Toolkit/ShellDialogs/ShellBrowserDialogTFM.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ShellDialogs/ShellBrowserDialogTFM.cs
@@ -98,6 +98,15 @@ namespace Krypton.Toolkit
             }
         }
 
+#if NET6_0_OR_GREATER
+        /// <inheritdoc />
+        public override Guid? ClientGuid
+        {
+            get => _internalOpenFileDialog.ClientGuid;
+            set => _internalOpenFileDialog.ClientGuid = value;
+        }
+#endif
+
         /// <inheritdoc />
         [AllowNull]
         public override string Title

--- a/Source/Krypton Components/Krypton.Toolkit/ShellDialogs/ShellDialogWrapper.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ShellDialogs/ShellDialogWrapper.cs
@@ -200,7 +200,7 @@ namespace Krypton.Toolkit
         [Description("Gets or sets the file dialog box Icon")]
         public Icon? Icon { get; set; }
 
-#if NET60_OR_GREATER
+#if NET6_0_OR_GREATER
         /// <summary>
         /// <para>
         /// Gets or sets the GUID to associate with this dialog state. Typically, state such


### PR DESCRIPTION
- Sort out access to the correct named static fields that have been renamed in `netCore`

- Sort usage of the `#if NET6...` define usages

#1314

![image](https://github.com/Krypton-Suite/Standard-Toolkit/assets/2418812/81b2b352-71fc-4445-a0e9-77fb55606fd8)
