### PR TITLE
1418-cleanup-warnings-0043

### DIFF
--- a/Source/Krypton Components/Krypton.Ribbon/Palette/PaletteRibbonStyles.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Palette/PaletteRibbonStyles.cs
@@ -34,10 +34,10 @@ namespace Krypton.Ribbon
         {
             Debug.Assert(_ribbon is not null);
 
-            _ribbon = ribbon; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(ribbon));
+            _ribbon = ribbon;
 
             // Store the provided paint notification delegate
-            NeedPaint = needPaint; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(needPaint));
+            NeedPaint = needPaint;
         }
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecManagerBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecManagerBase.cs
@@ -69,7 +69,7 @@ namespace Krypton.Toolkit
             Debug.Assert(getRenderer is not null);
 
             // Remember references
-            Control = control; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(control));
+            Control = control;
             _redirector = redirector;
             _variableSpecs = variableSpecs;
             _fixedSpecs = fixedSpecs;
@@ -77,7 +77,7 @@ namespace Krypton.Toolkit
             _viewMetricIntOutside = viewMetricIntOutside;
             _viewMetricIntInside = viewMetricIntInside;
             _viewMetricPaddings = viewMetricPaddings;
-            _getRenderer = getRenderer; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(getRenderer));
+            _getRenderer = getRenderer;
             NeedPaint = needPaint;
 
             if (_viewMetrics != null)

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/ButtonController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/ButtonController.cs
@@ -101,7 +101,7 @@ namespace Krypton.Toolkit
             AllowDragging = false;
             _dragging = false;
             ClickOnDown = false;
-            Target = target!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(target));
+            Target = target!;
             Repeat = false;
             NeedPaint = needPaint;
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/CheckBoxController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/CheckBoxController.cs
@@ -50,8 +50,8 @@ namespace Krypton.Toolkit
             // Remember target for state changes
             // Debug.Assert() causes the null assignment warning.
             // Suppressed by the null forgiving operator
-            _target = target!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(target));
-            _top = top!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(top));
+            _target = target!;
+            _top = top!;
             NeedPaint = needPaint;
         }
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/LinkLabelController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/LinkLabelController.cs
@@ -64,7 +64,7 @@ namespace Krypton.Toolkit
             Debug.Assert(target is not null);
 
             // Remember target for state changes
-            _target = target!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(target));
+            _target = target!;
             _paletteDisabled = paletteDisabled;
             _paletteNormal = paletteNormal;
             _paletteTracking = paletteTracking;

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/MenuCheckBoxController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/MenuCheckBoxController.cs
@@ -56,10 +56,10 @@ namespace Krypton.Toolkit
             Debug.Assert(checkBox is not null);
             Debug.Assert(needPaint is not null);
 
-            ViewManager = viewManager!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(viewManager));
-            _target = target!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(target));
-            _menuCheckBox = checkBox!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(checkBox));
-            NeedPaint = needPaint; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(needPaint));
+            ViewManager = viewManager!;
+            _target = target!;
+            _menuCheckBox = checkBox!;
+            NeedPaint = needPaint;
         }
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/MenuCheckButtonController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/MenuCheckButtonController.cs
@@ -56,10 +56,10 @@ namespace Krypton.Toolkit
             Debug.Assert(checkButton is not null);
             Debug.Assert(needPaint is not null);
 
-            ViewManager = viewManager!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(viewManager));
-            _target = target!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(target));
-            _menuCheckButton = checkButton!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(checkButton));
-            NeedPaint = needPaint; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(needPaint));
+            ViewManager = viewManager!;
+            _target = target!;
+            _menuCheckButton = checkButton!;
+            NeedPaint = needPaint;
 
             // Set initial display state
             UpdateTarget();

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/MenuColorBlockController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/MenuColorBlockController.cs
@@ -55,10 +55,10 @@ namespace Krypton.Toolkit
             Debug.Assert(colorBlock is not null);
             Debug.Assert(needPaint is not null);
 
-            ViewManager = viewManager!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(viewManager));
-            _target = target!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(target));
-            _menuColorBlock = colorBlock!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(colorBlock));
-            NeedPaint = needPaint; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(needPaint));
+            ViewManager = viewManager!;
+            _target = target!;
+            _menuColorBlock = colorBlock!;
+            NeedPaint = needPaint;
 
             // Set initial display state
             UpdateTarget();

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/MenuImageSelectController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/MenuImageSelectController.cs
@@ -58,10 +58,10 @@ namespace Krypton.Toolkit
             Debug.Assert(needPaint is not null);
 
             MousePoint = CommonHelper.NullPoint;
