### PR TITLE
- **Breaking Change** `KryptonMessageBox` does not obey tab characters like `MessageBox`

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-##-## - Build 24## (Patch ##) - ## 2024
+* Resolved [#1424](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1424), **Breaking Change** `KryptonMessageBox` does not obey tab characters like `MessageBox`
 * Resolved [#1383](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1383), Closing last Page in undocked page group prevents addition of further Pages via `KryptonDockingManager.AddToWorkspace`
 * Resolved [#1381](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1381), **[Regression]** Docking Persistence broken since build ##.23.10.303
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ Follow the links to see the different objects and layouts that this framework al
 
 # Breaking Changes
 
+## V85.## (2024-##-## - Build 24## - ##)
+* Resolved [#1424](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1424), **Breaking Change** `KryptonMessageBox` does not obey tab characters like `MessageBox`
+  - The optional `ContentAlignment` for a `KryptonMessageBox.Show` cammand is no longer possible.
+
 ## V80.## (2023-11-14 - Build 2311 - November 2023)
 There are list of changes that have occurred during the development of the V80.## version
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMessageBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMessageBox.cs
@@ -10,8 +10,6 @@
  */
 #endregion
 
-using ContentAlignment = System.Drawing.ContentAlignment;
-
 // ReSharper disable ClassNeverInstantiated.Global
 // ReSharper disable UnusedMethodReturnValue.Global
 
@@ -36,18 +34,16 @@ namespace Krypton.Toolkit
         /// <param name="linkAreaCommand">Specifies a <see cref="T:KryptonCommand"/> if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
         /// <param name="linkLaunchArgument">Specifies the <see cref="ProcessStartInfo"/> if a <paramref name="linkAreaCommand"> has not been defined.</paramref></param>
         /// <param name="contentLinkArea">Specifies the area within the <see cref="KryptonLinkWrapLabel"/> to be regarded as a link. See <see cref="LinkArea"/>.</param>
-        /// <param name="messageTextAlignment">Specifies how the message text should be aligned. See <see cref="System.Drawing.ContentAlignment"/> for supported values.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
         public static DialogResult Show(string text, string caption, bool? showCtrlCopy = null,
                                         MessageBoxContentAreaType? contentAreaType = null,
                                         KryptonCommand? linkAreaCommand = null,
                                         ProcessStartInfo? linkLaunchArgument = null,
-                                        LinkArea? contentLinkArea = null,
-                                        ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft) =>
+                                        LinkArea? contentLinkArea = null) =>
             ShowCore(null, text, caption, KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.None,
                      KryptonMessageBoxDefaultButton.Button4, 0, null, showCtrlCopy,
                      null, null, @"", null, null, @"",
-                     contentAreaType, linkAreaCommand, linkLaunchArgument, contentLinkArea, messageTextAlignment);
+                     contentAreaType, linkAreaCommand, linkLaunchArgument, contentLinkArea);
 
         /// <summary>
         /// Displays a message box in front+center of the application and with the specified text, caption and buttons.
@@ -58,20 +54,18 @@ namespace Krypton.Toolkit
         /// <param name="linkAreaCommand">Specifies a <see cref="T:KryptonCommand"/> if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
         /// <param name="linkLaunchArgument">Specifies the <see cref="ProcessStartInfo"/> if a <paramref name="linkAreaCommand"> has not been defined.</paramref></param>
         /// <param name="contentLinkArea">Specifies the area within the <see cref="KryptonLinkWrapLabel"/> to be regarded as a link. See <see cref="LinkArea"/>.</param>
-        /// <param name="messageTextAlignment">Specifies how the message text should be aligned. See <see cref="System.Drawing.ContentAlignment"/> for supported values.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
         public static DialogResult Show(string text, bool? showCtrlCopy = null,
                                         MessageBoxContentAreaType? contentAreaType = null,
                                         KryptonCommand? linkAreaCommand = null,
                                         ProcessStartInfo? linkLaunchArgument = null,
-                                        LinkArea? contentLinkArea = null,
-                                        ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft) =>
+                                        LinkArea? contentLinkArea = null) =>
             ShowCore(null, text, @"", KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.None,
                      KryptonMessageBoxDefaultButton.Button4, 0,
                      null, showCtrlCopy, false, null, @"",
                      null, null, @"",
                      contentAreaType, linkAreaCommand, linkLaunchArgument,
-                     contentLinkArea, messageTextAlignment);
+                     contentLinkArea);
 
         /// <summary>
         /// Displays a message box in front+center of the specified object and with the specified text, caption, buttons, icon, default button, and options.
