### PR TITLE
**Breaking Change** `KryptonMessageBox` does not obey tab characters like `MessageBox`

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
+* Resolved [#1424](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1424), **Breaking Change** `KryptonMessageBox` does not obey tab characters like `MessageBox`
 * Resolved [#1381](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1381), **[Regression]** Docking Persistence broken since build ##.23.10.303
 * Resolved [#1301](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1301), **[Regression]** When Maximised - intergrated KryptonRibbon has titlebar issues
 * Resolved [#1383](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1383), Closing last Page in undocked page group prevents addition of further Pages via `KryptonDockingManager.AddToWorkspace` (fix courtesy of [stizler](https://github.com/stigzler))

--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ Follow the links to see the different objects and layouts that this framework al
 
 ## V90.## (2024-11-xx - Build 2411 - November 2024)
 There are list of changes that have occurred during the development of the V90.## version
+- [#1424](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1424), **Breaking Change** `KryptonMessageBox` does not obey tab characters like `MessageBox`
+  - The optional `ContentAlignment` for a `KryptonMessageBox.Show` command is no longer possible.
 - [#1356](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1356), AppButton colours don't change while switching themes
     - See https://github.com/Krypton-Suite/Standard-Toolkit/issues/1356#issuecomment-2039412890
     - `RibbonAppButton` has become `RibbonFileAppButton` 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMessageBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMessageBox.cs
@@ -10,9 +10,6 @@
  */
 #endregion
 
-// Only used in this class
-using ContentAlignment = System.Drawing.ContentAlignment;
-
 // ReSharper disable ClassNeverInstantiated.Global
 // ReSharper disable UnusedMethodReturnValue.Global
 
@@ -37,7 +34,6 @@ namespace Krypton.Toolkit
         /// <param name="linkAreaCommand">Specifies a <see cref="T:KryptonCommand"/> if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
         /// <param name="linkLaunchArgument">Specifies the <see cref="ProcessStartInfo"/> if a <paramref name="linkAreaCommand"> has not been defined.</paramref></param>
         /// <param name="contentLinkArea">Specifies the area within the <see cref="KryptonLinkWrapLabel"/> to be regarded as a link. See <see cref="LinkArea"/>.</param>
-        /// <param name="messageTextAlignment">Specifies how the message text should be aligned. See <see cref="System.Drawing.ContentAlignment"/> for supported values.</param>
         /// <param name="showCloseButton">Displays the close button. If null (default), then the close button will be displayed.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
         public static DialogResult Show(string text, string caption, bool? showCtrlCopy = null,
@@ -45,12 +41,11 @@ namespace Krypton.Toolkit
                                         KryptonCommand? linkAreaCommand = null,
                                         ProcessStartInfo? linkLaunchArgument = null,
                                         LinkArea? contentLinkArea = null,
-                                        ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft,
                                         bool? showCloseButton = null) =>
             ShowCore(null, text, caption, KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.None,
                      KryptonMessageBoxDefaultButton.Button4, 0, null, showCtrlCopy,
                      null, null, @"",
-                     contentAreaType, linkAreaCommand, linkLaunchArgument, contentLinkArea, messageTextAlignment, null,
+                     contentAreaType, linkAreaCommand, linkLaunchArgument, contentLinkArea, null,
                      showCloseButton);
 
         /// <summary>
@@ -62,7 +57,6 @@ namespace Krypton.Toolkit
         /// <param name="linkAreaCommand">Specifies a <see cref="T:KryptonCommand"/> if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
         /// <param name="linkLaunchArgument">Specifies the <see cref="ProcessStartInfo"/> if a <paramref name="linkAreaCommand"> has not been defined.</paramref></param>
         /// <param name="contentLinkArea">Specifies the area within the <see cref="KryptonLinkWrapLabel"/> to be regarded as a link. See <see cref="LinkArea"/>.</param>
-        /// <param name="messageTextAlignment">Specifies how the message text should be aligned. See <see cref="System.Drawing.ContentAlignment"/> for supported values.</param>
         /// <param name="showCloseButton">Displays the close button. If null (default), then the close button will be displayed.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
         public static DialogResult Show(string text, bool? showCtrlCopy = null,
@@ -70,14 +64,12 @@ namespace Krypton.Toolkit
                                         KryptonCommand? linkAreaCommand = null,
                                         ProcessStartInfo? linkLaunchArgument = null,
                                         LinkArea? contentLinkArea = null,
-                                        ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft,
                                         bool? showCloseButton = null) =>
             ShowCore(null, text, @"", KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.None,
                      KryptonMessageBoxDefaultButton.Button4, 0,
                      null, showCtrlCopy, false, null, @"",
                      contentAreaType, linkAreaCommand, linkLaunchArgument,
-                     contentLinkArea, messageTextAlignment,
-                     null, showCloseButton);
+                     contentLinkArea, null, showCloseButton);
 
         /// <summary>
         /// Displays a message box in front+center of the specified object and with the specified text, caption, buttons, icon, default button, and options.
@@ -89,7 +81,6 @@ namespace Krypton.Toolkit
         /// <param name="linkAreaCommand">Specifies a <see cref="T:KryptonCommand"/> if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
         /// <param name="linkLaunchArgument">Specifies the <see cref="ProcessStartInfo"/> if a <paramref name="linkAreaCommand"> has not been defined.</paramref></param>
         /// <param name="contentLinkArea">Specifies the area within the <see cref="KryptonLinkWrapLabel"/> to be regarded as a link. See <see cref="LinkArea"/>.</param>
-        /// <param name="messageTextAlignment">Specifies how the message text should be aligned. See <see cref="System.Drawing.ContentAlignment"/> for supported values.</param>
         /// <param name="showCloseButton">Displays the close button. If null (default), then the close button will be displayed.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
         public static DialogResult Show(IWin32Window? owner, string text, bool? showCtrlCopy = null,
@@ -97,14 +88,13 @@ namespace Krypton.Toolkit
                                         KryptonCommand? linkAreaCommand = null,
                                         ProcessStartInfo? linkLaunchArgument = null,
                                         LinkArea? contentLinkArea = null,
-                                        ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft,
                                         bool? showCloseButton = null) =>
             ShowCore(owner, text, @"", KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.None,
                      KryptonMessageBoxDefaultButton.Button4, 0, null, showCtrlCopy,
                      false,
                      null, @"",
                      contentAreaType, linkAreaCommand, linkLaunchArgument, contentLinkArea,
-                     messageTextAlignment, null, showCloseButton);
+                     null, showCloseButton);
 
         /// <summary>
         /// Displays a message box in front+center of the specified object and with the specified text, caption, buttons, icon, default button, and options.
@@ -117,7 +107,6 @@ namespace Krypton.Toolkit
         /// <param name="linkAreaCommand">Specifies a <see cref="T:KryptonCommand"/> if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
         /// <param name="linkLaunchArgument">Specifies the <see cref="ProcessStartInfo"/> if a <paramref name="linkAreaCommand"> has not been defined.</paramref></param>
         /// <param name="contentLinkArea">Specifies the area within the <see cref="KryptonLinkWrapLabel"/> to be regarded as a link. See <see cref="LinkArea"/>.</param>
-        /// <param name="messageTextAlignment">Specifies how the message text should be aligned. See <see cref="System.Drawing.ContentAlignment"/> for supported values.</param>
         /// <param name="showCloseButton">Displays the close button. If null (default), then the close button will be displayed.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
         public static DialogResult Show(IWin32Window? owner, string? text, string caption, bool? showCtrlCopy = null,
@@ -125,14 +114,13 @@ namespace Krypton.Toolkit
                                         KryptonCommand? linkAreaCommand = null,
                                         ProcessStartInfo? linkLaunchArgument = null,
                                         LinkArea? contentLinkArea = null,
-                                        ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft,
                                         bool? showCloseButton = null) =>
             ShowCore(owner, text, caption, KryptonMessageBoxButtons.OK, KryptonMessageBoxIcon.None,
                      KryptonMessageBoxDefaultButton.Button4, 0, null, showCtrlCopy,
                      false,
                      null, @"",
                      contentAreaType, linkAreaCommand, linkLaunchArgument, contentLinkArea,
-                     messageTextAlignment, null, showCloseButton);
+                     null, showCloseButton);
 
         /// <summary>
         /// Displays a message box in front+center of the application and with the specified text, caption and buttons.
@@ -145,7 +133,6 @@ namespace Krypton.Toolkit
         /// <param name="linkAreaCommand">Specifies a <see cref="T:KryptonCommand"/> if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
         /// <param name="linkLaunchArgument">Specifies the <see cref="ProcessStartInfo"/> if a <paramref name="linkAreaCommand"> has not been defined.</paramref></param>
         /// <param name="contentLinkArea">Specifies the area within the <see cref="KryptonLinkWrapLabel"/> to be regarded as a link. See <see cref="LinkArea"/>.</param>
-        /// <param name="messageTextAlignment">Specifies how the message text should be aligned. See <see cref="System.Drawing.ContentAlignment"/> for supported values.</param>
         /// <param name="showCloseButton">Displays the close button. If null (default), then the close button will be displayed.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
         public static DialogResult Show(string text, string caption, KryptonMessageBoxButtons buttons,
@@ -154,13 +141,13 @@ namespace Krypton.Toolkit
                                         KryptonCommand? linkAreaCommand = null,
                                         ProcessStartInfo? linkLaunchArgument = null,
                                         LinkArea? contentLinkArea = null,
-                                        ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft, bool? showCloseButton = null) =>
+                                        bool? showCloseButton = null) =>
                                        ShowCore(null, text, caption, buttons, KryptonMessageBoxIcon.None,
                                                 KryptonMessageBoxDefaultButton.Button1, 0,
                                                 new HelpInfo(@"", 0, null), showCtrlCopy,
                                                 null, null, @"",
                                                 contentAreaType, linkAreaCommand, linkLaunchArgument,
-                                                contentLinkArea, messageTextAlignment, null,
+                                                contentLinkArea, null,
                                                 showCloseButton);
 
         /// <summary>
@@ -181,7 +168,6 @@ namespace Krypton.Toolkit
         /// <param name="linkAreaCommand">Specifies a <see cref="T:KryptonCommand"/> if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
         /// <param name="linkLaunchArgument">Specifies the <see cref="ProcessStartInfo"/> if a <paramref name="linkAreaCommand"> has not been defined.</paramref></param>
         /// <param name="contentLinkArea">Specifies the area within the <see cref="KryptonLinkWrapLabel"/> to be regarded as a link. See <see cref="LinkArea"/>.</param>
-        /// <param name="messageTextAlignment">Specifies how the message text should be aligned. See <see cref="System.Drawing.ContentAlignment"/> for supported values.</param>
         /// <param name="forceUseOfOperatingSystemIcons">If set to true, the <see cref="VisualMessageBoxForm"/> will use standard operating system icons.</param>
         /// <param name="showCloseButton">Displays the close button. If null (default), then the close button will be displayed.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
@@ -195,7 +181,6 @@ namespace Krypton.Toolkit
                                          MessageBoxContentAreaType? contentAreaType = null,
                                          KryptonCommand? linkAreaCommand = null,
                                          LinkArea? contentLinkArea = null,
-                                         ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft,
                                          bool? forceUseOfOperatingSystemIcons = null,
                                          bool? showCloseButton = null)
             =>
@@ -203,7 +188,7 @@ namespace Krypton.Toolkit
                          displayHelpButton ? new HelpInfo() : null, showCtrlCopy,
                          showHelpButton, applicationImage, applicationPath,
                          contentAreaType, linkAreaCommand, linkLaunchArgument,
-                         contentLinkArea, messageTextAlignment, forceUseOfOperatingSystemIcons, showCloseButton);
+                         contentLinkArea, forceUseOfOperatingSystemIcons, showCloseButton);
 
 
         /// <summary>
