### PR TITLE
1418-cleanup-warnings-0031

### DIFF
--- a/Source/Krypton Components/Krypton.Ribbon/Palette/PaletteRibbonStyles.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Palette/PaletteRibbonStyles.cs
@@ -29,8 +29,8 @@ namespace Krypton.Ribbon
         /// </summary>
         /// <param name="ribbon">Source ribbon control instance.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteRibbonStyles([DisallowNull] KryptonRibbon ribbon,
-                                   [DisallowNull] NeedPaintHandler needPaint)
+        public PaletteRibbonStyles(KryptonRibbon ribbon,
+                                   NeedPaintHandler? needPaint)
         {
             Debug.Assert(_ribbon is not null);
 

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecManagerBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecManagerBase.cs
@@ -34,7 +34,7 @@ namespace Krypton.Toolkit
         private readonly PaletteMetricPadding[] _viewMetricPaddings;
         private readonly ListSpacers[] _viewSpacers;
         private readonly ButtonSpecLookup _specLookup;
-        private readonly GetToolStripRenderer _getRenderer;
+        private readonly GetToolStripRenderer? _getRenderer;
 
         #endregion
 
@@ -52,7 +52,7 @@ namespace Krypton.Toolkit
         /// <param name="viewMetricPaddings">Array of target metrics for button padding.</param>
         /// <param name="getRenderer">Delegate for returning a tool strip renderer.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        protected ButtonSpecManagerBase([DisallowNull] Control control,
+        protected ButtonSpecManagerBase(Control control,
                                         PaletteRedirect redirector,
                                         ButtonSpecCollectionBase? variableSpecs,
                                         ButtonSpecCollectionBase? fixedSpecs,
@@ -60,7 +60,7 @@ namespace Krypton.Toolkit
                                         PaletteMetricInt[] viewMetricIntOutside,
                                         PaletteMetricInt[] viewMetricIntInside,
                                         PaletteMetricPadding[] viewMetricPaddings,
-                                        [DisallowNull] GetToolStripRenderer getRenderer,
+                                        GetToolStripRenderer? getRenderer,
                                         NeedPaintHandler needPaint)
         {
             Debug.Assert(control is not null);
@@ -105,7 +105,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the owning control.
         /// </summary>
-        public Control Control { get; }
+        public Control? Control { get; }
 
         /// <summary>
         /// Gets and sets the associated tooltip manager.
@@ -405,7 +405,7 @@ namespace Krypton.Toolkit
         /// Get a tool strip renderer appropriate for the hosting control.
         /// </summary>
         /// <returns></returns>
-        public ToolStripRenderer RenderToolStrip() => _getRenderer();
+        public ToolStripRenderer? RenderToolStrip() => _getRenderer?.Invoke();
 
         /// <summary>
         /// Requests a repaint and optional layout be performed.

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/ButtonController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/ButtonController.cs
@@ -87,9 +87,12 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="target">Target for state changes.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public ButtonController([DisallowNull] ViewBase target,
+        public ButtonController(ViewBase target,
                                 NeedPaintHandler needPaint)
         {
+
+            // Debug.Assert() causes the null assignment warning.
+            // Suppressed by the null forgiving operator
             Debug.Assert(target is not null);
 
             MousePoint = CommonHelper.NullPoint;
@@ -98,7 +101,7 @@ namespace Krypton.Toolkit
             AllowDragging = false;
             _dragging = false;
             ClickOnDown = false;
-            Target = target; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(target));
+            Target = target!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(target));
             Repeat = false;
             NeedPaint = needPaint;
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/CheckBoxController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/CheckBoxController.cs
@@ -40,16 +40,18 @@ namespace Krypton.Toolkit
         /// <param name="target">Target for state changes.</param>
         /// <param name="top">Top element for the check box control.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public CheckBoxController([DisallowNull] ViewDrawCheckBox target,
-                                  [DisallowNull] ViewBase top,
+        public CheckBoxController(ViewDrawCheckBox target,
+                                  ViewBase top,
                                   NeedPaintHandler needPaint)
         {
             Debug.Assert(target is not null);
             Debug.Assert(top is not null);
 
             // Remember target for state changes
-            _target = target; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(target));
-            _top = top; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(top));
+            // Debug.Assert() causes the null assignment warning.
+            // Suppressed by the null forgiving operator
+            _target = target!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(target));
+            _top = top!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(top));
             NeedPaint = needPaint;
         }
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/LinkLabelController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/LinkLabelController.cs
@@ -51,18 +51,20 @@ namespace Krypton.Toolkit
         /// <param name="palettePressed">Palette to use in the pressed state.</param>
         /// <param name="pressed">Override to update with the pressed state.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public LinkLabelController([DisallowNull] ViewDrawContent target,
+        public LinkLabelController(ViewDrawContent target,
                                    IPaletteContent paletteDisabled,
                                    IPaletteContent paletteNormal,
                                    IPaletteContent paletteTracking,
                                    IPaletteContent palettePressed,
                                    PaletteContentInheritOverride pressed,
-                                   NeedPaintHandler needPaint)
+                                   NeedPaintHandler? needPaint)
         {
+            // Debug.Assert() causes the null assignment warning.
+            // Suppressed by the null forgiving operator
             Debug.Assert(target is not null);
 
             // Remember target for state changes
-            _target = target; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(target));
+            _target = target!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(target));
             _paletteDisabled = paletteDisabled;
             _paletteNormal = paletteNormal;
             _paletteTracking = paletteTracking;

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/MenuCheckBoxController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/MenuCheckBoxController.cs
@@ -44,19 +44,21 @@ namespace Krypton.Toolkit
         /// <param name="target">Target for state changes.</param>
         /// <param name="checkBox">Drawing element that owns check box display.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public MenuCheckBoxController([DisallowNull] ViewContextMenuManager viewManager,
