### PR TITLE
1418-cleanup-warnings-0030

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCommandLinkButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCommandLinkButton.cs
@@ -17,12 +17,30 @@ namespace Krypton.Toolkit
     [DefaultProperty("Heading")]
     [Designer(typeof(KryptonCommandLinkButtonDesigner))]
     [DesignerCategory("code")]
+#if NET6_0
+#pragma warning disable CS0618
+#endif
     [ClassInterface(ClassInterfaceType.AutoDispatch)]
+#if NET6_0
+#pragma warning restore CS0618
+#endif
     [DisplayName("Krypton Command Link")]
     [Description("A Krypton Command Link Button.")]
     [ComVisible(true)]
     public class KryptonCommandLinkButton : VisualSimpleBase, IButtonControl
     {
+        // [ClassInterface(ClassInterfaceType.AutoDispatch)]
+        // generates warning CS0618:
+        //      'ClassInterfaceType.AutoDispatch' is obsolete: 'Support for IDispatch may be unavailable in future releases.'
+        //      Krypton.Toolkit 2022 (net6.0-windows)
+        //
+        // Only for net6.0 and not for newer releases.
+        //
+        // Therefore the warning has been disabled for NET 6.0, since it has only been marked as obsolete in future releases
+        // but does seems to remain supported in contrast to the warning
+        //
+        // May it become marked obsolete in future releases new warnings will appear.
+
         #region Static Fields
 
         private const int BCM_SETSHIELD = 0x0000160C;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewButtonColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewButtonColumn.cs
@@ -109,9 +109,13 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(true)]
         [Category(@"Appearance")]
-        public override DataGridViewCellStyle? DefaultCellStyle
+        [AllowNull]
+        public override DataGridViewCellStyle DefaultCellStyle
         {
-            get =>base.DefaultCellStyle;
+            // Data type made non-nullable again to keep it inline with the underlying virtual base method 
+            // Added [AllowNull] attribute since the base can take null as a value
+
+            get => base.DefaultCellStyle;
             set => base.DefaultCellStyle = value;
         }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxEditingControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxEditingControl.cs
@@ -50,11 +50,19 @@ namespace Krypton.Toolkit
 
         /// <summary>
         /// Property which represents the current formatted value of the editing control
+        /// <para>Allows null as input, but null will saved as an empty string.</para>
         /// </summary>
-        public virtual object EditingControlFormattedValue
+        [AllowNull]
+        public virtual object EditingControlFormattedValue 
         {
+            // [AllowNull] removes warning CS8767, but allows for null input, which is undesired.
+            // The Text property is a non-nullable string and therefore null input
+            // will be converted to String.Empty.
+
             get => GetEditingControlFormattedValue(DataGridViewDataErrorContexts.Formatting);
-            set => Text = value as string;
+            set => Text = value is string str && str is not null
+                ? str
+                : string.Empty;
         }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewCustomEditingControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewCustomEditingControl.cs
@@ -50,11 +50,19 @@ namespace Krypton.Toolkit
 
         /// <summary>
         /// Property which represents the current formatted value of the editing control
+        /// <para>Allows null as input, but null will saved as an empty string.</para>
         /// </summary>
-        public virtual object EditingControlFormattedValue
+        [AllowNull]
+        public virtual object EditingControlFormattedValue 
         {
+            // [AllowNull] removes warning CS8767, but allows for null input, which is undesired.
+            // The Text property is a non-nullable string and therefore null input
+            // will be converted to String.Empty.
+
             get => GetEditingControlFormattedValue(DataGridViewDataErrorContexts.Formatting);
-            set => Text = value as string;
+            set => Text = value is string str && str is not null
+                ? str
+                : string.Empty;
         }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDateTimePickerEditingControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDateTimePickerEditingControl.cs
@@ -55,8 +55,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Property which represents the current formatted value of the editing control
         /// </summary>