@@ -225,7 +210,6 @@ namespace Krypton.Toolkit
         /// <param name="linkAreaCommand">Specifies a <see cref="T:KryptonCommand"/> if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
         /// <param name="linkLaunchArgument">Specifies the <see cref="ProcessStartInfo"/> if a <paramref name="linkAreaCommand"> has not been defined.</paramref></param>
         /// <param name="contentLinkArea">Specifies the area within the <see cref="KryptonLinkWrapLabel"/> to be regarded as a link. See <see cref="LinkArea"/>.</param>
-        /// <param name="messageTextAlignment">Specifies how the message text should be aligned. See <see cref="System.Drawing.ContentAlignment"/> for supported values.</param>
         /// <param name="forceUseOfOperatingSystemIcons">If set to true, the <see cref="VisualMessageBoxForm"/> will use standard operating system icons.</param>
         /// <param name="showCloseButton">Displays the close button. If null (default), then the close button will be displayed.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
@@ -239,7 +223,6 @@ namespace Krypton.Toolkit
                                         KryptonCommand? linkAreaCommand = null,
                                         ProcessStartInfo? linkLaunchArgument = null,
                                         LinkArea? contentLinkArea = null,
-                                        ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft,
                                         bool? forceUseOfOperatingSystemIcons = null,
                                         bool? showCloseButton = null)
             =>
