### PR TITLE
1507-Revise-Theme-Selector-Controls

### DIFF
--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupThemeComboBox.cs
@@ -22,9 +22,7 @@ namespace Krypton.Ribbon
     [DefaultProperty(nameof(Text))]
     public class KryptonRibbonGroupThemeComboBox : KryptonRibbonGroupComboBox, IKryptonThemeSelectorBase
     {
-        /*
-         * TODO: grouped Ribbon controls do expose designers, needs a closer look
-         */
+        // TODO: grouped Ribbon controls do expose designers, needs a closer look
 
         #region Instance Fields
 

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupThemeComboBox.cs
@@ -22,6 +22,10 @@ namespace Krypton.Ribbon
     [DefaultProperty(nameof(Text))]
     public class KryptonRibbonGroupThemeComboBox : KryptonRibbonGroupComboBox, IKryptonThemeSelectorBase
     {
+        /*
+         * TODO: grouped Ribbon controls do expose designers, needs a closer look
+         */
+
         #region Instance Fields
 
         /// <summary> When we change the palette, Krypton Manager will notify us that there was a change. Since we are changing it that notification can be skipped.</summary>
@@ -48,12 +52,8 @@ namespace Krypton.Ribbon
             Items.Clear();
             Items.AddRange(CommonHelperThemeSelectors.GetThemesArray());
 
-            // If the DefaultPaletteMode is Global and KManager.GlobalPaletteMode is not Custom or Global, set the combo's text:
-            if (CommonHelperThemeSelectors.InitFromManagerPalette(DefaultPalette, _manager))
-            {
-                // This triggers OnSelectedIndexChanged
-                SelectedIndex = CommonHelperThemeSelectors.GetPaletteIndex(Items, _manager.GlobalPaletteMode);
-            }
+            // Sets the intial palette from either global or DefaultPalette property
+            SelectedIndex = CommonHelperThemeSelectors.GetInitialSelectedIndex(DefaultPalette, _manager, Items);
 
             // React to theme changes from outside this control.
             KryptonManager.GlobalPaletteChanged += KryptonManagerGlobalPaletteChanged;
@@ -75,7 +75,8 @@ namespace Krypton.Ribbon
         [Description(@"The custom assigned palette mode.")]
         [DefaultValue(null)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
-        public KryptonCustomPaletteBase? KryptonCustomPalette {
+        public KryptonCustomPaletteBase? KryptonCustomPalette 
+        {
             get => _kryptonCustomPalette;
             set => _kryptonCustomPalette = value;
         }
@@ -99,7 +100,6 @@ namespace Krypton.Ribbon
 
         #endregion
 
-
         #region Implementation
 
         /// <summary>
@@ -117,7 +117,6 @@ namespace Krypton.Ribbon
 
         #region Protected Overrides
 
-        /// <inheritdoc />
         /// <inheritdoc />
         protected override void OnSelectedIndexChanged(EventArgs e)
         {
@@ -196,7 +195,8 @@ namespace Krypton.Ribbon
         /// <summary>Gets and sets the selected index.</summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public new int SelectedIndex {
+        public new int SelectedIndex 
+        {
             get => base.SelectedIndex;
             set => base.SelectedIndex = value;
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
@@ -11,8 +11,14 @@ namespace Krypton.Toolkit
 {
     /// <summary>Allows the user to change themes using a <see cref="KryptonComboBox"/>.</summary>
     /// <seealso cref="KryptonComboBox" />
+    [Designer(typeof(ControlDesigner))]
     public class KryptonThemeComboBox : KryptonComboBox, IKryptonThemeSelectorBase
     {
+        /*
+         * Since their is no suitable designer and the inherited isn't a good match
+         * It's overridden by using the Base class ControlDesigner which effectively removes the designer.
+         */
+
         #region Instance Fields
 
         /// <summary> When we change the palette, Krypton Manager will notify us that there was a change. Since we are changing it that notification can be skipped.</summary>
@@ -39,12 +45,8 @@ namespace Krypton.Toolkit
             Items.Clear();
             Items.AddRange(CommonHelperThemeSelectors.GetThemesArray());
 
-            // If the DefaultPaletteMode is Global and KManager.GlobalPaletteMode is not Custom or Global, set the combo's text:
-            if (CommonHelperThemeSelectors.InitFromManagerPalette(DefaultPalette, _manager))
-            {
-                // This triggers OnSelectedIndexChanged
-                SelectedIndex = CommonHelperThemeSelectors.GetPaletteIndex(Items, _manager.GlobalPaletteMode);
-            }
+            // Sets the intial palette from either global or DefaultPalette property
+            SelectedIndex = CommonHelperThemeSelectors.GetInitialSelectedIndex(DefaultPalette, _manager, Items);
 
             // React to theme changes from outside this control.
             KryptonManager.GlobalPaletteChanged += KryptonManagerGlobalPaletteChanged;
@@ -187,7 +189,8 @@ namespace Krypton.Toolkit
         /// <summary>Gets or sets the text completion behavior of the combobox.</summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public new AutoCompleteMode AutoCompleteMode {
+        public new AutoCompleteMode AutoCompleteMode 
+        {
             get => base.AutoCompleteMode;
             set => base.AutoCompleteMode = value;
         }
@@ -195,11 +198,11 @@ namespace Krypton.Toolkit
         /// <summary>Gets or sets the autocomplete source, which can be one of the values from AutoCompleteSource enumeration.</summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public new AutoCompleteSource AutoCompleteSource {
+        public new AutoCompleteSource AutoCompleteSource 
+        {
             get => base.AutoCompleteSource;
             set => base.AutoCompleteSource = value;
         }
-
 
         /// <summary>Gets and sets the selected index.</summary>
         [Browsable(false)]

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeListBox.cs
@@ -12,52 +12,26 @@ namespace Krypton.Toolkit
 {
     /// <summary>Allows the user to change themes using a <see cref="KryptonListBox"/>.</summary>
     /// <seealso cref="KryptonListBox" />
-    [ToolboxItem(true)]
-    [ToolboxBitmap(typeof(KryptonListBox))]
-    [Designer(typeof(KryptonThemeBrowserDesigner))]
-    public class KryptonThemeListBox : KryptonListBox
+    [Designer(typeof(ControlDesigner))]
+    public class KryptonThemeListBox : KryptonListBox, IKryptonThemeSelectorBase
     {
+        /*
+         * Since their is no suitable designer and the inherited isn't a good match
+         * It's overridden by using the Base class ControlDesigner which effectively removes the designer.
+         */
+
         #region Instance Fields
 
-        private readonly int? _defaultSelectedIndex = GlobalStaticValues.GLOBAL_DEFAULT_THEME_INDEX;
-
-        private int _selectedThemeIndex;
-
-        #endregion
-
-        #region Public
-
-        /// <summary>
-        /// Gets and sets the ThemeSelectedIndex.
-        /// </summary>
-        [Category(@"Visuals")]
-        [Description(@"Theme Selected Index. (Default = `Office 365 - Blue`)")]
-        [DefaultValue(33)]
-        public int ThemeSelectedIndex
-        {
-            get => _selectedThemeIndex;
-
-            set => SelectedIndex = value;
-        }
-
-        private void ResetThemeSelectedIndex() => _selectedThemeIndex = 33;
-
-        private bool ShouldSerializeThemeSelectedIndex() => _selectedThemeIndex != 33;
-
-        /// <summary>
-        /// Gets and sets the ThemeSelectedIndex.
-        /// </summary>
-        [Category(@"Visuals")]
-        [Description(@"Custom Theme to use when `Custom` is selected")]
-        [DefaultValue(null)]
-        public KryptonCustomPaletteBase? KryptonCustomPalette { get; set; }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public KryptonManager Manager
-        {
-            get;
-
-        } = new KryptonManager();
+        /// <summary> When we change the palette, Krypton Manager will notify us that there was a change. Since we are changing it that notification can be skipped.</summary>
+        private bool _isLocalUpdate = false;
+        /// <summary> Suppress code execution in the SelectedIndexChanged event handler, when a theme change via the KManager has been performed.</summary>
+        private bool _isExternalUpdate = false;
+        /// <summary> Backing var for the DefaultPalette property.</summary>
+        private PaletteMode _defaultPalette;
+        /// <summary> Local Krypton Manager instance.</summary>
+        private readonly KryptonManager _manager;
+        /// <summary> User defined palette.</summary>
+        private KryptonCustomPaletteBase? _kryptonCustomPalette = null;
 
         #endregion
 
@@ -66,52 +40,91 @@ namespace Krypton.Toolkit
         /// <summary>Initializes a new instance of the <see cref="KryptonThemeListBox" /> class.</summary>
         public KryptonThemeListBox()
         {
-            foreach (var kvp in PaletteModeStrings.SupportedThemesMap)
-            {
-                Items.Add(kvp.Key);
-            }
-            Text = ThemeManager.ReturnPaletteModeAsString(PaletteMode.Microsoft365Blue);
-            _selectedThemeIndex = SelectedIndex = _defaultSelectedIndex ?? GlobalStaticValues.GLOBAL_DEFAULT_THEME_INDEX;
-            Debug.Assert(_selectedThemeIndex == GlobalStaticValues.GLOBAL_DEFAULT_THEME_INDEX, $@"Microsoft365Blue needs to be at index: {GlobalStaticValues.GLOBAL_DEFAULT_THEME_INDEX} for backward compatibility");
+            _manager = new KryptonManager();
+
+            Items.Clear();
+            Items.AddRange(CommonHelperThemeSelectors.GetThemesArray());
+
+            // Sets the intial palette from either global or DefaultPalette property
+            SelectedIndex = CommonHelperThemeSelectors.GetInitialSelectedIndex(DefaultPalette, _manager, Items);
+
+            // React to theme changes from outside this control.
+            KryptonManager.GlobalPaletteChanged += KryptonManagerGlobalPaletteChanged;
         }
+
+        #endregion
+
+        #region Public
+
+        // TODO: Deprecated should be removed
+        /// <summary>
+        /// ReportSelectedThemeIndex is deprecated and will be removed.
+        /// </summary>
+        [Browsable(false)]
+        public bool ReportSelectedThemeIndex { get; set; }
+
+        /// <inheritdoc/>
+        [Category(@"Visuals")]
+        [Description(@"The custom assigned palette mode.")]
+        [DefaultValue(null)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public KryptonCustomPaletteBase? KryptonCustomPalette 
+        {
+            get => _kryptonCustomPalette;
+            set => _kryptonCustomPalette = value;
+        }
+
+        private void ResetKryptonCustomPalette() => _kryptonCustomPalette = null;
+        private bool ShouldSerializeKryptonCustomPalette() => _kryptonCustomPalette is not null;
+
+        /// <inheritdoc/>
+        [Category(@"Visuals")]
+        [Description(@"The default palette mode.")]
+        [DefaultValue(PaletteMode.Global)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public PaletteMode DefaultPalette 
+        {
+            get => _defaultPalette;
+            set => SelectedIndex = CommonHelperThemeSelectors.DefaultPaletteSetter(ref _defaultPalette, value, Items, SelectedIndex);
+        }
+
+        private void ResetDefaultPalette() => DefaultPalette = PaletteMode.Global;
+        private bool ShouldSerializeDefaultPalette() => _defaultPalette != PaletteMode.Global;
 
         #endregion
 
         #region Implementation
 
-        /// <summary>Returns the palette mode.</summary>
-        public PaletteMode ReturnPaletteMode() => Manager.GlobalPaletteMode;
+        /// <summary>
+        /// This method will run when the KryptonManager.GlobalPaletteChanged event is fired.<br/>
+        /// It will synchronize the SelectedIndex with the newly assigned Global Palette.
+        /// </summary>
+        /// <param name="sender">Object that intiated the call.</param>
+        /// <param name="e">Eventargs object data (not used).</param>
+        private void KryptonManagerGlobalPaletteChanged(object sender, EventArgs e)
+        {
+            SelectedIndex = CommonHelperThemeSelectors.KryptonManagerGlobalPaletteChanged(_isLocalUpdate, ref _isExternalUpdate, SelectedIndex, Items);
+        }
 
         #endregion
 
-        #region Protected
-
-        /// <inheritdoc />
-        protected override void OnCreateControl()
-        {
-            base.OnCreateControl();
-
-            SelectedIndex = _selectedThemeIndex;
-        }
+        #region Protected Overrides
 
         /// <inheritdoc />
         protected override void OnSelectedIndexChanged(EventArgs e)
         {
-            if (SelectedItem is null)
+            // The theme listbox needs a check first since SelectedItem is of type: object?
+            string themeName = SelectedIndex > -1 && SelectedItem is string str && str.Length > 0
+                ? str
+                : string.Empty;
+
+            if (!CommonHelperThemeSelectors.OnSelectedIndexChanged(ref _isLocalUpdate, _isExternalUpdate, ref _defaultPalette, themeName, _manager, _kryptonCustomPalette))
             {
-                return;
+                //theme change went wrong, make the active theme the selected theme in the list.
+                SelectedIndex = CommonHelperThemeSelectors.GetPaletteIndex(Items, _manager.GlobalPaletteMode);
             }
-
-            ThemeManager.ApplyTheme(GetItemText(SelectedItem)!, Manager);
-
-            ThemeSelectedIndex = SelectedIndex;
 
             base.OnSelectedIndexChanged(e);
-
-            if ((ThemeManager.GetThemeManagerMode(GetItemText(SelectedItem)!) == PaletteMode.Custom) && (KryptonCustomPalette is not null))
-            {
-                Manager.GlobalCustomPalette = KryptonCustomPalette;
-            }
         }
 
         #endregion
@@ -128,10 +141,28 @@ namespace Krypton.Toolkit
             set => base.Text = value;
         }
 
+        /// <summary>Gets or sets the format specifier characters that indicate how a value is to be Displayed.</summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public new string FormatString 
+        {
+            get => base.FormatString;
+            set => base.FormatString = value;
+        }
+
         /// <summary>Gets the items of the KryptonListBox.</summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public new ListBox.ObjectCollection Items => base.Items;
+
+        /// <summary>Gets and sets the selected index.</summary>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public new int SelectedIndex 
+        {
+            get => base.SelectedIndex;
+            set => base.SelectedIndex = value;
+        }
 
         #endregion
     }

--- a/Source/Krypton Components/TestForm/TestForm.csproj
+++ b/Source/Krypton Components/TestForm/TestForm.csproj
@@ -41,15 +41,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Reference Include="Krypton.Docking">
-          <HintPath>..\Krypton.Docking\obj\Debug\net462\Krypton.Docking.dll</HintPath>
-        </Reference>
-        <Reference Include="Krypton.Toolkit">
-          <HintPath>..\Krypton.Toolkit\obj\Debug\net462\Krypton.Toolkit.dll</HintPath>
-        </Reference>
-        <Reference Include="Krypton.Workspace">
-          <HintPath>..\Krypton.Workspace\obj\Debug\net462\Krypton.Workspace.dll</HintPath>
-        </Reference>
         <Reference Include="System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="$(TargetFramework.StartsWith('net4'))">
             <SpecificVersion>True</SpecificVersion>
             <Version>4.0.0.0</Version>

--- a/Source/Krypton Components/TestForm/TestForm.csproj
+++ b/Source/Krypton Components/TestForm/TestForm.csproj
@@ -16,6 +16,7 @@
         <ProjectReference Include="..\Krypton.Navigator\Krypton.Navigator 2022.csproj" />
         <ProjectReference Include="..\Krypton.Ribbon\Krypton.Ribbon 2022.csproj" />
         <ProjectReference Include="..\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />
+        <ProjectReference Include="..\Krypton.Workspace\Krypton.Workspace 2022.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Source/Krypton Components/TestForm/ThemeControlExamples.Designer.cs
+++ b/Source/Krypton Components/TestForm/ThemeControlExamples.Designer.cs
@@ -34,7 +34,6 @@
             this.kryptonThemeComboBox1 = new Krypton.Toolkit.KryptonThemeComboBox();
             this.kryptonLabel1 = new Krypton.Toolkit.KryptonLabel();
             this.kryptonThemeListBox1 = new Krypton.Toolkit.KryptonThemeListBox();
-            this.kryptonThemeListBox2 = new Krypton.Toolkit.KryptonThemeListBox();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).BeginInit();
             this.kryptonPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonThemeComboBox1)).BeginInit();
@@ -42,7 +41,7 @@
             // 
             // kryptonPanel1
             // 
-            this.kryptonPanel1.Controls.Add(this.kryptonThemeListBox2);
+            this.kryptonPanel1.Controls.Add(this.kryptonThemeListBox1);
             this.kryptonPanel1.Controls.Add(this.kbtnThemeBrowser);
             this.kryptonPanel1.Controls.Add(this.kryptonLabel2);
             this.kryptonPanel1.Controls.Add(this.kryptonThemeComboBox1);
@@ -55,6 +54,7 @@
             // 
             // kbtnThemeBrowser
             // 
+            this.kbtnThemeBrowser.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.kbtnThemeBrowser.Location = new System.Drawing.Point(13, 413);
             this.kbtnThemeBrowser.Name = "kbtnThemeBrowser";
             this.kbtnThemeBrowser.Size = new System.Drawing.Size(173, 25);
@@ -95,21 +95,14 @@
             // 
             // kryptonThemeListBox1
             // 
+            this.kryptonThemeListBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left)));
             this.kryptonThemeListBox1.DefaultPalette = Krypton.Toolkit.PaletteMode.ProfessionalSystem;
-            this.kryptonThemeListBox1.Location = new System.Drawing.Point(0, 0);
+            this.kryptonThemeListBox1.Location = new System.Drawing.Point(141, 40);
             this.kryptonThemeListBox1.Name = "kryptonThemeListBox1";
             this.kryptonThemeListBox1.ReportSelectedThemeIndex = false;
-            this.kryptonThemeListBox1.Size = new System.Drawing.Size(120, 96);
-            this.kryptonThemeListBox1.TabIndex = 0;
-            // 
-            // kryptonThemeListBox2
-            // 
-            this.kryptonThemeListBox2.DefaultPalette = Krypton.Toolkit.PaletteMode.ProfessionalSystem;
-            this.kryptonThemeListBox2.Location = new System.Drawing.Point(141, 40);
-            this.kryptonThemeListBox2.Name = "kryptonThemeListBox2";
-            this.kryptonThemeListBox2.ReportSelectedThemeIndex = false;
-            this.kryptonThemeListBox2.Size = new System.Drawing.Size(334, 334);
-            this.kryptonThemeListBox2.TabIndex = 4;
+            this.kryptonThemeListBox1.Size = new System.Drawing.Size(334, 356);
+            this.kryptonThemeListBox1.TabIndex = 4;
             // 
             // ThemeControlExamples
             // 
@@ -133,8 +126,7 @@
         private KryptonLabel kryptonLabel1;
         private KryptonThemeComboBox kryptonThemeComboBox1;
         private KryptonLabel kryptonLabel2;
+           private KryptonButton kbtnThemeBrowser;
         private KryptonThemeListBox kryptonThemeListBox1;
-        private KryptonButton kbtnThemeBrowser;
-        private KryptonThemeListBox kryptonThemeListBox2;
     }
 }

--- a/Source/Krypton Components/TestForm/ThemeControlExamples.Designer.cs
+++ b/Source/Krypton Components/TestForm/ThemeControlExamples.Designer.cs
@@ -29,11 +29,12 @@
         private void InitializeComponent()
         {
             this.kryptonPanel1 = new Krypton.Toolkit.KryptonPanel();
+            this.kbtnThemeBrowser = new Krypton.Toolkit.KryptonButton();
             this.kryptonLabel2 = new Krypton.Toolkit.KryptonLabel();
             this.kryptonThemeComboBox1 = new Krypton.Toolkit.KryptonThemeComboBox();
             this.kryptonLabel1 = new Krypton.Toolkit.KryptonLabel();
             this.kryptonThemeListBox1 = new Krypton.Toolkit.KryptonThemeListBox();
-            this.kbtnThemeBrowser = new Krypton.Toolkit.KryptonButton();
+            this.kryptonThemeListBox2 = new Krypton.Toolkit.KryptonThemeListBox();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).BeginInit();
             this.kryptonPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonThemeComboBox1)).BeginInit();
