### PR TITLE
1508-V85-ButtonSpec-Does-Not-Open-Assigned-Context-Menu

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,11 +3,17 @@
 =======
 
 ## 2024-06-24 - Build 2406 (Patch 3) - June 2024
+* Resolved [#1508](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1508), **[Breaking Change]** ButtonSpec does not open assigned context menu when clicked.
+    - Added property `ShowDrop`, which displays a drop down arrow on the button.
+    - When a `KryptonContextMenu` is connected the menu is shown when the button is clicked.
+    - When a WinForms `ContextMenuStrip` is connected the menu is shown when the button is clicked.
+    - When both type of the above ContextMenus are connected the `KryptonContextMenu` takes precedence.
+    - The ButtonSpec's `Type` property does not need setting to "Context" to display the menu.
 * Resolved [#619](https://github.com/Krypton-Suite/Standard-Toolkit/issues/619), KButton and KListbox unclear text color in certain scenarios
 * Resolved [#1516](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1516), Theme Office 2010 Black Dark Mode causes a crash
 * Resolved [#1328](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1328), Tentative adjustment to bring PaletteMode and the theme dictionary in line.
 * Resolved [#1388](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1388), `KryptonButton` and `KryptonDropButton` Dropdown arrow color does not react to theme changes and is not visible.
-* Resolved [#1424](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1424), **Breaking Change** `KryptonMessageBox` does not obey tab characters like `MessageBox`
+* Resolved [#1424](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1424), **[Breaking Change]** `KryptonMessageBox` does not obey tab characters like `MessageBox`
 * Resolved [#1383](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1383), Closing last Page in undocked page group prevents addition of further Pages via `KryptonDockingManager.AddToWorkspace`
 * Resolved [#1381](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1381), **[Regression]** Docking Persistence broken since build ##.23.10.303
 * Version bump `80.xx.xx.xxx` -> `85.xx.xx.xx`

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecAny.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecAny.cs
@@ -167,7 +167,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Localizable(true)]
         [Category(@"Behavior")]
-        [Description(@"Defines if the button is checked or capable of being checked.")]
+        [Description(@"Displays a drop down arrow on the button.")]
         [RefreshProperties(RefreshProperties.All)]
         [DefaultValue(false)]
         public bool ShowDrop

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecView.cs
@@ -379,13 +379,10 @@ namespace Krypton.Toolkit
             // Never show a context menu in design mode
             if (!CommonHelper.DesignMode(Manager.Control))
             {
-                var showMenu = false;
-                var performDefaultClick = true;
-                if (ButtonSpec is ButtonSpecAny { ShowDrop: true })
-                {
-                    showMenu = ViewButton?.SplitRectangle.Contains(e.Location) ?? false;
-                    performDefaultClick = !showMenu;
-                }
+                // ButtonSpec's used to drop menu's if they had a context menu;
+                // BUT; Disable default action, if this is a drop button and it is clicked
+                bool performDefaultClick = !(ButtonSpec is ButtonSpecAny { ShowDrop: true }
+                                           && ViewButton!.SplitRectangle.Contains(e.Location));
 
                 if (performDefaultClick)
                 {
@@ -393,45 +390,42 @@ namespace Krypton.Toolkit
                     ButtonSpec.PerformClick(e);
                 }
 
-                if (showMenu)
+                // Does the button spec define a krypton context menu?
+                if ((ButtonSpec.KryptonContextMenu != null) && (ViewButton != null))
                 {
-                    // Does the button spec define a krypton context menu?
-                    if ((ButtonSpec.KryptonContextMenu != null) && (ViewButton != null))
+                    performFinishDelegate = false;
+                    // Convert from control coordinates to screen coordinates
+                    Rectangle rect = ViewButton.ClientRectangle;
+
+                    // If the button spec is on the chrome titlebar then find position manually
+                    Point pt = Manager.Control is Form
+                        ? new Point(Manager.Control.Left + rect.Left, Manager.Control.Top + rect.Bottom + 3)
+                        : Manager.Control!.PointToScreen(new Point(rect.Left, rect.Bottom + 3));
+
+                    // Show the context menu just below the view itself
+                    ButtonSpec.KryptonContextMenu.Closed += OnKryptonContextMenuClosed;
+                    if (!ButtonSpec.KryptonContextMenu.Show(ButtonSpec, pt))
                     {
-                        performFinishDelegate = false;
-                        // Convert from control coordinates to screen coordinates
-                        Rectangle rect = ViewButton.ClientRectangle;
+                        // Menu not being shown, so clean up
+                        ButtonSpec.KryptonContextMenu.Closed -= OnKryptonContextMenuClosed;
 
-                        // If the button spec is on the chrome titlebar then find position manually
-                        Point pt = Manager.Control is Form
-                            ? new Point(Manager.Control.Left + rect.Left, Manager.Control.Top + rect.Bottom + 3)
-                            : Manager.Control!.PointToScreen(new Point(rect.Left, rect.Bottom + 3));
-
-                        // Show the context menu just below the view itself
-                        ButtonSpec.KryptonContextMenu.Closed += OnKryptonContextMenuClosed;
-                        if (!ButtonSpec.KryptonContextMenu.Show(ButtonSpec, pt))
-                        {
-                            // Menu not being shown, so clean up
-                            ButtonSpec.KryptonContextMenu.Closed -= OnKryptonContextMenuClosed;
-
-                            // Not showing a context menu, so remove the fixed view immediately
-                            _finishDelegate?.Invoke(this, EventArgs.Empty);
-                        }
+                        // Not showing a context menu, so remove the fixed view immediately
+                        _finishDelegate?.Invoke(this, EventArgs.Empty);
                     }
-                    else if ((ButtonSpec.ContextMenuStrip != null) && (ViewButton != null))
-                    {
-                        performFinishDelegate = false;
-                        // Set the correct renderer for the menu strip
-                        ButtonSpec.ContextMenuStrip.Renderer = Manager.RenderToolStrip();
+                }
+                else if ((ButtonSpec.ContextMenuStrip != null) && (ViewButton != null))
+                {
+                    performFinishDelegate = false;
+                    // Set the correct renderer for the menu strip
+                    ButtonSpec.ContextMenuStrip.Renderer = Manager.RenderToolStrip();
 
-                        // Convert from control coordinates to screen coordinates
-                        Rectangle rect = ViewButton.ClientRectangle;
-                        Point pt = Manager.Control!.PointToScreen(new Point(rect.Left, rect.Bottom + 3));
+                    // Convert from control coordinates to screen coordinates
+                    Rectangle rect = ViewButton.ClientRectangle;
+                    Point pt = Manager.Control!.PointToScreen(new Point(rect.Left, rect.Bottom + 3));
 
-                        // Show the context menu just below the view itself
-                        VisualPopupManager.Singleton.ShowContextMenuStrip(ButtonSpec.ContextMenuStrip, pt,
-                            _finishDelegate);
-                    }
+                    // Show the context menu just below the view itself
+                    VisualPopupManager.Singleton.ShowContextMenuStrip(ButtonSpec.ContextMenuStrip, pt,
+                        _finishDelegate);
                 }
             }
 


### PR DESCRIPTION
1508-V85-ButtonSpec-Does-Not-Open-Assigned-Context-Menu
[Issue 1508](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1508)
Brought inline with the V90 code which handles this.
And the change log.

![compile-results](https://github.com/Krypton-Suite/Standard-Toolkit/assets/96108132/9bcf614a-c10a-4599-902f-df1ac32a14fe)