@@ -247,7 +230,7 @@ namespace Krypton.Toolkit
                          displayHelpButton ? new HelpInfo() : null, showCtrlCopy,
                          showHelpButton, applicationImage, applicationPath,
                          contentAreaType, linkAreaCommand, linkLaunchArgument,
-                         contentLinkArea, messageTextAlignment, forceUseOfOperatingSystemIcons,
+                         contentLinkArea, forceUseOfOperatingSystemIcons,
                          showCloseButton);
 
         /// <param name="text">The text to display in the message box.</param>
@@ -267,7 +250,6 @@ namespace Krypton.Toolkit
         /// <param name="linkAreaCommand">Specifies a <see cref="T:KryptonCommand"/> if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
         /// <param name="linkLaunchArgument">Specifies the <see cref="ProcessStartInfo"/> if a <paramref name="linkAreaCommand"> has not been defined.</paramref></param>
         /// <param name="contentLinkArea">Specifies the area within the <see cref="KryptonLinkWrapLabel"/> to be regarded as a link. See <see cref="LinkArea"/>.</param>
-        /// <param name="messageTextAlignment">Specifies how the message text should be aligned. See <see cref="System.Drawing.ContentAlignment"/> for supported values.</param>
         /// <param name="forceUseOfOperatingSystemIcons">If set to true, the <see cref="VisualMessageBoxForm"/> will use standard operating system icons.</param>
         /// <param name="showCloseButton">Displays the close button. If null (default), then the close button will be displayed.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
@@ -281,14 +263,13 @@ namespace Krypton.Toolkit
                                         KryptonCommand? linkAreaCommand = null,
                                         ProcessStartInfo? linkLaunchArgument = null,
                                         LinkArea? contentLinkArea = null,
