### PR TITLE
1502-docking-persistence-2

### DIFF
--- a/Source/Krypton Components/Krypton.Ribbon/Palette/PaletteRibbonStyles.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Palette/PaletteRibbonStyles.cs
@@ -32,9 +32,11 @@ namespace Krypton.Ribbon
         public PaletteRibbonStyles(KryptonRibbon ribbon,
                                    NeedPaintHandler? needPaint)
         {
-            Debug.Assert(_ribbon is not null);
-
-            _ribbon = ribbon;
+            // Debug.Assert() causes the null assignment warning.
+            // Suppressed by the null forgiving operator
+            Debug.Assert(ribbon is not null);
+            
+            _ribbon = ribbon!;
 
             // Store the provided paint notification delegate
             NeedPaint = needPaint;

--- a/Source/Krypton Components/TestForm/TestForm.csproj
+++ b/Source/Krypton Components/TestForm/TestForm.csproj
@@ -12,6 +12,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\Krypton.Docking\Krypton.Docking 2022.csproj" />
         <ProjectReference Include="..\Krypton.Navigator\Krypton.Navigator 2022.csproj" />
         <ProjectReference Include="..\Krypton.Ribbon\Krypton.Ribbon 2022.csproj" />
         <ProjectReference Include="..\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />


### PR DESCRIPTION
1502-docking-persistence-2
[Issue 1502](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1502#issuecomment-2143734532)

TestForm was missing  a project reference to Docking.
Corrected and tested as requested.

![compile-results](https://github.com/Krypton-Suite/Standard-Toolkit/assets/96108132/232f5968-6c7e-4329-97ec-56d14e45bd39)