@@ -41,6 +42,7 @@
             // 
             // kryptonPanel1
             // 
+            this.kryptonPanel1.Controls.Add(this.kryptonThemeListBox2);
             this.kryptonPanel1.Controls.Add(this.kbtnThemeBrowser);
             this.kryptonPanel1.Controls.Add(this.kryptonLabel2);
             this.kryptonPanel1.Controls.Add(this.kryptonThemeComboBox1);
@@ -51,12 +53,22 @@
             this.kryptonPanel1.Size = new System.Drawing.Size(800, 450);
             this.kryptonPanel1.TabIndex = 0;
             // 
+            // kbtnThemeBrowser
+            // 
+            this.kbtnThemeBrowser.Location = new System.Drawing.Point(13, 413);
+            this.kbtnThemeBrowser.Name = "kbtnThemeBrowser";
+            this.kbtnThemeBrowser.Size = new System.Drawing.Size(173, 25);
+            this.kbtnThemeBrowser.TabIndex = 3;
+            this.kbtnThemeBrowser.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnThemeBrowser.Values.Text = "Theme Browser";
+            this.kbtnThemeBrowser.Click += new System.EventHandler(this.kbtnThemeBrowser_Click);
+            // 
             // kryptonLabel2
             // 
             this.kryptonLabel2.LabelStyle = Krypton.Toolkit.LabelStyle.BoldPanel;
             this.kryptonLabel2.Location = new System.Drawing.Point(13, 40);
             this.kryptonLabel2.Name = "kryptonLabel2";
