### PR TITLE
1388-drop-button-icon-is-not-drawn

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
+* Resolved [#1388](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1388) `KryptonButton` and `KryptonDropButton` do not react to theme changes and setting a custom color.
 * Resolved [#1497](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1497) When pressing ALT to show the Ribbon KeyTips a null reference exception is thrown.
 * Resolved [#1462](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1462) TestForm app: KCombobox from main.cs causes a crash
 * Resolved [#1414](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1414) `SetDate` API is missing from `KryptonMonthCalendar`

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonButton.cs
@@ -689,34 +689,17 @@ namespace Krypton.Toolkit
         {
             if (Values.UseAsADialogButton)
             {
-                if (DialogResult == DialogResult.Abort)
+                Text = DialogResult switch
                 {
-                    Text = KryptonManager.Strings.GeneralStrings.Abort;
-                }
-                else if (DialogResult == DialogResult.Cancel)
-                {
-                    Text = KryptonManager.Strings.GeneralStrings.Cancel;
-                }
-                else if (DialogResult == DialogResult.OK)
-                {
-                    Text = KryptonManager.Strings.GeneralStrings.OK;
-                }
-                else if (DialogResult == DialogResult.Yes)
-                {
-                    Text = KryptonManager.Strings.GeneralStrings.Yes;
-                }
-                else if (DialogResult == DialogResult.No)
-                {
-                    Text = KryptonManager.Strings.GeneralStrings.No;
-                }
-                else if (DialogResult == DialogResult.Retry)
-                {
-                    Text = KryptonManager.Strings.GeneralStrings.Retry;
-                }
-                else if (DialogResult == DialogResult.Ignore)
-                {
-                    Text = KryptonManager.Strings.GeneralStrings.Ignore;
-                }
+                    DialogResult.Abort => KryptonManager.Strings.GeneralStrings.Abort,
+                    DialogResult.Cancel => KryptonManager.Strings.GeneralStrings.Cancel,
+                    DialogResult.OK => KryptonManager.Strings.GeneralStrings.OK,
+                    DialogResult.Yes => KryptonManager.Strings.GeneralStrings.Yes,
+                    DialogResult.No => KryptonManager.Strings.GeneralStrings.No,
+                    DialogResult.Retry => KryptonManager.Strings.GeneralStrings.Retry,
+                    DialogResult.Ignore => KryptonManager.Strings.GeneralStrings.Ignore,
+                    _ => Text
+                };
             }
 
             if (Values.UseAsUACElevationButton)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonButton.cs
@@ -257,7 +257,7 @@ namespace Krypton.Toolkit
 
         //[Category(@"Visuals"), Description(@"UAC Shield Values"), DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         //public UACShieldValues UACShieldValues { get; }
-
+            
         //private bool ShouldSerializeUACShieldValues() => !UACShieldValues.IsDefault;
 
         /// <summary>
@@ -693,33 +693,27 @@ namespace Krypton.Toolkit
                 {
                     Text = KryptonManager.Strings.GeneralStrings.Abort;
                 }
-
-                if (DialogResult == DialogResult.Cancel)
+                else if (DialogResult == DialogResult.Cancel)
                 {
                     Text = KryptonManager.Strings.GeneralStrings.Cancel;
                 }
-
-                if (DialogResult == DialogResult.OK)
+                else if (DialogResult == DialogResult.OK)
                 {
                     Text = KryptonManager.Strings.GeneralStrings.OK;
                 }
-
-                if (DialogResult == DialogResult.Yes)
+                else if (DialogResult == DialogResult.Yes)
                 {
                     Text = KryptonManager.Strings.GeneralStrings.Yes;
                 }
-
-                if (DialogResult == DialogResult.No)
+                else if (DialogResult == DialogResult.No)
                 {
                     Text = KryptonManager.Strings.GeneralStrings.No;
                 }
-
-                if (DialogResult == DialogResult.Retry)
+                else if (DialogResult == DialogResult.Retry)
                 {
                     Text = KryptonManager.Strings.GeneralStrings.Retry;
                 }
-
-                if (DialogResult == DialogResult.Ignore)
+                else if (DialogResult == DialogResult.Ignore)
                 {
                     Text = KryptonManager.Strings.GeneralStrings.Ignore;
                 }
@@ -955,9 +949,13 @@ namespace Krypton.Toolkit
 
             midPoint.X += (rectangle.Width % 2);
 
-            Color color = dropDownArrowColor ?? Color.Black;
+            // Testing for null and EMPTY_COLOR, makes the arrow color react to theme changes, 
+            // otherwise a custom color is in effect.
+            Color? color = dropDownArrowColor is not null && dropDownArrowColor != GlobalStaticValues.EMPTY_COLOR
+                ? dropDownArrowColor
+                : KryptonManager.CurrentGlobalPalette.GetContentShortTextColor1(PaletteContentStyle.ButtonStandalone, PaletteState.Normal);
 
-            SolidBrush dropDownBrush = new SolidBrush(color);
+            SolidBrush dropDownBrush = new SolidBrush(color.Value);
 
             var arrow = new Point[]
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Values/ButtonValues.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/ButtonValues.cs
@@ -385,9 +385,9 @@ namespace Krypton.Toolkit
 
             set
             {
-                if (_dropDownArrowColor != null)
+                if (_dropDownArrowColor != value)
                 {
-                    _dropDownArrowColor = value;
+                    _dropDownArrowColor = value ?? GlobalStaticValues.EMPTY_COLOR;
 
                     PerformNeedPaint(true);
                 }


### PR DESCRIPTION
1388-drop-button-icon-is-not-drawn
[issue 1388](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1388)

Kbutton has been changed so the arrow color reacts to theme changes.
Also KDropButton was affected by this, but only needed the change in ButtonValues.cs.

On the way the code block in `KButton.cs` method `OnPaint` of multiple if statement testing for a `DialogResult` value has been transformed into an if else if block.

https://github.com/Krypton-Suite/Standard-Toolkit/assets/96108132/25b7be13-9e6c-46aa-91e0-2f039df26677

![compile-results](https://github.com/Krypton-Suite/Standard-Toolkit/assets/96108132/cd7f70b9-6e63-4981-b7da-e116ac2f0cdb)