-                                        ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft,
                                         bool? forceUseOfOperatingSystemIcons = null,
                                         bool? showCloseButton = null)
             => ShowCore(null, text, caption, buttons, icon, defaultButton, options,
                         new HelpInfo(helpFilePath, navigator, param), showCtrlCopy,
                         showHelpButton, applicationImage, applicationPath,
                         contentAreaType, linkAreaCommand, linkLaunchArgument,
-                        contentLinkArea, messageTextAlignment, forceUseOfOperatingSystemIcons,
+                        contentLinkArea, forceUseOfOperatingSystemIcons,
                         showCloseButton);
 
         /// <summary>
@@ -312,7 +293,6 @@ namespace Krypton.Toolkit
         /// <param name="linkAreaCommand">Specifies a <see cref="T:KryptonCommand"/> if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
         /// <param name="linkLaunchArgument">Specifies the <see cref="ProcessStartInfo"/> if a <paramref name="linkAreaCommand"> has not been defined.</paramref></param>
         /// <param name="contentLinkArea">Specifies the area within the <see cref="KryptonLinkWrapLabel"/> to be regarded as a link. See <see cref="LinkArea"/>.</param>
-        /// <param name="messageTextAlignment">Specifies how the message text should be aligned. See <see cref="System.Drawing.ContentAlignment"/> for supported values.</param>
         /// <param name="forceUseOfOperatingSystemIcons">If set to true, the <see cref="VisualMessageBoxForm"/> will use standard operating system icons.</param>
         /// <param name="showCloseButton">Displays the close button. If null (default), then the close button will be displayed.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
@@ -330,14 +310,13 @@ namespace Krypton.Toolkit
                                         KryptonCommand? linkAreaCommand = null,
                                         ProcessStartInfo? linkLaunchArgument = null,
                                         LinkArea? contentLinkArea = null,
-                                        ContentAlignment? messageTextAlignment = ContentAlignment.MiddleLeft,
                                         bool? forceUseOfOperatingSystemIcons = null,
                                         bool? showCloseButton = null)
             => ShowCore(owner, text, caption, buttons, icon, defaultButton, options,
                         new HelpInfo(helpFilePath, navigator, param),
                         showCtrlCopy, showHelpButton, applicationImage,
                         applicationPath, contentAreaType, linkAreaCommand,
-                        linkLaunchArgument, contentLinkArea, messageTextAlignment, forceUseOfOperatingSystemIcons, showCloseButton);
+                        linkLaunchArgument, contentLinkArea, forceUseOfOperatingSystemIcons, showCloseButton);
 
         /// <summary>Displays a message box with the specified text, caption, buttons, icon, default button, options, and Help button, using the specified Help file, HelpNavigator, and Help topic.</summary>
         /// <param name="messageBoxData">The message box data.</param>
@@ -366,12 +345,11 @@ namespace Krypton.Toolkit
         /// <param name="linkLabelCommand">Specifies a <see cref="T:KryptonCommand"/> if using the <see cref="T:MessageBoxContentAreaType.LinkLabel"/> type.</param>
         /// <param name="linkLaunchArgument">Specifies the <see cref="ProcessStartInfo"/> if a <paramref name="linkLabelCommand"> has not been defined.</paramref></param>
         /// <param name="contentLinkArea">Specifies the area within the <see cref="KryptonLinkWrapLabel"/> to be regarded as a link. See <see cref="LinkArea"/>.</param>
-        /// <param name="messageTextAlignment">Specifies how the message text should be aligned. See <see cref="System.Drawing.ContentAlignment"/> for supported values.</param>
         /// <param name="forceUseOfOperatingSystemIcons">If set to true, the <see cref="VisualMessageBoxForm"/> will use standard operating system icons.</param>
         /// <param name="showCloseButton">Displays the close button. If null (default), then the close button will be displayed.</param>
         /// <returns>One of the System.Windows.Forms.DialogResult values.</returns>
         private static DialogResult ShowCore(IWin32Window? owner,
-                                             string? text, string caption,
+                                             string? text, string? caption,
                                              KryptonMessageBoxButtons buttons,
                                              KryptonMessageBoxIcon icon,
                                              KryptonMessageBoxDefaultButton defaultButton,
@@ -383,7 +361,6 @@ namespace Krypton.Toolkit
                                              KryptonCommand? linkLabelCommand,
                                              ProcessStartInfo? linkLaunchArgument,
                                              LinkArea? contentLinkArea,
-                                             ContentAlignment? messageTextAlignment,
                                              bool? forceUseOfOperatingSystemIcons,
                                              bool? showCloseButton)
         {
@@ -398,7 +375,7 @@ namespace Krypton.Toolkit
                 using var kmbrtl = new VisualMessageBoxRtlAwareForm(showOwner, text, caption, buttons, icon,
                     defaultButton, helpInfo, showCtrlCopy, showHelpButton, applicationImage, applicationPath,
                     contentAreaType, linkLabelCommand,
-                    linkLaunchArgument, contentLinkArea, messageTextAlignment,
+                    linkLaunchArgument, contentLinkArea,
                     forceUseOfOperatingSystemIcons, showCloseButton);
 
                 kmbrtl.StartPosition = showOwner == null ? FormStartPosition.CenterScreen : FormStartPosition.CenterParent;
@@ -410,7 +387,7 @@ namespace Krypton.Toolkit
                 using var kmb = new VisualMessageBoxForm(showOwner, text, caption, buttons, icon,
                     defaultButton, helpInfo, showCtrlCopy, showHelpButton, applicationImage, applicationPath,
                     contentAreaType, linkLabelCommand,
-                    linkLaunchArgument, contentLinkArea, messageTextAlignment,
+                    linkLaunchArgument, contentLinkArea,
                     forceUseOfOperatingSystemIcons, showCloseButton);
 
                 kmb.StartPosition = showOwner == null ? FormStartPosition.CenterScreen : FormStartPosition.CenterParent;
@@ -471,16 +448,13 @@ namespace Krypton.Toolkit
             if ((helpInfo != null) ||
                 ((options & (MessageBoxOptions.ServiceNotification | MessageBoxOptions.DefaultDesktopOnly)) == 0))
             {
-                // If do not have an owner passed in then get the active window and use that instead
+                // If do not have an owner passed in? then get the active window and use that instead
                 showOwner = owner ?? Control.FromHandle(PI.GetActiveWindow());
             }
 
             return showOwner;
         }
