### PR TITLE
1455-V85-KComboBox-text-is-clipped

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-06-24 - Build 2406 (Patch 3) - June 2024
+* Resolved [#1455] (https://github.com/Krypton-Suite/Standard-Toolkit/issues/1455), **[Regression]** KryptonComboBox text is clipped; as height is incorrect.
 * Resolved [#619](https://github.com/Krypton-Suite/Standard-Toolkit/issues/619), KButton and KListbox unclear text color in certain scenarios
 * Resolved [#1516](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1516), Theme Office 2010 Black Dark Mode causes a crash
 * Resolved [#1328](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1328), Tentative adjustment to bring PaletteMode and the theme dictionary in line.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -225,27 +225,38 @@ namespace Krypton.Toolkit
             protected override void OnFontChanged(EventArgs e)
             {
                 // Working on Windows XP or earlier systems?
-                if (_osMajorVersion < 6)
-                {
-                    // Fudge by adding one to the font height, this gives the actual space used by the
-                    // combo box control to draw an individual item in the main part of the control
-                    ItemHeight = Font.Height + 1;
-                }
-                else
-                {
-                    // Vista performs differently depending of the use of themes...
-                    if (IsAppThemed)
-                    {
-                        // Fudge by subtracting 1, which ensure correct sizing of combo box main area
-                        ItemHeight = Font.Height - 1;
-                    }
-                    else
-                    {
-                        // On under Vista without themes is the font height the actual height used
-                        // by the combo box for the space required for drawing the actual item
-                        ItemHeight = Font.Height;
-                    }
-                }
+                //if (_osMajorVersion < 6)
+                //{
+                //    // Fudge by adding one to the font height, this gives the actual space used by the
+                //    // combo box control to draw an individual item in the main part of the control
+                //    ItemHeight = Font.Height + 1;
+                //}
+                //else
+                //{
+                //    // Vista performs differently depending of the use of themes...
+                //    if (IsAppThemed)
+                //    {
+                //        // Fudge by subtracting 1, which ensure correct sizing of combo box main area
+                //        //ItemHeight = Font.Height - 1;
+
+                //        // #1455 - The lower part of the text can become clipped with chars like g, y, p, etc.
+                //        // when subtracting one from the font height. 
+                //        ItemHeight = Font.Height;
+                //    }
+                //    else
+                //    {
+                //        // On under Vista without themes is the font height the actual height used
+                //        // by the combo box for the space required for drawing the actual item
+                //        ItemHeight = Font.Height;
+                //    }
+                //}
+
+                // #1455 - The lower part of the text can become clipped with chars like g, y, p, etc.
+                // when subtracting one from the font height. 
+                ItemHeight = _osMajorVersion < 6
+                    ? Font.Height + 1
+                    : Font.Height;
+
                 base.OnFontChanged(e);
             }
 


### PR DESCRIPTION
1455-V85-KComboBox-text-is-clipped
[Issue 1455](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1455)
- ItemHeight sizing by Font Height adjusted.
- And the Changelog.

![compile-results](https://github.com/Krypton-Suite/Standard-Toolkit/assets/96108132/25b2e2c1-1ef8-47c3-b1a8-834708aa5d6f)