-            this.kryptonLabel2.Size = new System.Drawing.Size(99, 20);
+            this.kryptonLabel2.Size = new System.Drawing.Size(99, 22);
             this.kryptonLabel2.TabIndex = 2;
             this.kryptonLabel2.Values.Text = "Theme ListBox:";
             // 
@@ -77,26 +89,27 @@
             this.kryptonLabel1.LabelStyle = Krypton.Toolkit.LabelStyle.BoldPanel;
             this.kryptonLabel1.Location = new System.Drawing.Point(13, 13);
             this.kryptonLabel1.Name = "kryptonLabel1";
-            this.kryptonLabel1.Size = new System.Drawing.Size(121, 20);
+            this.kryptonLabel1.Size = new System.Drawing.Size(121, 22);
             this.kryptonLabel1.TabIndex = 0;
             this.kryptonLabel1.Values.Text = "Theme ComboBox:";
             // 
             // kryptonThemeListBox1
             // 
+            this.kryptonThemeListBox1.DefaultPalette = Krypton.Toolkit.PaletteMode.ProfessionalSystem;
             this.kryptonThemeListBox1.Location = new System.Drawing.Point(0, 0);
             this.kryptonThemeListBox1.Name = "kryptonThemeListBox1";
+            this.kryptonThemeListBox1.ReportSelectedThemeIndex = false;
+            this.kryptonThemeListBox1.Size = new System.Drawing.Size(120, 96);
             this.kryptonThemeListBox1.TabIndex = 0;
