### PR TITLE
Fixed adding new Page to vacated Cell

### DIFF
--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingSpace.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingSpace.cs
@@ -63,14 +63,17 @@ namespace Krypton.Docking
             if (pages != null)
             {
                 ObserveAutoHiddenSlideSize(pages);
-                // If there is no active cell...
+                // If there is no active cell or cell is pageless...
                 KryptonWorkspaceCell? cell = SpaceControl?.ActiveCell;
-                if (cell == null)
+                if (cell == null || cell.Pages.Count() == 0)
                 {
+                    // remove the pageless cell if exists:
+                    if (cell?.Pages.Count == 0) SpaceControl!.Root.Children!.Remove(cell);
+
                     // ...create a new cell and place at the end of the root collection
                     cell = new KryptonWorkspaceCell();
                     SpaceControl!.Root.Children!.Add(cell);
-                }
+                }      
 
                 // Add all provided pages into the cell
                 cell.Pages.AddRange(pages);


### PR DESCRIPTION
Forgive me. I'm a hobby coder and this is my first pull request so please forgive any etiquette faux pas!

Original Issue: [Git Issue](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1383)

Have tested - seems to work well, but not aware of the wider architecture, so may need some review. Also, my code felt a bit smelly. My original (more readable?) code below, but held some repetition:

```cs
if (cell == null)
{
    // ...create a new cell and place at the end of the root collection
    cell = new KryptonWorkspaceCell();
    SpaceControl!.Root.Children!.Add(cell);
}
else if (cell.Pages.Count() == 0)
{
    // first remove the empty cell
    SpaceControl!.Root.Children!.Remove(cell);
    // now create a new cell and place at the end of the root collection
    cell = new KryptonWorkspaceCell();
    SpaceControl!.Root.Children!.Add(cell);
}
```
Likely a matter of taste?

Hope helps!