-
         #endregion
-
-
         #endregion
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareForm.cs
@@ -7,8 +7,6 @@
  */
 #endregion
 
-using ContentAlignment = System.Drawing.ContentAlignment;
-
 namespace Krypton.Toolkit
 {
     internal partial class VisualMessageBoxRtlAwareForm : KryptonForm
@@ -16,8 +14,8 @@ namespace Krypton.Toolkit
         #region Instance Fields
 
         private readonly bool _showHelpButton;
-        private readonly string _text;
-        private readonly string _caption;
+        private readonly string? _text;
+        private readonly string? _caption;
         private readonly string _applicationPath;
         private readonly KryptonMessageBoxButtons _buttons;
         private readonly KryptonMessageBoxIcon _kryptonMessageBoxIcon;
@@ -37,7 +35,6 @@ namespace Krypton.Toolkit
         private readonly MessageBoxContentAreaType? _contentAreaType;
         private readonly KryptonCommand? _linkLabelCommand;
         private readonly ProcessStartInfo? _linkLaunchArgument;
-        private readonly ContentAlignment? _messageTextAlignment;
         private readonly LinkArea _contentLinkArea;
 
         private KryptonMessageBoxResult _messageBoxResult;
@@ -62,7 +59,7 @@ namespace Krypton.Toolkit
             InitializeComponent();
         }
 