-                                      [DisallowNull] ViewBase target,
-                                      [DisallowNull] ViewDrawMenuCheckBox checkBox,
-                                      [DisallowNull] NeedPaintHandler needPaint)
+        public MenuCheckBoxController(ViewContextMenuManager viewManager,
+                                      ViewBase target,
+                                      ViewDrawMenuCheckBox checkBox,
+                                      NeedPaintHandler? needPaint)
         {
+            // Debug.Assert() causes the null assignment warning.
+            // Suppressed by the null forgiving operator
             Debug.Assert(viewManager is not null);
             Debug.Assert(target is not null);
             Debug.Assert(checkBox is not null);
             Debug.Assert(needPaint is not null);
 
-            ViewManager = viewManager; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(viewManager));
-            _target = target; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(target));
-            _menuCheckBox = checkBox; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(checkBox));
+            ViewManager = viewManager!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(viewManager));
+            _target = target!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(target));
+            _menuCheckBox = checkBox!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(checkBox));
             NeedPaint = needPaint; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(needPaint));
         }
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/MenuCheckButtonController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/MenuCheckButtonController.cs
@@ -44,19 +44,21 @@ namespace Krypton.Toolkit
         /// <param name="target">Target for state changes.</param>
         /// <param name="checkButton">Drawing element that owns check button display.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public MenuCheckButtonController([DisallowNull] ViewContextMenuManager viewManager,
-                                         [DisallowNull] ViewBase target,
-                                         [DisallowNull] ViewDrawMenuCheckButton checkButton,
-                                         [DisallowNull] NeedPaintHandler needPaint)
+        public MenuCheckButtonController(ViewContextMenuManager viewManager,
+                                         ViewBase target,
+                                         ViewDrawMenuCheckButton checkButton,
+                                         NeedPaintHandler? needPaint)
         {
+            // Debug.Assert() causes the null assignment warning.
+            // Suppressed by the null forgiving operator
             Debug.Assert(viewManager is not null);
             Debug.Assert(target is not null);
             Debug.Assert(checkButton is not null);
             Debug.Assert(needPaint is not null);
 
-            ViewManager = viewManager; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(viewManager));
-            _target = target; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(target));
-            _menuCheckButton = checkButton; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(checkButton));
+            ViewManager = viewManager!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(viewManager));
+            _target = target!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(target));
+            _menuCheckButton = checkButton!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(checkButton));
             NeedPaint = needPaint; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(needPaint));
 
             // Set initial display state

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/MenuColorBlockController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/MenuColorBlockController.cs
@@ -43,19 +43,21 @@ namespace Krypton.Toolkit
         /// <param name="target">Target for state changes.</param>
         /// <param name="colorBlock">Drawing element that owns color block display.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public MenuColorBlockController([DisallowNull] ViewContextMenuManager viewManager,
-                                        [DisallowNull] ViewBase target,
-                                        [DisallowNull] ViewDrawMenuColorBlock colorBlock,
-                                        [DisallowNull] NeedPaintHandler needPaint)
+        public MenuColorBlockController(ViewContextMenuManager viewManager,
+                                        ViewBase target,
+                                        ViewDrawMenuColorBlock colorBlock,
+                                        NeedPaintHandler needPaint)
         {
+            // Debug.Assert() causes the null assignment warning.
+            // Suppressed by the null forgiving operator
             Debug.Assert(viewManager is not null);
             Debug.Assert(target is not null);
             Debug.Assert(colorBlock is not null);
             Debug.Assert(needPaint is not null);
 
-            ViewManager = viewManager; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(viewManager));
-            _target = target; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(target));
-            _menuColorBlock = colorBlock; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(colorBlock));
+            ViewManager = viewManager!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(viewManager));
+            _target = target!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(target));
+            _menuColorBlock = colorBlock!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(colorBlock));
             NeedPaint = needPaint; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(needPaint));
 
             // Set initial display state

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/MenuImageSelectController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/MenuImageSelectController.cs
@@ -45,21 +45,23 @@ namespace Krypton.Toolkit
         /// <param name="target">Target for state changes.</param>
         /// <param name="layout">Reference to layout of the image items.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public MenuImageSelectController([DisallowNull] ViewContextMenuManager viewManager,