-            this.kryptonThemeListBox1.ThemeSelectedIndex = 30;
             // 
-            // kbtnThemeBrowser
+            // kryptonThemeListBox2
             // 
-            this.kbtnThemeBrowser.Location = new System.Drawing.Point(13, 413);
-            this.kbtnThemeBrowser.Name = "kbtnThemeBrowser";
-            this.kbtnThemeBrowser.Size = new System.Drawing.Size(173, 25);
-            this.kbtnThemeBrowser.TabIndex = 3;
-            this.kbtnThemeBrowser.Values.DropDownArrowColor = System.Drawing.Color.Empty;
-            this.kbtnThemeBrowser.Values.Text = "Theme Browser";
-            this.kbtnThemeBrowser.Click += new System.EventHandler(this.kbtnThemeBrowser_Click);
+            this.kryptonThemeListBox2.DefaultPalette = Krypton.Toolkit.PaletteMode.ProfessionalSystem;
+            this.kryptonThemeListBox2.Location = new System.Drawing.Point(141, 40);
+            this.kryptonThemeListBox2.Name = "kryptonThemeListBox2";
+            this.kryptonThemeListBox2.ReportSelectedThemeIndex = false;
+            this.kryptonThemeListBox2.Size = new System.Drawing.Size(334, 334);
+            this.kryptonThemeListBox2.TabIndex = 4;
             // 
             // ThemeControlExamples
             // 
