### PR TITLE
1508-ButtonSpec-Does-Not-Open-Assigned-Context-Menu

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
+* Resolved [#1381](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1508), Update `ButtonSpecAny` `ShowDrop` property description.
 * Resolved [#1381](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1502), Docking Persistence broken since build `##.23.10.303`
 * Resolved [#1522]()https://github.com/Krypton-Suite/Standard-Toolkit/issues/1522), **[Breaking Change]** Check `ThemeManager` & `KryptonManager` for the use of hard coded theme indexes. See issue for full details.
 * Resolved [#239](https://github.com/Krypton-Suite/Standard-Toolkit/issues/239), Toolstrip combo boxes do not have the theme background applied

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecAny.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecAny.cs
@@ -168,7 +168,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Localizable(true)]
         [Category(@"Behavior")]
-        [Description(@"Defines if the button is checked or capable of being checked.")]
+        [Description(@"Displays a drop down arrow on the button.")]
         [RefreshProperties(RefreshProperties.All)]
         [DefaultValue(false)]
         public bool ShowDrop


### PR DESCRIPTION
1508-ButtonSpec-Does-Not-Open-Assigned-Context-Menu
[Issue 1508](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1508)
Update ShowDrop property description

![compile-results](https://github.com/Krypton-Suite/Standard-Toolkit/assets/96108132/d1c4f4d5-6a65-4336-bd80-cfda54d82149)
