### PR TITLE
1507 revise theme selector controls

### DIFF
--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupThemeComboBox.cs
@@ -20,88 +20,20 @@ namespace Krypton.Ribbon
     [DesignTimeVisible(false)]
     [DefaultEvent("SelectedTextChanged")]
     [DefaultProperty(nameof(Text))]
-    public class KryptonRibbonGroupThemeComboBox : KryptonRibbonGroupComboBox
+    public class KryptonRibbonGroupThemeComboBox : KryptonRibbonGroupComboBox, IKryptonThemeSelectorBase
     {
         #region Instance Fields
 
-        private bool _synchronizeDropDownWidth;
-
-        private int _selectedIndex;
-
-        private readonly int _defaultPaletteIndex = (int)PaletteMode.Microsoft365Blue;
-
+        /// <summary> When we change the palette, Krypton Manager will notify us that there was a change. Since we are changing it that notification can be skipped.</summary>
+        private bool _isLocalUpdate = false;
+        /// <summary> Suppress code execution in the SelectedIndexChanged event handler, when a theme change via the KManager has been performed.</summary>
+        private bool _isExternalUpdate = false;
+        /// <summary> Backing var for the DefaultPalette property.</summary>
         private PaletteMode _defaultPalette;
-
-        #endregion
-
-        #region Public
-
-        /// <summary>Gets or sets a value indicating whether [synchronize drop down width].</summary>
-        /// <value><c>true</c> if [synchronize drop down width]; otherwise, <c>false</c>.</value>
-        [Category(@"Visuals")]
-        [Description(@"Synchronizes the drop-down width, with the width of the control.")]
-        [DefaultValue(false)]
-        public bool SynchronizeDropDownWidth
-        {
-            get => _synchronizeDropDownWidth;
-
-            set
-            {
-                if (value != _synchronizeDropDownWidth)
-                {
-                    _synchronizeDropDownWidth = value;
-
-                    UpdateDropDownWidth(MaximumSize);
-                }
-            }
-        }
-
-        /// <summary>Gets or sets the default palette mode.</summary>
-        /// <value>The default palette mode.</value>
-        [Category(@"Visuals")]
-        [Description(@"The default palette mode.")]
-        [DefaultValue(PaletteMode.Microsoft365Blue)]
-        public PaletteMode DefaultPalette
-        {
-            get => _defaultPalette;
-            set
-            {
-                _defaultPalette = value;
-                UpdateDefaultPaletteIndex(value);
-            }
-        }
-
-        /// <summary>
-        /// Gets and sets the ThemeSelectedIndex.
-        /// </summary>
-        [Category(@"Visuals")]
-        [Description(@"Theme Selected Index. (Default = `Office 365 - Blue`)")]
-        [DefaultValue((int)PaletteMode.Microsoft365Blue)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public int ThemeSelectedIndex
-        {
-            get => _selectedIndex;
-
-            private set => SelectedIndex = value;
-        }
-
-        private void ResetThemeSelectedIndex() => _selectedIndex = (int)PaletteMode.Microsoft365Blue;
-
-        private bool ShouldSerializeThemeSelectedIndex() => _selectedIndex != (int)PaletteMode.Microsoft365Blue;
-
-        /// <summary>
-        /// Gets and sets the ThemeSelectedIndex.
-        /// </summary>
-        [Category(@"Visuals")]
-        [Description(@"Custom Theme to use when `Custom` is selected")]
-        [DefaultValue(null)]
-        public KryptonCustomPaletteBase? KryptonCustomPalette { get; set; }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public KryptonManager Manager
-        {
-            get;
-        } = new KryptonManager();
+        /// <summary> Local Krypton Manager instance.</summary>
+        private readonly KryptonManager _manager;
+        /// <summary> User defined palette.</summary>
+        private KryptonCustomPaletteBase? _kryptonCustomPalette = null;
 
         #endregion
 
@@ -110,54 +42,93 @@ namespace Krypton.Ribbon
         /// <summary>Initializes a new instance of the <see cref="KryptonRibbonGroupThemeComboBox" /> class.</summary>
         public KryptonRibbonGroupThemeComboBox()
         {
-            _synchronizeDropDownWidth = false;
+            _manager = new KryptonManager();
             DropDownStyle = ComboBoxStyle.DropDownList;
-            DisplayMember = "Key";
-            ValueMember = "Value";
-            foreach (var kvp in PaletteModeStrings.SupportedThemesMap)
-            {
-                Items.Add(kvp);
-            }
-            var cnvtr = new PaletteModeConverter();
-            Text = cnvtr.ConvertToString(PaletteMode.Microsoft365Blue)!;
 
-            _selectedIndex = SelectedIndex = _defaultPaletteIndex;
-            _defaultPalette = PaletteMode.Microsoft365Blue;
-            Debug.Assert(_selectedIndex == _defaultPaletteIndex, $@"Microsoft365Blue needs to be at the index position of {_defaultPaletteIndex} for backward compatibility");
+            Items.Clear();
+            Items.AddRange(CommonHelperThemeSelectors.GetThemesArray());
+
+            // If the DefaultPaletteMode is Global and KManager.GlobalPaletteMode is not Custom or Global, set the combo's text:
+            if (CommonHelperThemeSelectors.InitFromManagerPalette(DefaultPalette, _manager))
+            {
+                // This triggers OnSelectedIndexChanged
+                SelectedIndex = CommonHelperThemeSelectors.GetPaletteIndex(Items, _manager.GlobalPaletteMode);
+            }
+
+            // React to theme changes from outside this control.
+            KryptonManager.GlobalPaletteChanged += KryptonManagerGlobalPaletteChanged;
         }
 
         #endregion
 
+        #region Public
+
+        // TODO: Deprecated should be removed
+        /// <summary>
+        /// ReportSelectedThemeIndex is deprecated and will be removed.
+        /// </summary>
+        [Browsable(false)]
+        public bool ReportSelectedThemeIndex { get; set; }
+
+        /// <inheritdoc/>
+        [Category(@"Visuals")]
+        [Description(@"The custom assigned palette mode.")]
+        [DefaultValue(null)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public KryptonCustomPaletteBase? KryptonCustomPalette {
+            get => _kryptonCustomPalette;
+            set => _kryptonCustomPalette = value;
+        }
+
+        private void ResetKryptonCustomPalette() => _kryptonCustomPalette = null;
+        private bool ShouldSerializeKryptonCustomPalette() => _kryptonCustomPalette is not null;
+
+        /// <inheritdoc/>
+        [Category(@"Visuals")]
+        [Description(@"The default palette mode.")]
+        [DefaultValue(PaletteMode.Global)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public PaletteMode DefaultPalette 
+        {
+            get => _defaultPalette;
+            set => SelectedIndex = CommonHelperThemeSelectors.DefaultPaletteSetter(ref _defaultPalette, value, Items, SelectedIndex);
+        }
+
+        private void ResetDefaultPalette() => DefaultPalette = PaletteMode.Global;
+        private bool ShouldSerializeDefaultPalette() => _defaultPalette != PaletteMode.Global;
+
+        #endregion
+
+
         #region Implementation
 
-        private void UpdateDefaultPaletteIndex(PaletteMode mode) => _selectedIndex = (int)mode;
-
-        /// <summary>Returns the palette mode.</summary>
-        /// <returns>
-        ///   <br />
-        /// </returns>
-        public PaletteMode ReturnPaletteMode() => Manager.GlobalPaletteMode;
-
-        private void UpdateDropDownWidth(Size size) => DropDownWidth = size.Width;
+        /// <summary>
+        /// This method will run when the KryptonManager.GlobalPaletteChanged event is fired.<br/>
+        /// It will synchronize the SelectedIndex with the newly assigned Global Palette.
+        /// </summary>
+        /// <param name="sender">Object that intiated the call.</param>
+        /// <param name="e">Eventargs object data (not used).</param>
+        private void KryptonManagerGlobalPaletteChanged(object sender, EventArgs e)
+        {
+            SelectedIndex = CommonHelperThemeSelectors.KryptonManagerGlobalPaletteChanged(_isLocalUpdate, ref _isExternalUpdate, SelectedIndex, Items);
+        }
 
         #endregion
 
         #region Protected Overrides
 
         /// <inheritdoc />
+        /// <inheritdoc />
         protected override void OnSelectedIndexChanged(EventArgs e)
         {
-            RibbonThemeManager.ApplyTheme(Text, Manager);
-
-            ThemeSelectedIndex = SelectedIndex;
+            if (!CommonHelperThemeSelectors.OnSelectedIndexChanged(ref _isLocalUpdate, _isExternalUpdate, ref _defaultPalette, Text, _manager, _kryptonCustomPalette))
+            {
+                //theme change went wrong, make the active theme the selected theme in the list.
+                SelectedIndex = CommonHelperThemeSelectors.GetPaletteIndex(Items, _manager.GlobalPaletteMode);
+            }
 
             base.OnSelectedIndexChanged(e);
-            if ((RibbonThemeManager.GetThemeManagerMode(Text) == PaletteMode.Custom) && (KryptonCustomPalette != null))
-            {
-                Manager.GlobalCustomPalette = KryptonCustomPalette;
-            }
         }
-
 
         #endregion
 
@@ -170,6 +141,15 @@ namespace Krypton.Ribbon
         {
             get => base.Text;
             set => base.Text = value;
+        }
+
+        /// <summary>Gets or sets the format specifier characters that indicate how a value is to be Displayed.</summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public new string FormatString 
+        {
+            get => base.FormatString;
+            set => base.FormatString = value;
         }
 
         /// <summary>Gets and sets the appearance and functionality of the KryptonComboBox.</summary>
@@ -211,6 +191,14 @@ namespace Krypton.Ribbon
         {
             get => base.AutoCompleteSource;
             set => base.AutoCompleteSource = value;
+        }
+
+        /// <summary>Gets and sets the selected index.</summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public new int SelectedIndex {
+            get => base.SelectedIndex;
+            set => base.SelectedIndex = value;
         }
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
@@ -22,7 +22,7 @@ namespace Krypton.Toolkit
         /// <summary> Backing var for the DefaultPalette property.</summary>
         private PaletteMode _defaultPalette;
         /// <summary> Local Krypton Manager instance.</summary>
-        private KryptonManager _manager;
+        private readonly KryptonManager _manager;
         /// <summary> User defined palette.</summary>
         private KryptonCustomPaletteBase? _kryptonCustomPalette = null;
 
@@ -79,7 +79,8 @@ namespace Krypton.Toolkit
         [Description(@"The default palette mode.")]
         [DefaultValue(PaletteMode.Global)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
-        public PaletteMode DefaultPalette {
+        public PaletteMode DefaultPalette 
+        {
             get => _defaultPalette;
             set => SelectedIndex = CommonHelperThemeSelectors.DefaultPaletteSetter(ref _defaultPalette, value, Items, SelectedIndex);
         }
@@ -182,6 +183,23 @@ namespace Krypton.Toolkit
             get => base.AutoCompleteCustomSource;
             set => base.AutoCompleteCustomSource = value;
         }
+
+        /// <summary>Gets or sets the text completion behavior of the combobox.</summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public new AutoCompleteMode AutoCompleteMode {
+            get => base.AutoCompleteMode;
+            set => base.AutoCompleteMode = value;
+        }
+
+        /// <summary>Gets or sets the autocomplete source, which can be one of the values from AutoCompleteSource enumeration.</summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public new AutoCompleteSource AutoCompleteSource {
+            get => base.AutoCompleteSource;
+            set => base.AutoCompleteSource = value;
+        }
+
 
         /// <summary>Gets and sets the selected index.</summary>
         [Browsable(false)]

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
@@ -9,21 +9,6 @@
 
 namespace Krypton.Toolkit
 {
-    internal interface IKryptonThemeSelectorBase
-    {
-        /// <summary>
-        /// Gets or sets the default palette mode.</summary>
-        /// <value>The default palette mode.</value>
-        PaletteMode DefaultPalette { get; set; }
-
-        /// <summary>
-        /// Gets or sets the user defined custom palette.</summary>
-        /// <value>The user defined palette mode.</value>
-        KryptonCustomPaletteBase? KryptonCustomPalette { get; set; }
-
-        bool ReportSelectedThemeIndex { get; set; }
-    }
-
     /// <summary>Allows the user to change themes using a <see cref="KryptonComboBox"/>.</summary>
     /// <seealso cref="KryptonComboBox" />
     public class KryptonThemeComboBox : KryptonComboBox, IKryptonThemeSelectorBase

--- a/Source/Krypton Components/Krypton.Toolkit/General/CommonHelperThemeSelectors.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/CommonHelperThemeSelectors.cs
@@ -24,9 +24,7 @@ namespace Krypton.Toolkit
         /// <returns>String array of theme names.</returns>
         internal static string[] GetThemesArray()
         {
-            return PaletteModeStrings.SupportedThemesMap
-                .Select(x => x.Key)
-                .ToArray();
+            return PaletteModeStrings.SupportedThemesMap.Keys.ToArray();
         }
 
         /// <summary>
@@ -39,7 +37,7 @@ namespace Krypton.Toolkit
         /// <param name="manager">Enter: this._manager.</param>
         /// <param name="kryptonCustomPalette">Enter: this._kryptonCustomPalette</param>
         /// <returns>True if the theme change was successful, false when custom was selected but no local external custom palette is set.</returns>
-        internal static bool OnSelectedIndexChanged(ref bool isLocalUpdate, bool isExternalUpdate, ref PaletteMode defaultPalette, 
+        internal static bool OnSelectedIndexChanged(ref bool isLocalUpdate, bool isExternalUpdate, ref PaletteMode defaultPalette,
             string themeName, KryptonManager manager, KryptonCustomPaletteBase? kryptonCustomPalette)
         {
             bool result = true;
@@ -163,7 +161,7 @@ namespace Krypton.Toolkit
             // Value needs to be different
             if (defaultPalette != value)
             {
-               defaultPalette = value;
+                defaultPalette = value;
 
                 // Any PaletteMode can be set as a theme, EXCEPT Global.
                 if (value != PaletteMode.Global)
@@ -176,6 +174,7 @@ namespace Krypton.Toolkit
             return result;
         }
     }
+   
     #endregion
 
     #region IKryptonThemeSelectorBase

--- a/Source/Krypton Components/Krypton.Toolkit/General/CommonHelperThemeSelectors.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/CommonHelperThemeSelectors.cs
@@ -8,6 +8,14 @@
 #endregion
 namespace Krypton.Toolkit
 {
+    #region Static
+    /// <summary>
+    /// Class CommonHelperThemeSelectors hold the common code for all Theme Selector controls:<br/>
+    /// - KryptonThemeComboBox<br/>
+    /// - KryptonThemeListBox<br/>
+    /// - KryptonRibbonGroupThemeComboBox<br/>
+    /// - KryptonThemeBrowser
+    /// </summary>
     internal static class CommonHelperThemeSelectors
     {
         /// <summary>
@@ -98,7 +106,7 @@ namespace Krypton.Toolkit
         /// <param name="selectedIndex">The currently selected index of the control.</param>
         /// <param name="items">The control's list of themes (usually Items).</param>
         /// <returns>The selected index.</returns>
-        public static int KryptonManagerGlobalPaletteChanged(bool isLocalUpdate, ref bool isExternalUpdate, int selectedIndex, IList items)
+        internal static int KryptonManagerGlobalPaletteChanged(bool isLocalUpdate, ref bool isExternalUpdate, int selectedIndex, IList items)
         {
             int result = selectedIndex;
 
@@ -168,4 +176,28 @@ namespace Krypton.Toolkit
             return result;
         }
     }
+    #endregion
+
+    #region IKryptonThemeSelectorBase
+
+    /// <summary>
+    /// Interface IKryptonThemeSelectorBase<br/>
+    /// Common public entities for the Theme Selector controls.
+    /// </summary>
+    internal interface IKryptonThemeSelectorBase
+    {
+        /// <summary>
+        /// Gets or sets the default palette mode.</summary>
+        /// <value>The default palette mode.</value>
+        PaletteMode DefaultPalette { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user defined custom palette.</summary>
+        /// <value>The user defined palette mode.</value>
+        KryptonCustomPaletteBase? KryptonCustomPalette { get; set; }
+
+        bool ReportSelectedThemeIndex { get; set; }
+    }
+
+    #endregion
 }


### PR DESCRIPTION
1507-Revise-Theme-Selector-Controls
[issue 1507](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1507)
Second part:
- Move the interface to CommonHelperThemeSelectors.cs.
- Updated KryptonRibbonGroupThemeComboBox with the revised code.
- Added AutoCompleteMode and AutoCompleteSource properties to KryptonThemeComboBox.

Source files: 
- [KryptonRibbonGroupThemeComboBox](https://github.com/giduac/Standard-Toolkit/blob/1507-Revise-Theme-Selector-Controls/Source/Krypton%20Components/Krypton.Ribbon/Group%20Contents/KryptonRibbonGroupThemeComboBox.cs)
- [KryptonThemeComboBox](https://github.com/giduac/Standard-Toolkit/blob/1507-Revise-Theme-Selector-Controls/Source/Krypton%20Components/Krypton.Toolkit/Controls%20Toolkit/KryptonThemeComboBox.cs)
- [CommonHelperThemeSelectors](https://github.com/giduac/Standard-Toolkit/blob/1507-Revise-Theme-Selector-Controls/Source/Krypton%20Components/Krypton.Toolkit/General/CommonHelperThemeSelectors.cs)

![compile-results](https://github.com/Krypton-Suite/Standard-Toolkit/assets/96108132/76049079-e191-4364-9e1b-a9cd386255e0)