-                                         [DisallowNull] ViewDrawMenuImageSelectItem target,
-                                         [DisallowNull] ViewLayoutMenuItemSelect layout,
-                                         [DisallowNull] NeedPaintHandler needPaint)
+        public MenuImageSelectController(ViewContextMenuManager viewManager,
+                                         ViewDrawMenuImageSelectItem target,
+                                         ViewLayoutMenuItemSelect layout,
+                                         NeedPaintHandler? needPaint)
         {
+            // Debug.Assert() causes the null assignment warning.
+            // Suppressed by the null forgiving operator
             Debug.Assert(viewManager is not null);
             Debug.Assert(target is not null);
             Debug.Assert(layout is not null);
             Debug.Assert(needPaint is not null);
 
             MousePoint = CommonHelper.NullPoint;
-            _viewManager = viewManager; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(viewManager));
-            _target = target; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(target));
-            _layout = layout; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(layout));
-            NeedPaint = needPaint; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(needPaint));
+            _viewManager = viewManager!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(viewManager));
+            _target = target!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(target));
+            _layout = layout!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(layout));
+            NeedPaint = needPaint!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(needPaint));
         }
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/MenuItemController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/MenuItemController.cs
@@ -32,16 +32,18 @@ namespace Krypton.Toolkit
         /// <param name="viewManager">Owning view manager instance.</param>
         /// <param name="menuItem">Target menu item view element.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public MenuItemController([DisallowNull] ViewContextMenuManager viewManager,
-                                  [DisallowNull] ViewDrawMenuItem menuItem,
-                                  [DisallowNull] NeedPaintHandler needPaint)
+        public MenuItemController(ViewContextMenuManager viewManager,
+                                  ViewDrawMenuItem menuItem,
+                                  NeedPaintHandler? needPaint)
         {
+            // Debug.Assert() causes the null assignment warning.
+            // Suppressed by the null forgiving operator
             Debug.Assert(viewManager is not null);
             Debug.Assert(menuItem is not null);
             Debug.Assert(needPaint is not null);
 
-            ViewManager = viewManager; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(viewManager));
-            _menuItem = menuItem; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(menuItem));
+            ViewManager = viewManager!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(viewManager));
+            _menuItem = menuItem!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(menuItem));
             NeedPaint = needPaint; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(needPaint));
         }
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/MenuLinkLabelController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/MenuLinkLabelController.cs
@@ -44,19 +44,21 @@ namespace Krypton.Toolkit
         /// <param name="target">Target for state changes.</param>
         /// <param name="linkLabel">Drawing element that owns link label display.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public MenuLinkLabelController([DisallowNull] ViewContextMenuManager viewManager,
-                                       [DisallowNull] ViewDrawContent target,
-                                       [DisallowNull] ViewDrawMenuLinkLabel linkLabel,
-                                       [DisallowNull] NeedPaintHandler needPaint)
+        public MenuLinkLabelController(ViewContextMenuManager viewManager,
+                                       ViewDrawContent target,
+                                       ViewDrawMenuLinkLabel linkLabel,
+                                       NeedPaintHandler? needPaint)
         {
+            // Debug.Assert() causes the null assignment warning.
+            // Suppressed by the null forgiving operator
             Debug.Assert(viewManager is not null);
             Debug.Assert(target is not null);
             Debug.Assert(linkLabel is not null);
             Debug.Assert(needPaint is not null);
 
-            ViewManager = viewManager; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(viewManager));
-            _target = target; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(target));
-            _menuLinkLabel = linkLabel; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(linkLabel));
+            ViewManager = viewManager!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(viewManager));
+            _target = target!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(target));
+            _menuLinkLabel = linkLabel!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(linkLabel));
             NeedPaint = needPaint; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(needPaint));
         }
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/MenuRadioButtonController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/MenuRadioButtonController.cs
@@ -44,19 +44,21 @@ namespace Krypton.Toolkit
         /// <param name="target">Target for state changes.</param>
         /// <param name="radioButton">Drawing element that owns radio button display.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public MenuRadioButtonController([DisallowNull] ViewContextMenuManager viewManager,
-                                         [DisallowNull] ViewBase target,
-                                         [DisallowNull] ViewDrawMenuRadioButton radioButton,
-                                         [DisallowNull] NeedPaintHandler needPaint)
+        public MenuRadioButtonController(ViewContextMenuManager viewManager,
+                                         ViewBase target,
+                                         ViewDrawMenuRadioButton radioButton,
+                                         NeedPaintHandler? needPaint)
         {
+            // Debug.Assert() causes the null assignment warning.
+            // Suppressed by the null forgiving operator
             Debug.Assert(viewManager is not null);
             Debug.Assert(target is not null);
             Debug.Assert(radioButton is not null);
             Debug.Assert(needPaint is not null);
 
-            ViewManager = viewManager; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(viewManager));
-            _target = target; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(target));
-            _menuRadioButton = radioButton; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(radioButton));
+            ViewManager = viewManager!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(viewManager));
+            _target = target!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(target));
+            _menuRadioButton = radioButton!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(radioButton));
             NeedPaint = needPaint; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(needPaint));
         }
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/RadioButtonController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/RadioButtonController.cs
@@ -37,16 +37,18 @@ namespace Krypton.Toolkit
         /// <param name="target">Target for state changes.</param>
         /// <param name="top">Top element for the radio button control.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public RadioButtonController([DisallowNull] ViewDrawRadioButton target,
-                                     [DisallowNull] ViewBase top,
-                                     NeedPaintHandler needPaint)
+        public RadioButtonController(ViewDrawRadioButton target,
+                                     ViewBase top,
+                                     NeedPaintHandler? needPaint)
         {
+            // Debug.Assert() causes the null assignment warning.
+            // Suppressed by the null forgiving operator
             Debug.Assert(target is not null);
             Debug.Assert(top is not null);
 
             // Remember target for state changes
-            _target = target; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(target));
-            _top = top; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(top));
+            _target = target!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(target));
+            _top = top!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(top));
             NeedPaint = needPaint; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(needPaint));
         }
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPanel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPanel.cs
@@ -54,18 +54,20 @@ namespace Krypton.Toolkit
         /// <param name="stateCommon">Common appearance state to inherit from.</param>
         /// <param name="stateDisabled">Disabled appearance state.</param>
         /// <param name="stateNormal">Normal appearance state.</param>
