### PR TITLE
1418-cleanup-warnings-0010

### DIFF
--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingManager.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingManager.cs
@@ -4093,9 +4093,15 @@ namespace Krypton.Docking
             }
         }
 
-        private void OnStringPropertyChanged(object sender, PropertyChangedEventArgs e) =>
+        private void OnStringPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
             // Piggyback the name of the changed property in the unique name parameter
-            PropogateAction(DockingPropogateAction.StringChanged, new[] { e.PropertyName });
+            string[]? uniqueNames = e.PropertyName is null
+                ? null
+                : new string[] { e.PropertyName };
+
+            PropogateAction(DockingPropogateAction.StringChanged, uniqueNames);
+        }
 
         private void OnDropDownWorkspaceClicked(object sender, EventArgs e)
         {


### PR DESCRIPTION
1418-cleanup-warnings-0010
[issue 1418](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1418)

This concludes the Docking module.
Only 1 file and 1 method was affected.

![compile-results](https://github.com/Krypton-Suite/Standard-Toolkit/assets/96108132/337725f7-fd4d-4888-8cb0-71f047c0f2c4)
