### PR TITLE
1418-cleanup-warnings-0001

### DIFF
--- a/Source/Krypton Components/Krypton.Ribbon/Controller/AppButtonController.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controller/AppButtonController.cs
@@ -30,6 +30,7 @@ namespace Krypton.Ribbon
         private bool _fixedPressed;
         private bool _hasFocus;
         private readonly Timer _updateTimer;
+        protected readonly string ribbonTabsAreaCannotBeNull = "Property ribbon.TabsArea cannot be null";
         #endregion
 
         #region Events
@@ -250,10 +251,15 @@ namespace Krypton.Ribbon
         /// <param name="e">A KeyEventArgs that contains the event data.</param>
         public void KeyDown(Control c, KeyEventArgs e)
         {
-            ViewBase newView = null;
+            ViewBase? newView = null;
             var ribbon = (KryptonRibbon)c;
 
-            switch (e.KeyData)
+            if ( ribbon.TabsArea is null )
+            {
+                throw new NullReferenceException( this.ribbonTabsAreaCannotBeNull );
+            }
+
+            switch ( e.KeyData)
             {
                 case Keys.Tab:
                 case Keys.Right:
@@ -373,6 +379,11 @@ namespace Krypton.Ribbon
         /// <param name="ribbon">Reference to owning ribbon instance.</param>
         public void KeyTipSelect(KryptonRibbon ribbon)
         {
+            if ( ribbon.TabsArea is null )
+            {
+                throw new NullReferenceException( this.ribbonTabsAreaCannotBeNull );
+            }
+
             // We leave key tips usage whenever we use the application button
             ribbon.KillKeyboardKeyTips();
 

--- a/Source/Krypton Components/Krypton.Ribbon/Controller/AppButtonController.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controller/AppButtonController.cs
@@ -381,7 +381,7 @@ namespace Krypton.Ribbon
         /// Perform actual selection of the item.
         /// </summary>
         /// <param name="ribbon">Reference to owning ribbon instance.</param>
-        public void KeyTipSelect(KryptonRibbon ribbon)
+        public void KeyTipSelect(KryptonRibbon? ribbon)
         {
             if (ribbon is null)
             {

--- a/Source/Krypton Components/Krypton.Ribbon/Controller/AppButtonController.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controller/AppButtonController.cs
@@ -30,7 +30,6 @@ namespace Krypton.Ribbon
         private bool _fixedPressed;
         private bool _hasFocus;
         private readonly Timer _updateTimer;
-        protected readonly string ribbonTabsAreaCannotBeNull = "Property ribbon.TabsArea cannot be null";
         #endregion
 
         #region Events
@@ -252,14 +251,19 @@ namespace Krypton.Ribbon
         public void KeyDown(Control c, KeyEventArgs e)
         {
             ViewBase? newView = null;
-            var ribbon = (KryptonRibbon)c;
+            var ribbon = c as KryptonRibbon;
 
-            if ( ribbon.TabsArea is null )
+            if (ribbon is null)
             {
-                throw new NullReferenceException( this.ribbonTabsAreaCannotBeNull );
+                throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull("ribbon"));
             }
 
-            switch ( e.KeyData)
+            if (ribbon.TabsArea is null)
+            {
+                throw new NullReferenceException(GlobalStaticValues.PropertyCannotBeNull("ribbon.TabsArea"));
+            }
+
+            switch (e.KeyData)
             {
                 case Keys.Tab:
                 case Keys.Right:
@@ -379,9 +383,14 @@ namespace Krypton.Ribbon
         /// <param name="ribbon">Reference to owning ribbon instance.</param>
         public void KeyTipSelect(KryptonRibbon ribbon)
         {
-            if ( ribbon.TabsArea is null )
+            if (ribbon is null)
             {
-                throw new NullReferenceException( this.ribbonTabsAreaCannotBeNull );
+                throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull("ribbon"));
+            }
+
+            if (ribbon.TabsArea is null)
+            {
+                throw new NullReferenceException(GlobalStaticValues.PropertyCannotBeNull("ribbon.TabsArea"));
             }
 
             // We leave key tips usage whenever we use the application button

--- a/Source/Krypton Components/Krypton.Ribbon/Controller/AppTabController.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controller/AppTabController.cs
@@ -29,7 +29,6 @@ namespace Krypton.Ribbon
         private bool _mouseDown;
         private bool _fixedPressed;
         private bool _hasFocus;
-        protected readonly string ribbonTabsAreaCannotBeNull = "Property ribbon.TabsArea cannot be null";
         #endregion
 
         #region Events
@@ -70,7 +69,7 @@ namespace Krypton.Ribbon
         /// Gets and sets the second target element.
         /// </summary>
         public ViewBase Target2 { get; set; }
-
+        
         /// <summary>
         /// Gets and sets the third target element.
         /// </summary>
@@ -246,14 +245,19 @@ namespace Krypton.Ribbon
         public void KeyDown(Control c, KeyEventArgs e)
         {
             ViewBase? newView = null;
-            var ribbon = (KryptonRibbon)c;
+            var ribbon = c as KryptonRibbon;
 
-            if ( ribbon.TabsArea is null )
+            if (ribbon is null)
             {
-                throw new NullReferenceException( this.ribbonTabsAreaCannotBeNull );
+                throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull("ribbon"));
             }
 
-            switch ( e.KeyData)
+            if (ribbon.TabsArea is null)
+            {
+                throw new NullReferenceException(GlobalStaticValues.PropertyCannotBeNull("ribbon.TabsArea"));
+            }
+
+            switch (e.KeyData)
             {
                 case Keys.Tab:
                 case Keys.Right:
@@ -369,9 +373,14 @@ namespace Krypton.Ribbon
         /// <param name="ribbon">Reference to owning ribbon instance.</param>
         public void KeyTipSelect(KryptonRibbon ribbon)
         {
-            if ( ribbon.TabsArea is null )
+            if (ribbon is null)
             {
-                throw new NullReferenceException( this.ribbonTabsAreaCannotBeNull );
+                throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull("ribbon"));
+            }
+
+            if (ribbon.TabsArea is null)
+            {
+                throw new NullReferenceException(GlobalStaticValues.PropertyCannotBeNull("ribbon.TabsArea"));
             }
 
             // We leave key tips usage whenever we use the application button

--- a/Source/Krypton Components/Krypton.Ribbon/Controller/AppTabController.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controller/AppTabController.cs
@@ -371,7 +371,7 @@ namespace Krypton.Ribbon
         /// Perform actual selection of the item.
         /// </summary>
         /// <param name="ribbon">Reference to owning ribbon instance.</param>
-        public void KeyTipSelect(KryptonRibbon ribbon)
+        public void KeyTipSelect(KryptonRibbon? ribbon)
         {
             if (ribbon is null)
             {

--- a/Source/Krypton Components/Krypton.Ribbon/Controller/AppTabController.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controller/AppTabController.cs
@@ -29,7 +29,7 @@ namespace Krypton.Ribbon
         private bool _mouseDown;
         private bool _fixedPressed;
         private bool _hasFocus;
-
+        protected readonly string ribbonTabsAreaCannotBeNull = "Property ribbon.TabsArea cannot be null";
         #endregion
 
         #region Events
@@ -245,10 +245,15 @@ namespace Krypton.Ribbon
         /// <param name="e">A KeyEventArgs that contains the event data.</param>
         public void KeyDown(Control c, KeyEventArgs e)
         {
-            ViewBase newView = null;
+            ViewBase? newView = null;
             var ribbon = (KryptonRibbon)c;
 
-            switch (e.KeyData)
+            if ( ribbon.TabsArea is null )
+            {
+                throw new NullReferenceException( this.ribbonTabsAreaCannotBeNull );
+            }
+
+            switch ( e.KeyData)
             {
                 case Keys.Tab:
                 case Keys.Right:
@@ -364,6 +369,11 @@ namespace Krypton.Ribbon
         /// <param name="ribbon">Reference to owning ribbon instance.</param>
         public void KeyTipSelect(KryptonRibbon ribbon)
         {
+            if ( ribbon.TabsArea is null )
+            {
+                throw new NullReferenceException( this.ribbonTabsAreaCannotBeNull );
+            }
+
             // We leave key tips usage whenever we use the application button
             ribbon.KillKeyboardKeyTips();
 

--- a/Source/Krypton Components/Krypton.Toolkit/General/GlobalStaticValues.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/GlobalStaticValues.cs
@@ -355,5 +355,21 @@ namespace Krypton.Toolkit
         /// The group image side size
         /// </summary>
         public static int GroupImageSide = 16;
+
+        #region Methods
+        /// <summary>
+        /// Helper method that returns a generic message when a variable is null.
+        /// </summary>
+        /// <param name="variableName">Name of the variable to be inserted into the text.</param>
+        /// <returns>The message.</returns>
+        public static string VariableCannotBeNull( string variableName ) => $"Variable {variableName} cannot be null.";
+
+        /// <summary>
+        /// Helper method that returns a generic message when a property is null.
+        /// </summary>
+        /// <param name="propertyName">Name of the property to be inserted into the text.</param>
+        /// <returns>The message.</returns>
+        public static string PropertyCannotBeNull( string propertyName ) => $"Property {propertyName} cannot be null.";
+        #endregion
     }
 }


### PR DESCRIPTION
First serious PR :)

Before the changes there were 30666 warnings and 30386 afterwards = -280.
![compile-results](https://github.com/Krypton-Suite/Standard-Toolkit/assets/96108132/62b13775-397d-4c0b-86f6-9aa47d361139)

Probably you have a look at the added string that is used in the throw.
Possibly that can be done via a globally used one with a param position to format....

Your comments please.

[issue 1418](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1418)