-        public KryptonPanel([DisallowNull] PaletteDoubleRedirect stateCommon,
-                            [DisallowNull] PaletteDouble stateDisabled,
-                            [DisallowNull] PaletteDouble stateNormal)
+        public KryptonPanel(PaletteDoubleRedirect stateCommon,
+                            PaletteDouble stateDisabled,
+                            PaletteDouble stateNormal)
         {
             SetStyle(ControlStyles.SupportsTransparentBackColor | ControlStyles.OptimizedDoubleBuffer, true);
 
+            // Debug.Assert() causes the null assignment warning.
+            // Suppressed by the null forgiving operator
             Debug.Assert(stateCommon is not null);
             Debug.Assert(stateDisabled is not null);
             Debug.Assert(stateNormal is not null);
 
             // Remember the palette storage
-            _stateCommon = stateCommon; //TEST-NoThrow ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull(nameof(stateCommon)));
+            _stateCommon = stateCommon!; //TEST-NoThrow ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull(nameof(stateCommon)));
             _stateDisabled = stateDisabled; //TEST-NoThrow ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull(nameof(stateDisabled)));
             _stateNormal = stateNormal; //TEST-NoThrow ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull(nameof(stateNormal)));
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBack/PaletteBackInheritRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBack/PaletteBackInheritRedirect.cs
@@ -18,7 +18,7 @@ namespace Krypton.Toolkit
     public class PaletteBackInheritRedirect : PaletteBackInherit
     {
         #region Instance Fields
-        private PaletteRedirect _redirect;
+        private PaletteRedirect? _redirect;
 
         #endregion
 
@@ -27,7 +27,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteBackInheritRedirect class.
         /// </summary>
         /// <param name="redirect">Source for inherit requests.</param>
-        public PaletteBackInheritRedirect(PaletteRedirect redirect)
+        public PaletteBackInheritRedirect(PaletteRedirect? redirect)
             : this(redirect, PaletteBackStyle.ButtonStandalone)
         {
         }
@@ -37,7 +37,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">Source for inherit requests.</param>
         /// <param name="style">Style used in requests.</param>
-        public PaletteBackInheritRedirect(PaletteRedirect redirect,
+        public PaletteBackInheritRedirect(PaletteRedirect? redirect,
                                           PaletteBackStyle style)
         {
             _redirect = redirect;
@@ -50,7 +50,7 @@ namespace Krypton.Toolkit
         /// Gets the redirector instance.
         /// </summary>
         /// <returns>Return the currently used redirector.</returns>
-        public PaletteRedirect GetRedirector() => _redirect;
+        public PaletteRedirect GetRedirector() => _redirect ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull(nameof(_redirect)));
 
         #endregion
 
@@ -76,70 +76,70 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>InheritBool value.</returns>
-        public override InheritBool GetBackDraw(PaletteState state) => _redirect.GetBackDraw(Style, state);
+        public override InheritBool GetBackDraw(PaletteState state) => _redirect?.GetBackDraw(Style, state) ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull(nameof(_redirect)));
 
         /// <summary>
         /// Gets the graphics drawing hint.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>PaletteGraphicsHint value.</returns>
-        public override PaletteGraphicsHint GetBackGraphicsHint(PaletteState state) => _redirect.GetBackGraphicsHint(Style, state);
+        public override PaletteGraphicsHint GetBackGraphicsHint(PaletteState state) => _redirect?.GetBackGraphicsHint(Style, state) ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull(nameof(_redirect)));
 
         /// <summary>
         /// Gets the first background color from the redirector.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public override Color GetBackColor1(PaletteState state) => _redirect.GetBackColor1(Style, state);
+        public override Color GetBackColor1(PaletteState state) => _redirect?.GetBackColor1(Style, state) ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull(nameof(_redirect)));
 
         /// <summary>
         /// Gets the second back color from the redirector.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public override Color GetBackColor2(PaletteState state) => _redirect.GetBackColor2(Style, state);
+        public override Color GetBackColor2(PaletteState state) => _redirect?.GetBackColor2(Style, state) ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull(nameof(_redirect)));
 
         /// <summary>
         /// Gets the color drawing style from the redirector.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color drawing style.</returns>
-        public override PaletteColorStyle GetBackColorStyle(PaletteState state) => _redirect.GetBackColorStyle(Style, state);
+        public override PaletteColorStyle GetBackColorStyle(PaletteState state) => _redirect?.GetBackColorStyle(Style, state) ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull(nameof(_redirect)));
 
         /// <summary>
         /// Gets the color alignment style from the redirector.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color alignment style.</returns>
-        public override PaletteRectangleAlign GetBackColorAlign(PaletteState state) => _redirect.GetBackColorAlign(Style, state);
+        public override PaletteRectangleAlign GetBackColorAlign(PaletteState state) => _redirect?.GetBackColorAlign(Style, state) ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull(nameof(_redirect)));
 
         /// <summary>
         /// Gets the color background angle from the redirector.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Angle used for color drawing.</returns>
