### PR TITLE
1561-V85-KryptonRibbonGroup-Controls-Remain-Enabled

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-06-24 - Build 2406 - June 2024
+* Resolved [#1561](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1561), KryptonRibbonGroup Controls remain enabled at runtime when set to disabled in the designer.
 * Resolved [#1302](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1302), **[Breaking Change]** Font being used by "Professional" theme is pants !
 * Resolved [#1528](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1528), Tracking colours need reviewing
 * Resolved [#982](https://github.com/Krypton-Suite/Standard-Toolkit/issues/982), Double click on the Form1 file in the Krypton toolkit test project results in a designer error

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupComboBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupComboBox.cs
@@ -80,7 +80,7 @@ namespace Krypton.Ribbon
             // Give paint delegate to combobox so its palette changes are redrawn
             GroupComboBox.ViewPaintDelegate = needPaint;
 
-            // Update all views to reflect current button state
+            // Update all views to reflect current state
             UpdateEnabled(GroupComboBox.ComboBox);
             UpdateVisible(GroupComboBox.ComboBox);
 

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupComboBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupComboBox.cs
@@ -80,6 +80,10 @@ namespace Krypton.Ribbon
             // Give paint delegate to combobox so its palette changes are redrawn
             GroupComboBox.ViewPaintDelegate = needPaint;
 
+            // Update all views to reflect current button state
+            UpdateEnabled(GroupComboBox.ComboBox);
+            UpdateVisible(GroupComboBox.ComboBox);
+
             // Hook into changes in the ribbon custom definition
             GroupComboBox.PropertyChanged += OnComboBoxPropertyChanged;
 

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupCustomControl.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupCustomControl.cs
@@ -80,6 +80,10 @@ namespace Krypton.Ribbon
             // Give paint delegate to label so its palette changes are redrawn
             GroupCustomControl.ViewPaintDelegate = needPaint;
 
+            // Update all views to reflect current button state
+            UpdateEnabled(GroupCustomControl.CustomControl);
+            UpdateVisible(GroupCustomControl.CustomControl);
+
             // Hook into changes in the ribbon custom definition
             GroupCustomControl.PropertyChanged += OnCustomPropertyChanged;
             NULL_CONTROL_WIDTH = (int)(50 * FactorDpiX);

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupCustomControl.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupCustomControl.cs
@@ -80,8 +80,7 @@ namespace Krypton.Ribbon
             // Give paint delegate to label so its palette changes are redrawn
             GroupCustomControl.ViewPaintDelegate = needPaint;
 
-            // Update all views to reflect current button state
-            UpdateEnabled(GroupCustomControl.CustomControl);
+            // Update all views to reflect current state
             UpdateVisible(GroupCustomControl.CustomControl);
 
             // Hook into changes in the ribbon custom definition

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupDateTimePicker.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupDateTimePicker.cs
@@ -80,7 +80,7 @@ namespace Krypton.Ribbon
             // Give paint delegate to date time picker so its palette changes are redrawn
             GroupDateTimePicker.ViewPaintDelegate = needPaint;
 
-            // Update all views to reflect current button state
+            // Update all views to reflect current state
             UpdateEnabled(GroupDateTimePicker.DateTimePicker);
             UpdateVisible(GroupDateTimePicker.DateTimePicker);
 

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupDateTimePicker.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupDateTimePicker.cs
@@ -80,6 +80,10 @@ namespace Krypton.Ribbon
             // Give paint delegate to date time picker so its palette changes are redrawn
             GroupDateTimePicker.ViewPaintDelegate = needPaint;
 
+            // Update all views to reflect current button state
+            UpdateEnabled(GroupDateTimePicker.DateTimePicker);
+            UpdateVisible(GroupDateTimePicker.DateTimePicker);
+
             // Hook into changes in the ribbon custom definition
             GroupDateTimePicker.PropertyChanged += OnDateTimePickerPropertyChanged;
             NULL_CONTROL_WIDTH = (int)(50 * FactorDpiX);

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupDomainUpDown.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupDomainUpDown.cs
@@ -80,7 +80,7 @@ namespace Krypton.Ribbon
             // Give paint delegate to domain up-down so its palette changes are redrawn
             GroupDomainUpDown.ViewPaintDelegate = needPaint;
 
-            // Update all views to reflect current button state
+            // Update all views to reflect current state
             UpdateEnabled(GroupDomainUpDown.DomainUpDown);
             UpdateVisible(GroupDomainUpDown.DomainUpDown);
 

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupDomainUpDown.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupDomainUpDown.cs
@@ -80,6 +80,10 @@ namespace Krypton.Ribbon
             // Give paint delegate to domain up-down so its palette changes are redrawn
             GroupDomainUpDown.ViewPaintDelegate = needPaint;
 
+            // Update all views to reflect current button state
+            UpdateEnabled(GroupDomainUpDown.DomainUpDown);
+            UpdateVisible(GroupDomainUpDown.DomainUpDown);
+
             // Hook into changes in the ribbon custom definition
             GroupDomainUpDown.PropertyChanged += OnDomainUpDownPropertyChanged;
             NULL_CONTROL_WIDTH = (int)(50 * FactorDpiX);

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupGallery.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupGallery.cs
@@ -93,6 +93,10 @@ namespace Krypton.Ribbon
             // Give paint delegate to gallery so its palette changes are redrawn
             GroupGallery.ViewPaintDelegate = needPaint;
 
+            // Update all views to reflect current button state
+            UpdateEnabled(GroupGallery.Gallery);
+            UpdateVisible(GroupGallery.Gallery);
+
             // Hook into changes in the ribbon custom definition
             GroupGallery.PropertyChanged += OnGalleryPropertyChanged;
             NULL_CONTROL_WIDTH = (int)(50 * FactorDpiX);

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupGallery.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupGallery.cs
@@ -93,7 +93,7 @@ namespace Krypton.Ribbon
             // Give paint delegate to gallery so its palette changes are redrawn
             GroupGallery.ViewPaintDelegate = needPaint;
 
-            // Update all views to reflect current button state
+            // Update all views to reflect current state
             UpdateEnabled(GroupGallery.Gallery);
             UpdateVisible(GroupGallery.Gallery);
 

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupMaskedTextBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupMaskedTextBox.cs
@@ -80,6 +80,10 @@ namespace Krypton.Ribbon
             // Give paint delegate to masked textbox so its palette changes are redrawn
             GroupMaskedTextBox.ViewPaintDelegate = needPaint;
 
+            // Update all views to reflect current button state
+            UpdateEnabled(GroupMaskedTextBox.MaskedTextBox);
+            UpdateVisible(GroupMaskedTextBox.MaskedTextBox);
+
             // Hook into changes in the ribbon custom definition
             GroupMaskedTextBox.PropertyChanged += OnMaskedTextBoxPropertyChanged;
             NULL_CONTROL_WIDTH = (int)(50 * FactorDpiX);

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupMaskedTextBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupMaskedTextBox.cs
@@ -80,7 +80,7 @@ namespace Krypton.Ribbon
             // Give paint delegate to masked textbox so its palette changes are redrawn
             GroupMaskedTextBox.ViewPaintDelegate = needPaint;
 
-            // Update all views to reflect current button state
+            // Update all views to reflect current state
             UpdateEnabled(GroupMaskedTextBox.MaskedTextBox);
             UpdateVisible(GroupMaskedTextBox.MaskedTextBox);
 

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupNumericUpDown.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupNumericUpDown.cs
@@ -80,7 +80,7 @@ namespace Krypton.Ribbon
             // Give paint delegate to numeric up-down so its palette changes are redrawn
             GroupNumericUpDown.ViewPaintDelegate = needPaint;
 
-            // Update all views to reflect current button state
+            // Update all views to reflect current state
             UpdateEnabled(GroupNumericUpDown.NumericUpDown);
             UpdateVisible(GroupNumericUpDown.NumericUpDown);
 

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupNumericUpDown.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupNumericUpDown.cs
@@ -80,6 +80,10 @@ namespace Krypton.Ribbon
             // Give paint delegate to numeric up-down so its palette changes are redrawn
             GroupNumericUpDown.ViewPaintDelegate = needPaint;
 
+            // Update all views to reflect current button state
+            UpdateEnabled(GroupNumericUpDown.NumericUpDown);
+            UpdateVisible(GroupNumericUpDown.NumericUpDown);
+
             // Hook into changes in the ribbon custom definition
             GroupNumericUpDown.PropertyChanged += OnNumericUpDownPropertyChanged;
             NULL_CONTROL_WIDTH = (int)(50 * FactorDpiX);

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupRichTextBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupRichTextBox.cs
@@ -80,6 +80,10 @@ namespace Krypton.Ribbon
             // Give paint delegate to richtextbox so its palette changes are redrawn
             GroupRichTextBox.ViewPaintDelegate = needPaint;
 
+            // Update all views to reflect current button state
+            UpdateEnabled(GroupRichTextBox.RichTextBox);
+            UpdateVisible(GroupRichTextBox.RichTextBox);
+
             // Hook into changes in the ribbon custom definition
             GroupRichTextBox.PropertyChanged += OnRichTextBoxPropertyChanged;
             NULL_CONTROL_WIDTH = (int)(50 * FactorDpiX);

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupRichTextBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupRichTextBox.cs
@@ -80,7 +80,7 @@ namespace Krypton.Ribbon
             // Give paint delegate to richtextbox so its palette changes are redrawn
             GroupRichTextBox.ViewPaintDelegate = needPaint;
 
-            // Update all views to reflect current button state
+            // Update all views to reflect current state
             UpdateEnabled(GroupRichTextBox.RichTextBox);
             UpdateVisible(GroupRichTextBox.RichTextBox);
 

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupTextBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupTextBox.cs
@@ -80,7 +80,7 @@ namespace Krypton.Ribbon
             // Give paint delegate to textbox so its palette changes are redrawn
             GroupTextBox.ViewPaintDelegate = needPaint;
 
-            // Update all views to reflect current button state
+            // Update all views to reflect current state
             UpdateEnabled(GroupTextBox.TextBox);
             UpdateVisible(GroupTextBox.TextBox);
 

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupTextBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupTextBox.cs
@@ -80,6 +80,10 @@ namespace Krypton.Ribbon
             // Give paint delegate to textbox so its palette changes are redrawn
             GroupTextBox.ViewPaintDelegate = needPaint;
 
+            // Update all views to reflect current button state
+            UpdateEnabled(GroupTextBox.TextBox);
+            UpdateVisible(GroupTextBox.TextBox);
+
             // Hook into changes in the ribbon custom definition
             GroupTextBox.PropertyChanged += OnTextBoxPropertyChanged;
             NULL_CONTROL_WIDTH = (int)(50 * FactorDpiX);

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupTrackBar.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupTrackBar.cs
@@ -85,7 +85,7 @@ namespace Krypton.Ribbon
             UpdateVisible(GroupTrackBar.TrackBar);
 
             // Hook into changes in the ribbon custom definition
-            GroupTrackBar.PropertyChanged += OnTrackbarPropertyChanged;
+            GroupTrackBar.PropertyChanged += OnTrackBarPropertyChanged;
             NULL_CONTROL_WIDTH = (int)(50 * FactorDpiX);
         }
 
@@ -111,7 +111,7 @@ namespace Krypton.Ribbon
                     GroupTrackBar.MouseEnterControl -= OnMouseEnterControl;
                     GroupTrackBar.MouseLeaveControl -= OnMouseLeaveControl;
                     GroupTrackBar.ViewPaintDelegate = null;
-                    GroupTrackBar.PropertyChanged -= OnTrackbarPropertyChanged;
+                    GroupTrackBar.PropertyChanged -= OnTrackBarPropertyChanged;
                     _ribbon.ViewRibbonManager.LayoutAfter -= OnLayoutAction;
                     _ribbon.ViewRibbonManager.LayoutBefore -= OnLayoutAction;
 
@@ -379,7 +379,7 @@ namespace Krypton.Ribbon
         #region Implementation
         private void OnContextClick(object sender, MouseEventArgs e) => GroupTrackBar.OnDesignTimeContextMenu(e);
 
-        private void OnTrackbarPropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void OnTrackBarPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             var updateLayout = false;
             const bool UPDATE_PAINT = false;

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupTrackBar.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupTrackBar.cs
@@ -80,7 +80,7 @@ namespace Krypton.Ribbon
             // Give paint delegate to textbox so its palette changes are redrawn
             GroupTrackBar.ViewPaintDelegate = needPaint;
 
-            // Update all views to reflect current button state
+            // Update all views to reflect current state
             UpdateEnabled(GroupTrackBar.TrackBar);
             UpdateVisible(GroupTrackBar.TrackBar);
 

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupTrackBar.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonGroupTrackBar.cs
@@ -80,8 +80,12 @@ namespace Krypton.Ribbon
             // Give paint delegate to textbox so its palette changes are redrawn
             GroupTrackBar.ViewPaintDelegate = needPaint;
 
+            // Update all views to reflect current button state
+            UpdateEnabled(GroupTrackBar.TrackBar);
+            UpdateVisible(GroupTrackBar.TrackBar);
+
             // Hook into changes in the ribbon custom definition
-            GroupTrackBar.PropertyChanged += OnTextBoxPropertyChanged;
+            GroupTrackBar.PropertyChanged += OnTrackbarPropertyChanged;
             NULL_CONTROL_WIDTH = (int)(50 * FactorDpiX);
         }
 
@@ -107,7 +111,7 @@ namespace Krypton.Ribbon
                     GroupTrackBar.MouseEnterControl -= OnMouseEnterControl;
                     GroupTrackBar.MouseLeaveControl -= OnMouseLeaveControl;
                     GroupTrackBar.ViewPaintDelegate = null;
-                    GroupTrackBar.PropertyChanged -= OnTextBoxPropertyChanged;
+                    GroupTrackBar.PropertyChanged -= OnTrackbarPropertyChanged;
                     _ribbon.ViewRibbonManager.LayoutAfter -= OnLayoutAction;
                     _ribbon.ViewRibbonManager.LayoutBefore -= OnLayoutAction;
 
@@ -375,7 +379,7 @@ namespace Krypton.Ribbon
         #region Implementation
         private void OnContextClick(object sender, MouseEventArgs e) => GroupTrackBar.OnDesignTimeContextMenu(e);
 
-        private void OnTextBoxPropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void OnTrackbarPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             var updateLayout = false;
             const bool UPDATE_PAINT = false;


### PR DESCRIPTION
1561-V85-KryptonRibbonGroup-Controls-Remain-Enabled
[Issue 1561](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1561)
Handling of properties `Enabled` and `Visible` adjusted
- ViewDrawRibbonGroupComboBox
- ViewDrawRibbonGroupCustomControl
- ViewDrawRibbonGroupDateTimePicker
- ViewDrawRibbonGroupDomainUpDown
- ViewDrawRibbonGroupGallery
- ViewDrawRibbonGroupMaskedTextBox
- ViewDrawRibbonGroupNumericUpDown
- ViewDrawRibbonGroupRichTextBox
- ViewDrawRibbonGroupTextBox
- ViewDrawRibbonGroupTrackBar

![compile-results](https://github.com/Krypton-Suite/Standard-Toolkit/assets/96108132/25df081c-2c89-4012-8639-db97f7a5d0ea)
