### PR TITLE
1418-cleanup-warnings-0042

### DIFF
--- a/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonRibbon.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonRibbon.cs
@@ -941,7 +941,10 @@ namespace Krypton.Ribbon
         /// Internal design time method.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool InDesignMode => DesignMode;
+        public new bool InDesignMode => 
+            // Removed warning CS0108: "IndesignMode hides inherited member VisualControl.InDesignMode".
+            // By marking the property as new.
+            DesignMode;
 
         /// <summary>
         /// Internal design time method.

--- a/Source/Krypton Components/Krypton.Ribbon/Global/GlobalDeclarations.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Global/GlobalDeclarations.cs
@@ -40,4 +40,7 @@ global using System.Runtime.CompilerServices;
 [assembly: Dependency(@"System.Drawing", LoadHint.Always)]
 [assembly: Dependency(@"System.Windows.Forms", LoadHint.Always)]
 [assembly: Dependency(@"Krypton.Toolkit", LoadHint.Always)]
-[assembly: InternalsVisibleTo(@"Krypton.Toolkit, PublicKey=a87e673e9ecb6e8e", AllInternalsVisible = true)]
+
+// Public key value needs to be the full key. Before, this was the PublicKeyToken value.
+// See: https://stackoverflow.com/questions/106880/internalsvisibleto-attribute-isnt-working/107958#107958
+[assembly: InternalsVisibleTo( "Krypton.Toolkit, PublicKey=00240000048000009400000006020000002400005253413100040000010001001f208b6887f7b4f8fad6c30b9eca9849f09cbfbd37901e222f8e888331622c907dfa686c56389c95966b86b33f0dd0ab4cca46b1f1ed92efd7d5ddee2e2274f485867202c581f68c32bd3278ab1188e978a53ea6851be2c14d87efe9ed78c71df95e1a7f7d6923b6703c00dc56b76fd582f945cd0c1951844ebe478a911fcab4", AllInternalsVisible = true)]

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonSplitterPanelDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonSplitterPanelDesigner.cs
@@ -179,7 +179,9 @@ namespace Krypton.Toolkit
                 }
                 else
                 {
-                    return base.InheritanceAttribute;
+                    // Null forgiving operator added to remove the null reference return warning.
+                    // base.InheritanceAttribute will always return a reference.
+                    return base.InheritanceAttribute!;
                 }
             }
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Global/GlobalDeclarations.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Global/GlobalDeclarations.cs
@@ -93,5 +93,8 @@ global using Microsoft.Win32.SafeHandles;
 [assembly: Dependency(nameof(System), LoadHint.Always)]
 [assembly: Dependency(@"System.Drawing", LoadHint.Always)]
 [assembly: Dependency(@"System.Windows.Forms", LoadHint.Always)]
-[assembly: InternalsVisibleTo(@"Krypton.Navigator, PublicKey=a87e673e9ecb6e8e", AllInternalsVisible = true)]
-[assembly: InternalsVisibleTo(@"Krypton.Ribbon, PublicKey=a87e673e9ecb6e8e", AllInternalsVisible = true)]
+
+// Public key value needs to be the full key. Before, this was the PublicKeyToken value.
+// See: https://stackoverflow.com/questions/106880/internalsvisibleto-attribute-isnt-working/107958#107958
+[assembly: InternalsVisibleTo( "Krypton.Navigator, PublicKey=00240000048000009400000006020000002400005253413100040000010001001f208b6887f7b4f8fad6c30b9eca9849f09cbfbd37901e222f8e888331622c907dfa686c56389c95966b86b33f0dd0ab4cca46b1f1ed92efd7d5ddee2e2274f485867202c581f68c32bd3278ab1188e978a53ea6851be2c14d87efe9ed78c71df95e1a7f7d6923b6703c00dc56b76fd582f945cd0c1951844ebe478a911fcab4", AllInternalsVisible = true)]
+[assembly: InternalsVisibleTo( "Krypton.Ribbon, PublicKey=00240000048000009400000006020000002400005253413100040000010001001f208b6887f7b4f8fad6c30b9eca9849f09cbfbd37901e222f8e888331622c907dfa686c56389c95966b86b33f0dd0ab4cca46b1f1ed92efd7d5ddee2e2274f485867202c581f68c32bd3278ab1188e978a53ea6851be2c14d87efe9ed78c71df95e1a7f7d6923b6703c00dc56b76fd582f945cd0c1951844ebe478a911fcab4", AllInternalsVisible = true)]


### PR DESCRIPTION
1418-cleanup-warnings-0042
[issue 1418](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1418)
Removes the publickey warnings CS1700
And 2 more warnings from components.

![compile-results](https://github.com/Krypton-Suite/Standard-Toolkit/assets/96108132/8173dc35-7fbd-4f30-93e6-11712211eca4)