@@ -83,19 +77,17 @@ namespace Krypton.Toolkit
         /// <param name="linkAreaCommand">Specifies a <see cref="T:KryptonCommand"/> if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
         /// <param name="linkLaunchArgument">Specifies the <see cref="ProcessStartInfo"/> if a <paramref name="linkAreaCommand"> has not been defined.</paramref></param>
         /// <param name="contentLinkArea">Specifies the area within the <see cref="KryptonLinkWrapLabel"/> to be regarded as a link. See <see cref="LinkArea"/>.</param>
-        /// <param name="messageTextAlignment">Specifies how the message text should be aligned. See <see cref="System.Drawing.ContentAlignment"/> for supported values.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
         public static DialogResult Show(IWin32Window? owner, string text, bool? showCtrlCopy = null,
                                         MessageBoxContentAreaType? contentAreaType = null,
                                         KryptonCommand? linkAreaCommand = null,
                                         ProcessStartInfo? linkLaunchArgument = null,
-                                        LinkArea? contentLinkArea = null,
-                                        ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft) =>
+                                        LinkArea? contentLinkArea = null) =>
             ShowCore(owner, text, @"", KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.None,
                      KryptonMessageBoxDefaultButton.Button4, 0, null, showCtrlCopy,
                      false, null, @"", null,
                      null, @"",
-                     contentAreaType, linkAreaCommand, linkLaunchArgument, contentLinkArea, messageTextAlignment);
+                     contentAreaType, linkAreaCommand, linkLaunchArgument, contentLinkArea);
 
         /// <summary>
         /// Displays a message box in front+center of the specified object and with the specified text, caption, buttons, icon, default button, and options.
@@ -108,19 +100,17 @@ namespace Krypton.Toolkit
         /// <param name="linkAreaCommand">Specifies a <see cref="T:KryptonCommand"/> if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
         /// <param name="linkLaunchArgument">Specifies the <see cref="ProcessStartInfo"/> if a <paramref name="linkAreaCommand"> has not been defined.</paramref></param>
         /// <param name="contentLinkArea">Specifies the area within the <see cref="KryptonLinkWrapLabel"/> to be regarded as a link. See <see cref="LinkArea"/>.</param>
-        /// <param name="messageTextAlignment">Specifies how the message text should be aligned. See <see cref="System.Drawing.ContentAlignment"/> for supported values.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
         public static DialogResult Show(IWin32Window? owner, string text, string caption, bool? showCtrlCopy = null,
                                         MessageBoxContentAreaType? contentAreaType = null,
                                         KryptonCommand? linkAreaCommand = null,
                                         ProcessStartInfo? linkLaunchArgument = null,
-                                        LinkArea? contentLinkArea = null,
-                                        ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft) =>
+                                        LinkArea? contentLinkArea = null) =>
             ShowCore(owner, text, caption, KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.None,
                      KryptonMessageBoxDefaultButton.Button4, 0, null, showCtrlCopy,
                      false, null, @"", null,
                      null, @"",
-                     contentAreaType, linkAreaCommand, linkLaunchArgument, contentLinkArea, messageTextAlignment);
+                     contentAreaType, linkAreaCommand, linkLaunchArgument, contentLinkArea);
 
         /// <summary>
         /// Displays a message box in front+center of the application and with the specified text, caption and buttons.
@@ -133,22 +123,20 @@ namespace Krypton.Toolkit
         /// <param name="linkAreaCommand">Specifies a <see cref="T:KryptonCommand"/> if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
         /// <param name="linkLaunchArgument">Specifies the <see cref="ProcessStartInfo"/> if a <paramref name="linkAreaCommand"> has not been defined.</paramref></param>
         /// <param name="contentLinkArea">Specifies the area within the <see cref="KryptonLinkWrapLabel"/> to be regarded as a link. See <see cref="LinkArea"/>.</param>