-        public override float GetBackColorAngle(PaletteState state) => _redirect.GetBackColorAngle(Style, state);
+        public override float GetBackColorAngle(PaletteState state) => _redirect?.GetBackColorAngle(Style, state) ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull(nameof(_redirect)));
 
         /// <summary>
         /// Gets a background image from the redirector.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Image instance.</returns>
-        public override Image? GetBackImage(PaletteState state) => _redirect.GetBackImage(Style, state);
+        public override Image? GetBackImage(PaletteState state) => _redirect?.GetBackImage(Style, state) ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull(nameof(_redirect)));
 
         /// <summary>
         /// Gets the background image style from the redirector.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Image style value.</returns>
-        public override PaletteImageStyle GetBackImageStyle(PaletteState state) => _redirect.GetBackImageStyle(Style, state);
+        public override PaletteImageStyle GetBackImageStyle(PaletteState state) => _redirect?.GetBackImageStyle(Style, state) ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull(nameof(_redirect)));
 
         /// <summary>
         /// Gets the image alignment style from the redirector.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Image alignment style.</returns>
-        public override PaletteRectangleAlign GetBackImageAlign(PaletteState state) => _redirect.GetBackImageAlign(Style, state);
+        public override PaletteRectangleAlign GetBackImageAlign(PaletteState state) => _redirect?.GetBackImageAlign(Style, state) ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull(nameof(_redirect)));
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBorder/PaletteBorderInheritRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBorder/PaletteBorderInheritRedirect.cs
@@ -18,7 +18,7 @@ namespace Krypton.Toolkit
     public class PaletteBorderInheritRedirect : PaletteBorderInherit
     {
         #region Instance Fields
-        private PaletteRedirect _redirect;
+        private PaletteRedirect? _redirect;
 
         #endregion
 
@@ -27,7 +27,7 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteBorderInheritRedirect class.
         /// </summary>
         /// <param name="redirect">Source for inherit requests.</param>
-        public PaletteBorderInheritRedirect(PaletteRedirect redirect)
+        public PaletteBorderInheritRedirect(PaletteRedirect? redirect)
             : this(redirect, PaletteBorderStyle.ButtonStandalone)
         {
         }
@@ -37,7 +37,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">Source for inherit requests.</param>
         /// <param name="style">Style used in requests.</param>
-        public PaletteBorderInheritRedirect(PaletteRedirect redirect,
+        public PaletteBorderInheritRedirect(PaletteRedirect? redirect,
                                             PaletteBorderStyle style)
         {
             _redirect = redirect;
@@ -58,7 +58,7 @@ namespace Krypton.Toolkit
         /// Gets the redirector instance.
         /// </summary>
         /// <returns>Return the currently used redirector.</returns>
-        public PaletteRedirect GetRedirector() => _redirect;
+        public PaletteRedirect GetRedirector() => _redirect ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull(nameof(_redirect)));
 
         #endregion
 
@@ -84,92 +84,93 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>InheritBool value.</returns>
-        public override InheritBool GetBorderDraw(PaletteState state) =>
-            OverrideBorderToFalse ? InheritBool.False : _redirect.GetBorderDraw(Style, state);
+        public override InheritBool GetBorderDraw(PaletteState state) => OverrideBorderToFalse 
+            ? InheritBool.False 
+            : _redirect?.GetBorderDraw(Style, state) ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull(nameof(_redirect)));
 
         /// <summary>
         /// Gets a value indicating which borders to draw.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>PaletteDrawBorders value.</returns>
-        public override PaletteDrawBorders GetBorderDrawBorders(PaletteState state) => _redirect.GetBorderDrawBorders(Style, state);
+        public override PaletteDrawBorders GetBorderDrawBorders(PaletteState state) => _redirect?.GetBorderDrawBorders(Style, state) ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull(nameof(_redirect)));
 
         /// <summary>
         /// Gets the graphics drawing hint.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>PaletteGraphicsHint value.</returns>
-        public override PaletteGraphicsHint GetBorderGraphicsHint(PaletteState state) => _redirect.GetBorderGraphicsHint(Style, state);
+        public override PaletteGraphicsHint GetBorderGraphicsHint(PaletteState state) => _redirect?.GetBorderGraphicsHint(Style, state) ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull(nameof(_redirect)));
 
         /// <summary>
         /// Gets the first border color from the redirector.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public override Color GetBorderColor1(PaletteState state) => _redirect.GetBorderColor1(Style, state);
+        public override Color GetBorderColor1(PaletteState state) => _redirect?.GetBorderColor1(Style, state) ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull(nameof(_redirect)));
 
         /// <summary>
         /// Gets the second border color from the redirector.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color value.</returns>
-        public override Color GetBorderColor2(PaletteState state) => _redirect.GetBorderColor2(Style, state);
+        public override Color GetBorderColor2(PaletteState state) => _redirect?.GetBorderColor2(Style, state) ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull(nameof(_redirect)));
 
         /// <summary>
         /// Gets the color drawing style from the redirector.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color drawing style.</returns>
-        public override PaletteColorStyle GetBorderColorStyle(PaletteState state) => _redirect.GetBorderColorStyle(Style, state);
+        public override PaletteColorStyle GetBorderColorStyle(PaletteState state) => _redirect?.GetBorderColorStyle(Style, state) ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull(nameof(_redirect)));
 
         /// <summary>
         /// Gets the color alignment style from the redirector.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Color alignment style.</returns>