-            _viewManager = viewManager!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(viewManager));
-            _target = target!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(target));
-            _layout = layout!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(layout));
-            NeedPaint = needPaint!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(needPaint));
+            _viewManager = viewManager!;
+            _target = target!;
+            _layout = layout!;
+            NeedPaint = needPaint!;
         }
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/MenuItemController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/MenuItemController.cs
@@ -42,9 +42,9 @@ namespace Krypton.Toolkit
             Debug.Assert(menuItem is not null);
             Debug.Assert(needPaint is not null);
 
-            ViewManager = viewManager!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(viewManager));
-            _menuItem = menuItem!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(menuItem));
-            NeedPaint = needPaint; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(needPaint));
+            ViewManager = viewManager!;
+            _menuItem = menuItem!;
+            NeedPaint = needPaint;
         }
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/MenuLinkLabelController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/MenuLinkLabelController.cs
@@ -56,10 +56,10 @@ namespace Krypton.Toolkit
             Debug.Assert(linkLabel is not null);
             Debug.Assert(needPaint is not null);
 
-            ViewManager = viewManager!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(viewManager));
-            _target = target!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(target));
-            _menuLinkLabel = linkLabel!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(linkLabel));
-            NeedPaint = needPaint; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(needPaint));
+            ViewManager = viewManager!;
+            _target = target!;
+            _menuLinkLabel = linkLabel!;
+            NeedPaint = needPaint;
         }
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/MenuRadioButtonController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/MenuRadioButtonController.cs
@@ -56,10 +56,10 @@ namespace Krypton.Toolkit
             Debug.Assert(radioButton is not null);
             Debug.Assert(needPaint is not null);
 
-            ViewManager = viewManager!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(viewManager));
-            _target = target!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(target));
-            _menuRadioButton = radioButton!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(radioButton));
-            NeedPaint = needPaint; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(needPaint));
+            ViewManager = viewManager!;
+            _target = target!;
+            _menuRadioButton = radioButton!;
+            NeedPaint = needPaint;
         }
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/RadioButtonController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/RadioButtonController.cs
@@ -47,9 +47,9 @@ namespace Krypton.Toolkit
             Debug.Assert(top is not null);
 
             // Remember target for state changes
-            _target = target!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(target));
-            _top = top!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(top));
-            NeedPaint = needPaint; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(needPaint));
+            _target = target!;
+            _top = top!;
+            NeedPaint = needPaint;
         }
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPanel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPanel.cs
@@ -67,9 +67,9 @@ namespace Krypton.Toolkit
             Debug.Assert(stateNormal is not null);
 
             // Remember the palette storage
-            _stateCommon = stateCommon!; //TEST-NoThrow ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull(nameof(stateCommon)));
-            _stateDisabled = stateDisabled; //TEST-NoThrow ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull(nameof(stateDisabled)));
-            _stateNormal = stateNormal; //TEST-NoThrow ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull(nameof(stateNormal)));
+            _stateCommon = stateCommon!;
+            _stateDisabled = stateDisabled;
+            _stateNormal = stateNormal;
 
             Construct();
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDouble/PaletteDoubleMetricRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDouble/PaletteDoubleMetricRedirect.cs
@@ -52,7 +52,7 @@ namespace Krypton.Toolkit
                    borderStyle,
                    needPaint) =>
             // Remember the redirect reference
-            _redirect = redirect; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(redirect));
+            _redirect = redirect;
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteElementColor/PaletteElementColorInheritRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteElementColor/PaletteElementColorInheritRedirect.cs
@@ -35,7 +35,7 @@ namespace Krypton.Toolkit
             // Suppressed by the null forgiving operator
             Debug.Assert(redirect is not null);
 
-            _redirect = redirect!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(redirect));
+            _redirect = redirect!;
             Element = element;
         }
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteMetric/PaletteMetricRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteMetric/PaletteMetricRedirect.cs
@@ -34,7 +34,7 @@ namespace Krypton.Toolkit
             Debug.Assert(redirect is not null);
 
             // Remember the redirect reference
-            _redirect = redirect!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(redirect));
+            _redirect = redirect!;
         }
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonBackRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonBackRedirect.cs
@@ -45,12 +45,6 @@ namespace Krypton.Toolkit
             // Store the provided paint notification delegate
             NeedPaint = needPaint;
 
-            //TEST-NoThrow
-            //if (redirect is null)
-            //{
-            //    throw new ArgumentNullException(nameof(redirect));
-            //}
-
             // Store the inherit instances
             _inheritBack = new PaletteRibbonBackInheritRedirect(redirect!, backStyle);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonDoubleInheritRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonDoubleInheritRedirect.cs
@@ -37,7 +37,7 @@ namespace Krypton.Toolkit
             // Suppressed by the null forgiving operator
             Debug.Assert(redirect is not null);
 