@@ -122,5 +135,6 @@
         private KryptonLabel kryptonLabel2;
         private KryptonThemeListBox kryptonThemeListBox1;
         private KryptonButton kbtnThemeBrowser;
+        private KryptonThemeListBox kryptonThemeListBox2;
     }
 }

--- a/Source/Krypton Components/TestForm/ThemeControlExamples.resx
+++ b/Source/Krypton Components/TestForm/ThemeControlExamples.resx
@@ -117,7 +117,4 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="kryptonThemeListBox1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
 </root>


### PR DESCRIPTION
1507-Revise-Theme-Selector-Controls
[issue 1507](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1507)
Third part:
- Updated KryptonThemeListBox
- Added some checks and changes to the CommonHelperThemeSelectors.
- All Theme Selector constructors now use  CommonHelperThemeSelectors.GetInitialSelectedIndex(...) which respects the DefaultPalette set in the designer.
- KthemeCBB and KthemeLB use the ControlDesigner as designer. Which effectivily turns it off (for now) since there is no really a suitable designer.
- Added the KthemeLB to TestForm.

Source files (themes only):
- [KryptonRibbonGroupThemeComboBox](https://github.com/giduac/Standard-Toolkit/blob/1507-Revise-Theme-Selector-Controls/Source/Krypton%20Components/Krypton.Ribbon/Group%20Contents/KryptonRibbonGroupThemeComboBox.cs)
- [KryptonThemeComboBox](https://github.com/giduac/Standard-Toolkit/blob/1507-Revise-Theme-Selector-Controls/Source/Krypton%20Components/Krypton.Toolkit/Controls%20Toolkit/KryptonThemeComboBox.cs)
- [KryptonThemeListBox](https://github.com/giduac/Standard-Toolkit/blob/1507-Revise-Theme-Selector-Controls/Source/Krypton%20Components/Krypton.Toolkit/Controls%20Toolkit/KryptonThemeListBox.cs)
- [CommonHelperThemeSelectors](https://github.com/giduac/Standard-Toolkit/blob/1507-Revise-Theme-Selector-Controls/Source/Krypton%20Components/Krypton.Toolkit/General/CommonHelperThemeSelectors.cs)

![compile-results](https://github.com/Krypton-Suite/Standard-Toolkit/assets/96108132/376ba0dd-6b3e-454a-a3a0-955050afc01d)
