### PR TITLE
1388-v85-drop-button-icon-is-not-drawn

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-06-24 - Build 2406 (Patch 3) - June 2024
+* Resolved [#1388](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1388) `KryptonButton` and `KryptonDropButton` Dropdown arrow color does not react to theme changes and is not visible.
 * Resolved [#1424](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1424), **Breaking Change** `KryptonMessageBox` does not obey tab characters like `MessageBox`
 * Resolved [#1383](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1383), Closing last Page in undocked page group prevents addition of further Pages via `KryptonDockingManager.AddToWorkspace`
 * Resolved [#1381](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1381), **[Regression]** Docking Persistence broken since build ##.23.10.303

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonButton.cs
@@ -770,40 +770,17 @@ namespace Krypton.Toolkit
         {
             if (_useAsDialogButton)
             {
-                if (DialogResult == DialogResult.Abort)
+                Text = DialogResult switch
                 {
-                    Text = KryptonLanguageManager.GeneralToolkitStrings.Abort;
-                }
-
-                if (DialogResult == DialogResult.Cancel)
-                {
-                    Text = KryptonLanguageManager.GeneralToolkitStrings.Cancel;
-                }
-
-                if (DialogResult == DialogResult.OK)
-                {
-                    Text = KryptonLanguageManager.GeneralToolkitStrings.OK;
-                }
-
-                if (DialogResult == DialogResult.Yes)
-                {
-                    Text = KryptonLanguageManager.GeneralToolkitStrings.Yes;
-                }
-
-                if (DialogResult == DialogResult.No)
-                {
-                    Text = KryptonLanguageManager.GeneralToolkitStrings.No;
-                }
-
-                if (DialogResult == DialogResult.Retry)
-                {
-                    Text = KryptonLanguageManager.GeneralToolkitStrings.Retry;
-                }
-
-                if (DialogResult == DialogResult.Ignore)
-                {
-                    Text = KryptonLanguageManager.GeneralToolkitStrings.Ignore;
-                }
+                    DialogResult.Abort => KryptonLanguageManager.GeneralToolkitStrings.Abort,
+                    DialogResult.Cancel => KryptonLanguageManager.GeneralToolkitStrings.Cancel,
+                    DialogResult.OK => KryptonLanguageManager.GeneralToolkitStrings.OK,
+                    DialogResult.Yes => KryptonLanguageManager.GeneralToolkitStrings.Yes,
+                    DialogResult.No => KryptonLanguageManager.GeneralToolkitStrings.No,
+                    DialogResult.Retry => KryptonLanguageManager.GeneralToolkitStrings.Retry,
+                    DialogResult.Ignore => KryptonLanguageManager.GeneralToolkitStrings.Ignore,
+                    _ => Text
+                };
             }
 
             base.OnPaint(e);
@@ -1124,7 +1101,12 @@ namespace Krypton.Toolkit
                 midPoint with { Y = midPoint.Y + 2 }
             };
 
-            graphics.FillPolygon(SystemBrushes.ControlText, arrow);
+            // Issue 1388, an adaptation from PR 1500 applied here to fix the color of the drop down arrow.
+            // This version does not have the customizable Values.DropArrowColor property.
+            // This applies the theme color and if something is null, it'll be Black.
+            SolidBrush brush = new( KryptonManager.CurrentGlobalPalette?.GetContentShortTextColor1(PaletteContentStyle.ButtonStandalone, PaletteState.Normal) ?? Color.Black );
+
+            graphics.FillPolygon(brush, arrow);
         }
 
         private void ShowContextMenuStrip()


### PR DESCRIPTION
1388-v85-drop-button-icon-is-not-drawn
An adaptation of 1388 alpha branch for the master-V85 branch.
Fixes the dropdown arrow colour.

https://github.com/Krypton-Suite/Standard-Toolkit/assets/96108132/913fa25f-1ca5-45b6-b5dd-7b7d4dee5e86

![compile-results](https://github.com/Krypton-Suite/Standard-Toolkit/assets/96108132/475d9909-91a7-4a48-8cb4-5f19a9ea0cdb)