-        /// <param name="messageTextAlignment">Specifies how the message text should be aligned. See <see cref="System.Drawing.ContentAlignment"/> for supported values.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
         public static DialogResult Show(string text, string caption, KryptonMessageBoxButtons buttons,
                                         bool? showCtrlCopy = null,
                                         MessageBoxContentAreaType? contentAreaType = null,
                                         KryptonCommand? linkAreaCommand = null,
                                         ProcessStartInfo? linkLaunchArgument = null,
-                                        LinkArea? contentLinkArea = null,
-                                        ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft) =>
+                                        LinkArea? contentLinkArea = null) =>
                                        ShowCore(null, text, caption, buttons, KryptonMessageBoxIcon.None,
                                                 KryptonMessageBoxDefaultButton.Button1, 0,
                                                 new HelpInfo(@"", 0, null), showCtrlCopy,
                                                 null, null, @"",
                                                 null, null, @"",
                                                 contentAreaType, linkAreaCommand, linkLaunchArgument,
-                                                contentLinkArea, messageTextAlignment);
+                                                contentLinkArea);
 
         /// <summary>
         /// Displays a message box in front+center of the application and with the specified text, caption, buttons, icon, default button, and options.
@@ -171,7 +159,6 @@ namespace Krypton.Toolkit
         /// <param name="linkAreaCommand">Specifies a <see cref="T:KryptonCommand"/> if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
         /// <param name="linkLaunchArgument">Specifies the <see cref="ProcessStartInfo"/> if a <paramref name="linkAreaCommand"> has not been defined.</paramref></param>
         /// <param name="contentLinkArea">Specifies the area within the <see cref="KryptonLinkWrapLabel"/> to be regarded as a link. See <see cref="LinkArea"/>.</param>
-        /// <param name="messageTextAlignment">Specifies how the message text should be aligned. See <see cref="System.Drawing.ContentAlignment"/> for supported values.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
         public static DialogResult Show(string text, string caption, KryptonMessageBoxButtons buttons,
                                          KryptonMessageBoxIcon icon,
@@ -183,15 +170,14 @@ namespace Krypton.Toolkit
                                          string? applicationPath = @"",
                                          MessageBoxContentAreaType? contentAreaType = null,
                                          KryptonCommand? linkAreaCommand = null,
-                                         LinkArea? contentLinkArea = null,
-                                         ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft)
+                                         LinkArea? contentLinkArea = null)
             =>
                 ShowCore(null, text, caption, buttons, icon, defaultButton, options,
                          displayHelpButton ? new HelpInfo() : null, showCtrlCopy,
                          showHelpButton, showActionButton,
                          actionButtonText, actionButtonCommand, applicationImage, applicationPath,
                          contentAreaType, linkAreaCommand, linkLaunchArgument,
-                         contentLinkArea, messageTextAlignment);
+                         contentLinkArea);
 
 
         /// <summary>
@@ -216,7 +202,6 @@ namespace Krypton.Toolkit
         /// <param name="linkAreaCommand">Specifies a <see cref="T:KryptonCommand"/> if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
         /// <param name="linkLaunchArgument">Specifies the <see cref="ProcessStartInfo"/> if a <paramref name="linkAreaCommand"> has not been defined.</paramref></param>
         /// <param name="contentLinkArea">Specifies the area within the <see cref="KryptonLinkWrapLabel"/> to be regarded as a link. See <see cref="LinkArea"/>.</param>
-        /// <param name="messageTextAlignment">Specifies how the message text should be aligned. See <see cref="System.Drawing.ContentAlignment"/> for supported values.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
         public static DialogResult Show(IWin32Window? owner, string text, string caption,
                                         KryptonMessageBoxButtons buttons, KryptonMessageBoxIcon icon,
@@ -229,15 +214,14 @@ namespace Krypton.Toolkit
                                         MessageBoxContentAreaType? contentAreaType = null,
                                         KryptonCommand? linkAreaCommand = null,
                                         ProcessStartInfo? linkLaunchArgument = null,
-                                        LinkArea? contentLinkArea = null,
-                                        ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft)
+                                        LinkArea? contentLinkArea = null)
             =>
                 ShowCore(owner, text, caption, buttons, icon, defaultButton, options,
                          displayHelpButton ? new HelpInfo() : null, showCtrlCopy,
                          showHelpButton, showActionButton, actionButtonText,
                          actionButtonCommand, applicationImage, applicationPath,
                          contentAreaType, linkAreaCommand, linkLaunchArgument,
-                         contentLinkArea, messageTextAlignment);
+                         contentLinkArea);
 
         /// <param name="text">The text to display in the message box.</param>
         /// <param name="caption" >The text to display in the title bar of the message box. default="string.Empty"</param>
@@ -259,7 +243,6 @@ namespace Krypton.Toolkit
         /// <param name="linkAreaCommand">Specifies a <see cref="T:KryptonCommand"/> if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
         /// <param name="linkLaunchArgument">Specifies the <see cref="ProcessStartInfo"/> if a <paramref name="linkAreaCommand"> has not been defined.</paramref></param>
         /// <param name="contentLinkArea">Specifies the area within the <see cref="KryptonLinkWrapLabel"/> to be regarded as a link. See <see cref="LinkArea"/>.</param>
