### PR TITLE
1328-v85-ThemeCBB-invalid-designer-code

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-06-24 - Build 2406 (Patch 3) - June 2024
+* Resolved [#1328](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1328) Tentative adjustment to bring PaletteMode and the theme dictionary in line.
 * Resolved [#1388](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1388) `KryptonButton` and `KryptonDropButton` Dropdown arrow color does not react to theme changes and is not visible.
 * Resolved [#1424](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1424), **Breaking Change** `KryptonMessageBox` does not obey tab characters like `MessageBox`
 * Resolved [#1383](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1383), Closing last Page in undocked page group prevents addition of further Pages via `KryptonDockingManager.AddToWorkspace`

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupThemeComboBox.cs
@@ -99,7 +99,8 @@ namespace Krypton.Ribbon
 
             _selectedIndex = SelectedIndex = _defaultPaletteIndex;
             _defaultPalette = PaletteMode.Microsoft365Blue;
-            Debug.Assert(_selectedIndex == _defaultPaletteIndex, $@"Microsoft365Blue needs to be at the index position of {_defaultPaletteIndex} for backward compatibility");
+            
+            Debug.Assert(_selectedIndex == (int)PaletteMode.Microsoft365Blue, "Selected index needs to be set to Microsoft365Blue for backward compatibility");
         }
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
@@ -94,13 +94,13 @@ namespace Krypton.Toolkit
 
             _defaultPalette = PaletteMode.Microsoft365Blue;
 
-            Debug.Assert(_selectedIndex == _defaultPaletteIndex, $@"Microsoft365Blue needs to be at the index position of {_defaultPaletteIndex} for backward compatibility");
+            Debug.Assert(_selectedIndex == (int)PaletteMode.Microsoft365Blue, "Selected index needs to be set to Microsoft365Blue for backward compatibility");
         }
         #endregion
 
         #region Implementation
 
-        private void UpdateDefaultPaletteIndex(PaletteMode mode) => ThemeSelectedIndex = (int)mode + 1;
+        private void UpdateDefaultPaletteIndex(PaletteMode mode) => ThemeSelectedIndex = (int)mode;// (int)mode + 1;
 
         /// <summary>Returns the palette mode.</summary>
         /// <returns>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeListBox.cs
@@ -35,9 +35,9 @@ namespace Krypton.Toolkit
             set => SelectedIndex = value;
         }
 
-        private void ResetThemeSelectedIndex() => _selectedThemeIndex = 33;
+        private void ResetThemeSelectedIndex() => _selectedThemeIndex = (int)PaletteMode.Microsoft365Blue;
 
-        private bool ShouldSerializeThemeSelectedIndex() => _selectedThemeIndex != 33;
+        private bool ShouldSerializeThemeSelectedIndex() => _selectedThemeIndex != (int)PaletteMode.Microsoft365Blue;
 
         /// <summary>
         /// Gets and sets the ThemeSelectedIndex.
@@ -67,7 +67,8 @@ namespace Krypton.Toolkit
             }
             Text = ThemeManager.ReturnPaletteModeAsString(PaletteMode.Microsoft365Blue);
             _selectedThemeIndex = SelectedIndex;
