### PR TITLE
1507-Revise-Theme-Selector-Controls

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,14 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
+* Implemented [#1507](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1507), **[Breaking Change]** `KryptonThemeComboBox`, `KryptonThemeListBox` & `KryptonRibbonGroupThemeComboBox`:
+    - All controls had their code base updated to one standard.
+    - The assignment of themes via an index has been removed from all. 
+    - The previous has been replaced by assignment per PaletteMode identifier.
+    - All controls do now react to theme changes propagated via the KryptonManager. The control will then synchronize the selected item in the list with the newly activated theme.
+    - Form designer files or your code using a theme selector control might hold references to these properties: `KryptonManager`, `ReportSelectedThemeIndex`, `ThemeSelectedIndex` & `SynchronizeDropDownWidth`. These can, safely, be removed.
+    - The DefaultPalette property is now stored in the designer file and if set, the selected palette wil be loaded when the selector control is instantiated. 
+    - The DefaultPalette property can also be used to switch palettes from code.
 * Resolved [#1502](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1502), Fixes some problems creating workspaces introduced through warnings removal.
 * Resolved [#1497](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1497), When pressing ALT to show the Ribbon KeyTips a null reference exception is thrown.
 * Resolved [#1462](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1462), TestForm app: KCombobox from main.cs causes a crash
@@ -15,7 +23,7 @@
 * Resolved [#1475](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1475), Build Scripts will run when no suitable environment is detected. Add 'BinLog' option to `build-*.cmd`
 * Implemented [#1435](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1435), **Breaking Change** Take KMB back to the Winform override (Remove Checkbox etc)
 * Implemented [#1432](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1432), Copy `KryptonMessageBox` to `KryptonMessageBoxDep`
-* Resolved [#1424](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1424), **Breaking Change** `KryptonMessageBox` does not obey tab characters like `MessageBox`
+* Resolved [#1424](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1424), *[Breaking Change]** `KryptonMessageBox` does not obey tab characters like `MessageBox`
 * Resolved [#1381](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1381), **[Regression]** Docking Persistence broken since build ##.23.10.303
 * Resolved [#1301](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1301), **[Regression]** When Maximised - intergrated KryptonRibbon has titlebar issues
 * Resolved [#1383](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1383), Closing last Page in undocked page group prevents addition of further Pages via `KryptonDockingManager.AddToWorkspace` (fix courtesy of [stizler](https://github.com/stigzler))
@@ -602,3 +610,4 @@ Cannot add items to KryptonGroupBox in WinForms Designer
 * Support for .NET Core LTS (currently 3.1)
 * Changed `490` to `500`
 * Builds from now on will be labelled as `YYMM`
+

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupThemeComboBox.cs
@@ -42,7 +42,7 @@ namespace Krypton.Ribbon
         #region Identity
 
         /// <summary>Initializes a new instance of the <see cref="KryptonRibbonGroupThemeComboBox" /> class.</summary>
-        public KryptonRibbonGroupThemeComboBox()
+        public KryptonRibbonGroupThemeComboBox() : base()
         {
             _manager = new KryptonManager();
             DropDownStyle = ComboBoxStyle.DropDownList;
@@ -60,13 +60,6 @@ namespace Krypton.Ribbon
         #endregion
 
         #region Public
-
-        // TODO: Deprecated should be removed
-        /// <summary>
-        /// ReportSelectedThemeIndex is deprecated and will be removed.
-        /// </summary>
-        [Browsable(false)]
-        public bool ReportSelectedThemeIndex { get; set; }
 
         /// <inheritdoc/>
         [Category(@"Visuals")]

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
@@ -55,13 +55,6 @@ namespace Krypton.Toolkit
 
         #region Public
 
-        // TODO: Deprecated should be removed
-        /// <summary>
-        /// ReportSelectedThemeIndex is deprecated and will be removed.
-        /// </summary>
-        [Browsable(false)]
-        public bool ReportSelectedThemeIndex { get; set; }
-
         /// <inheritdoc/>
         [Category(@"Visuals")]
         [Description(@"The custom assigned palette mode.")]

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeListBox.cs
@@ -56,13 +56,6 @@ namespace Krypton.Toolkit
 
         #region Public
 
-        // TODO: Deprecated should be removed
-        /// <summary>
-        /// ReportSelectedThemeIndex is deprecated and will be removed.
-        /// </summary>
-        [Browsable(false)]
-        public bool ReportSelectedThemeIndex { get; set; }
-
         /// <inheritdoc/>
         [Category(@"Visuals")]
         [Description(@"The custom assigned palette mode.")]

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualAboutBoxRtlAwareForm.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualAboutBoxRtlAwareForm.Designer.cs
@@ -552,7 +552,6 @@
             this.kryptonThemeComboBox1.Location = new System.Drawing.Point(5, 256);
             this.kryptonThemeComboBox1.Margin = new System.Windows.Forms.Padding(5);
             this.kryptonThemeComboBox1.Name = "kryptonThemeComboBox1";
-            this.kryptonThemeComboBox1.ReportSelectedThemeIndex = false;
             this.kryptonThemeComboBox1.Size = new System.Drawing.Size(746, 21);
             this.kryptonThemeComboBox1.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
             this.kryptonThemeComboBox1.TabIndex = 0;
@@ -678,7 +677,6 @@
             this.ktcmbCurrentTheme.Location = new System.Drawing.Point(5, 231);
             this.ktcmbCurrentTheme.Margin = new System.Windows.Forms.Padding(5);
             this.ktcmbCurrentTheme.Name = "ktcmbCurrentTheme";
-            this.ktcmbCurrentTheme.ReportSelectedThemeIndex = false;
             this.ktcmbCurrentTheme.Size = new System.Drawing.Size(672, 21);
             this.ktcmbCurrentTheme.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
             this.ktcmbCurrentTheme.TabIndex = 3;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualAboutBoxForm.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualAboutBoxForm.Designer.cs
@@ -607,7 +607,6 @@
             this.kryptonThemeComboBox1.Location = new System.Drawing.Point(5, 300);
             this.kryptonThemeComboBox1.Margin = new System.Windows.Forms.Padding(5);
             this.kryptonThemeComboBox1.Name = "kryptonThemeComboBox1";
-            this.kryptonThemeComboBox1.ReportSelectedThemeIndex = false;
             this.kryptonThemeComboBox1.Size = new System.Drawing.Size(767, 21);
             this.kryptonThemeComboBox1.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
             this.kryptonThemeComboBox1.TabIndex = 0;
@@ -734,7 +733,6 @@
             this.ktcmbCurrentTheme.Location = new System.Drawing.Point(79, 275);
             this.ktcmbCurrentTheme.Margin = new System.Windows.Forms.Padding(5);
             this.ktcmbCurrentTheme.Name = "ktcmbCurrentTheme";
-            this.ktcmbCurrentTheme.ReportSelectedThemeIndex = false;
             this.ktcmbCurrentTheme.Size = new System.Drawing.Size(693, 21);
             this.ktcmbCurrentTheme.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
             this.ktcmbCurrentTheme.TabIndex = 3;

--- a/Source/Krypton Components/Krypton.Toolkit/General/CommonHelperThemeSelectors.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/CommonHelperThemeSelectors.cs
@@ -212,8 +212,6 @@ namespace Krypton.Toolkit
         /// Gets or sets the user defined custom palette.
         /// </summary>
         KryptonCustomPaletteBase? KryptonCustomPalette { get; set; }
-
-        bool ReportSelectedThemeIndex { get; set; }
     }
 
     #endregion

--- a/Source/Krypton Components/TestForm/CalendarTest.Designer.cs
+++ b/Source/Krypton Components/TestForm/CalendarTest.Designer.cs
@@ -74,7 +74,6 @@ namespace TestForm
             this.kryptonThemeComboBox1.IntegralHeight = false;
             this.kryptonThemeComboBox1.Location = new System.Drawing.Point(13, 230);
             this.kryptonThemeComboBox1.Name = "kryptonThemeComboBox1";
-            this.kryptonThemeComboBox1.ReportSelectedThemeIndex = true;
             this.kryptonThemeComboBox1.Size = new System.Drawing.Size(230, 21);
             this.kryptonThemeComboBox1.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
             this.kryptonThemeComboBox1.TabIndex = 2;

--- a/Source/Krypton Components/TestForm/CustomPaletteTest.Designer.cs
+++ b/Source/Krypton Components/TestForm/CustomPaletteTest.Designer.cs
@@ -78,7 +78,6 @@ namespace TestForm
             this.kryptonThemeComboBox1.IntegralHeight = false;
             this.kryptonThemeComboBox1.Location = new System.Drawing.Point(239, 217);
             this.kryptonThemeComboBox1.Name = "kryptonThemeComboBox1";
-            this.kryptonThemeComboBox1.ReportSelectedThemeIndex = false;
             this.kryptonThemeComboBox1.Size = new System.Drawing.Size(301, 21);
             this.kryptonThemeComboBox1.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
             this.kryptonThemeComboBox1.TabIndex = 0;

--- a/Source/Krypton Components/TestForm/DataGridViewTest.Designer.cs
+++ b/Source/Krypton Components/TestForm/DataGridViewTest.Designer.cs
@@ -139,7 +139,6 @@ namespace TestForm
             this.kryptonThemeComboBox1.IntegralHeight = false;
             this.kryptonThemeComboBox1.Location = new System.Drawing.Point(13, 271);
             this.kryptonThemeComboBox1.Name = "kryptonThemeComboBox1";
-            this.kryptonThemeComboBox1.ReportSelectedThemeIndex = true;
             this.kryptonThemeComboBox1.Size = new System.Drawing.Size(323, 21);
             this.kryptonThemeComboBox1.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
             this.kryptonThemeComboBox1.TabIndex = 3;

--- a/Source/Krypton Components/TestForm/GroupBoxTest.Designer.cs
+++ b/Source/Krypton Components/TestForm/GroupBoxTest.Designer.cs
@@ -161,7 +161,6 @@ namespace TestForm
             this.kryptonThemeComboBox3.Location = new System.Drawing.Point(28, 174);
             this.kryptonThemeComboBox3.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonThemeComboBox3.Name = "kryptonThemeComboBox3";
-            this.kryptonThemeComboBox3.ReportSelectedThemeIndex = false;
             this.kryptonThemeComboBox3.Size = new System.Drawing.Size(121, 25);
             this.kryptonThemeComboBox3.TabIndex = 2;
             this.kryptonThemeComboBox3.ValueMember = "Value";
@@ -215,7 +214,6 @@ namespace TestForm
             this.kryptonThemeComboBox1.Location = new System.Drawing.Point(65, 92);
             this.kryptonThemeComboBox1.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonThemeComboBox1.Name = "kryptonThemeComboBox1";
-            this.kryptonThemeComboBox1.ReportSelectedThemeIndex = false;
             this.kryptonThemeComboBox1.Size = new System.Drawing.Size(250, 25);
             this.kryptonThemeComboBox1.StateCommon.Item.Content.ShortText.Font = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.kryptonThemeComboBox1.TabIndex = 0;
@@ -241,7 +239,6 @@ namespace TestForm
             this.kryptonThemeComboBox2.Location = new System.Drawing.Point(28, 28);
             this.kryptonThemeComboBox2.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonThemeComboBox2.Name = "kryptonThemeComboBox2";
-            this.kryptonThemeComboBox2.ReportSelectedThemeIndex = false;
             this.kryptonThemeComboBox2.Size = new System.Drawing.Size(121, 25);
             this.kryptonThemeComboBox2.TabIndex = 0;
             this.kryptonThemeComboBox2.ValueMember = "Value";

--- a/Source/Krypton Components/TestForm/Main.Designer.cs
+++ b/Source/Krypton Components/TestForm/Main.Designer.cs
@@ -152,7 +152,6 @@ namespace TestForm
             this.kryptonThemeComboBox1.Location = new System.Drawing.Point(17, 15);
             this.kryptonThemeComboBox1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.kryptonThemeComboBox1.Name = "kryptonThemeComboBox1";
-            this.kryptonThemeComboBox1.ReportSelectedThemeIndex = false;
             this.kryptonThemeComboBox1.Size = new System.Drawing.Size(581, 25);
             this.kryptonThemeComboBox1.TabIndex = 1;
             // 

--- a/Source/Krypton Components/TestForm/RibbonTest.Designer.cs
+++ b/Source/Krypton Components/TestForm/RibbonTest.Designer.cs
@@ -177,7 +177,6 @@ namespace TestForm
             this.kryptonThemeComboBox1.IntegralHeight = false;
             this.kryptonThemeComboBox1.Location = new System.Drawing.Point(34, 82);
             this.kryptonThemeComboBox1.Name = "kryptonThemeComboBox1";
-            this.kryptonThemeComboBox1.ReportSelectedThemeIndex = true;
             this.kryptonThemeComboBox1.Size = new System.Drawing.Size(394, 21);
             this.kryptonThemeComboBox1.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
             this.kryptonThemeComboBox1.TabIndex = 2;

--- a/Source/Krypton Components/TestForm/StartScreen.Designer.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.Designer.cs
@@ -126,7 +126,6 @@ namespace TestForm
             this.kryptonThemeComboBox1.IntegralHeight = false;
             this.kryptonThemeComboBox1.Location = new System.Drawing.Point(10, 11);
             this.kryptonThemeComboBox1.Name = "kryptonThemeComboBox1";
-            this.kryptonThemeComboBox1.ReportSelectedThemeIndex = false;
             this.kryptonThemeComboBox1.Size = new System.Drawing.Size(417, 21);
             this.kryptonThemeComboBox1.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
             this.kryptonThemeComboBox1.TabIndex = 18;

--- a/Source/Krypton Components/TestForm/ThemeControlExamples.Designer.cs
+++ b/Source/Krypton Components/TestForm/ThemeControlExamples.Designer.cs
@@ -79,7 +79,6 @@
             this.kryptonThemeComboBox1.IntegralHeight = false;
             this.kryptonThemeComboBox1.Location = new System.Drawing.Point(141, 13);
             this.kryptonThemeComboBox1.Name = "kryptonThemeComboBox1";
-            this.kryptonThemeComboBox1.ReportSelectedThemeIndex = false;
             this.kryptonThemeComboBox1.Size = new System.Drawing.Size(334, 21);
             this.kryptonThemeComboBox1.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
             this.kryptonThemeComboBox1.TabIndex = 1;
@@ -100,7 +99,6 @@
             this.kryptonThemeListBox1.DefaultPalette = Krypton.Toolkit.PaletteMode.ProfessionalSystem;
             this.kryptonThemeListBox1.Location = new System.Drawing.Point(141, 40);
             this.kryptonThemeListBox1.Name = "kryptonThemeListBox1";
-            this.kryptonThemeListBox1.ReportSelectedThemeIndex = false;
             this.kryptonThemeListBox1.Size = new System.Drawing.Size(334, 356);
             this.kryptonThemeListBox1.TabIndex = 4;
             // 

--- a/Source/Krypton Components/TestForm/ThemeTest.Designer.cs
+++ b/Source/Krypton Components/TestForm/ThemeTest.Designer.cs
@@ -162,7 +162,6 @@ namespace TestForm
             this.kryptonThemeComboBox1.Location = new System.Drawing.Point(15, 176);
             this.kryptonThemeComboBox1.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonThemeComboBox1.Name = "kryptonThemeComboBox1";
-            this.kryptonThemeComboBox1.ReportSelectedThemeIndex = false;
             this.kryptonThemeComboBox1.Size = new System.Drawing.Size(452, 23);
             this.kryptonThemeComboBox1.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
             this.kryptonThemeComboBox1.TabIndex = 12;

--- a/Source/Krypton Components/TestForm/TreeViewExample.Designer.cs
+++ b/Source/Krypton Components/TestForm/TreeViewExample.Designer.cs
@@ -194,7 +194,6 @@ namespace TestForm
             this.kryptonThemeComboBox1.Location = new System.Drawing.Point(445, 16);
             this.kryptonThemeComboBox1.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonThemeComboBox1.Name = "kryptonThemeComboBox1";
-            this.kryptonThemeComboBox1.ReportSelectedThemeIndex = false;
             this.kryptonThemeComboBox1.Size = new System.Drawing.Size(503, 25);
             this.kryptonThemeComboBox1.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
             this.kryptonThemeComboBox1.TabIndex = 1;


### PR DESCRIPTION
1507-Revise-Theme-Selector-Controls
[issue 1507](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1507)
Fourth part:
- Remove all references to the ReportSelectedThemeIndex property throughout alpha.
- Update the change log for this ticket.

![compile-results](https://github.com/Krypton-Suite/Standard-Toolkit/assets/96108132/18d593f1-fcd0-4b43-803f-6ebae6159f14)