-        /// <param name="messageTextAlignment">Specifies how the message text should be aligned. See <see cref="System.Drawing.ContentAlignment"/> for supported values.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
         public static DialogResult Show(string text, string caption, KryptonMessageBoxButtons buttons,
                                         KryptonMessageBoxIcon icon, KryptonMessageBoxDefaultButton defaultButton,
@@ -271,14 +254,13 @@ namespace Krypton.Toolkit
                                         MessageBoxContentAreaType? contentAreaType = null,
                                         KryptonCommand? linkAreaCommand = null,
                                         ProcessStartInfo? linkLaunchArgument = null,
-                                        LinkArea? contentLinkArea = null,
-                                        ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft)
+                                        LinkArea? contentLinkArea = null)
             => ShowCore(null, text, caption, buttons, icon, defaultButton, options,
                         new HelpInfo(helpFilePath, navigator, param), showCtrlCopy,
                         showHelpButton, showActionButton, actionButtonText,
                         actionButtonCommand, applicationImage, applicationPath,
                         contentAreaType, linkAreaCommand, linkLaunchArgument,
-                        contentLinkArea, messageTextAlignment);
+                        contentLinkArea);
 
         /// <summary>
         /// Displays a message box with the specified text, caption, buttons, icon, default button, options, and Help button, using the specified Help file, HelpNavigator, and Help topic.
@@ -304,7 +286,6 @@ namespace Krypton.Toolkit
         /// <param name="linkAreaCommand">Specifies a <see cref="T:KryptonCommand"/> if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
         /// <param name="linkLaunchArgument">Specifies the <see cref="ProcessStartInfo"/> if a <paramref name="linkAreaCommand"> has not been defined.</paramref></param>
         /// <param name="contentLinkArea">Specifies the area within the <see cref="KryptonLinkWrapLabel"/> to be regarded as a link. See <see cref="LinkArea"/>.</param>
-        /// <param name="messageTextAlignment">Specifies how the message text should be aligned. See <see cref="System.Drawing.ContentAlignment"/> for supported values.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
         public static DialogResult Show(IWin32Window? owner, string text, string caption,
                                         KryptonMessageBoxButtons buttons,
@@ -322,14 +303,13 @@ namespace Krypton.Toolkit
                                         MessageBoxContentAreaType? contentAreaType = null,
                                         KryptonCommand? linkAreaCommand = null,
                                         ProcessStartInfo? linkLaunchArgument = null,
-                                        LinkArea? contentLinkArea = null,
-                                        ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft)
+                                        LinkArea? contentLinkArea = null)
             => ShowCore(owner, text, caption, buttons, icon, defaultButton, options,
                         new HelpInfo(helpFilePath, navigator, param),
                         showCtrlCopy, showHelpButton, showActionButton,
                         actionButtonText, actionButtonCommand, applicationImage,
                         applicationPath, contentAreaType, linkAreaCommand,
-                        linkLaunchArgument, contentLinkArea, messageTextAlignment);
+                        linkLaunchArgument, contentLinkArea);
 
         #endregion
 
@@ -356,7 +336,6 @@ namespace Krypton.Toolkit
         /// <param name="linkLabelCommand">Specifies a <see cref="T:KryptonCommand"/> if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
         /// <param name="linkLaunchArgument">Specifies the <see cref="ProcessStartInfo"/> if a <paramref name="linkLabelCommand"> has not been defined.</paramref></param>
         /// <param name="contentLinkArea">Specifies the area within the <see cref="KryptonLinkWrapLabel"/> to be regarded as a link. See <see cref="LinkArea"/>.</param>