-        public override PaletteRectangleAlign GetBorderColorAlign(PaletteState state) => _redirect.GetBorderColorAlign(Style, state);
+        public override PaletteRectangleAlign GetBorderColorAlign(PaletteState state) => _redirect?.GetBorderColorAlign(Style, state) ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull(nameof(_redirect)));
 
         /// <summary>
         /// Gets the color border angle from the redirector.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Angle used for color drawing.</returns>
-        public override float GetBorderColorAngle(PaletteState state) => _redirect.GetBorderColorAngle(Style, state);
+        public override float GetBorderColorAngle(PaletteState state) => _redirect?.GetBorderColorAngle(Style, state) ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull(nameof(_redirect)));
 
         /// <summary>
         /// Gets the border width from the redirector.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Border width.</returns>
-        public override int GetBorderWidth(PaletteState state) => _redirect.GetBorderWidth(Style, state);
+        public override int GetBorderWidth(PaletteState state) => _redirect?.GetBorderWidth(Style, state) ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull(nameof(_redirect)));
 
         /// <summary>
         /// Gets the border rounding from the redirector.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Border rounding.</returns>
-        public override float GetBorderRounding(PaletteState state) => _redirect.GetBorderRounding(Style, state);
+        public override float GetBorderRounding(PaletteState state) => _redirect?.GetBorderRounding(Style, state) ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull(nameof(_redirect)));
 
         /// <summary>
         /// Gets a border image from the redirector.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Image instance.</returns>
-        public override Image? GetBorderImage(PaletteState state) => _redirect.GetBorderImage(Style, state);
+        public override Image? GetBorderImage(PaletteState state) => _redirect?.GetBorderImage(Style, state) ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull(nameof(_redirect)));
 
         /// <summary>
         /// Gets the border image style from the redirector.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Image style value.</returns>
-        public override PaletteImageStyle GetBorderImageStyle(PaletteState state) => _redirect.GetBorderImageStyle(Style, state);
+        public override PaletteImageStyle GetBorderImageStyle(PaletteState state) => _redirect?.GetBorderImageStyle(Style, state) ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull(nameof(_redirect)));
 
         /// <summary>
         /// Gets the image alignment style from the redirector.
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Image alignment style.</returns>
-        public override PaletteRectangleAlign GetBorderImageAlign(PaletteState state) => _redirect.GetBorderImageAlign(Style, state);
+        public override PaletteRectangleAlign GetBorderImageAlign(PaletteState state) => _redirect?.GetBorderImageAlign(Style, state) ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull(nameof(_redirect)));
         #endregion
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentJustImage.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentJustImage.cs
@@ -24,7 +24,7 @@ namespace Krypton.Toolkit
         /// <param name="inherit">Source for inheriting defaulted values.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
         public PaletteContentJustImage(IPaletteContent inherit,
-                                       NeedPaintHandler needPaint)
+                                       NeedPaintHandler? needPaint)
             : base(inherit, needPaint)
         {
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteElementColor/PaletteElementColor.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteElementColor/PaletteElementColor.cs
@@ -34,7 +34,7 @@ namespace Krypton.Toolkit
         /// <param name="inheritElementColor">Source for inheriting values.</param>
         /// <param name="needPaint">Delegate for notifying changes in value.</param>
         public PaletteElementColor(IPaletteElementColor? inheritElementColor,
-                                   NeedPaintHandler needPaint) 
+                                   NeedPaintHandler? needPaint) 
         {
             // Remember inheritance
             _inheritElementColor = inheritElementColor;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteElementColor/PaletteElementColorInheritRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteElementColor/PaletteElementColorInheritRedirect.cs
@@ -28,12 +28,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">Source for inherit requests.</param>
         /// <param name="element">Element value..</param>
-        public PaletteElementColorInheritRedirect([DisallowNull] PaletteRedirect redirect,
+        public PaletteElementColorInheritRedirect(PaletteRedirect redirect,
                                                   PaletteElement element)
         {
-            Debug.Assert(redirect != null);
+            // Debug.Assert() causes the null assignment warning.
+            // Suppressed by the null forgiving operator
+            Debug.Assert(redirect is not null);
 
-            _redirect = redirect; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(redirect));
+            _redirect = redirect!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(redirect));
             Element = element;
         }
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteElementColor/PaletteElementColorRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteElementColor/PaletteElementColorRedirect.cs
@@ -28,18 +28,11 @@ namespace Krypton.Toolkit
         /// <param name="redirect">Source for inheriting values.</param>
         /// <param name="element">Element value.</param>
         /// <param name="needPaint">Delegate for notifying changes in value.</param>
