### PR TITLE
- Remove `###DoubleClick` from the designer events:

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
+* Resolved [#1461](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1461) Remove designer visibility of MouseDoubleClick and DoubleClick Events for the KryptonComboxBox
 * Resolved [#1478](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1478) Wrongly assigned designers to `KryptonListview` and `KryptonProgressBar` corrected. DesignerActionLists code updated.
 * Resolved [#1475](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1475), Build Scripts will run when no suitable environment is detected. Add 'BinLog' option to `build-*.cmd`
 * Implemented [#1435](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1435), **Breaking Change** Take KMB back to the Winform override (Remove Checkbox etc)

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
+* Resolved [#1489](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1489) **[Regression]** KMessageBox (and "Deprecated") using Error Icon plays the wrong sound
 * Resolved [#1461](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1461) Remove designer visibility of MouseDoubleClick and DoubleClick Events for the KryptonComboxBox
 * Resolved [#1478](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1478) Wrongly assigned designers to `KryptonListview` and `KryptonProgressBar` corrected. DesignerActionLists code updated.
 * Resolved [#1475](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1475), Build Scripts will run when no suitable environment is detected. Add 'BinLog' option to `build-*.cmd`

--- a/Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln
+++ b/Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln
@@ -21,7 +21,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Development", "Development"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Help", "Help", "{C2B58A1A-4451-4A21-8487-14DBA720672D}"
 	ProjectSection(SolutionItems) = preProject
-		..\..\Documents\Help\Changelog.md = ..\..\Documents\Help\Changelog.md
 		..\..\Documents\Help\Designer-Fix.md = ..\..\Documents\Help\Designer-Fix.md
 	EndProjectSection
 EndProject
@@ -110,6 +109,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Issue Templates", "Issue Te
 		..\..\.github\ISSUE_TEMPLATE\feature_request.md = ..\..\.github\ISSUE_TEMPLATE\feature_request.md
 		..\..\.github\ISSUE_TEMPLATE\other-issues.md = ..\..\.github\ISSUE_TEMPLATE\other-issues.md
 		..\..\.github\ISSUE_TEMPLATE\post-a-question.md = ..\..\.github\ISSUE_TEMPLATE\post-a-question.md
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ChangeLog", "ChangeLog", "{F0BC3940-BAC0-40B9-AECB-2FC752486AD5}"
+	ProjectSection(SolutionItems) = preProject
+		..\..\Documents\Changelog\Changelog.md = ..\..\Documents\Changelog\Changelog.md
 	EndProjectSection
 EndProject
 Global
@@ -205,6 +209,7 @@ Global
 		{CAB40818-55B1-4E1D-AD8E-C94642EA5124} = {56F1A41E-584B-4F91-9E98-7D8BF678210C}
 		{FB5BC976-FCC7-4729-9331-C2420DE7ADB6} = {405E4318-4C8A-4DC7-B624-8F7097CDFF60}
 		{40B83627-BD68-488E-ACB0-5B83D0A8B69C} = {FB5BC976-FCC7-4729-9331-C2420DE7ADB6}
+		{F0BC3940-BAC0-40B9-AECB-2FC752486AD5} = {405E4318-4C8A-4DC7-B624-8F7097CDFF60}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C8204ACC-48AA-49AC-8236-6E9C162EC2FA}

--- a/Source/Krypton Components/Krypton.Docking/General/DockingHelper.cs
+++ b/Source/Krypton Components/Krypton.Docking/General/DockingHelper.cs
@@ -10,8 +10,6 @@
  */
 #endregion
 
-using static System.Windows.Forms.AxHost;
-
 namespace Krypton.Docking
 {
     /// <summary>

--- a/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavClose.cs
+++ b/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavClose.cs
@@ -10,8 +10,6 @@
  */
 #endregion
 
-using System.Windows.Forms.VisualStyles;
-
 namespace Krypton.Navigator
 {
     /// <summary>

--- a/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavContext.cs
+++ b/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavContext.cs
@@ -10,8 +10,6 @@
  */
 #endregion
 
-using System.Windows.Forms.VisualStyles;
-
 namespace Krypton.Navigator
 {
     /// <summary>

--- a/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavNext.cs
+++ b/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavNext.cs
@@ -10,8 +10,6 @@
  */
 #endregion
 
-using System.Windows.Forms.VisualStyles;
-
 namespace Krypton.Navigator
 {
     /// <summary>

--- a/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavigator.cs
+++ b/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavigator.cs
@@ -10,8 +10,6 @@
  */
 #endregion
 
-using System.Windows.Forms.VisualStyles;
-
 namespace Krypton.Navigator
 {
     /// <summary>

--- a/Source/Krypton Components/Krypton.Ribbon/Palette/FileApplicationTabToContent.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Palette/FileApplicationTabToContent.cs
@@ -8,8 +8,6 @@
  */
 #endregion
 
-using static System.Windows.Forms.AxHost;
-
 namespace Krypton.Ribbon
 {
     internal class FileApplicationTabToContent : RibbonToContent

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -10,8 +10,6 @@
  */
 #endregion
 
-using System.ComponentModel;
-
 namespace Krypton.Toolkit
 {
     /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -10,6 +10,8 @@
  */
 #endregion
 
+using System.ComponentModel;
+
 namespace Krypton.Toolkit
 {
     /// <summary>
@@ -839,6 +841,24 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Events
+        /// <summary>This event is not relevant for this class.</summary>
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public new event EventHandler DoubleClick
+        {
+            add => base.DoubleClick += value;
+            remove => base.DoubleClick -= value;
+        }
+
+        /// <summary>This event is not relevant for this class.</summary>
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public new event MouseEventHandler MouseDoubleClick
+        {
+            add => base.MouseDoubleClick += value;
+            remove => base.MouseDoubleClick -= value;
+        }
+
         /// <summary>
         /// Occurs when [draw item].
         /// </summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -10,8 +10,6 @@
  */
 #endregion
 
-using static System.Windows.Forms.AxHost;
-
 namespace Krypton.Toolkit
 {
     /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMessageBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMessageBox.cs
@@ -153,7 +153,7 @@ namespace Krypton.Toolkit
             KryptonMessageBoxIcon icon, KryptonMessageBoxDefaultButton defaultButton, MessageBoxOptions options, HelpInfo helpInfo,
             bool? showCtrlCopy = null,
             bool? showCloseButton = null) =>
-            ShowCore(null, text, caption, buttons, icon, defaultButton, options,
+            ShowCore(null, text, caption, buttons, icon, defaultButton, options, helpInfo,
                 showCtrlCopy: showCtrlCopy,
                 showHelpButton: false,
                 showCloseButton: showCloseButton);
@@ -191,7 +191,7 @@ namespace Krypton.Toolkit
         public static DialogResult Show(IWin32Window owner, string text,
             bool? showCtrlCopy = null,
             bool? showCloseButton = null) =>
-            ShowCore(null, text, string.Empty,
+            ShowCore(owner, text, string.Empty,
                 showCtrlCopy: showCtrlCopy,
                 showHelpButton: false,
                 showCloseButton: showCloseButton);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareForm.cs
@@ -154,11 +154,11 @@ namespace Krypton.Toolkit
                         break;
                     case KryptonMessageBoxIcon.Stop:
                         _messageIcon.Image = MessageBoxImageResources.GenericStop;
-                        SystemSounds.Asterisk.Play();
+                        SystemSounds.Hand.Play();
                         break;
                     case KryptonMessageBoxIcon.Error:
                         _messageIcon.Image = MessageBoxImageResources.Critical_Windows_11;
-                        SystemSounds.Asterisk.Play();
+                        SystemSounds.Hand.Play();
                         break;
                     case KryptonMessageBoxIcon.Warning:
                         _messageIcon.Image = MessageBoxImageResources.Warning_Windows_11;
@@ -166,7 +166,7 @@ namespace Krypton.Toolkit
                         break;
                     case KryptonMessageBoxIcon.Information:
                         _messageIcon.Image = MessageBoxImageResources.Information_Windows_11;
-                        SystemSounds.Asterisk.Play();
+                        SystemSounds.Exclamation.Play();
                         break;
                     case KryptonMessageBoxIcon.Shield:
                         _messageIcon.Image = UACShieldIconResources.UAC_Shield_Windows_11;
@@ -234,11 +234,11 @@ namespace Krypton.Toolkit
                         break;
                     case KryptonMessageBoxIcon.Stop:
                         _messageIcon.Image = MessageBoxImageResources.GenericStop;
-                        SystemSounds.Asterisk.Play();
+                        SystemSounds.Hand.Play();
                         break;
                     case KryptonMessageBoxIcon.Error:
                         _messageIcon.Image = MessageBoxImageResources.GenericCritical;
-                        SystemSounds.Asterisk.Play();
+                        SystemSounds.Hand.Play();
                         break;
                     case KryptonMessageBoxIcon.Warning:
                         _messageIcon.Image = MessageBoxImageResources.GenericWarning;
@@ -246,7 +246,7 @@ namespace Krypton.Toolkit
                         break;
                     case KryptonMessageBoxIcon.Information:
                         _messageIcon.Image = MessageBoxImageResources.GenericInformation;
-                        SystemSounds.Asterisk.Play();
+                        SystemSounds.Exclamation.Play();
                         break;
                     case KryptonMessageBoxIcon.Shield:
                         _messageIcon.Image = OSUtilities.IsWindowsTen
@@ -385,27 +385,20 @@ namespace Krypton.Toolkit
 
         private void UpdateDefault()
         {
-            switch (_defaultButton)
+            AcceptButton = _defaultButton switch
             {
-                case KryptonMessageBoxDefaultButton.Button1:
+                KryptonMessageBoxDefaultButton.Button1 =>
                     //_button1.Select();
-                    AcceptButton = _button1;
-                    break;
-                case KryptonMessageBoxDefaultButton.Button2:
+                    _button1,
+                KryptonMessageBoxDefaultButton.Button2 =>
                     //_button2.Select();
-                    AcceptButton = _button2;
-                    break;
-                case KryptonMessageBoxDefaultButton.Button3:
+                    _button2,
+                KryptonMessageBoxDefaultButton.Button3 =>
                     //_button3.Select();
-                    AcceptButton = _button3;
-                    break;
-                case KryptonMessageBoxDefaultButton.Button4:
-                    AcceptButton = _showHelpButton ? _button4 : _button1;
-                    break;
-                default:
-                    AcceptButton = _showHelpButton ? _button4 : _button1;
-                    break;
-            }
+                    _button3,
+                KryptonMessageBoxDefaultButton.Button4 => _showHelpButton ? _button4 : _button1,
+                _ => _showHelpButton ? _button4 : _button1
+            };
         }
 
         private void UpdateHelp()

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareFormDep.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareFormDep.cs
@@ -7,6 +7,8 @@
  */
 #endregion
 
+using System.Data;
+
 namespace Krypton.Toolkit
 {
     internal partial class VisualMessageBoxRtlAwareFormDep : KryptonForm
@@ -224,11 +226,11 @@ namespace Krypton.Toolkit
                         break;
                     case KryptonMessageBoxIcon.Stop:
                         _messageIcon.Image = MessageBoxImageResources.GenericStop;
-                        SystemSounds.Asterisk.Play();
+                        SystemSounds.Hand.Play();
                         break;
                     case KryptonMessageBoxIcon.Error:
                         _messageIcon.Image = MessageBoxImageResources.Critical_Windows_11;
-                        SystemSounds.Asterisk.Play();
+                        SystemSounds.Hand.Play();
                         break;
                     case KryptonMessageBoxIcon.Warning:
                         _messageIcon.Image = MessageBoxImageResources.Warning_Windows_11;
@@ -236,7 +238,7 @@ namespace Krypton.Toolkit
                         break;
                     case KryptonMessageBoxIcon.Information:
                         _messageIcon.Image = MessageBoxImageResources.Information_Windows_11;
-                        SystemSounds.Asterisk.Play();
+                        SystemSounds.Exclamation.Play();
                         break;
                     case KryptonMessageBoxIcon.Shield:
                         _messageIcon.Image = UACShieldIconResources.UAC_Shield_Windows_11;
@@ -315,11 +317,11 @@ namespace Krypton.Toolkit
                         break;
                     case KryptonMessageBoxIcon.Stop:
                         _messageIcon.Image = MessageBoxImageResources.GenericStop;
-                        SystemSounds.Asterisk.Play();
+                        SystemSounds.Hand.Play();
                         break;
                     case KryptonMessageBoxIcon.Error:
                         _messageIcon.Image = MessageBoxImageResources.GenericCritical;
-                        SystemSounds.Asterisk.Play();
+                        SystemSounds.Hand.Play();
                         break;
                     case KryptonMessageBoxIcon.Warning:
                         _messageIcon.Image = MessageBoxImageResources.GenericWarning;
@@ -327,7 +329,7 @@ namespace Krypton.Toolkit
                         break;
                     case KryptonMessageBoxIcon.Information:
                         _messageIcon.Image = MessageBoxImageResources.GenericInformation;
-                        SystemSounds.Asterisk.Play();
+                        SystemSounds.Exclamation.Play();
                         break;
                     case KryptonMessageBoxIcon.Shield:
                         if (OSUtilities.IsAtLeastWindowsEleven)
@@ -422,11 +424,11 @@ namespace Krypton.Toolkit
                         break;
                     case KryptonMessageBoxIcon.Stop:
                         _messageIcon.Image = MessageBoxImageResources.GenericStop;
-                        SystemSounds.Asterisk.Play();
+                        SystemSounds.Hand.Play();
                         break;
                     case KryptonMessageBoxIcon.Error:
                         _messageIcon.Image = MessageBoxImageResources.Critical_Windows_11;
-                        SystemSounds.Asterisk.Play();
+                        SystemSounds.Hand.Play();
                         break;
                     case KryptonMessageBoxIcon.Warning:
                         _messageIcon.Image = MessageBoxImageResources.Warning_Windows_11;
@@ -434,7 +436,7 @@ namespace Krypton.Toolkit
                         break;
                     case KryptonMessageBoxIcon.Information:
                         _messageIcon.Image = MessageBoxImageResources.Information_Windows_11;
-                        SystemSounds.Asterisk.Play();
+                        SystemSounds.Exclamation.Play();
                         break;
                     case KryptonMessageBoxIcon.Shield:
                         _messageIcon.Image = UACShieldIconResources.UAC_Shield_Windows_11;
@@ -512,11 +514,11 @@ namespace Krypton.Toolkit
                         break;
                     case KryptonMessageBoxIcon.Stop:
                         _messageIcon.Image = MessageBoxImageResources.GenericStop;
-                        SystemSounds.Asterisk.Play();
+                        SystemSounds.Hand.Play();
                         break;
                     case KryptonMessageBoxIcon.Error:
                         _messageIcon.Image = MessageBoxImageResources.GenericCritical;
-                        SystemSounds.Asterisk.Play();
+                        SystemSounds.Hand.Play();
                         break;
                     case KryptonMessageBoxIcon.Warning:
                         _messageIcon.Image = MessageBoxImageResources.GenericWarning;
@@ -524,7 +526,7 @@ namespace Krypton.Toolkit
                         break;
                     case KryptonMessageBoxIcon.Information:
                         _messageIcon.Image = MessageBoxImageResources.GenericInformation;
-                        SystemSounds.Asterisk.Play();
+                        SystemSounds.Exclamation.Play();
                         break;
                     case KryptonMessageBoxIcon.Shield:
                         if (OSUtilities.IsAtLeastWindowsEleven)
@@ -789,55 +791,39 @@ namespace Krypton.Toolkit
 
         private void UpdateDefault(KryptonMessageBoxDefaultButton? defaultButton)
         {
-            switch (defaultButton)
+            AcceptButton = defaultButton switch
             {
-                case KryptonMessageBoxDefaultButton.Button1:
+                KryptonMessageBoxDefaultButton.Button1 =>
                     //_button1.Select();
-                    AcceptButton = _button1;
-                    break;
-                case KryptonMessageBoxDefaultButton.Button2:
+                    _button1,
+                KryptonMessageBoxDefaultButton.Button2 =>
                     //_button2.Select();
-                    AcceptButton = _button2;
-                    break;
-                case KryptonMessageBoxDefaultButton.Button3:
+                    _button2,
+                KryptonMessageBoxDefaultButton.Button3 =>
                     //_button3.Select();
-                    AcceptButton = _button3;
-                    break;
-                case KryptonMessageBoxDefaultButton.Button4:
-                    AcceptButton = _showHelpButton ? _button4 : _button1;
-                    break;
-                case null:
-                    AcceptButton = _button1;
-                    break;
-                default:
-                    AcceptButton = _showHelpButton ? _button4 : _button1;
-                    break;
-            }
+                    _button3,
+                KryptonMessageBoxDefaultButton.Button4 => _showHelpButton ? _button4 : _button1,
+                null => _button1,
+                _ => _showHelpButton ? _button4 : _button1
+            };
         }
 
         private void UpdateDefault()
         {
-            switch (_defaultButton)
+            AcceptButton = _defaultButton switch
             {
-                case KryptonMessageBoxDefaultButton.Button1:
+                KryptonMessageBoxDefaultButton.Button1 =>
                     //_button1.Select();
-                    AcceptButton = _button1;
-                    break;
-                case KryptonMessageBoxDefaultButton.Button2:
+                    _button1,
+                KryptonMessageBoxDefaultButton.Button2 =>
                     //_button2.Select();
-                    AcceptButton = _button2;
-                    break;
-                case KryptonMessageBoxDefaultButton.Button3:
+                    _button2,
+                KryptonMessageBoxDefaultButton.Button3 =>
                     //_button3.Select();
-                    AcceptButton = _button3;
-                    break;
-                case KryptonMessageBoxDefaultButton.Button4:
-                    AcceptButton = _showHelpButton ? _button4 : _button1;
-                    break;
-                default:
-                    AcceptButton = _showHelpButton ? _button4 : _button1;
-                    break;
-            }
+                    _button3,
+                KryptonMessageBoxDefaultButton.Button4 => _showHelpButton ? _button4 : _button1,
+                _ => _showHelpButton ? _button4 : _button1
+            };
         }
 
         private void UpdateHelp(bool? showHelpButton)
@@ -856,7 +842,7 @@ namespace Krypton.Toolkit
                 KryptonMessageBoxButtons.AbortRetryIgnore
                     or KryptonMessageBoxButtons.YesNoCancel
                     or KryptonMessageBoxButtons.CancelTryContinue => _button4,
-                _ => throw new ArgumentOutOfRangeException()
+                _ => throw new EvaluateException("_buttons out of range")
             };
             if (helpButton != null)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxForm.cs
@@ -161,11 +161,11 @@ namespace Krypton.Toolkit
                         break;
                     case KryptonMessageBoxIcon.Stop:
                         _messageIcon.Image = MessageBoxImageResources.GenericStop;
-                        SystemSounds.Asterisk.Play();
+                        SystemSounds.Hand.Play();
                         break;
                     case KryptonMessageBoxIcon.Error:
                         _messageIcon.Image = MessageBoxImageResources.Critical_Windows_11;
-                        SystemSounds.Asterisk.Play();
+                        SystemSounds.Hand.Play();
                         break;
                     case KryptonMessageBoxIcon.Warning:
                         _messageIcon.Image = MessageBoxImageResources.Warning_Windows_11;
@@ -173,7 +173,7 @@ namespace Krypton.Toolkit
                         break;
                     case KryptonMessageBoxIcon.Information:
                         _messageIcon.Image = MessageBoxImageResources.Information_Windows_11;
-                        SystemSounds.Asterisk.Play();
+                        SystemSounds.Exclamation.Play();
                         break;
                     case KryptonMessageBoxIcon.Shield:
                         _messageIcon.Image = UACShieldIconResources.UAC_Shield_Windows_11;
@@ -241,11 +241,11 @@ namespace Krypton.Toolkit
                         break;
                     case KryptonMessageBoxIcon.Stop:
                         _messageIcon.Image = MessageBoxImageResources.GenericStop;
-                        SystemSounds.Asterisk.Play();
+                        SystemSounds.Hand.Play();
                         break;
                     case KryptonMessageBoxIcon.Error:
                         _messageIcon.Image = MessageBoxImageResources.GenericCritical;
-                        SystemSounds.Asterisk.Play();
+                        SystemSounds.Hand.Play();
                         break;
                     case KryptonMessageBoxIcon.Warning:
                         _messageIcon.Image = MessageBoxImageResources.GenericWarning;
@@ -253,7 +253,7 @@ namespace Krypton.Toolkit
                         break;
                     case KryptonMessageBoxIcon.Information:
                         _messageIcon.Image = MessageBoxImageResources.GenericInformation;
-                        SystemSounds.Asterisk.Play();
+                        SystemSounds.Exclamation.Play();
                         break;
                     case KryptonMessageBoxIcon.Shield:
                         _messageIcon.Image = OSUtilities.IsWindowsTen 
@@ -392,27 +392,20 @@ namespace Krypton.Toolkit
 
         private void UpdateDefault()
         {
-            switch (_defaultButton)
+            AcceptButton = _defaultButton switch
             {
-                case KryptonMessageBoxDefaultButton.Button1:
+                KryptonMessageBoxDefaultButton.Button1 =>
                     //_button1.Select();
-                    AcceptButton = _button1;
-                    break;
-                case KryptonMessageBoxDefaultButton.Button2:
+                    _button1,
+                KryptonMessageBoxDefaultButton.Button2 =>
                     //_button2.Select();
-                    AcceptButton = _button2;
-                    break;
-                case KryptonMessageBoxDefaultButton.Button3:
+                    _button2,
+                KryptonMessageBoxDefaultButton.Button3 =>
                     //_button3.Select();
-                    AcceptButton = _button3;
-                    break;
-                case KryptonMessageBoxDefaultButton.Button4:
-                    AcceptButton = _showHelpButton ? _button4 : _button1;
-                    break;
-                default:
-                    AcceptButton = _showHelpButton ? _button4 : _button1;
-                    break;
-            }
+                    _button3,
+                KryptonMessageBoxDefaultButton.Button4 => _showHelpButton ? _button4 : _button1,
+                _ => _showHelpButton ? _button4 : _button1
+            };
         }
 
         private void UpdateHelp()

--- a/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
@@ -1921,7 +1921,10 @@ namespace Krypton.Toolkit
         /// </summary>
         SystemStop = MessageBoxIcon.Stop,
 
-        /// <summary>Specify a error icon.</summary>
+        /// <summary>
+        /// Specify a error icon.
+        /// The message box contains a symbol consisting of white X in a circle with a red background.
+        /// </summary>
         Error = 6,
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/General/KryptonAboutBoxUtilities.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/KryptonAboutBoxUtilities.cs
@@ -7,9 +7,6 @@
  */
 #endregion
 
-using static System.Windows.Forms.VisualStyles.VisualStyleElement.ToolTip;
-using System;
-
 namespace Krypton.Toolkit
 {
     /// <summary>This class does the heavy lifting for <see cref="VisualAboutBoxForm"/> and its associated components.</summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2010/PaletteVisualStudio2010With2010Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2010/PaletteVisualStudio2010With2010Base.cs
@@ -7,8 +7,6 @@
  */
 #endregion
 
-using System.Drawing.Drawing2D;
-
 namespace Krypton.Toolkit
 {
     /// <summary>Provides a base for Visual Studio palettes.</summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Utilities/IOutlookGridGroup.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Utilities/IOutlookGridGroup.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Krypton.Toolkit
+﻿namespace Krypton.Toolkit
 {
     /// <summary>
     /// IOutlookGridGroup specifies the interface of any implementation of a OutlookGridGroup class

--- a/Source/Krypton Components/Krypton.Toolkit/Utilities/KryptonDataGridViewProxy.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Utilities/KryptonDataGridViewProxy.cs
@@ -7,8 +7,6 @@
  */
 #endregion
 
-using System;
-
 namespace Krypton.Toolkit
 {
     public class KryptonDataGridViewProxy

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawCanvas.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawCanvas.cs
@@ -10,8 +10,6 @@
  */
 #endregion
 
-using static System.Windows.Forms.AxHost;
-
 namespace Krypton.Toolkit
 {
     /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawWeekNumbers.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawWeekNumbers.cs
@@ -10,8 +10,6 @@
  */
 #endregion
 
-using static System.Windows.Forms.AxHost;
-
 namespace Krypton.Toolkit
 {
     /// <summary>

--- a/Source/Krypton Components/TestForm/BasicToastNotificationTest.cs
+++ b/Source/Krypton Components/TestForm/BasicToastNotificationTest.cs
@@ -95,8 +95,6 @@ namespace TestForm
             _reportToastLocation = false;
             _showDoNotShowAgainOption = false;
             _titleAlignment = ContentAlignment.MiddleCenter;
-            _contentFont = null;
-            _titleFont = null;
             _countDownSeconds = 60;
             _notificationIcon = KryptonToastNotificationIcon.Information;
             _notificationTitleText = ktxtToastTitle.Text;

--- a/Source/Krypton Components/TestForm/CalendarTest.cs
+++ b/Source/Krypton Components/TestForm/CalendarTest.cs
@@ -7,13 +7,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace TestForm
 {
     public partial class CalendarTest : KryptonForm

--- a/Source/Krypton Components/TestForm/CustomPaletteTest.cs
+++ b/Source/Krypton Components/TestForm/CustomPaletteTest.cs
@@ -7,13 +7,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace TestForm
 {
     public partial class CustomPaletteTest : KryptonForm

--- a/Source/Krypton Components/TestForm/DataGridViewTest.cs
+++ b/Source/Krypton Components/TestForm/DataGridViewTest.cs
@@ -7,13 +7,6 @@
  */
 #endregion
 
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace TestForm
 {
     public partial class DataGridViewTest : KryptonForm

--- a/Source/Krypton Components/TestForm/GroupBoxTest.Designer.cs
+++ b/Source/Krypton Components/TestForm/GroupBoxTest.Designer.cs
@@ -299,8 +299,6 @@ namespace TestForm
         #endregion
 
         private Krypton.Navigator.KryptonNavigator kryptonNavigator1;
-        private Krypton.Navigator.KryptonPage kryptonPage1;
-        private Krypton.Navigator.KryptonPage kryptonPage2;
         private Krypton.Toolkit.KryptonCommand kryptonCommand1;
         private Krypton.Toolkit.KryptonGroupBox kryptonGroupBox1;
         private Krypton.Toolkit.KryptonComboBox kryptonComboBox1;

--- a/Source/Krypton Components/TestForm/HeaderExamples.Designer.cs
+++ b/Source/Krypton Components/TestForm/HeaderExamples.Designer.cs
@@ -53,7 +53,6 @@
         }
 
         #endregion
-        private KryptonHeaderGroup kryptonHeaderGroup1;
         private KryptonHeader kryptonHeader1;
     }
 }

--- a/Source/Krypton Components/TestForm/HeaderExamples.cs
+++ b/Source/Krypton Components/TestForm/HeaderExamples.cs
@@ -1,14 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms;
-
-namespace TestForm
+﻿namespace TestForm
 {
     public partial class HeaderExamples : /*Krypton*/Form
     {

--- a/Source/Krypton Components/TestForm/MessageBoxTest.cs
+++ b/Source/Krypton Components/TestForm/MessageBoxTest.cs
@@ -20,23 +20,11 @@ namespace TestForm
 
         private void kbtnTestMessagebox_Click(object sender, EventArgs e)
         {
-            KryptonMessageBoxDataDep data = new KryptonMessageBoxDataDep
-            {
-                MessageText = @"This is a test!",
-                Caption = @"Hello World",
-                Buttons = KryptonMessageBoxButtons.OK,
-                Icon = KryptonMessageBoxIcon.Information,
-                MessageContentAreaType = MessageBoxContentAreaType.LinkLabel,
-                ShowCloseButton = kryptonCheckBox1.Checked,
-                //Options = MessageBoxOptions.RtlReading
-            };
+            KryptonMessageBox.Show(@"This is a test!", @"Testing", KryptonMessageBoxButtons.OK,
+                KryptonMessageBoxIcon.Error, showCloseButton: kryptonCheckBox1.Checked);
 
             KryptonMessageBoxDep.Show(@"This is a test!", @"Testing", KryptonMessageBoxButtons.OK,
-                KryptonMessageBoxIcon.Information, contentAreaType: MessageBoxContentAreaType.LinkLabel,
-                linkAreaCommand: kcmdMessageboxTest, showCloseButton: kryptonCheckBox1.Checked);
-
-            KryptonMessageBoxDep.Show(@"This is a test!", @"Testing", KryptonMessageBoxButtons.OK,
-                KryptonMessageBoxIcon.Information, options: MessageBoxOptions.RtlReading,
+                KryptonMessageBoxIcon.Error, options: MessageBoxOptions.RtlReading,
                 contentAreaType: MessageBoxContentAreaType.LinkLabel,
                 linkAreaCommand: kcmdMessageboxTest, showCloseButton: kryptonCheckBox1.Checked);
         }

--- a/Source/Krypton Components/TestForm/OutlookGridPriceGroup.cs
+++ b/Source/Krypton Components/TestForm/OutlookGridPriceGroup.cs
@@ -175,14 +175,14 @@ namespace TestForm
         /// </summary>
         /// <param name="obj"></param>
         /// <returns></returns>
-        public override int CompareTo(object obj)
+        public override int CompareTo(object? obj)
         {
             int orderModifier = (Column.SortDirection == SortOrder.Ascending ? 1 : -1);
             int priceOther = 0;
 
-            if (obj is OutlookGridPriceGroup)
+            if (obj is OutlookGridPriceGroup group)
             {
-                priceOther = ((OutlookGridPriceGroup)obj)._priceCode;
+                priceOther = group._priceCode;
             }
             else
             {

--- a/Source/Krypton Components/TestForm/OutlookGridTest.cs
+++ b/Source/Krypton Components/TestForm/OutlookGridTest.cs
@@ -8,14 +8,7 @@
 #endregion
 
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
 using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.Expando;
-using System.Text;
-using System.Threading.Tasks;
 using System.Xml;
 
 namespace TestForm

--- a/Source/Krypton Components/TestForm/OutlookGridTest.cs
+++ b/Source/Krypton Components/TestForm/OutlookGridTest.cs
@@ -46,12 +46,11 @@ namespace TestForm
             kryptonOutlookGrid1.ClearInternalRows();
             kryptonOutlookGrid1.FillMode = GridFillMode.GroupsAndNodes;
 
-            List<Token> tokensList = new List<Token>();
-            tokensList.Add(new Token("Best seller", Color.Orange, Color.Black));
-            tokensList.Add(new Token("New", Color.LightGreen, Color.Black));
-            tokensList.Add(null);
-            tokensList.Add(null);
-            tokensList.Add(null);
+            List<Token> tokensList =
+            [
+                new Token("Best seller", Color.Orange, Color.Black),
+                new Token("New", Color.LightGreen, Color.Black)
+            ];
 
             Random random = new Random();
 

--- a/Source/Krypton Components/TestForm/ToastNotificationQuickTestForm.cs
+++ b/Source/Krypton Components/TestForm/ToastNotificationQuickTestForm.cs
@@ -8,12 +8,6 @@
 #endregion
 
 using System.Collections;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace TestForm
 {

--- a/Source/Krypton Components/TestForm/TreeViewExample.cs
+++ b/Source/Krypton Components/TestForm/TreeViewExample.cs
@@ -19,25 +19,25 @@ namespace TestForm
         {
             InitializeComponent();
 
-            buttonAppend_Click(null, EventArgs.Empty);
-            buttonInsert_Click(null, EventArgs.Empty);
-            buttonInsert_Click(null, EventArgs.Empty);
-            buttonInsert_Click(null, EventArgs.Empty);
+            buttonAppend_Click(this, EventArgs.Empty);
+            buttonInsert_Click(this, EventArgs.Empty);
+            buttonInsert_Click(this, EventArgs.Empty);
+            buttonInsert_Click(this, EventArgs.Empty);
             ktvTest.SelectedNode = null;
-            buttonAppend_Click(null, EventArgs.Empty);
-            buttonInsert_Click(null, EventArgs.Empty);
-            buttonInsert_Click(null, EventArgs.Empty);
+            buttonAppend_Click(this, EventArgs.Empty);
+            buttonInsert_Click(this, EventArgs.Empty);
+            buttonInsert_Click(this, EventArgs.Empty);
             ktvTest.SelectedNode = null;
-            buttonAppend_Click(null, EventArgs.Empty);
-            buttonInsert_Click(null, EventArgs.Empty);
+            buttonAppend_Click(this, EventArgs.Empty);
+            buttonInsert_Click(this, EventArgs.Empty);
             ktvTest.SelectedNode = null;
-            buttonAppend_Click(null, EventArgs.Empty);
-            buttonAppend_Click(null, EventArgs.Empty);
+            buttonAppend_Click(this, EventArgs.Empty);
+            buttonAppend_Click(this, EventArgs.Empty);
         }
 
         private KryptonTreeNode CreateNewItem()
         {
-            KryptonTreeNode item = new KryptonTreeNode
+            var item = new KryptonTreeNode
             {
                 Text = $@"Item {_next++}",
                 ImageIndex = _random.Next(imageList.Images.Count - 1)
@@ -80,7 +80,7 @@ namespace TestForm
             }
             else
             {
-                buttonAppend_Click(null, EventArgs.Empty);
+                buttonAppend_Click(sender, EventArgs.Empty);
             }
         }
 

--- a/Source/Krypton Components/TestForm/UserInputToastNotificationTest.cs
+++ b/Source/Krypton Components/TestForm/UserInputToastNotificationTest.cs
@@ -19,12 +19,6 @@ namespace TestForm
 
         private bool _useRTLReading;
 
-        private bool _boolResult;
-
-        private CheckState _checkStateResult;
-
-        private DateTime _dateTimeResult;
-
         private string _stringResult;
 
         private int _integerResult;


### PR DESCRIPTION
![image](https://github.com/Krypton-Suite/Standard-Toolkit/assets/2418812/c5d8462d-b4e7-408e-bae8-53ce418363ba)

- Also remove some warnings from the "TestForm" project
#1461

![image](https://github.com/Krypton-Suite/Standard-Toolkit/assets/2418812/72532b4f-91cb-4162-80cf-cbc9bc844707)