-        /// <param name="messageTextAlignment">Specifies how the message text should be aligned. See <see cref="System.Drawing.ContentAlignment"/> for supported values.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
         private static DialogResult ShowCore(IWin32Window? owner,
                                              string text, string caption,
@@ -372,8 +351,7 @@ namespace Krypton.Toolkit
                                              MessageBoxContentAreaType? contentAreaType,
                                              KryptonCommand? linkLabelCommand,
                                              ProcessStartInfo? linkLaunchArgument,
-                                             LinkArea? contentLinkArea,
-                                             ContentAlignment? messageTextAlignment)
+                                             LinkArea? contentLinkArea)
         {
             caption = string.IsNullOrEmpty(caption) ? @" " : caption;
 
@@ -385,7 +363,7 @@ namespace Krypton.Toolkit
                                                       showActionButton, actionButtonText,
                                                       actionButtonCommand, applicationImage, applicationPath,
                                                       contentAreaType, linkLabelCommand,
-                                                      linkLaunchArgument, contentLinkArea, messageTextAlignment);
+                                                      linkLaunchArgument, contentLinkArea);
 
             kmb.StartPosition = showOwner == null ? FormStartPosition.CenterScreen : FormStartPosition.CenterParent;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMessageBoxForm.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMessageBoxForm.Designer.cs
@@ -52,7 +52,7 @@ namespace Krypton.Toolkit
             this.kryptonPanel1 = new Krypton.Toolkit.KryptonPanel();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this._panelContentArea = new Krypton.Toolkit.KryptonPanel();
-            this._messageText = new Krypton.Toolkit.KryptonWrapLabel();
+            this._messageText = new Krypton.Toolkit.KryptonTextBox();
             this._linkLabelMessageText = new Krypton.Toolkit.KryptonLinkWrapLabel();
             ((System.ComponentModel.ISupportInitialize)(this._messageIcon)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this._panelButtons)).BeginInit();
@@ -68,10 +68,10 @@ namespace Krypton.Toolkit
             // 
             this._messageIcon.BackColor = System.Drawing.Color.Transparent;
             this._messageIcon.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._messageIcon.Location = new System.Drawing.Point(8, 4);
-            this._messageIcon.Margin = new System.Windows.Forms.Padding(8, 4, 4, 4);
+            this._messageIcon.Location = new System.Drawing.Point(11, 5);
+            this._messageIcon.Margin = new System.Windows.Forms.Padding(11, 5, 5, 5);
             this._messageIcon.Name = "_messageIcon";
-            this._messageIcon.Size = new System.Drawing.Size(33, 34);
+            this._messageIcon.Size = new System.Drawing.Size(44, 42);
             this._messageIcon.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
             this._messageIcon.TabIndex = 0;
             this._messageIcon.TabStop = false;
@@ -86,11 +86,11 @@ namespace Krypton.Toolkit
             this._panelButtons.Controls.Add(this._button2);
             this._panelButtons.Controls.Add(this._button5);
             this._panelButtons.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._panelButtons.Location = new System.Drawing.Point(0, 42);
+            this._panelButtons.Location = new System.Drawing.Point(0, 52);
             this._panelButtons.Margin = new System.Windows.Forms.Padding(0);
             this._panelButtons.Name = "_panelButtons";
             this._panelButtons.PanelBackStyle = Krypton.Toolkit.PaletteBackStyle.PanelAlternate;
-            this._panelButtons.Size = new System.Drawing.Size(183, 21);
+            this._panelButtons.Size = new System.Drawing.Size(244, 26);
             this._panelButtons.TabIndex = 0;
             // 
             // _borderEdge
@@ -98,9 +98,9 @@ namespace Krypton.Toolkit
             this._borderEdge.BorderStyle = Krypton.Toolkit.PaletteBorderStyle.HeaderPrimary;
             this._borderEdge.Dock = System.Windows.Forms.DockStyle.Top;
             this._borderEdge.Location = new System.Drawing.Point(0, 0);
-            this._borderEdge.Margin = new System.Windows.Forms.Padding(2);
+            this._borderEdge.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this._borderEdge.Name = "_borderEdge";
-            this._borderEdge.Size = new System.Drawing.Size(183, 1);
+            this._borderEdge.Size = new System.Drawing.Size(244, 1);
             this._borderEdge.Text = "kryptonBorderEdge1";
             // 
             // _button4
@@ -109,11 +109,11 @@ namespace Krypton.Toolkit
             this._button4.AutoSize = true;
             this._button4.Enabled = false;
             this._button4.IgnoreAltF4 = false;
-            this._button4.Location = new System.Drawing.Point(183, 0);
+            this._button4.Location = new System.Drawing.Point(244, 0);
             this._button4.Margin = new System.Windows.Forms.Padding(0);
-            this._button4.MinimumSize = new System.Drawing.Size(38, 21);
+            this._button4.MinimumSize = new System.Drawing.Size(51, 26);
             this._button4.Name = "_button4";