-            Debug.Assert(_selectedThemeIndex == 33, "Microsoft365Blue needs to be at the 33rd index for backward compatibility");
+            
+            Debug.Assert(_selectedThemeIndex == (int)PaletteMode.Microsoft365Blue, "_selectedThemeIndex needs to be set to Microsoft365Blue for backward compatibility");
         }
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteMode.cs
@@ -18,10 +18,22 @@ namespace Krypton.Toolkit
     [TypeConverter(typeof(PaletteModeConverter))]
     public enum PaletteMode
     {
+        /*
+         * Adjustements made as per ticket 1328.
+         * See: https://github.com/Krypton-Suite/Standard-Toolkit/issues/1328
+         * 
+         * These entries (also those disabled) are now sorted in the order of the SupportedThemes Dictionary.
+         * 
+         * By starting the enum at Global = -1 all following entries will have numbers assigned that are equivalent to 
+         * their respective Theme Dictionary position (PaletteModeStrings.SupportedThemes)
+         * 
+         * IT IS MANDATORY TO KEEP THE PALETTEMODE ENUM AND THE DICTIONARY IN THE SAME ORDER. 
+         */
+
         /// <summary>
         /// Specifies the renderer defined by the KryptonManager be used.
         /// </summary>
-        Global,
+        Global = -1,
 
         /// <summary>
         /// Specifies a professional appearance based on system settings.
@@ -32,17 +44,6 @@ namespace Krypton.Toolkit
         /// Specifies a professional appearance with a preference to use theme colors.
         /// </summary>
         ProfessionalOffice2003,
-
-        // ToDo: Re-enable when the gray themes are completed
-        /// <summary>
-        /// Specifies the dark Gray color variant of the Office 2007 appearance.
-        /// </summary>
-        Office2007DarkGray,
-        /*
-            /// <summary>
-            /// Specifies the light Gray color variant of the Office 2007 appearance.
-            /// </summary>
-            Office2007LightGray,*/
 
         /// <summary>
         /// Specifies the Blue color variant of the Office 2007 appearance.
@@ -89,16 +90,18 @@ namespace Krypton.Toolkit
         /// </summary>
         Office2007BlackDarkMode,
 
-        // ToDo: Re-enable when the gray themes are completed
         /// <summary>
-        /// Specifies the dark Gray color variant of the Office 2010 appearance.
+        /// Specifies the dark Gray color variant of the Office 2007 appearance.
         /// </summary>
-        Office2010DarkGray,
-        /*
-            /// <summary>
-            /// Specifies the light Gray color variant of the Office 2010 appearance.
-            /// </summary>
-            Office2010LightGray,*/
+        ///
+        Office2007DarkGray,
+
+        /* ToDo: Re-enable when the gray themes are completed
+        /// <summary>
+        /// Specifies the light Gray color variant of the Office 2007 appearance.
+        /// </summary>
+        Office2007LightGray,
+        */
 
         /// <summary>
         /// Specifies the Blue color variant of the Office 2010 appearance.
@@ -145,11 +148,23 @@ namespace Krypton.Toolkit
         /// </summary>
         Office2010BlackDarkMode,
 
-        // ToDo: Re-enable when the gray themes are completed
+        /// <summary>
+        /// Specifies the dark Gray color variant of the Office 2010 appearance.
+        /// </summary>
+        Office2010DarkGray,
+
+        /* ToDo: Re-enable when the gray themes are completed
+        /// <summary>
+        /// Specifies the light Gray color variant of the Office 2010 appearance.
+        /// </summary>
+        Office2010LightGray,
+        */
+
         /// <summary>
         /// Specifies the dark Gray color variant of the Office 2013 appearance.
         /// </summary>
         Office2013DarkGray,
+
         /// <summary>
         /// Specifies the light Gray color variant of the Office 2013 appearance.
         /// </summary>
@@ -159,62 +174,6 @@ namespace Krypton.Toolkit
         /// Specifies the White color variant of the Office 2013 appearance.
         /// </summary>
         Office2013White,
-
-        // ToDo: Re-enable when the gray themes are completed
-        /// <summary>
-        /// Specifies the dark Gray color variant of the Microsoft 365 appearance.
-        /// </summary>
-        Microsoft365DarkGray,
-        /*
-            /// <summary>
-            /// Specifies the light Gray color variant of the Microsoft 365 appearance.
-            /// </summary>
-            Microsoft365LightGray,*/
-
-        /// <summary>
-        /// Specifies the Black color variant of the Microsoft 365 appearance.
-        /// </summary>
-        Microsoft365Black,
-
-        /// <summary>
-        /// Specifies the dark Black color variant of the Microsoft 365 appearance.
-        /// </summary>
-        Microsoft365BlackDarkMode,
-
-        /// <summary>
-        /// Specifies the Blue color variant of the Microsoft 365 appearance.
-        /// </summary>
-        Microsoft365Blue,
-
-        /// <summary>
-        /// Specifies the dark Blue color variant of the Microsoft 365 appearance.
-        /// </summary>
-        Microsoft365BlueDarkMode,
-
-        /// <summary>
-        /// Specifies the light Blue color variant of the Microsoft 365 appearance.
-        /// </summary>
-        Microsoft365BlueLightMode,
-
-        /// <summary>
-        /// Specifies the Silver color variant of the Microsoft 365 appearance.
-        /// </summary>
-        Microsoft365Silver,
-
-        /// <summary>
-        /// Specifies the dark Silver color variant of the Microsoft 365 appearance.
-        /// </summary>
-        Microsoft365SilverDarkMode,
-
-        /// <summary>
-        /// Specifies the light Silver color variant of the Microsoft 365 appearance.
-        /// </summary>
-        Microsoft365SilverLightMode,
-
-        /// <summary>
-        /// Specifies the White color variant of the Microsoft 365 appearance.
-        /// </summary>
-        Microsoft365White,
 
         /// <summary>
         /// Specifies the Blue color variant on the Sparkle palette theme.
@@ -260,6 +219,64 @@ namespace Krypton.Toolkit
         /// Specifies the light Purple color variant on the Sparkle palette theme.
         /// </summary>
         SparklePurpleLightMode,
+
+        /// <summary>
+        /// Specifies the Blue color variant of the Microsoft 365 appearance.
+        /// </summary>
+        Microsoft365Blue,
+
+        /// <summary>
+        /// Specifies the dark Blue color variant of the Microsoft 365 appearance.
+        /// </summary>
+        Microsoft365BlueDarkMode,
+
+        /// <summary>
+        /// Specifies the light Blue color variant of the Microsoft 365 appearance.
+        /// </summary>
+        Microsoft365BlueLightMode,
+
+        /// <summary>
+        /// Specifies the Silver color variant of the Microsoft 365 appearance.
+        /// </summary>
+        Microsoft365Silver,
+
+        /// <summary>
+        /// Specifies the dark Silver color variant of the Microsoft 365 appearance.
+        /// </summary>
+        Microsoft365SilverDarkMode,
+
+        /// <summary>
+        /// Specifies the light Silver color variant of the Microsoft 365 appearance.
+        /// </summary>
+        Microsoft365SilverLightMode,
+
+        /// <summary>
+        /// Specifies the White color variant of the Microsoft 365 appearance.
+        /// </summary>
+        Microsoft365White,
+
+        /// <summary>
+        /// Specifies the Black color variant of the Microsoft 365 appearance.
+        /// </summary>
+        Microsoft365Black,
+
+        /// <summary>
+        /// Specifies the dark Black color variant of the Microsoft 365 appearance.
+        /// </summary>
+        Microsoft365BlackDarkMode,
+
+        /// <summary>
+        /// Specifies the dark Gray color variant of the Microsoft 365 appearance.
+        /// </summary>
+        Microsoft365DarkGray,
+
+
+        /* ToDo: Re-enable when the gray themes are completed
+        /// <summary>
+        /// Specifies the light Gray color variant of the Microsoft 365 appearance.
+        /// </summary>
+        Microsoft365LightGray,
+        */
 
         /// <summary>
         /// Specifies the visual studio 2010 palette theme, with the 2007 render.

--- a/Source/Krypton Components/Krypton.Toolkit/Translations/Converters/PaletteModeStrings.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Translations/Converters/PaletteModeStrings.cs
@@ -85,74 +85,104 @@ namespace Krypton.Toolkit
 
         #region Instance Fields
         internal static readonly BiDictionary<string, PaletteMode> SupportedThemes =
-    new BiDictionary<string, PaletteMode>(new Dictionary<string, PaletteMode>
-    {
-        // Use default strings, because these are used to match xml strings when importing palettes, and in the designer(s)
-                { DEFAULT_PALETTE_SYSTEM, PaletteMode.ProfessionalSystem },
-                { DEFAULT_PALETTE_OFFICE_2003, PaletteMode.ProfessionalOffice2003 },
-                { DEFAULT_PALETTE_OFFICE_2007_BLUE, PaletteMode.Office2007Blue },
-                { DEFAULT_PALETTE_OFFICE_2007_BLUE_DARK_MODE, PaletteMode.Office2007BlueDarkMode },
-                { DEFAULT_PALETTE_OFFICE_2007_BLUE_LIGHT_MODE, PaletteMode.Office2007BlueLightMode },
-                { DEFAULT_PALETTE_OFFICE_2007_SILVER, PaletteMode.Office2007Silver },
-                { DEFAULT_PALETTE_OFFICE_2007_SILVER_DARK_MODE, PaletteMode.Office2007SilverDarkMode },
-                { DEFAULT_PALETTE_OFFICE_2007_SILVER_LIGHT_MODE, PaletteMode.Office2007SilverLightMode },
-                { DEFAULT_PALETTE_OFFICE_2007_WHITE, PaletteMode.Office2007White },
-                { DEFAULT_PALETTE_OFFICE_2007_BLACK, PaletteMode.Office2007Black },
-                { DEFAULT_PALETTE_OFFICE_2007_BLACK_DARK_MODE, PaletteMode.Office2007BlackDarkMode },
-                //{ DEFAULT_PALETTE_OFFICE_2007_DARK_GRAY, PaletteMode.Office2007DarkGray },
-                //{ PaletteModeStrings.DEFAULT_PALETTE_OFFICE_2007_LIGHT_GRAY, PaletteMode.Office2007LightGray },
-                { DEFAULT_PALETTE_OFFICE_2010_BLUE, PaletteMode.Office2010Blue },
-                { DEFAULT_PALETTE_OFFICE_2010_BLUE_DARK_MODE, PaletteMode.Office2010BlueDarkMode },
-                { DEFAULT_PALETTE_OFFICE_2010_BLUE_LIGHT_MODE, PaletteMode.Office2010BlueLightMode },
-                { DEFAULT_PALETTE_OFFICE_2010_SILVER, PaletteMode.Office2010Silver },
-                { DEFAULT_PALETTE_OFFICE_2010_SILVER_DARK_MODE, PaletteMode.Office2010SilverDarkMode },
-                { DEFAULT_PALETTE_OFFICE_2010_SILVER_LIGHT_MODE, PaletteMode.Office2010SilverLightMode },
-                { DEFAULT_PALETTE_OFFICE_2010_WHITE, PaletteMode.Office2010White },
-                { DEFAULT_PALETTE_OFFICE_2010_BLACK, PaletteMode.Office2010Black },
-                { DEFAULT_PALETTE_OFFICE_2010_BLACK_DARK_MODE, PaletteMode.Office2010BlackDarkMode },
-                //{ DEFAULT_PALETTE_OFFICE_2010_DARK_GRAY, PaletteMode.Office2010DarkGray },
-                //{ PaletteModeStrings.DEFAULT_PALETTE_OFFICE_2010_LIGHT_GRAY, PaletteMode.Office2010LightGray },
-                //{ DEFAULT_PALETTE_OFFICE_2013_DARK_GRAY, PaletteMode.Office2013DarkGray },
-                //{ PaletteModeStrings.DEFAULT_PALETTE_OFFICE_2013_LIGHT_GRAY, PaletteMode.Office2013LightGray },
-                { DEFAULT_PALETTE_OFFICE_2013_WHITE, PaletteMode.Office2013White },
-                { DEFAULT_PALETTE_SPARKLE_BLUE, PaletteMode.SparkleBlue },
-                { DEFAULT_PALETTE_SPARKLE_BLUE_DARK_MODE, PaletteMode.SparkleBlueDarkMode },
-                { DEFAULT_PALETTE_SPARKLE_BLUE_LIGHT_MODE, PaletteMode.SparkleBlueLightMode },
-                { DEFAULT_PALETTE_SPARKLE_ORANGE, PaletteMode.SparkleOrange },
-                { DEFAULT_PALETTE_SPARKLE_ORANGE_DARK_MODE, PaletteMode.SparkleOrangeDarkMode },
-                { DEFAULT_PALETTE_SPARKLE_ORANGE_LIGHT_MODE, PaletteMode.SparkleOrangeLightMode },
-                { DEFAULT_PALETTE_SPARKLE_PURPLE, PaletteMode.SparklePurple },
-                { DEFAULT_PALETTE_SPARKLE_PURPLE_DARK_MODE, PaletteMode.SparklePurpleDarkMode },
-                { DEFAULT_PALETTE_SPARKLE_PURPLE_LIGHT_MODE, PaletteMode.SparklePurpleLightMode },
-                { DEFAULT_PALETTE_MICROSOFT_365_BLUE, PaletteMode.Microsoft365Blue },
-                { DEFAULT_PALETTE_MICROSOFT_365_BLUE_DARK_MODE, PaletteMode.Microsoft365BlueDarkMode },
-                { DEFAULT_PALETTE_MICROSOFT_365_BLUE_LIGHT_MODE, PaletteMode.Microsoft365BlueLightMode },
-                { DEFAULT_PALETTE_MICROSOFT_365_SILVER, PaletteMode.Microsoft365Silver },
-                { DEFAULT_PALETTE_MICROSOFT_365_SILVER_DARK_MODE, PaletteMode.Microsoft365SilverDarkMode },
-                { DEFAULT_PALETTE_MICROSOFT_365_SILVER_LIGHT_MODE, PaletteMode.Microsoft365SilverLightMode },
-                { DEFAULT_PALETTE_MICROSOFT_365_WHITE, PaletteMode.Microsoft365White },
-                { DEFAULT_PALETTE_MICROSOFT_365_BLACK, PaletteMode.Microsoft365Black },
-                { DEFAULT_PALETTE_MICROSOFT_365_BLACK_DARK_MODE, PaletteMode.Microsoft365BlackDarkMode },
-                { DEFAULT_PALETTE_MICROSOFT_365_DARK_GRAY, PaletteMode.Microsoft365DarkGray },
-                //{ PaletteModeStrings.DEFAULT_PALETTE_MICROSOFT_365_LIGHT_GRAY, PaletteMode.Microsoft365LightGray },
-                { DEFAULT_PALETTE_VISUAL_STUDIO_2010_RENDER_2007, PaletteMode.VisualStudio2010Render2007 },
-                { DEFAULT_PALETTE_VISUAL_STUDIO_2010_RENDER_2010, PaletteMode.VisualStudio2010Render2010 },
-                { DEFAULT_PALETTE_VISUAL_STUDIO_2010_RENDER_2013, PaletteMode.VisualStudio2010Render2013 },
-                { DEFAULT_PALETTE_VISUAL_STUDIO_2010_RENDER_365, PaletteMode.VisualStudio2010Render365 },
-                //{ DEFAULT_PALETTE_VISUAL_STUDIO_2012_DARK_MODE, PaletteMode.VisualStudio2012DarkMode },
-                //{ DEFAULT_PALETTE_VISUAL_STUDIO_2012_LIGHT_MODE, PaletteMode.VisualStudio2012LightMode },
-                //{ DEFAULT_PALETTE_VISUAL_STUDIO_2013_DARK_MODE, PaletteMode.VisualStudio2013DarkMode },
-                //{ DEFAULT_PALETTE_VISUAL_STUDIO_2013_LIGHT_MODE, PaletteMode.VisualStudio2013LightMode },
-                //{ DEFAULT_PALETTE_VISUAL_STUDIO_2015_DARK_MODE, PaletteMode.VisualStudio2015DarkMode },
-                //{ DEFAULT_PALETTE_VISUAL_STUDIO_2015_LIGHT_MODE, PaletteMode.VisualStudio2015LightMode },
-                //{ DEFAULT_PALETTE_VISUAL_STUDIO_2017_DARK_MODE, PaletteMode.VisualStudio2017DarkMode },
-                //{ DEFAULT_PALETTE_VISUAL_STUDIO_2017_LIGHT_MODE, PaletteMode.VisualStudio2017LightMode },
-                //{ DEFAULT_PALETTE_VISUAL_STUDIO_2019_DARK_MODE, PaletteMode.VisualStudio2019DarkMode },
-                //{ DEFAULT_PALETTE_VISUAL_STUDIO_2019_LIGHT_MODE, PaletteMode.VisualStudio2019LightMode },
-                //{ DEFAULT_PALETTE_VISUAL_STUDIO_2022_DARK_MODE, PaletteMode.VisualStudio2022DarkMode },
-                //{ DEFAULT_PALETTE_VISUAL_STUDIO_2022_LIGHT_MODE, PaletteMode.VisualStudio2022LightMode },
-                { DEFAULT_PALETTE_CUSTOM, PaletteMode.Custom }
-    });
+            new BiDictionary<string, PaletteMode>(new Dictionary<string, PaletteMode>
+        {
+            /*
+             * Adjustements made as per ticket 1328.
+             * See: https://github.com/Krypton-Suite/Standard-Toolkit/issues/1328
+             * 
+             * When ever this list is changed, inspect the PaletteMode enum for consistency.
+             * 
+             * IT IS MANDATORY TO KEEP THE PALETTEMODE ENUM AND THE DICTIONARY IN THE SAME ORDER.
+             */
+
+            // Use default strings, because these are used to match xml strings when importing palettes, and in the designer(s)
+            { DEFAULT_PALETTE_SYSTEM, PaletteMode.ProfessionalSystem },
+            { DEFAULT_PALETTE_OFFICE_2003, PaletteMode.ProfessionalOffice2003 },
+
+            { DEFAULT_PALETTE_OFFICE_2007_BLUE, PaletteMode.Office2007Blue },
+            { DEFAULT_PALETTE_OFFICE_2007_BLUE_DARK_MODE, PaletteMode.Office2007BlueDarkMode },
+            { DEFAULT_PALETTE_OFFICE_2007_BLUE_LIGHT_MODE, PaletteMode.Office2007BlueLightMode },
+
+            { DEFAULT_PALETTE_OFFICE_2007_SILVER, PaletteMode.Office2007Silver },
+            { DEFAULT_PALETTE_OFFICE_2007_SILVER_DARK_MODE, PaletteMode.Office2007SilverDarkMode },
+            { DEFAULT_PALETTE_OFFICE_2007_SILVER_LIGHT_MODE, PaletteMode.Office2007SilverLightMode },
+
+            { DEFAULT_PALETTE_OFFICE_2007_WHITE, PaletteMode.Office2007White },
+            { DEFAULT_PALETTE_OFFICE_2007_BLACK, PaletteMode.Office2007Black },
+            { DEFAULT_PALETTE_OFFICE_2007_BLACK_DARK_MODE, PaletteMode.Office2007BlackDarkMode },
+            
+            { DEFAULT_PALETTE_OFFICE_2007_DARK_GRAY, PaletteMode.Office2007DarkGray },
+            //{ DEFAULT_PALETTE_OFFICE_2007_LIGHT_GRAY, PaletteMode.Office2007LightGray },
+            
+            { DEFAULT_PALETTE_OFFICE_2010_BLUE, PaletteMode.Office2010Blue },
+            { DEFAULT_PALETTE_OFFICE_2010_BLUE_DARK_MODE, PaletteMode.Office2010BlueDarkMode },
+            { DEFAULT_PALETTE_OFFICE_2010_BLUE_LIGHT_MODE, PaletteMode.Office2010BlueLightMode },
+
+            { DEFAULT_PALETTE_OFFICE_2010_SILVER, PaletteMode.Office2010Silver },
+            { DEFAULT_PALETTE_OFFICE_2010_SILVER_DARK_MODE, PaletteMode.Office2010SilverDarkMode },
+            { DEFAULT_PALETTE_OFFICE_2010_SILVER_LIGHT_MODE, PaletteMode.Office2010SilverLightMode },
+
+            { DEFAULT_PALETTE_OFFICE_2010_WHITE, PaletteMode.Office2010White },
+            { DEFAULT_PALETTE_OFFICE_2010_BLACK, PaletteMode.Office2010Black },
+            { DEFAULT_PALETTE_OFFICE_2010_BLACK_DARK_MODE, PaletteMode.Office2010BlackDarkMode },
+            
+            { DEFAULT_PALETTE_OFFICE_2010_DARK_GRAY, PaletteMode.Office2010DarkGray },
+            //{ DEFAULT_PALETTE_OFFICE_2010_LIGHT_GRAY, PaletteMode.Office2010LightGray },
+            
+            { DEFAULT_PALETTE_OFFICE_2013_DARK_GRAY, PaletteMode.Office2013DarkGray },
+            { DEFAULT_PALETTE_OFFICE_2013_LIGHT_GRAY, PaletteMode.Office2013LightGray },
+            
+            { DEFAULT_PALETTE_OFFICE_2013_WHITE, PaletteMode.Office2013White },
+
+            { DEFAULT_PALETTE_SPARKLE_BLUE, PaletteMode.SparkleBlue },
+            { DEFAULT_PALETTE_SPARKLE_BLUE_DARK_MODE, PaletteMode.SparkleBlueDarkMode },
+            { DEFAULT_PALETTE_SPARKLE_BLUE_LIGHT_MODE, PaletteMode.SparkleBlueLightMode },
+
+            { DEFAULT_PALETTE_SPARKLE_ORANGE, PaletteMode.SparkleOrange },
+            { DEFAULT_PALETTE_SPARKLE_ORANGE_DARK_MODE, PaletteMode.SparkleOrangeDarkMode },
+            { DEFAULT_PALETTE_SPARKLE_ORANGE_LIGHT_MODE, PaletteMode.SparkleOrangeLightMode },
+
+            { DEFAULT_PALETTE_SPARKLE_PURPLE, PaletteMode.SparklePurple },
+            { DEFAULT_PALETTE_SPARKLE_PURPLE_DARK_MODE, PaletteMode.SparklePurpleDarkMode },
+            { DEFAULT_PALETTE_SPARKLE_PURPLE_LIGHT_MODE, PaletteMode.SparklePurpleLightMode },
+
+            { DEFAULT_PALETTE_MICROSOFT_365_BLUE, PaletteMode.Microsoft365Blue },
+            { DEFAULT_PALETTE_MICROSOFT_365_BLUE_DARK_MODE, PaletteMode.Microsoft365BlueDarkMode },
+            { DEFAULT_PALETTE_MICROSOFT_365_BLUE_LIGHT_MODE, PaletteMode.Microsoft365BlueLightMode },
+
+            { DEFAULT_PALETTE_MICROSOFT_365_SILVER, PaletteMode.Microsoft365Silver },
+            { DEFAULT_PALETTE_MICROSOFT_365_SILVER_DARK_MODE, PaletteMode.Microsoft365SilverDarkMode },
+            { DEFAULT_PALETTE_MICROSOFT_365_SILVER_LIGHT_MODE, PaletteMode.Microsoft365SilverLightMode },
+
+            { DEFAULT_PALETTE_MICROSOFT_365_WHITE, PaletteMode.Microsoft365White },
+
+            { DEFAULT_PALETTE_MICROSOFT_365_BLACK, PaletteMode.Microsoft365Black },
+            { DEFAULT_PALETTE_MICROSOFT_365_BLACK_DARK_MODE, PaletteMode.Microsoft365BlackDarkMode },
+
+            { DEFAULT_PALETTE_MICROSOFT_365_DARK_GRAY, PaletteMode.Microsoft365DarkGray },
+            
+            //{ DEFAULT_PALETTE_MICROSOFT_365_LIGHT_GRAY, PaletteMode.Microsoft365LightGray },
+
+            { DEFAULT_PALETTE_VISUAL_STUDIO_2010_RENDER_2007, PaletteMode.VisualStudio2010Render2007 },
+            { DEFAULT_PALETTE_VISUAL_STUDIO_2010_RENDER_2010, PaletteMode.VisualStudio2010Render2010 },
+            { DEFAULT_PALETTE_VISUAL_STUDIO_2010_RENDER_2013, PaletteMode.VisualStudio2010Render2013 },
+            { DEFAULT_PALETTE_VISUAL_STUDIO_2010_RENDER_365, PaletteMode.VisualStudio2010Render365 },
+
+            //{ DEFAULT_PALETTE_VISUAL_STUDIO_2012_DARK_MODE, PaletteMode.VisualStudio2012DarkMode },
+            //{ DEFAULT_PALETTE_VISUAL_STUDIO_2012_LIGHT_MODE, PaletteMode.VisualStudio2012LightMode },
+            //{ DEFAULT_PALETTE_VISUAL_STUDIO_2013_DARK_MODE, PaletteMode.VisualStudio2013DarkMode },
+            //{ DEFAULT_PALETTE_VISUAL_STUDIO_2013_LIGHT_MODE, PaletteMode.VisualStudio2013LightMode },
+            //{ DEFAULT_PALETTE_VISUAL_STUDIO_2015_DARK_MODE, PaletteMode.VisualStudio2015DarkMode },
+            //{ DEFAULT_PALETTE_VISUAL_STUDIO_2015_LIGHT_MODE, PaletteMode.VisualStudio2015LightMode },
+            //{ DEFAULT_PALETTE_VISUAL_STUDIO_2017_DARK_MODE, PaletteMode.VisualStudio2017DarkMode },
+            //{ DEFAULT_PALETTE_VISUAL_STUDIO_2017_LIGHT_MODE, PaletteMode.VisualStudio2017LightMode },
+            //{ DEFAULT_PALETTE_VISUAL_STUDIO_2019_DARK_MODE, PaletteMode.VisualStudio2019DarkMode },
+            //{ DEFAULT_PALETTE_VISUAL_STUDIO_2019_LIGHT_MODE, PaletteMode.VisualStudio2019LightMode },
+            //{ DEFAULT_PALETTE_VISUAL_STUDIO_2022_DARK_MODE, PaletteMode.VisualStudio2022DarkMode },
+            //{ DEFAULT_PALETTE_VISUAL_STUDIO_2022_LIGHT_MODE, PaletteMode.VisualStudio2022LightMode },
+            { DEFAULT_PALETTE_CUSTOM, PaletteMode.Custom }
+        });
 
         #endregion
 


### PR DESCRIPTION
1328-v85-ThemeCBB-invalid-designer-code
[Issue 1328](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1328)
Adjusts PaletteMode enum and SupportedThemes list.
Tentative adjustment to bring PaletteMode and the theme dictionary in line.

> I left the disabled entries in their place because the dictionary has them listed in the same order. If one is re-enabled again then it's in the right spot at once.
> 
> Keeping PaletteMode and the Dictionary in the same order will make it easier to maintain consistency.
> 
> In the future PaletteMode will not be used as an index anymore. Like you pointed out the needed values can be retrieved from the BiDirectional map in either way.
> 
> PaletteMode will then only serve as a unique identifier. That can be different per theme throughout builds.
> 
> That all will be implemented in the follow-up on this where all three selectors will be revised.

Will be continued in: https://github.com/Krypton-Suite/Standard-Toolkit/issues/1507

![compile-results](https://github.com/Krypton-Suite/Standard-Toolkit/assets/96108132/4171ab6e-8976-4707-9262-0f6fa2010e3d)