-        public PaletteElementColorRedirect(PaletteRedirect? redirect,
+        public PaletteElementColorRedirect(PaletteRedirect redirect,
                                            PaletteElement element,
-                                           NeedPaintHandler needPaint)
+                                           NeedPaintHandler? needPaint)
             : base(null, needPaint)
         {
-
-            //TEST-NoThrow
-            //if (redirect is null)
-            //{
-            //    throw new ArgumentNullException(nameof(redirect));
-            //}
-
             // Setup inheritance to recover values from the redirect instance
             _redirect = new PaletteElementColorInheritRedirect(redirect, element);
             SetInherit(_redirect);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteMetric/PaletteMetricRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteMetric/PaletteMetricRedirect.cs
@@ -27,12 +27,14 @@ namespace Krypton.Toolkit
         /// Initialize a new instance of the PaletteMetricRedirect class.
         /// </summary>
         /// <param name="redirect">inheritance redirection instance.</param>
-        public PaletteMetricRedirect([DisallowNull] PaletteRedirect redirect)
+        public PaletteMetricRedirect(PaletteRedirect redirect)
         {
-            Debug.Assert(redirect != null);
+            // Debug.Assert() causes the null assignment warning.
+            // Suppressed by the null forgiving operator
+            Debug.Assert(redirect is not null);
 
             // Remember the redirect reference
-            _redirect = redirect; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(redirect));
+            _redirect = redirect!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(redirect));
         }
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonBackRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonBackRedirect.cs
@@ -34,10 +34,12 @@ namespace Krypton.Toolkit
         /// <param name="redirect">inheritance redirection instance.</param>
         /// <param name="backStyle">inheritance ribbon back style.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteRibbonBackRedirect([DisallowNull] PaletteRedirect redirect,