-            this._button4.Size = new System.Drawing.Size(38, 23);
+            this._button4.Size = new System.Drawing.Size(51, 32);
             this._button4.TabIndex = 2;
             this._button4.Values.Text = "B4";
             this._button4.Visible = false;
@@ -124,11 +124,11 @@ namespace Krypton.Toolkit
             this._button3.AutoSize = true;
             this._button3.Enabled = false;
             this._button3.IgnoreAltF4 = false;
-            this._button3.Location = new System.Drawing.Point(146, 0);
+            this._button3.Location = new System.Drawing.Point(195, 0);
             this._button3.Margin = new System.Windows.Forms.Padding(0);
-            this._button3.MinimumSize = new System.Drawing.Size(38, 21);
+            this._button3.MinimumSize = new System.Drawing.Size(51, 26);
             this._button3.Name = "_button3";
-            this._button3.Size = new System.Drawing.Size(38, 23);
+            this._button3.Size = new System.Drawing.Size(51, 32);
             this._button3.TabIndex = 2;
             this._button3.Values.Text = "B3";
             this._button3.Visible = false;
@@ -139,11 +139,11 @@ namespace Krypton.Toolkit
             this._button1.AutoSize = true;
             this._button1.Enabled = false;
             this._button1.IgnoreAltF4 = false;
-            this._button1.Location = new System.Drawing.Point(70, 0);
+            this._button1.Location = new System.Drawing.Point(93, 0);
             this._button1.Margin = new System.Windows.Forms.Padding(0);
-            this._button1.MinimumSize = new System.Drawing.Size(38, 21);
+            this._button1.MinimumSize = new System.Drawing.Size(51, 26);
             this._button1.Name = "_button1";
-            this._button1.Size = new System.Drawing.Size(38, 23);
+            this._button1.Size = new System.Drawing.Size(51, 32);
             this._button1.TabIndex = 0;
             this._button1.Values.Text = "B1";
             this._button1.Visible = false;
@@ -154,11 +154,11 @@ namespace Krypton.Toolkit
             this._button2.AutoSize = true;
             this._button2.Enabled = false;
             this._button2.IgnoreAltF4 = false;
-            this._button2.Location = new System.Drawing.Point(108, 0);
+            this._button2.Location = new System.Drawing.Point(144, 0);
             this._button2.Margin = new System.Windows.Forms.Padding(0);
-            this._button2.MinimumSize = new System.Drawing.Size(38, 21);
+            this._button2.MinimumSize = new System.Drawing.Size(51, 26);
             this._button2.Name = "_button2";
-            this._button2.Size = new System.Drawing.Size(38, 23);
+            this._button2.Size = new System.Drawing.Size(51, 32);
             this._button2.TabIndex = 1;
             this._button2.Values.Text = "B2";
             this._button2.Visible = false;
@@ -170,9 +170,9 @@ namespace Krypton.Toolkit
             this._button5.IgnoreAltF4 = false;
             this._button5.Location = new System.Drawing.Point(0, 0);
             this._button5.Margin = new System.Windows.Forms.Padding(0);
-            this._button5.MinimumSize = new System.Drawing.Size(38, 21);
+            this._button5.MinimumSize = new System.Drawing.Size(51, 26);
             this._button5.Name = "_button5";
-            this._button5.Size = new System.Drawing.Size(38, 23);
+            this._button5.Size = new System.Drawing.Size(51, 32);
             this._button5.TabIndex = 3;
             this._button5.Values.Text = "B5";
             this._button5.Visible = false;
@@ -182,9 +182,9 @@ namespace Krypton.Toolkit
             this.kryptonPanel1.Controls.Add(this.tableLayoutPanel1);
             this.kryptonPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonPanel1.Location = new System.Drawing.Point(0, 0);
-            this.kryptonPanel1.Margin = new System.Windows.Forms.Padding(2);
+            this.kryptonPanel1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kryptonPanel1.Name = "kryptonPanel1";
-            this.kryptonPanel1.Size = new System.Drawing.Size(183, 63);
+            this.kryptonPanel1.Size = new System.Drawing.Size(244, 78);
             this.kryptonPanel1.TabIndex = 1;
             // 
             // tableLayoutPanel1
@@ -198,12 +198,12 @@ namespace Krypton.Toolkit
             this.tableLayoutPanel1.Controls.Add(this._panelContentArea, 1, 0);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
-            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(2);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(183, 63);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(244, 78);
             this.tableLayoutPanel1.TabIndex = 0;
             // 
             // _panelContentArea