-            _redirect = redirect!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(redirect));
+            _redirect = redirect!;
             StyleBack = styleBack;
             StyleText = styleText;
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonDoubleRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonDoubleRedirect.cs
@@ -47,12 +47,6 @@ namespace Krypton.Toolkit
             // Suppressed by the null forgiving operator
             Debug.Assert(redirect is not null);
 
-            //TEST-NoThrow
-            //if ( redirect is null)
-            //{
-            //    throw new ArgumentNullException(nameof(redirect));
-            //}
-
             // Store the provided paint notification delegate
             NeedPaint = needPaint;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonTextInheritRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRibbon/PaletteRibbonTextInheritRedirect.cs
@@ -35,7 +35,7 @@ namespace Krypton.Toolkit
             // Suppressed by the null forgiving operator
             Debug.Assert(redirect is not null);
 
-            _redirect = redirect!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(redirect));
+            _redirect = redirect!;
             StyleText = styleText;
         }
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTab/PaletteTabTripleRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTab/PaletteTabTripleRedirect.cs
@@ -47,12 +47,6 @@ namespace Krypton.Toolkit
             // Store the provided paint notification delegate
             NeedPaint = needPaint;
 
-            //TEST-NoThrow
-            //if (redirect is null)
-            //{
-            //    throw new ArgumentNullException(nameof(redirect));
-            //}
-
             // Store the inherit instances
             _backInherit = new PaletteBackInheritRedirect(redirect!, backStyle);
             _borderInherit = new PaletteBorderInheritRedirect(redirect!, borderStyle);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTripleJustImage.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTripleJustImage.cs
@@ -40,12 +40,6 @@ namespace Krypton.Toolkit
             // Suppressed by the null forgiving operator
             Debug.Assert(inherit is not null);
 
-            //TEST-NoThrow
-            //if (inherit is null)
-            //{
-            //    throw new ArgumentNullException(nameof(inherit));
-            //}
-
             // Store the provided paint notification delegate
             NeedPaint = needPaint;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTripleJustImageRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTripleJustImageRedirect.cs
@@ -68,12 +68,6 @@ namespace Krypton.Toolkit
                                               PaletteContentStyle contentStyle,
                                               NeedPaintHandler? needPaint)
         {
-            //TEST-NoThrow
-            //if (redirect is null)
-            //{
-            //    throw new ArgumentNullException(nameof(redirect));
-            //}
-
             // Store the provided paint notification delegate
             NeedPaint = needPaint;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTripleMetricRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTripleMetricRedirect.cs
@@ -47,7 +47,7 @@ namespace Krypton.Toolkit
             Debug.Assert(redirect is not null);
 
             // Remember the redirect reference
-            _redirect = redirect!; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(redirect));
+            _redirect = redirect!;
         }
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTripleRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTripleRedirect.cs
@@ -71,12 +71,6 @@ namespace Krypton.Toolkit
             // Store the provided paint notification delegate
             NeedPaint = needPaint;
 
-            //TEST-NoThrow
-            //if (redirect is null)
-            //{
-            //    throw new ArgumentNullException(nameof(redirect));
-            //}
-
             // Store the inherit instances
             _backInherit = new PaletteBackInheritRedirect(redirect, backStyle);
             _borderInherit = new PaletteBorderInheritRedirect(redirect, borderStyle);

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawCanvas.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawCanvas.cs
@@ -63,7 +63,7 @@ namespace Krypton.Toolkit
             // Cache the starting values
             _paletteBorder = paletteBorder;
             _paletteBack = paletteBack;
-            _paletteMetric = paletteMetric; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(paletteMetric));
+            _paletteMetric = paletteMetric;
             _metricPadding = metricPadding;
             Orientation = orientation;
             IncludeBorderEdge = orientation;

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawSplitCanvas.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawSplitCanvas.cs
@@ -69,7 +69,7 @@ namespace Krypton.Toolkit
                 ForceDraw = InheritBool.True
             };
             _paletteBackLight = new PaletteBackLightenColors(PaletteBack);
-            PaletteMetric = paletteMetric; //TEST-NoThrow ?? throw new ArgumentNullException(nameof(paletteMetric));
+            PaletteMetric = paletteMetric;
             _metricPadding = metricPadding;
             Orientation = orientation;
             DrawTabBorder = false;


### PR DESCRIPTION
1418-cleanup-warnings-0043
[issue 1418](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1418)
Remove disabled null checks

This concludes the removal of warnings.

![compile-results](https://github.com/Krypton-Suite/Standard-Toolkit/assets/96108132/33e3f6bc-4960-4718-9752-6105cbafb088)