+        public PaletteRibbonBackRedirect(PaletteRedirect redirect,
                                          PaletteRibbonBackStyle backStyle,
-                                         NeedPaintHandler needPaint) 
+                                         NeedPaintHandler? needPaint) 
         {
+            // Debug.Assert() causes the null assignment warning.
+            // Suppressed by the null forgiving operator
             Debug.Assert(redirect is not null);
 
             // Store the provided paint notification delegate
@@ -50,7 +52,7 @@ namespace Krypton.Toolkit
             //}
 
             // Store the inherit instances
-            _inheritBack = new PaletteRibbonBackInheritRedirect(redirect, backStyle);
+            _inheritBack = new PaletteRibbonBackInheritRedirect(redirect!, backStyle);
 
             // Define default values
             _backColor1 = GlobalStaticValues.EMPTY_COLOR;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonDoubleInheritRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonDoubleInheritRedirect.cs
@@ -29,13 +29,15 @@ namespace Krypton.Toolkit
         /// <param name="redirect">Source for inherit requests.</param>
         /// <param name="styleBack">Ribbon item background style.</param>
         /// <param name="styleText">Ribbon item text style.</param>
-        public PaletteRibbonDoubleInheritRedirect([DisallowNull] PaletteRedirect redirect,
+        public PaletteRibbonDoubleInheritRedirect(PaletteRedirect redirect,
                                                   PaletteRibbonBackStyle styleBack,
                                                   PaletteRibbonTextStyle styleText)
         {
+            // Debug.Assert() causes the null assignment warning.
+            // Suppressed by the null forgiving operator
             Debug.Assert(redirect is not null);
 
-            _redirect = redirect; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(redirect));
+            _redirect = redirect!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(redirect));
             StyleBack = styleBack;
             StyleText = styleText;
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonDoubleRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonDoubleRedirect.cs
@@ -38,11 +38,13 @@ namespace Krypton.Toolkit
         /// <param name="backStyle">inheritance ribbon back style.</param>
         /// <param name="textStyle">inheritance ribbon text style.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteRibbonDoubleRedirect([DisallowNull] PaletteRedirect redirect,
+        public PaletteRibbonDoubleRedirect(PaletteRedirect redirect,
                                            PaletteRibbonBackStyle backStyle,
                                            PaletteRibbonTextStyle textStyle,
-                                           NeedPaintHandler needPaint) 
+                                           NeedPaintHandler? needPaint) 
         {
+            // Debug.Assert() causes the null assignment warning.
+            // Suppressed by the null forgiving operator
             Debug.Assert(redirect is not null);
 
             //TEST-NoThrow
@@ -55,8 +57,8 @@ namespace Krypton.Toolkit
             NeedPaint = needPaint;
 
             // Store the inherit instances
-            _inheritBack = new PaletteRibbonBackInheritRedirect(redirect, backStyle);
-            _inheritText = new PaletteRibbonTextInheritRedirect(redirect, textStyle);
+            _inheritBack = new PaletteRibbonBackInheritRedirect(redirect!, backStyle);
+            _inheritText = new PaletteRibbonTextInheritRedirect(redirect!, textStyle);
 
             // Define default values
             _backColor1 = GlobalStaticValues.EMPTY_COLOR;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonTextInheritRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonTextInheritRedirect.cs
@@ -28,12 +28,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="redirect">Source for inherit requests.</param>
         /// <param name="styleText">Ribbon item text style.</param>
-        public PaletteRibbonTextInheritRedirect([DisallowNull] PaletteRedirect redirect,
+        public PaletteRibbonTextInheritRedirect(PaletteRedirect redirect,
                                                 PaletteRibbonTextStyle styleText)
         {
+            // Debug.Assert() causes the null assignment warning.
+            // Suppressed by the null forgiving operator
             Debug.Assert(redirect is not null);
 
-            _redirect = redirect; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(redirect));
+            _redirect = redirect!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(redirect));
             StyleText = styleText;
         }
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTab/PaletteTabBorder.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTab/PaletteTabBorder.cs
@@ -24,7 +24,7 @@ namespace Krypton.Toolkit
         /// <param name="inherit">Source for inheriting defaulted values.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
         public PaletteTabBorder(IPaletteBorder inherit,
-                                NeedPaintHandler needPaint)
+                                NeedPaintHandler? needPaint)
             : base(inherit, needPaint)
         {
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTab/PaletteTabTripleRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTab/PaletteTabTripleRedirect.cs
@@ -38,8 +38,10 @@ namespace Krypton.Toolkit
                                         PaletteBackStyle backStyle,
                                         PaletteBorderStyle borderStyle,
                                         PaletteContentStyle contentStyle,
-                                        NeedPaintHandler needPaint)
+                                        NeedPaintHandler? needPaint)
         {
+            // Debug.Assert() causes the null assignment warning.
+            // Suppressed by the null forgiving operator
             Debug.Assert(redirect is not null);
 
             // Store the provided paint notification delegate
@@ -52,9 +54,9 @@ namespace Krypton.Toolkit
             //}
 
             // Store the inherit instances
-            _backInherit = new PaletteBackInheritRedirect(redirect, backStyle);
-            _borderInherit = new PaletteBorderInheritRedirect(redirect, borderStyle);
-            _contentInherit = new PaletteContentInheritRedirect(redirect, contentStyle);
+            _backInherit = new PaletteBackInheritRedirect(redirect!, backStyle);
+            _borderInherit = new PaletteBorderInheritRedirect(redirect!, borderStyle);
+            _contentInherit = new PaletteContentInheritRedirect(redirect!, contentStyle);
 
             // Create storage that maps onto the inherit instances
             Back = new PaletteBack(_backInherit, needPaint);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTripleJustImage.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTripleJustImage.cs
@@ -33,9 +33,11 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="inherit">Source for inheriting values.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteTripleJustImage([DisallowNull] IPaletteTriple inherit,
+        public PaletteTripleJustImage(IPaletteTriple inherit,
                                       NeedPaintHandler? needPaint)
         {
+            // Debug.Assert() causes the null assignment warning.
+            // Suppressed by the null forgiving operator
             Debug.Assert(inherit is not null);
 
             //TEST-NoThrow
@@ -48,9 +50,9 @@ namespace Krypton.Toolkit
             NeedPaint = needPaint;
 
             // Create storage that maps onto the inherit instances
-            Back = new PaletteBack(inherit.PaletteBack, needPaint);
-            Border = new PaletteBorder(inherit.PaletteBorder!, needPaint);
-            Content = new PaletteContentJustImage(inherit.PaletteContent!, needPaint);
+            Back = new PaletteBack(inherit!.PaletteBack, needPaint);
+            Border = new PaletteBorder(inherit!.PaletteBorder!, needPaint);
+            Content = new PaletteContentJustImage(inherit!.PaletteContent!, needPaint);
         }
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTripleMetricRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTripleMetricRedirect.cs
@@ -31,7 +31,7 @@ namespace Krypton.Toolkit
         /// <param name="borderStyle">Style for the border.</param>
         /// <param name="contentStyle">Style for the content.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
-        public PaletteTripleMetricRedirect([DisallowNull] PaletteRedirect redirect,
+        public PaletteTripleMetricRedirect(PaletteRedirect redirect,
                                            PaletteBackStyle backStyle,
                                            PaletteBorderStyle borderStyle,
                                            PaletteContentStyle contentStyle,
@@ -42,10 +42,12 @@ namespace Krypton.Toolkit
                    contentStyle,
                    needPaint)
         {
+            // Debug.Assert() causes the null assignment warning.
+            // Suppressed by the null forgiving operator
             Debug.Assert(redirect is not null);
 
             // Remember the redirect reference
-            _redirect = redirect; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(redirect));
+            _redirect = redirect!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(redirect));
         }
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawCanvas.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawCanvas.cs
@@ -22,7 +22,7 @@ namespace Krypton.Toolkit
         #region Instance Fields
         internal IPaletteBack? _paletteBack;
         internal IPaletteBorder? _paletteBorder;
-        internal IPaletteMetric _paletteMetric;
+        internal IPaletteMetric? _paletteMetric;
         internal PaletteMetricPadding _metricPadding;
         private IDisposable? _mementoBack;
         private PaletteBorderInheritForced? _borderForced;
@@ -127,7 +127,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the currently used metric palette.
         /// </summary>
-        public IPaletteMetric PaletteMetric
+        public IPaletteMetric? PaletteMetric
         {
             [DebuggerStepThrough]
             get => _paletteMetric;

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawSplitCanvas.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawSplitCanvas.cs
@@ -139,7 +139,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the currently used metric palette.
         /// </summary>
-        public IPaletteMetric PaletteMetric
+        public IPaletteMetric? PaletteMetric
         {
             [DebuggerStepThrough]
             get;
@@ -201,7 +201,7 @@ namespace Krypton.Toolkit
         /// <param name="paletteMetric">Palette source for the metric.</param>
         public virtual void SetPalettes([DisallowNull] IPaletteBack paletteBack, 
                                         [DisallowNull] IPaletteBorder paletteBorder,
-                                        IPaletteMetric paletteMetric)
+                                        IPaletteMetric? paletteMetric)
         {
             Debug.Assert(paletteBorder != null);
             Debug.Assert(paletteBack != null);


### PR DESCRIPTION
Revisits previously disabled throw statements.
Earlier warings corrected without the use of throw statements. 
Part of the fall out is handled with the use throws since these statements return non-nullable types.

The commented-out throw statements are left in for now in case a correction is needed. 
Will remove those later on when all is proven stable.

Warnings before 348.

![compile-results](https://github.com/Krypton-Suite/Standard-Toolkit/assets/96108132/4ed99935-efd5-470c-97b2-194eac674546)