@@ -211,48 +211,50 @@ namespace Krypton.Toolkit
             this._panelContentArea.Controls.Add(this._messageText);
             this._panelContentArea.Controls.Add(this._linkLabelMessageText);
             this._panelContentArea.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._panelContentArea.Location = new System.Drawing.Point(48, 3);
+            this._panelContentArea.Location = new System.Drawing.Point(64, 4);
+            this._panelContentArea.Margin = new System.Windows.Forms.Padding(4);
             this._panelContentArea.Name = "_panelContentArea";
-            this._panelContentArea.Size = new System.Drawing.Size(132, 36);
+            this._panelContentArea.Size = new System.Drawing.Size(176, 44);
             this._panelContentArea.TabIndex = 1;
             // 
             // _messageText
             // 
-            this._messageText.AutoSize = false;
             this._messageText.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._messageText.Font = new System.Drawing.Font("Segoe UI", 9F);
-            this._messageText.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(30)))), ((int)(((byte)(57)))), ((int)(((byte)(91)))));
-            this._messageText.LabelStyle = Krypton.Toolkit.LabelStyle.NormalControl;
+            this._messageText.InputControlStyle = Krypton.Toolkit.InputControlStyle.PanelClient;
             this._messageText.Location = new System.Drawing.Point(0, 0);
-            this._messageText.Margin = new System.Windows.Forms.Padding(4, 0, 0, 0);
+            this._messageText.Margin = new System.Windows.Forms.Padding(5, 0, 0, 0);
+            this._messageText.Multiline = true;
             this._messageText.Name = "_messageText";
-            this._messageText.Size = new System.Drawing.Size(132, 36);
-            this._messageText.Text = "Message Text";
-            this._messageText.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this._messageText.ReadOnly = true;
+            this._messageText.Size = new System.Drawing.Size(176, 44);
+            this._messageText.StateCommon.Border.DrawBorders = Krypton.Toolkit.PaletteDrawBorders.None;
+            this._messageText.TabIndex = 0;
+            this._messageText.TabStop = false;
+            this._messageText.Text = "Message Text\r\n.\ttabbed";
             // 
             // _linkLabelMessageText
             // 
             this._linkLabelMessageText.AutoSize = false;
             this._linkLabelMessageText.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._linkLabelMessageText.Font = new System.Drawing.Font("Segoe UI", 9F);
-            this._linkLabelMessageText.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(30)))), ((int)(((byte)(57)))), ((int)(((byte)(91)))));
             this._linkLabelMessageText.LabelStyle = Krypton.Toolkit.LabelStyle.NormalControl;
             this._linkLabelMessageText.Location = new System.Drawing.Point(0, 0);
+            this._linkLabelMessageText.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this._linkLabelMessageText.Name = "_linkLabelMessageText";
-            this._linkLabelMessageText.Size = new System.Drawing.Size(132, 36);
+            this._linkLabelMessageText.Size = new System.Drawing.Size(176, 44);
+            this._linkLabelMessageText.TabIndex = 0;
             this._linkLabelMessageText.Text = "Message Text";
             this._linkLabelMessageText.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this._linkLabelMessageText.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkClicked);
             // 
             // KryptonMessageBoxForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(183, 63);
+            this.ClientSize = new System.Drawing.Size(244, 78);
             this.Controls.Add(this.kryptonPanel1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.KeyPreview = true;
-            this.Margin = new System.Windows.Forms.Padding(2);
+            this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "KryptonMessageBoxForm";
@@ -272,7 +274,6 @@ namespace Krypton.Toolkit
             ((System.ComponentModel.ISupportInitialize)(this._panelContentArea)).EndInit();
             this._panelContentArea.ResumeLayout(false);
             this.ResumeLayout(false);
-
         }
 
         #endregion
@@ -288,6 +289,6 @@ namespace Krypton.Toolkit
         private MessageButton _button5;
         private KryptonPanel _panelContentArea;
         private KryptonLinkWrapLabel _linkLabelMessageText;
-        private KryptonWrapLabel _messageText;
+        private KryptonTextBox _messageText;
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMessageBoxForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMessageBoxForm.cs
@@ -62,7 +62,6 @@ namespace Krypton.Toolkit
             InitializeComponent();
         }
 