-        public VisualMessageBoxRtlAwareForm(IWin32Window? showOwner, string text, string caption,
+        public VisualMessageBoxRtlAwareForm(IWin32Window? showOwner, string? text, string? caption,
             KryptonMessageBoxButtons buttons,
             KryptonMessageBoxIcon icon,
             KryptonMessageBoxDefaultButton defaultButton,
@@ -74,7 +71,6 @@ namespace Krypton.Toolkit
             KryptonCommand? linkLabelCommand,
             ProcessStartInfo? linkLaunchArgument,
             LinkArea? contentLinkArea,
-            ContentAlignment? messageTextAlignment,
             bool? forceUseOfOperatingSystemIcons,
             bool? showCloseButton)
         {
@@ -95,7 +91,6 @@ namespace Krypton.Toolkit
                 ? new LinkArea(0, 0)
                 : contentLinkArea ?? new LinkArea(0, text.Length);
             _linkLaunchArgument = linkLaunchArgument ?? new ProcessStartInfo();
-            _messageTextAlignment = messageTextAlignment ?? ContentAlignment.MiddleLeft;
             _forceUseOfOperatingSystemIcons = forceUseOfOperatingSystemIcons ?? false;
             _showCloseButton = showCloseButton ?? true;
 
@@ -110,7 +105,6 @@ namespace Krypton.Toolkit
             UpdateHelp();
             UpdateTextExtra(showCtrlCopy);
             UpdateContentAreaType(contentAreaType);
-            UpdateContentAreaTextAlignment(contentAreaType, messageTextAlignment);
             UpdateContentLinkArea(contentLinkArea);
 
             // Finally calculate and set form sizing
@@ -133,7 +127,6 @@ namespace Krypton.Toolkit
             UpdateHelp(_messageBoxData.ShowHelpButton);
             UpdateTextExtra(_messageBoxData.ShowCtrlCopy);
             UpdateContentAreaType(_messageBoxData.MessageContentAreaType);
-            UpdateContentAreaTextAlignment(_messageBoxData.MessageContentAreaType, _messageBoxData.MessageTextAlignment);
             UpdateContentLinkArea(_messageBoxData.ContentLinkArea);
 
             ShowCloseButton(_messageBoxData.ShowCloseButton);
@@ -353,7 +346,7 @@ namespace Krypton.Toolkit
                         break;
                     case KryptonMessageBoxIcon.WindowsLogo:
                         // Because Windows 11 displays a generic application icon,
-                        // we need to rely on a image instead
+                        // we need to rely on an image instead
                         if (OSUtilities.IsWindowsEleven)
                         {
                             _messageIcon.Image = MessageBoxImageResources.Windows11;
@@ -549,7 +542,7 @@ namespace Krypton.Toolkit
                         break;
                     case KryptonMessageBoxIcon.WindowsLogo:
                         // Because Windows 11 displays a generic application icon,
-                        // we need to rely on a image instead
+                        // we need to rely on an image instead
                         if (OSUtilities.IsWindowsEleven)
                         {
                             _messageIcon.Image = MessageBoxImageResources.Windows11;
@@ -1060,7 +1053,7 @@ namespace Krypton.Toolkit
             // Start positioning buttons 10 pixels from right edge
             var right = _panelButtons.Right - GlobalStaticValues.GLOBAL_BUTTON_PADDING;
 
-            var left = _panelButtons.Left - GlobalStaticValues.GLOBAL_BUTTON_PADDING;
+            //var left = _panelButtons.Left - GlobalStaticValues.GLOBAL_BUTTON_PADDING;
 
             // If Button4 is visible
             if (_button4.Enabled)
@@ -1185,24 +1178,6 @@ namespace Krypton.Toolkit
                     klwlblMessageText.Visible = false;
 
                     kwlblMessageText.Visible = true;
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(contentAreaType), contentAreaType, null);
-            }
-        }
-
-        private void UpdateContentAreaTextAlignment(MessageBoxContentAreaType? contentAreaType, ContentAlignment? messageTextAlignment)
-        {
-            switch (contentAreaType)
-            {
-                case MessageBoxContentAreaType.Normal:
-                    kwlblMessageText.TextAlign = messageTextAlignment ?? ContentAlignment.MiddleLeft;
-                    break;
-                case MessageBoxContentAreaType.LinkLabel:
-                    klwlblMessageText.TextAlign = messageTextAlignment ?? ContentAlignment.MiddleLeft;
-                    break;
-                case null:
-                    kwlblMessageText.TextAlign = messageTextAlignment ?? ContentAlignment.MiddleLeft;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(contentAreaType), contentAreaType, null);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxForm.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxForm.Designer.cs
@@ -51,7 +51,7 @@ namespace Krypton.Toolkit
             this.kryptonPanel1 = new Krypton.Toolkit.KryptonPanel();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.kpnlContentArea = new Krypton.Toolkit.KryptonPanel();
-            this.kwlblMessageText = new Krypton.Toolkit.KryptonWrapLabel();
+            this.kwlblMessageText = new Krypton.Toolkit.KryptonTextBox();
             this.klwlblMessageText = new Krypton.Toolkit.KryptonLinkWrapLabel();
             ((System.ComponentModel.ISupportInitialize)(this._messageIcon)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this._panelButtons)).BeginInit();
@@ -202,24 +202,24 @@ namespace Krypton.Toolkit
             // 
             // kwlblMessageText
             // 
-            this.kwlblMessageText.AutoSize = false;
             this.kwlblMessageText.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.kwlblMessageText.Font = new System.Drawing.Font("Segoe UI", 9F);
-            this.kwlblMessageText.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(30)))), ((int)(((byte)(57)))), ((int)(((byte)(91)))));
-            this.kwlblMessageText.LabelStyle = Krypton.Toolkit.LabelStyle.AlternateControl;
+            this.kwlblMessageText.InputControlStyle = Krypton.Toolkit.InputControlStyle.PanelClient;
             this.kwlblMessageText.Location = new System.Drawing.Point(0, 0);
-            this.kwlblMessageText.Name = "kwlblMessageText";
-            this.kwlblMessageText.Size = new System.Drawing.Size(152, 81);
-            this.kwlblMessageText.Text = "Message Text";
-            this.kwlblMessageText.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.kwlblMessageText.Margin = new System.Windows.Forms.Padding(5, 0, 0, 0);
+            this.kwlblMessageText.Multiline = true;
+            this.kwlblMessageText.Name = "_messageText";
+            this.kwlblMessageText.ReadOnly = true;
+            this.kwlblMessageText.Size = new System.Drawing.Size(176, 44);
+            this.kwlblMessageText.StateCommon.Border.DrawBorders = Krypton.Toolkit.PaletteDrawBorders.None;
+            this.kwlblMessageText.TabIndex = 0;
+            this.kwlblMessageText.TabStop = false;
+            this.kwlblMessageText.Text = "Message Text\r\n.\ttabbed";
             // 
             // klwlblMessageText
             // 
             this.klwlblMessageText.AutoSize = false;
             this.klwlblMessageText.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.klwlblMessageText.Font = new System.Drawing.Font("Segoe UI", 9F);
-            this.klwlblMessageText.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(30)))), ((int)(((byte)(57)))), ((int)(((byte)(91)))));
-            this.klwlblMessageText.LabelStyle = Krypton.Toolkit.LabelStyle.AlternateControl;
+            this.klwlblMessageText.LabelStyle = Krypton.Toolkit.LabelStyle.NormalControl;
             this.klwlblMessageText.Location = new System.Drawing.Point(0, 0);
             this.klwlblMessageText.Name = "klwlblMessageText";
             this.klwlblMessageText.Size = new System.Drawing.Size(152, 81);