+        [AllowNull]
         public virtual object EditingControlFormattedValue
         {
+            // [AllowNull] removes warning CS8767 and allows to write null
+            // although the interface defines the property as non-nullable
+
             get => GetEditingControlFormattedValue(DataGridViewDataErrorContexts.Formatting);
 
             set

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownEditingControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownEditingControl.cs
@@ -50,11 +50,19 @@ namespace Krypton.Toolkit
 
         /// <summary>
         /// Property which represents the current formatted value of the editing control
+        /// <para>Allows null as input, but null will saved as an empty string.</para>
         /// </summary>
-        public virtual object EditingControlFormattedValue
+        [AllowNull]
+        public virtual object EditingControlFormattedValue 
         {
+            // [AllowNull] removes warning CS8767, but allows for null input, which is undesired.
+            // The Text property is a non-nullable string and therefore null input
+            // will be converted to String.Empty.
+
             get => GetEditingControlFormattedValue(DataGridViewDataErrorContexts.Formatting);
-            set => Text = value as string;
+            set => Text = value is string str && str is not null
+                ? str
+                : string.Empty;
         }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewMaskedTextBoxEditingControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewMaskedTextBoxEditingControl.cs
@@ -50,11 +50,19 @@ namespace Krypton.Toolkit
 
         /// <summary>
         /// Property which represents the current formatted value of the editing control
+        /// <para>Allows null as input, but null will saved as an empty string.</para>
         /// </summary>
-        public virtual object EditingControlFormattedValue
+        [AllowNull]
+        public virtual object EditingControlFormattedValue 
         {
+            // [AllowNull] removes warning CS8767, but allows for null input, which is undesired.
+            // The Text property is a non-nullable string and therefore null input
+            // will be converted to String.Empty.
+
             get => GetEditingControlFormattedValue(DataGridViewDataErrorContexts.Formatting);
-            set => Text = value as string;
+            set => Text = value is string str && str is not null
+                ? str
+                : string.Empty;
         }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewNumericUpDownEditingControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewNumericUpDownEditingControl.cs
@@ -50,11 +50,19 @@ namespace Krypton.Toolkit
 
         /// <summary>
         /// Property which represents the current formatted value of the editing control
+        /// <para>Allows null as input, but null will saved as an empty string.</para>
         /// </summary>
-        public virtual object EditingControlFormattedValue
+        [AllowNull]
+        public virtual object EditingControlFormattedValue 
         {
+            // [AllowNull] removes warning CS8767, but allows for null input, which is undesired.
+            // The Text property is a non-nullable string and therefore null input
+            // will be converted to String.Empty.
+
             get => GetEditingControlFormattedValue(DataGridViewDataErrorContexts.Formatting);
-            set => Text = value as string;
+            set => Text = value is string str && str is not null
+                ? str
+                : string.Empty;
         }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxColumn.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+﻿    #region BSD License
 /*
  * 
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -151,6 +151,9 @@ namespace Krypton.Toolkit
         [AllowNull]
         public override DataGridViewCellStyle DefaultCellStyle
         {
+            // base.DefaultCellStyle will take a null value and handle it.
+            // [NotNull] if the base getter encounters a null value it will always return a DefaultCellStyle
+
             get => base.DefaultCellStyle;
 
             set

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxEditingControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxEditingControl.cs
@@ -50,11 +50,19 @@ namespace Krypton.Toolkit
 
         /// <summary>
         /// Property which represents the current formatted value of the editing control
+        /// <para>Allows null as input, but null will saved as an empty string.</para>
         /// </summary>
-        public virtual object EditingControlFormattedValue
+        [AllowNull]
+        public virtual object EditingControlFormattedValue 
         {
+            // [AllowNull] removes warning CS8767, but allows for null input, which is undesired.
+            // The Text property is a non-nullable string and therefore null input
+            // will be converted to String.Empty.
+
             get => GetEditingControlFormattedValue(DataGridViewDataErrorContexts.Formatting);
-            set => Text = value as string;
+            set => Text = value is string str && str is not null
+                ? str
+                : string.Empty;
         }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListBox.cs
@@ -647,6 +647,7 @@ namespace Krypton.Toolkit
         [AllowNull]
         public override string Text
         {
+            // Control.Text can take null but will always return an empty string when the input was null
             get => base.Text;
             set => base.Text = value;
         }
@@ -674,6 +675,9 @@ namespace Krypton.Toolkit
         [AllowNull]
         public override Font Font
         {
+            // base.Font will always return a Font
+            // base can take null as a value
+
             get => base.Font;
             set => base.Font = value;
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonProgressBar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonProgressBar.cs
@@ -392,6 +392,9 @@ namespace Krypton.Toolkit
         [AllowNull]
         public override string Text
         {
+            // Values.Text can be set to null
+            // The getter will always return a string
+
             get => Values.Text;
 
             set
@@ -878,9 +881,7 @@ namespace Krypton.Toolkit
         [AllowNull, MaybeNull]
         public override ContextMenuStrip ContextMenuStrip
         {
-            // base.ContextMenuStrip ca be null
-
-            get => base.ContextMenuStrip;
+            get => base.ContextMenuStrip!;
             set => base.ContextMenuStrip = value;
         }
 
@@ -899,6 +900,9 @@ namespace Krypton.Toolkit
         [AllowNull]
         public override Font Font
         {
+            // base.Font will always return a Font
+            // base can take null as a value
+
             get => base.Font;
             set => base.Font = value;
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonProgressBarToolStripItem.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonProgressBarToolStripItem.cs
@@ -159,6 +159,9 @@ namespace Krypton.Toolkit
         [AllowNull]
         public override string Text
         {
+            // KryptonProgress.Values.Text can be set to null
+            // The getter will always return a string
+
             get => KryptonProgressBarHost.Text;
             set => KryptonProgressBarHost.Text = value;
         }


### PR DESCRIPTION
1418-cleanup-warnings-0030
Several warnings removed that have been delayed for a closer look.
From: https://github.com/Krypton-Suite/Standard-Toolkit/issues/1418#issuecomment-2073323392
issue 1418: https://github.com/Krypton-Suite/Standard-Toolkit/issues/1418

Warnings on current Alpha: 429.
![compile-results](https://github.com/Krypton-Suite/Standard-Toolkit/assets/96108132/c0891fe5-dcaa-4417-8320-1319fd45de6d)