-
         internal KryptonMessageBoxForm(IWin32Window? showOwner, string text, string caption,
                                        KryptonMessageBoxButtons buttons,
                                        KryptonMessageBoxIcon icon,
@@ -77,8 +76,7 @@ namespace Krypton.Toolkit
                                        MessageBoxContentAreaType? contentAreaType,
                                        KryptonCommand? linkLabelCommand,
                                        ProcessStartInfo? linkLaunchArgument,
-                                       LinkArea? contentLinkArea,
-                                       ContentAlignment? messageTextAlignment)
+                                       LinkArea? contentLinkArea)
         {
             // Store incoming values
             _text = text;
@@ -99,7 +97,6 @@ namespace Krypton.Toolkit
             _linkLabelCommand = linkLabelCommand ?? new KryptonCommand();
             _contentLinkArea = contentLinkArea ?? new LinkArea(0, text.Length);
             _linkLaunchArgument = linkLaunchArgument ?? new ProcessStartInfo();
-            _messageTextAlignment = messageTextAlignment ?? ContentAlignment.MiddleLeft;
 
             // Create the form contents
             InitializeComponent();
@@ -114,7 +111,6 @@ namespace Krypton.Toolkit
             UpdateHelp();
             UpdateTextExtra(showCtrlCopy);
             UpdateContentAreaType(contentAreaType);
-            UpdateContentAreaTextAlignment(contentAreaType, messageTextAlignment);
             UpdateContentLinkArea(contentLinkArea);
 
             SetupActionButtonUI(_showActionButton);
@@ -358,9 +354,7 @@ namespace Krypton.Toolkit
                         break;
                 }
             }
-
             _messageIcon.Visible = (_kryptonMessageBoxIcon != KryptonMessageBoxIcon.None);
-
         }
 
         private void UpdateButtons()
@@ -564,7 +558,6 @@ namespace Krypton.Toolkit
             {
                 // Do nothing if failure to send to Parent
             }
-
         }
 
         private void UpdateSizing(IWin32Window? showOwner)
@@ -588,7 +581,6 @@ namespace Krypton.Toolkit
                 SizeF scaledMonitorSize = screen.Bounds.Size;
                 scaledMonitorSize.Width *= 2 / 3.0f;
                 scaledMonitorSize.Height *= 0.95f;
-                _messageText.UpdateFont();
                 SizeF messageSize = g.MeasureString(_text, _messageText.Font, scaledMonitorSize);
                 // SKC: Don't forget to add the TextExtra into the calculation
                 SizeF captionSize = g.MeasureString($@"{_caption} {TextExtra}", _messageText.Font, scaledMonitorSize);
@@ -656,7 +648,6 @@ namespace Krypton.Toolkit
 
             // Start positioning buttons 10 pixels from right edge
             var right = _panelButtons.Right - GAP;
-
             var left = _panelButtons.Left - GAP;
 
             // If Action button is visible
@@ -720,7 +711,6 @@ namespace Krypton.Toolkit
 
             const string DIVIDER = @"---------------------------";
             const string BUTTON_TEXT_SPACER = @"   ";
-
             // Pressing Ctrl+C should copy message text into the clipboard
             var sb = new StringBuilder();
 
@@ -756,9 +746,7 @@ namespace Krypton.Toolkit
         private void SetupActionButtonUI(bool visible)
         {
             _button5.Visible = visible;
-
             _button5.Enabled = visible;
-
             _button5.Click += (sender, args) =>
             {
                 try
@@ -809,24 +797,6 @@ namespace Krypton.Toolkit
 
                     _messageText.Visible = false;
                     break;
-            }
-        }
-
-        private void UpdateContentAreaTextAlignment(MessageBoxContentAreaType? contentAreaType, ContentAlignment? messageTextAlignment)
-        {
-            switch (contentAreaType)
-            {
-                case MessageBoxContentAreaType.Normal:
-                    _messageText.TextAlign = messageTextAlignment ?? ContentAlignment.MiddleLeft;
-                    break;
-                case MessageBoxContentAreaType.LinkLabel:
-                    _linkLabelMessageText.TextAlign = messageTextAlignment ?? ContentAlignment.MiddleLeft;
-                    break;
-                case null:
-                    _messageText.TextAlign = messageTextAlignment ?? ContentAlignment.MiddleLeft;
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(contentAreaType), contentAreaType, null);
             }
         }
 


### PR DESCRIPTION
**Breaking Change** `KryptonMessageBox` does not obey tab characters like `MessageBox`
  - The optional `ContentAlignment` for a `KryptonMessageBox.Show` cammand is no longer possible.

#1424

![image](https://github.com/Krypton-Suite/Standard-Toolkit/assets/2418812/7a82ea0e-1858-44e8-87f0-27fd1d85e1c2)