@@ -254,7 +254,6 @@ namespace Krypton.Toolkit
             ((System.ComponentModel.ISupportInitialize)(this.kpnlContentArea)).EndInit();
             this.kpnlContentArea.ResumeLayout(false);
             this.ResumeLayout(false);
-
         }
 
         #endregion
@@ -269,6 +268,6 @@ namespace Krypton.Toolkit
         private TableLayoutPanel tableLayoutPanel1;
         private KryptonPanel kpnlContentArea;
         private KryptonLinkWrapLabel klwlblMessageText;
-        private KryptonWrapLabel kwlblMessageText;
+        private KryptonTextBox kwlblMessageText;
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxForm.cs
@@ -12,8 +12,6 @@
 
 // ReSharper disable InconsistentNaming
 // ReSharper disable UnusedParameter.Local
-using ContentAlignment = System.Drawing.ContentAlignment;
-using Timer = System.Windows.Forms.Timer;
 
 namespace Krypton.Toolkit
 {
@@ -22,8 +20,8 @@ namespace Krypton.Toolkit
         #region Instance Fields
 
         private readonly bool _showHelpButton;
-        private readonly string _text;
-        private readonly string _caption;
+        private readonly string? _text;
+        private readonly string? _caption;
         private readonly string _applicationPath;
         private readonly KryptonMessageBoxButtons _buttons;
         private readonly KryptonMessageBoxIcon _kryptonMessageBoxIcon;
@@ -42,7 +40,6 @@ namespace Krypton.Toolkit
         private readonly MessageBoxContentAreaType? _contentAreaType;
         private readonly KryptonCommand? _linkLabelCommand;
         private readonly ProcessStartInfo? _linkLaunchArgument;
-        private readonly ContentAlignment? _messageTextAlignment;
         private readonly LinkArea _contentLinkArea;
 
         private KryptonMessageBoxResult _messageBoxResult;
@@ -68,7 +65,7 @@ namespace Krypton.Toolkit
         }
 
 
