### PR TITLE
1475-Build Scripts will run when no suitable environment is detected

### DIFF
--- a/Scripts/build-canary.cmd
+++ b/Scripts/build-canary.cmd
@@ -9,6 +9,7 @@ if exist "%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current
 echo "Unable to detect suitable environment. Check if VS 2022 is installed."
 
 pause
+goto exitbatch
 
 :vs17prev
 set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin
@@ -58,3 +59,5 @@ if %answer%==n exit
 cd ..
 
 run.cmd
+
+:exitbatch

--- a/Scripts/build-installer.cmd
+++ b/Scripts/build-installer.cmd
@@ -9,6 +9,7 @@ if exist "%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current
 echo "Unable to detect suitable environment. Check if VS 2022 is installed."
 
 pause
+goto exitbatch
 
 :vs17prev
 set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin
@@ -58,3 +59,5 @@ if %answer%==n exit
 cd ..
 
 run.cmd
+
+:exitbatch

--- a/Scripts/build-nightly-custom.cmd
+++ b/Scripts/build-nightly-custom.cmd
@@ -9,6 +9,7 @@ if exist "%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current
 echo "Unable to detect suitable environment. Check if VS 2022 is installed."
 
 pause
+goto exitbatch
 
 :vs17prev
 set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin
@@ -42,3 +43,5 @@ if not "%~1" == "" set targets=%~1
 "%msbuildpath%\msbuild.exe" /t:%targets% nightly.proj /fl /flp:logfile=build.log
 
 @echo Build Completed: %date% %time% %zone%
+
+:exitbatch

--- a/Scripts/build-nightly.cmd
+++ b/Scripts/build-nightly.cmd
@@ -9,6 +9,7 @@ if exist "%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current
 echo "Unable to detect suitable environment. Check if VS 2022 is installed."
 
 pause
+goto exitbatch
 
 :vs17prev
 set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin
@@ -39,7 +40,7 @@ for /f "tokens=* usebackq" %%A in (`tzutil /g`) do (
 @echo
 set targets=Build
 if not "%~1" == "" set targets=%~1
-"%msbuildpath%\msbuild.exe" -t:%targets% nightly.proj /fl /flp:logfile=build.log 
+"%msbuildpath%\msbuild.exe" -t:%targets% nightly.proj /fl /flp:logfile=build.log /bl
 
 :: -t:rebuild
 
@@ -62,3 +63,5 @@ if %answer%==n exit
 cd ..
 
 run.cmd
+
+:exitbatch

--- a/Scripts/build-stable.cmd
+++ b/Scripts/build-stable.cmd
@@ -7,6 +7,7 @@ if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\
 if exist "%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin" goto vs17build
 
 echo "Unable to detect suitable environment. Check if VS 2022 is installed."
+goto exitbatch
 
 goto end
 
@@ -61,3 +62,5 @@ run.cmd
 
 :end
 pause
+
+:exitbatch

--- a/Scripts/buildsolution.cmd
+++ b/Scripts/buildsolution.cmd
@@ -14,6 +14,7 @@ if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Cur
 if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
 
 echo "Unable to detect suitable environment. Check if VS 2019 is installed."
+goto exitbatch
 
 pause
 
@@ -52,7 +53,7 @@ if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\
 if exist "%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin" goto vs17build
 
 echo "Unable to detect suitable environment. Check if VS 2022 is installed."
-
+goto exitbatch
 pause
 
 :vs17prev
@@ -106,3 +107,5 @@ build-2022.cmd Pack
 :break
 pause
 @echo Build Completed: %date% %time%
+
+:exitbatch

--- a/Scripts/debug.cmd
+++ b/Scripts/debug.cmd
@@ -7,6 +7,7 @@ if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Cur
 if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin" goto vs16build
 
 echo "Unable to detect suitable environment. Check if VS 2019 is installed."
+goto exitbatch
 
 pause
 
@@ -42,3 +43,5 @@ if not "%~1" == "" set targets=%~1
 echo Plese alter file '{Path}\Directory.Build.props' before executing 'publish.cmd' script!
 
 pause
+
+:exitbatch

--- a/Scripts/rebuild-build-nightly.cmd
+++ b/Scripts/rebuild-build-nightly.cmd
@@ -9,6 +9,7 @@ if exist "%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current
 echo "Unable to detect suitable environment. Check if VS 2022 is installed."
 
 pause
+goto exitbatch
 
 :vs17prev
 set msbuildpath=%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin
@@ -60,3 +61,5 @@ if %answer%==n exit
 cd ..
 
 run.cmd
+
+:exitbatch


### PR DESCRIPTION
Build Scripts will run when no suitable environment is detected.
Add the /BL parameter to build-nightly.cmd.
Issue 1475: https://github.com/Krypton-Suite/Standard-Toolkit/issues/1475

![compile-results](https://github.com/Krypton-Suite/Standard-Toolkit/assets/96108132/1d289a79-7219-4acd-b806-f03772a0b4cd)
