### PR TITLE
1522-Check-ThemeManager-KryptonManager-for-hard-coded-theme-indexes

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
+* Resolved [#1522](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1522), Declare `ThemeManager.SetTheme()` Obsolete from V100
 * Resolved [#1561](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1561), KryptonRibbonGroup Controls remain enabled at runtime when set to disabled in the designer.
 * Resolved [#1536](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1536), Build script does not follow same behaviour when 'rebuilding'
 * Resolved [#1381](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1508), Update `ButtonSpecAny` `ShowDrop` property description.

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/ThemeManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/ThemeManager.cs
@@ -54,7 +54,10 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="themeName">Name of the theme.</param>
         /// <param name="manager">The manager.</param>
-        public static void SetTheme(string themeName, KryptonManager manager) => ApplyGlobalTheme(manager, GetThemeManagerMode(themeName));
+        [Obsolete("Deprecated and will be removed in V100. Replace this with calls to ApplyTheme( . . . )")]
+        public static void SetTheme(string themeName, KryptonManager manager) =>
+            //TODO V100 Remove SetTheme method
+            ApplyGlobalTheme(manager, GetThemeManagerMode(themeName));
 
         /// <summary>
         /// Applies the global theme.


### PR DESCRIPTION
1522-Check-ThemeManager-KryptonManager-for-hard-coded-theme-indexes
[Issue 1522](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1522)

SetTheme has a similar ApplyTheme overload, which has te preference and one call that can do this suffices.

![compile-results](https://github.com/Krypton-Suite/Standard-Toolkit/assets/96108132/070fdaa3-72dd-455d-8e5e-38ff9b468d7b)