-        internal VisualMessageBoxForm(IWin32Window? showOwner, string text, string caption,
+        internal VisualMessageBoxForm(IWin32Window? showOwner, string? text, string? caption,
                                        KryptonMessageBoxButtons buttons,
                                        KryptonMessageBoxIcon icon,
                                        KryptonMessageBoxDefaultButton defaultButton,
@@ -80,7 +77,6 @@ namespace Krypton.Toolkit
                                        KryptonCommand? linkLabelCommand,
                                        ProcessStartInfo? linkLaunchArgument,
                                        LinkArea? contentLinkArea,
-                                       ContentAlignment? messageTextAlignment,
                                        bool? forceUseOfOperatingSystemIcons,
                                        bool? showCloseButton)
         {
@@ -101,7 +97,6 @@ namespace Krypton.Toolkit
                 ? new LinkArea(0, 0)
                 : contentLinkArea ?? new LinkArea(0, text.Length);
             _linkLaunchArgument = linkLaunchArgument ?? new ProcessStartInfo();
-            _messageTextAlignment = messageTextAlignment ?? ContentAlignment.MiddleLeft;
             _forceUseOfOperatingSystemIcons = forceUseOfOperatingSystemIcons ?? false;
             _showCloseButton = showCloseButton ?? true;
 
@@ -116,7 +111,6 @@ namespace Krypton.Toolkit
             UpdateHelp();
             UpdateTextExtra(showCtrlCopy);
             UpdateContentAreaType(contentAreaType);
-            UpdateContentAreaTextAlignment(contentAreaType, messageTextAlignment);
             UpdateContentLinkArea(contentLinkArea);
 
             // Finally calculate and set form sizing
@@ -143,7 +137,6 @@ namespace Krypton.Toolkit
             UpdateHelp(_messageBoxData.ShowHelpButton);
             UpdateTextExtra(_messageBoxData.ShowCtrlCopy);
             UpdateContentAreaType(_messageBoxData.MessageContentAreaType);
-            UpdateContentAreaTextAlignment(_messageBoxData.MessageContentAreaType, _messageBoxData.MessageTextAlignment);
             UpdateContentLinkArea(_messageBoxData.ContentLinkArea);
 
             ShowCloseButton(_messageBoxData.ShowCloseButton);
@@ -156,7 +149,7 @@ namespace Krypton.Toolkit
 
         #region Implementation
 
-        private void UpdateText(string caption, string? text, MessageBoxOptions options, MessageBoxContentAreaType? contentAreaType)
+        private void UpdateText(string? caption, string? text, MessageBoxOptions options, MessageBoxContentAreaType? contentAreaType)
         {
             // Set the text of the form
             Text = string.IsNullOrEmpty(caption) ? string.Empty : caption.Split(Environment.NewLine.ToCharArray())[0];
@@ -376,7 +369,7 @@ namespace Krypton.Toolkit
                         break;
                     case KryptonMessageBoxIcon.WindowsLogo:
                         // Because Windows 11 displays a generic application icon,
-                        // we need to rely on a image instead
+                        // we need to rely on an image instead
                         if (OSUtilities.IsWindowsEleven)
                         {
                             _messageIcon.Image = MessageBoxImageResources.Windows11;
@@ -572,7 +565,7 @@ namespace Krypton.Toolkit
                         break;
                     case KryptonMessageBoxIcon.WindowsLogo:
                         // Because Windows 11 displays a generic application icon,
-                        // we need to rely on a image instead
+                        // we need to rely on an image instead
                         if (OSUtilities.IsWindowsEleven)
                         {
                             _messageIcon.Image = MessageBoxImageResources.Windows11;
@@ -610,9 +603,7 @@ namespace Krypton.Toolkit
                         break;
                 }
             }
-
             _messageIcon.Visible = (_kryptonMessageBoxIcon != KryptonMessageBoxIcon.None);
-
         }
 
         private void UpdateButtons()
@@ -999,7 +990,6 @@ namespace Krypton.Toolkit
             {
                 // Do nothing if failure to send to Parent
             }
-
         }
 
         private void UpdateSizing(IWin32Window? showOwner)
@@ -1023,7 +1013,6 @@ namespace Krypton.Toolkit
                 SizeF scaledMonitorSize = screen!.Bounds.Size;
                 scaledMonitorSize.Width *= 2 / 3.0f;
                 scaledMonitorSize.Height *= 0.95f;
-                kwlblMessageText.UpdateFont();
                 SizeF messageSize = g.MeasureString(_text, kwlblMessageText.Font, scaledMonitorSize);
                 // SKC: Don't forget to add the TextExtra into the calculation
                 SizeF captionSize = g.MeasureString($@"{_caption} {TextExtra}", kwlblMessageText.Font, scaledMonitorSize);
@@ -1083,7 +1072,7 @@ namespace Krypton.Toolkit
             // Start positioning buttons 10 pixels from right edge
             var right = _panelButtons.Right - GlobalStaticValues.GLOBAL_BUTTON_PADDING;
 
-            var left = _panelButtons.Left - GlobalStaticValues.GLOBAL_BUTTON_PADDING;
+            //var left = _panelButtons.Left - GlobalStaticValues.GLOBAL_BUTTON_PADDING;
 
             // If Button4 is visible
             if (_button4.Enabled)
@@ -1138,7 +1127,6 @@ namespace Krypton.Toolkit
 
             const string DIVIDER = @"---------------------------";
             const string BUTTON_TEXT_SPACER = @"   ";
-
             // Pressing Ctrl+C should copy message text into the clipboard
             var sb = new StringBuilder();
 
@@ -1208,24 +1196,6 @@ namespace Krypton.Toolkit
                     klwlblMessageText.Visible = false;
 
                     kwlblMessageText.Visible = true;
-                    break;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(contentAreaType), contentAreaType, null);
-            }
-        }
-
-        private void UpdateContentAreaTextAlignment(MessageBoxContentAreaType? contentAreaType, ContentAlignment? messageTextAlignment)
-        {
-            switch (contentAreaType)
-            {
-                case MessageBoxContentAreaType.Normal:
-                    kwlblMessageText.TextAlign = messageTextAlignment ?? ContentAlignment.MiddleLeft;
-                    break;
-                case MessageBoxContentAreaType.LinkLabel:
-                    klwlblMessageText.TextAlign = messageTextAlignment ?? ContentAlignment.MiddleLeft;
-                    break;
-                case null:
-                    kwlblMessageText.TextAlign = messageTextAlignment ?? ContentAlignment.MiddleLeft;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(contentAreaType), contentAreaType, null);

--- a/Source/Krypton Components/Krypton.Toolkit/General/KryptonMessageBoxData.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/KryptonMessageBoxData.cs
@@ -7,8 +7,6 @@
  */
 #endregion
 
-using ContentAlignment = System.Drawing.ContentAlignment;
-
 namespace Krypton.Toolkit
 {
     /// <summary>A structure that contains basic information for <see cref="VisualMessageBoxForm"/>.</summary>
@@ -26,7 +24,7 @@ namespace Krypton.Toolkit
 
         /// <summary>Gets or sets the window caption.</summary>
         /// <value>The window caption.</value>
-        public string Caption { get; set; }
+        public string? Caption { get; set; }
 
         /// <summary>Gets or sets the buttons.</summary>
         /// <value>The buttons.</value>
@@ -79,10 +77,6 @@ namespace Krypton.Toolkit
         /// <summary>Gets or sets the content link area.</summary>
         /// <value>The content link area.</value>
         public LinkArea? ContentLinkArea { get; set; }
-
-        /// <summary>Gets or sets the message text alignment.</summary>
-        /// <value>The message text alignment.</value>
-        public ContentAlignment? MessageTextAlignment { get; set; }
 
         /// <summary>Gets or sets the force use of operating system icons.</summary>
         /// <value>Forces the use of operating system icons.</value>


### PR DESCRIPTION
**Breaking Change** `KryptonMessageBox` does not obey tab characters like `MessageBox`
  - The optional `ContentAlignment` for a `KryptonMessageBox.Show` command is no longer possible.

#1424

![image](https://github.com/Krypton-Suite/Standard-Toolkit/assets/2418812/134cdc3e-fa34-481f-a20a-babf0fcf2c77)
