### PR TITLE
- Ensure that "Precedence" is given to the `Enabled` state of a control, over the `AlwaysActive` highlight state.

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
+* Resolved [#1573](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1573), KCheckedListbox & KListBox do not respect 'disabled' back colours
 * Resolved [#1522](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1522), Declare `ThemeManager.SetTheme()` Obsolete from V100
 * Resolved [#371](https://github.com/Krypton-Suite/Standard-Toolkit/issues/371), Office 365 Black theme ribbon needs better colours for disabled etc.
 * Resolved [#1522](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1522), Declare `ThemeManager.SetTheme()` Obsolete from V100

--- a/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonGallery.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonGallery.cs
@@ -6,9 +6,6 @@
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
  *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved. 
- *  
- *  Modified: Monday 12th April, 2021 @ 18:00 GMT
- *
  */
 #endregion
 
@@ -900,8 +897,7 @@ namespace Krypton.Ribbon
             _drawDocker.Enabled = Enabled;
 
             // Find the new state of the main view element
-            PaletteState state;
-            state = IsActive ? PaletteState.Tracking : PaletteState.Normal;
+            PaletteState state = Enabled ? (IsActive ? PaletteState.Tracking : PaletteState.Normal) : PaletteState.Disabled;
 
             _drawDocker.ElementState = state;
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckedListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckedListBox.cs
@@ -2168,22 +2168,14 @@ namespace Krypton.Toolkit
                 _drawDockerOuter.Enabled = Enabled;
 
                 // Find the new state of the main view element
-                PaletteState state;
-                if (IsActive)
-                {
-                    state = PaletteState.Tracking;
-                }
-                else
-                {
-                    state = Enabled ? PaletteState.Normal : PaletteState.Disabled;
-                }
+                PaletteState state = Enabled ? (IsActive ? PaletteState.Tracking : PaletteState.Normal) : PaletteState.Disabled;
 
                 _listBox.ViewDrawPanel.ElementState = state;
                 _drawDockerOuter.ElementState = state;
             }
         }
 
-        private IPaletteDouble GetDoubleState() => Enabled ? IsActive ? StateActive : StateNormal : StateDisabled;
+        private IPaletteDouble GetDoubleState() => Enabled ? (IsActive ? StateActive : StateNormal) : StateDisabled;
 
         private void OnListBoxDrawItem(object? sender, DrawItemEventArgs e)
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -2741,7 +2741,7 @@ namespace Krypton.Toolkit
             _drawDockerOuter.Enabled = Enabled;
 
             // Find the new state of the main view element
-            PaletteState state = IsActive ? PaletteState.Tracking : PaletteState.Normal;
+            PaletteState state = Enabled ? (IsActive ? PaletteState.Tracking : PaletteState.Normal) : PaletteState.Disabled;
 
             _drawDockerOuter.ElementState = state;
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDateTimePicker.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDateTimePicker.cs
@@ -1961,7 +1961,7 @@ namespace Krypton.Toolkit
             _drawDockerOuter.Enabled = Enabled;
 
             // Find the new state of the main view element
-            PaletteState state = IsActive ? PaletteState.Tracking : PaletteState.Normal;
+            PaletteState state = Enabled ? (IsActive ? PaletteState.Tracking : PaletteState.Normal) : PaletteState.Disabled;
 
             _drawDockerOuter.ElementState = state;
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
@@ -1855,7 +1855,7 @@ namespace Krypton.Toolkit
             _drawDockerOuter.Enabled = Enabled;
 
             // Find the new state of the main view element
-            PaletteState state = IsActive ? PaletteState.Tracking : PaletteState.Normal;
+            PaletteState state = Enabled ? (IsActive ? PaletteState.Tracking : PaletteState.Normal) : PaletteState.Disabled;
 
             _drawDockerOuter.ElementState = state;
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListBox.cs
@@ -1519,15 +1519,7 @@ namespace Krypton.Toolkit
                 _drawDockerOuter.Enabled = Enabled;
 
                 // Find the new state of the main view element
-                PaletteState state;
-                if (IsActive)
-                {
-                    state = PaletteState.Tracking;
-                }
-                else
-                {
-                    state = Enabled ? PaletteState.Normal : PaletteState.Disabled;
-                }
+                PaletteState state = Enabled ? (IsActive ? PaletteState.Tracking : PaletteState.Normal) : PaletteState.Disabled;
 
                 _listBox.ViewDrawPanel.ElementState = state;
                 _drawDockerOuter.ElementState = state;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListView.cs
@@ -413,15 +413,7 @@ namespace Krypton.Toolkit
                 _drawDockerOuter.Enabled = Enabled;
 
                 // Find the new state of the main view element
-                PaletteState state;
-                if (IsActive)
-                {
-                    state = PaletteState.Tracking;
-                }
-                else
-                {
-                    state = Enabled ? PaletteState.Normal : PaletteState.Disabled;
-                }
+                PaletteState state = Enabled ? (IsActive ? PaletteState.Tracking : PaletteState.Normal) : PaletteState.Disabled;
 
                 ViewDrawPanel.ElementState = state;
                 _drawDockerOuter.ElementState = state;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs
@@ -1766,7 +1766,7 @@ namespace Krypton.Toolkit
             _drawDockerOuter.Enabled = Enabled;
 
             // Find the new state of the main view element
-            PaletteState state = IsActive ? PaletteState.Tracking : PaletteState.Normal;
+            PaletteState state = Enabled ? (IsActive ? PaletteState.Tracking : PaletteState.Normal) : PaletteState.Disabled;
 
             _drawDockerOuter.ElementState = state;
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
@@ -1988,7 +1988,7 @@ namespace Krypton.Toolkit
             _drawDockerOuter.Enabled = Enabled;
 
             // Find the new state of the main view element
-            PaletteState state = IsActive ? PaletteState.Tracking : PaletteState.Normal;
+            PaletteState state = Enabled ? (IsActive ? PaletteState.Tracking : PaletteState.Normal) : PaletteState.Disabled;
 
             _drawDockerOuter.ElementState = state;
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
@@ -2103,7 +2103,7 @@ namespace Krypton.Toolkit
             _drawDockerOuter.Enabled = Enabled;
 
             // Find the new state of the main view element
-            PaletteState state = IsActive ? PaletteState.Tracking : PaletteState.Normal;
+            PaletteState state = Enabled ? (IsActive ? PaletteState.Tracking : PaletteState.Normal) : PaletteState.Disabled;
 
             _drawDockerOuter.ElementState = state;
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
@@ -188,8 +188,7 @@ namespace Krypton.Toolkit
                                     // it from the device context. Resulting in blurred text.
                                     g.TextRenderingHint =
                                         CommonHelper.PaletteTextHintToRenderingHint(
-                                            _kryptonTextBox.StateDisabled.PaletteContent!.GetContentShortTextHint(
-                                                PaletteState.Disabled));
+                                            _kryptonTextBox.StateDisabled.PaletteContent.GetContentShortTextHint(PaletteState.Disabled));
 
                                     // Define the string formatting requirements
                                     var stringFormat = new StringFormat
@@ -437,7 +436,7 @@ namespace Krypton.Toolkit
             // Contains another control and needs marking as such for validation to work
             SetStyle(ControlStyles.ContainerControl, true);
 
-            // By default we are not multiline and so the height is fixed
+            // By default, we are not multiline and so the height is fixed
             SetStyle(ControlStyles.FixedHeight, true);
 
             // Cannot select this control, only the child TextBox, and does not generate a click event
@@ -1016,7 +1015,7 @@ namespace Krypton.Toolkit
         }
 
         /// <summary>
-        /// Gets or sets a the character to display for password input for single-line edit controls.
+        /// Gets or sets the character to display for password input for single-line edit controls.
         /// </summary>
         [Category(@"Behavior")]
         [Description(@"Indicates the character to display for password input for single-line edit controls.")]
@@ -1175,59 +1174,59 @@ namespace Krypton.Toolkit
         /// Appends text to the current text of a rich text box.
         /// </summary>
         /// <param name="text">The text to append to the current contents of the text box.</param>
-        public void AppendText(string text) => _textBox?.AppendText(text);
+        public void AppendText(string text) => _textBox.AppendText(text);
 
         /// <summary>
         /// Clears all text from the text box control.
         /// </summary>
-        public void Clear() => _textBox?.Clear();
+        public void Clear() => _textBox.Clear();
 
         /// <summary>
         /// Clears information about the most recent operation from the undo buffer of the rich text box. 
         /// </summary>
-        public void ClearUndo() => _textBox?.ClearUndo();
+        public void ClearUndo() => _textBox.ClearUndo();
 
         /// <summary>
         /// Copies the current selection in the text box to the Clipboard.
         /// </summary>
-        public void Copy() => _textBox?.Copy();
+        public void Copy() => _textBox.Copy();
 
         /// <summary>
         /// Moves the current selection in the text box to the Clipboard.
         /// </summary>
-        public void Cut() => _textBox?.Cut();
+        public void Cut() => _textBox.Cut();
 
         /// <summary>
         /// Replaces the current selection in the text box with the contents of the Clipboard.
         /// </summary>
-        public void Paste() => _textBox?.Paste();
+        public void Paste() => _textBox.Paste();
 
         /// <summary>
         /// Scrolls the contents of the control to the current caret position.
         /// </summary>
-        public void ScrollToCaret() => _textBox?.ScrollToCaret();
+        public void ScrollToCaret() => _textBox.ScrollToCaret();
 
         /// <summary>
         /// Selects a range of text in the control.
         /// </summary>
         /// <param name="start">The position of the first character in the current text selection within the text box.</param>
         /// <param name="length">The number of characters to select.</param>
-        public void Select(int start, int length) => _textBox?.Select(start, length);
+        public void Select(int start, int length) => _textBox.Select(start, length);
 
         /// <summary>
         /// Selects all text in the control.
         /// </summary>
-        public void SelectAll() => _textBox?.SelectAll();
+        public void SelectAll() => _textBox.SelectAll();
 
         /// <summary>
         /// Undoes the last edit operation in the text box.
         /// </summary>
-        public void Undo() => _textBox?.Undo();
+        public void Undo() => _textBox.Undo();
 
         /// <summary>
         /// Specifies that the value of the SelectionLength property is zero so that no characters are selected in the control.
         /// </summary>
-        public void DeselectAll() => _textBox?.DeselectAll();
+        public void DeselectAll() => _textBox.DeselectAll();
 
         /// <summary>
         /// Retrieves the character that is closest to the specified location within the control.
@@ -1288,18 +1287,18 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool IsActive => _textBox != null && (_fixedActive ?? DesignMode || AlwaysActive || ContainsFocus || _mouseOver || _textBox.MouseOver);
+        public bool IsActive => (_fixedActive ?? DesignMode || AlwaysActive || ContainsFocus || _mouseOver || _textBox.MouseOver);
 
         /// <summary>
         /// Sets input focus to the control.
         /// </summary>
         /// <returns>true if the input focus request was successful; otherwise, false.</returns>
-        public new bool Focus() => TextBox?.Focus() == true;
+        public new bool Focus() => TextBox.Focus();
 
         /// <summary>
         /// Activates the control.
         /// </summary>
-        public new void Select() => TextBox?.Select();
+        public new void Select() => TextBox.Select();
 
         /// <summary>
         /// Get the preferred size of the control based on a proposed size.
@@ -1552,7 +1551,7 @@ namespace Krypton.Toolkit
         protected override void OnGotFocus(EventArgs e)
         {
             base.OnGotFocus(e);
-            _textBox?.Focus();
+            _textBox.Focus();
         }
 
         /// <summary>
@@ -1635,7 +1634,7 @@ namespace Krypton.Toolkit
         {
             _mouseOver = true;
             PerformNeedPaint(true);
-            _textBox?.Invalidate();
+            _textBox.Invalidate();
             base.OnMouseEnter(e);
         }
 
@@ -1647,7 +1646,7 @@ namespace Krypton.Toolkit
         {
             _mouseOver = false;
             PerformNeedPaint(true);
-            _textBox?.Invalidate();
+            _textBox.Invalidate();
             base.OnMouseLeave(e);
         }
 
@@ -1704,7 +1703,7 @@ namespace Krypton.Toolkit
         {
             if (IsHandleCreated && !e.NeedLayout)
             {
-                _textBox?.Invalidate();
+                _textBox.Invalidate();
             }
             else
             {
@@ -1717,7 +1716,7 @@ namespace Krypton.Toolkit
                 UpdateStateAndPalettes();
                 IPaletteTriple triple = GetTripleState();
                 PaletteState state = _drawDockerOuter.State;
-                _textBox!.BackColor = triple.PaletteBack.GetBackColor1(state);
+                _textBox.BackColor = triple.PaletteBack.GetBackColor1(state);
                 _textBox.ForeColor = triple.PaletteContent!.GetContentShortTextColor1(state);
 
                 // Only set the font if the text box has been created
@@ -1816,7 +1815,7 @@ namespace Krypton.Toolkit
             _drawDockerOuter.Enabled = Enabled;
 
             // Find the new state of the main view element
-            PaletteState state = IsActive ? PaletteState.Tracking : PaletteState.Normal;
+            PaletteState state = Enabled ? (IsActive ? PaletteState.Tracking : PaletteState.Normal) : PaletteState.Disabled;
 
             _drawDockerOuter.ElementState = state;
         }
@@ -2003,10 +2002,10 @@ namespace Krypton.Toolkit
             base.OnClick(e);
         // ReSharper restore RedundantBaseQualifier
 
-        private void SetIsInAlphaNumericMode(KryptonTextBox owner)
-        {
-            // TODO: Return to this...
-        }
+        //private void SetIsInAlphaNumericMode(KryptonTextBox owner)
+        //{
+        //    // TODO: Return to this...
+        //}
 
         private void ToggleEllipsisButtonVisibility(bool visible)
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
@@ -1994,20 +1994,11 @@ namespace Krypton.Toolkit
                 _drawDockerOuter.Enabled = Enabled;
 
                 // Find the new state of the main view element
-                PaletteState state;
-                if (IsActive)
-                {
-                    state = PaletteState.Tracking;
-                }
-                else
-                {
-                    state = Enabled ? PaletteState.Normal : PaletteState.Disabled;
-                }
+                PaletteState state = Enabled ? (IsActive ? PaletteState.Tracking : PaletteState.Normal) : PaletteState.Disabled;
 
                 _treeView.ViewDrawPanel.ElementState = state;
                 _drawDockerOuter.ElementState = state;
                 _treeView.Font = StateCommon.Node.Content.ShortText.Font;
-
             }
         }
 
@@ -2018,11 +2009,11 @@ namespace Krypton.Toolkit
             var depth = 0;
 
             // Count depth of our node in tree
-            TreeNode current = node;
+            TreeNode? current = node;
             while (current is not null)
             {
                 depth++;
-                current = current.Parent!;
+                current = current.Parent;
             }
 
             // Do we need the root level indent?

--- a/Source/Krypton Components/Krypton.Toolkit/General/OutlookGrid/General/OutlookGridColumnCollection.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/OutlookGrid/General/OutlookGridColumnCollection.cs
@@ -93,7 +93,7 @@ namespace Krypton.Toolkit
         /// Gets the number of columns grouped
         /// </summary>
         /// <returns>the number of columns grouped.</returns>
-        public int CountGrouped() => this.Count(c => c.IsGrouped == true);
+        public int CountGrouped() => this.Count(c => c.IsGrouped);
 
         /// <summary>
         /// Gets the list of grouped columns

--- a/Source/Krypton Components/Krypton.Toolkit/General/OutlookGrid/General/OutlookGridDefaultGroup.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/OutlookGrid/General/OutlookGridDefaultGroup.cs
@@ -378,7 +378,7 @@ namespace Krypton.Toolkit
                 {
                     bool b1 = (bool)_val;
                     bool b2 = (bool)o2!;
-                    compareResult = (b1 == b2 ? 0 : b1 == true ? 1 : -1) * orderModifier;
+                    compareResult = (b1 == b2 ? 0 : b1 ? 1 : -1) * orderModifier;
                 }
                 else if (_val is float)
                 {

--- a/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/VScrollSkin.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/VScrollSkin.cs
@@ -463,7 +463,7 @@ namespace Krypton.Toolkit
             var dgv = (DataGridView)_win;
             if (GetDGVScrollbar(ref dgv, out VSB))
             {
-                if (VSB.Visible == true)
+                if (VSB.Visible)
                 {
                     VScrollBar1.Visible = true;
                     SetDGVScrollBarValue(ref dgv, ref VSB);
@@ -476,7 +476,7 @@ namespace Krypton.Toolkit
 
             if (GetDGHScrollbar(ref dgv, out HSC))
             {
-                if (HSC.Visible == true)
+                if (HSC.Visible)
                 {
                     HScrollBar1.Visible = true;
                     SetDGVScrollBarValue(ref dgv, ref HSC);

--- a/Source/Krypton Components/TestForm/ControlsTest.Designer.cs
+++ b/Source/Krypton Components/TestForm/ControlsTest.Designer.cs
@@ -28,26 +28,26 @@
         /// </summary>
         private void InitializeComponent()
         {
-            System.Windows.Forms.ListViewItem listViewItem41 = new System.Windows.Forms.ListViewItem("1");
-            System.Windows.Forms.ListViewItem listViewItem42 = new System.Windows.Forms.ListViewItem("2");
-            System.Windows.Forms.ListViewItem listViewItem43 = new System.Windows.Forms.ListViewItem("3");
-            System.Windows.Forms.ListViewItem listViewItem44 = new System.Windows.Forms.ListViewItem("4");
-            System.Windows.Forms.ListViewItem listViewItem45 = new System.Windows.Forms.ListViewItem("5");
-            System.Windows.Forms.ListViewItem listViewItem46 = new System.Windows.Forms.ListViewItem("6");
-            System.Windows.Forms.ListViewItem listViewItem47 = new System.Windows.Forms.ListViewItem("7");
-            System.Windows.Forms.ListViewItem listViewItem48 = new System.Windows.Forms.ListViewItem("8");
-            System.Windows.Forms.ListViewItem listViewItem49 = new System.Windows.Forms.ListViewItem("9");
-            System.Windows.Forms.ListViewItem listViewItem50 = new System.Windows.Forms.ListViewItem("10");
-            System.Windows.Forms.ListViewItem listViewItem51 = new System.Windows.Forms.ListViewItem("1");
-            System.Windows.Forms.ListViewItem listViewItem52 = new System.Windows.Forms.ListViewItem("2");
-            System.Windows.Forms.ListViewItem listViewItem53 = new System.Windows.Forms.ListViewItem("3");
-            System.Windows.Forms.ListViewItem listViewItem54 = new System.Windows.Forms.ListViewItem("4");
-            System.Windows.Forms.ListViewItem listViewItem55 = new System.Windows.Forms.ListViewItem("5");
-            System.Windows.Forms.ListViewItem listViewItem56 = new System.Windows.Forms.ListViewItem("6");
-            System.Windows.Forms.ListViewItem listViewItem57 = new System.Windows.Forms.ListViewItem("7");
-            System.Windows.Forms.ListViewItem listViewItem58 = new System.Windows.Forms.ListViewItem("8");
-            System.Windows.Forms.ListViewItem listViewItem59 = new System.Windows.Forms.ListViewItem("9");
-            System.Windows.Forms.ListViewItem listViewItem60 = new System.Windows.Forms.ListViewItem("10");
+            System.Windows.Forms.ListViewItem listViewItem1 = new System.Windows.Forms.ListViewItem("1");
+            System.Windows.Forms.ListViewItem listViewItem2 = new System.Windows.Forms.ListViewItem("2");
+            System.Windows.Forms.ListViewItem listViewItem3 = new System.Windows.Forms.ListViewItem("3");
+            System.Windows.Forms.ListViewItem listViewItem4 = new System.Windows.Forms.ListViewItem("4");
+            System.Windows.Forms.ListViewItem listViewItem5 = new System.Windows.Forms.ListViewItem("5");
+            System.Windows.Forms.ListViewItem listViewItem6 = new System.Windows.Forms.ListViewItem("6");
+            System.Windows.Forms.ListViewItem listViewItem7 = new System.Windows.Forms.ListViewItem("7");
+            System.Windows.Forms.ListViewItem listViewItem8 = new System.Windows.Forms.ListViewItem("8");
+            System.Windows.Forms.ListViewItem listViewItem9 = new System.Windows.Forms.ListViewItem("9");
+            System.Windows.Forms.ListViewItem listViewItem10 = new System.Windows.Forms.ListViewItem("10");
+            System.Windows.Forms.ListViewItem listViewItem11 = new System.Windows.Forms.ListViewItem("1");
+            System.Windows.Forms.ListViewItem listViewItem12 = new System.Windows.Forms.ListViewItem("2");
+            System.Windows.Forms.ListViewItem listViewItem13 = new System.Windows.Forms.ListViewItem("3");
+            System.Windows.Forms.ListViewItem listViewItem14 = new System.Windows.Forms.ListViewItem("4");
+            System.Windows.Forms.ListViewItem listViewItem15 = new System.Windows.Forms.ListViewItem("5");
+            System.Windows.Forms.ListViewItem listViewItem16 = new System.Windows.Forms.ListViewItem("6");
+            System.Windows.Forms.ListViewItem listViewItem17 = new System.Windows.Forms.ListViewItem("7");
+            System.Windows.Forms.ListViewItem listViewItem18 = new System.Windows.Forms.ListViewItem("8");
+            System.Windows.Forms.ListViewItem listViewItem19 = new System.Windows.Forms.ListViewItem("9");
+            System.Windows.Forms.ListViewItem listViewItem20 = new System.Windows.Forms.ListViewItem("10");
             this.kryptonRibbon1 = new Krypton.Ribbon.KryptonRibbon();
             this.kryptonRibbonTab1 = new Krypton.Ribbon.KryptonRibbonTab();
             this.kryptonRibbonGroup1 = new Krypton.Ribbon.KryptonRibbonGroup();
@@ -64,6 +64,16 @@
             this.kryptonRibbonGroupThemeComboBox1 = new Krypton.Ribbon.KryptonRibbonGroupThemeComboBox();
             this.kryptonRibbonGroupThemeComboBox2 = new Krypton.Ribbon.KryptonRibbonGroupThemeComboBox();
             this.kryptonPanel1 = new Krypton.Toolkit.KryptonPanel();
+            this.kryptonTrackBar2 = new Krypton.Toolkit.KryptonTrackBar();
+            this.kryptonTrackBar1 = new Krypton.Toolkit.KryptonTrackBar();
+            this.kryptonGroupBox2 = new Krypton.Toolkit.KryptonGroupBox();
+            this.kryptonGroupBox1 = new Krypton.Toolkit.KryptonGroupBox();
+            this.kryptonPanel3 = new Krypton.Toolkit.KryptonPanel();
+            this.kryptonPanel2 = new Krypton.Toolkit.KryptonPanel();
+            this.kryptonRadioButton2 = new Krypton.Toolkit.KryptonRadioButton();
+            this.kryptonRadioButton1 = new Krypton.Toolkit.KryptonRadioButton();
+            this.kryptonTextBox2 = new Krypton.Toolkit.KryptonTextBox();
+            this.kryptonTextBox1 = new Krypton.Toolkit.KryptonTextBox();
             this.kryptonCheckBox2 = new Krypton.Toolkit.KryptonCheckBox();
             this.kryptonCheckBox1 = new Krypton.Toolkit.KryptonCheckBox();
             this.kryptonButton2 = new Krypton.Toolkit.KryptonButton();
@@ -78,9 +88,25 @@
             this.kryptonGalleryRange1 = new Krypton.Ribbon.KryptonGalleryRange();
             this.kryptonGalleryRange2 = new Krypton.Ribbon.KryptonGalleryRange();
             this.kryptonGalleryRange3 = new Krypton.Ribbon.KryptonGalleryRange();
+            this.kryptonDomainUpDown1 = new Krypton.Toolkit.KryptonDomainUpDown();
+            this.kryptonDomainUpDown2 = new Krypton.Toolkit.KryptonDomainUpDown();
+            this.kryptonNumericUpDown1 = new Krypton.Toolkit.KryptonNumericUpDown();
+            this.kryptonNumericUpDown2 = new Krypton.Toolkit.KryptonNumericUpDown();
+            this.kryptonMaskedTextBox1 = new Krypton.Toolkit.KryptonMaskedTextBox();
+            this.kryptonMaskedTextBox2 = new Krypton.Toolkit.KryptonMaskedTextBox();
+            this.kryptonTreeView1 = new Krypton.Toolkit.KryptonTreeView();
+            this.kryptonTreeView2 = new Krypton.Toolkit.KryptonTreeView();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonRibbon1)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).BeginInit();
             this.kryptonPanel1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonGroupBox2)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonGroupBox2.Panel)).BeginInit();
+            this.kryptonGroupBox2.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonGroupBox1)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonGroupBox1.Panel)).BeginInit();
+            this.kryptonGroupBox1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel3)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel2)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonThemeComboBox1)).BeginInit();
             this.SuspendLayout();
             // 
@@ -88,11 +114,11 @@
             // 
             this.kryptonRibbon1.InDesignHelperMode = true;
             this.kryptonRibbon1.Name = "kryptonRibbon1";
-            this.kryptonRibbon1.RibbonFileAppButton.AppButtonToolTipStyle = Krypton.Toolkit.LabelStyle.SuperTip;
+            this.kryptonRibbon1.RibbonFileAppButton.FormCloseBoxVisible = true;
             this.kryptonRibbon1.RibbonTabs.AddRange(new Krypton.Ribbon.KryptonRibbonTab[] {
             this.kryptonRibbonTab1});
             this.kryptonRibbon1.SelectedTab = this.kryptonRibbonTab1;
-            this.kryptonRibbon1.Size = new System.Drawing.Size(800, 115);
+            this.kryptonRibbon1.Size = new System.Drawing.Size(1067, 171);
             this.kryptonRibbon1.TabIndex = 0;
             // 
             // kryptonRibbonTab1
@@ -142,7 +168,7 @@
             this.kryptonRibbonGroupComboBox1.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.kryptonRibbonGroupComboBox1.DropDownWidth = 121;
             this.kryptonRibbonGroupComboBox1.FormattingEnabled = false;
-            this.kryptonRibbonGroupComboBox1.ItemHeight = 16;
+            this.kryptonRibbonGroupComboBox1.ItemHeight = 20;
             this.kryptonRibbonGroupComboBox1.Items.AddRange(new object[] {
             "1",
             "2",
@@ -162,7 +188,7 @@
             this.kryptonRibbonGroupComboBox2.DropDownWidth = 121;
             this.kryptonRibbonGroupComboBox2.Enabled = false;
             this.kryptonRibbonGroupComboBox2.FormattingEnabled = false;
-            this.kryptonRibbonGroupComboBox2.ItemHeight = 16;
+            this.kryptonRibbonGroupComboBox2.ItemHeight = 20;
             this.kryptonRibbonGroupComboBox2.Items.AddRange(new object[] {
             "1",
             "2",
@@ -183,9 +209,11 @@
             // kryptonRibbonGroupThemeComboBox1
             // 
             this.kryptonRibbonGroupThemeComboBox1.DefaultPalette = Krypton.Toolkit.PaletteMode.ProfessionalSystem;
-            this.kryptonRibbonGroupThemeComboBox1.DropDownWidth = 121;
+            this.kryptonRibbonGroupThemeComboBox1.DropDownWidth = 200;
             this.kryptonRibbonGroupThemeComboBox1.FormattingEnabled = false;
-            this.kryptonRibbonGroupThemeComboBox1.ItemHeight = 16;
+            this.kryptonRibbonGroupThemeComboBox1.ItemHeight = 20;
+            this.kryptonRibbonGroupThemeComboBox1.MaximumSize = new System.Drawing.Size(200, 0);
+            this.kryptonRibbonGroupThemeComboBox1.MinimumSize = new System.Drawing.Size(200, 0);
             // 
             // kryptonRibbonGroupThemeComboBox2
             // 
@@ -193,10 +221,29 @@
             this.kryptonRibbonGroupThemeComboBox2.DropDownWidth = 121;
             this.kryptonRibbonGroupThemeComboBox2.Enabled = false;
             this.kryptonRibbonGroupThemeComboBox2.FormattingEnabled = false;
-            this.kryptonRibbonGroupThemeComboBox2.ItemHeight = 16;
+            this.kryptonRibbonGroupThemeComboBox2.ItemHeight = 20;
+            this.kryptonRibbonGroupThemeComboBox2.MinimumSize = new System.Drawing.Size(200, 0);
             // 
             // kryptonPanel1
             // 
+            this.kryptonPanel1.Controls.Add(this.kryptonTreeView2);
+            this.kryptonPanel1.Controls.Add(this.kryptonTreeView1);
+            this.kryptonPanel1.Controls.Add(this.kryptonMaskedTextBox2);
+            this.kryptonPanel1.Controls.Add(this.kryptonMaskedTextBox1);
+            this.kryptonPanel1.Controls.Add(this.kryptonNumericUpDown2);
+            this.kryptonPanel1.Controls.Add(this.kryptonNumericUpDown1);
+            this.kryptonPanel1.Controls.Add(this.kryptonDomainUpDown2);
+            this.kryptonPanel1.Controls.Add(this.kryptonDomainUpDown1);
+            this.kryptonPanel1.Controls.Add(this.kryptonTrackBar2);
+            this.kryptonPanel1.Controls.Add(this.kryptonTrackBar1);
+            this.kryptonPanel1.Controls.Add(this.kryptonGroupBox2);
+            this.kryptonPanel1.Controls.Add(this.kryptonGroupBox1);
+            this.kryptonPanel1.Controls.Add(this.kryptonPanel3);
+            this.kryptonPanel1.Controls.Add(this.kryptonPanel2);
+            this.kryptonPanel1.Controls.Add(this.kryptonRadioButton2);
+            this.kryptonPanel1.Controls.Add(this.kryptonRadioButton1);
+            this.kryptonPanel1.Controls.Add(this.kryptonTextBox2);
+            this.kryptonPanel1.Controls.Add(this.kryptonTextBox1);
             this.kryptonPanel1.Controls.Add(this.kryptonCheckBox2);
             this.kryptonPanel1.Controls.Add(this.kryptonCheckBox1);
             this.kryptonPanel1.Controls.Add(this.kryptonButton2);
@@ -209,43 +256,129 @@
             this.kryptonPanel1.Controls.Add(this.kryptonCheckedListBox1);
             this.kryptonPanel1.Controls.Add(this.kryptonThemeComboBox1);
             this.kryptonPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.kryptonPanel1.Location = new System.Drawing.Point(0, 115);
+            this.kryptonPanel1.Location = new System.Drawing.Point(0, 171);
+            this.kryptonPanel1.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonPanel1.Name = "kryptonPanel1";
-            this.kryptonPanel1.Size = new System.Drawing.Size(800, 456);
+            this.kryptonPanel1.Size = new System.Drawing.Size(1067, 532);
             this.kryptonPanel1.TabIndex = 1;
+            // 
+            // kryptonTrackBar2
+            // 
+            this.kryptonTrackBar2.Enabled = false;
+            this.kryptonTrackBar2.Location = new System.Drawing.Point(640, 473);
+            this.kryptonTrackBar2.Name = "kryptonTrackBar2";
+            this.kryptonTrackBar2.Size = new System.Drawing.Size(142, 27);
+            this.kryptonTrackBar2.TabIndex = 20;
+            // 
+            // kryptonTrackBar1
+            // 
+            this.kryptonTrackBar1.Location = new System.Drawing.Point(483, 473);
+            this.kryptonTrackBar1.Name = "kryptonTrackBar1";
+            this.kryptonTrackBar1.Size = new System.Drawing.Size(142, 27);
+            this.kryptonTrackBar1.TabIndex = 19;
+            // 
+            // kryptonGroupBox2
+            // 
+            this.kryptonGroupBox2.Enabled = false;
+            this.kryptonGroupBox2.Location = new System.Drawing.Point(640, 402);
+            this.kryptonGroupBox2.Name = "kryptonGroupBox2";
+            this.kryptonGroupBox2.Size = new System.Drawing.Size(150, 65);
+            this.kryptonGroupBox2.TabIndex = 18;
+            this.kryptonGroupBox2.Values.Heading = "Disabled Grp";
+            // 
+            // kryptonGroupBox1
+            // 
+            this.kryptonGroupBox1.Location = new System.Drawing.Point(483, 402);
+            this.kryptonGroupBox1.Name = "kryptonGroupBox1";
+            this.kryptonGroupBox1.Size = new System.Drawing.Size(150, 65);
+            this.kryptonGroupBox1.TabIndex = 17;
+            this.kryptonGroupBox1.Values.Heading = "Enabled Grp";
+            // 
+            // kryptonPanel3
+            // 
+            this.kryptonPanel3.Enabled = false;
+            this.kryptonPanel3.Location = new System.Drawing.Point(640, 330);
+            this.kryptonPanel3.Name = "kryptonPanel3";
+            this.kryptonPanel3.Size = new System.Drawing.Size(134, 65);
+            this.kryptonPanel3.TabIndex = 16;
+            // 
+            // kryptonPanel2
+            // 
+            this.kryptonPanel2.Location = new System.Drawing.Point(483, 330);
+            this.kryptonPanel2.Name = "kryptonPanel2";
+            this.kryptonPanel2.Size = new System.Drawing.Size(134, 65);
+            this.kryptonPanel2.TabIndex = 15;
+            // 
+            // kryptonRadioButton2
+            // 
+            this.kryptonRadioButton2.Enabled = false;
+            this.kryptonRadioButton2.Location = new System.Drawing.Point(375, 368);
+            this.kryptonRadioButton2.Name = "kryptonRadioButton2";
+            this.kryptonRadioButton2.Size = new System.Drawing.Size(86, 26);
+            this.kryptonRadioButton2.TabIndex = 14;
+            this.kryptonRadioButton2.Values.Text = "Disabled";
+            // 
+            // kryptonRadioButton1
+            // 
+            this.kryptonRadioButton1.Location = new System.Drawing.Point(274, 368);
+            this.kryptonRadioButton1.Name = "kryptonRadioButton1";
+            this.kryptonRadioButton1.Size = new System.Drawing.Size(82, 26);
+            this.kryptonRadioButton1.TabIndex = 13;
+            this.kryptonRadioButton1.Values.Text = "Enabled";
+            // 
+            // kryptonTextBox2
+            // 
+            this.kryptonTextBox2.Enabled = false;
+            this.kryptonTextBox2.Location = new System.Drawing.Point(147, 368);
+            this.kryptonTextBox2.Name = "kryptonTextBox2";
+            this.kryptonTextBox2.Size = new System.Drawing.Size(120, 27);
+            this.kryptonTextBox2.TabIndex = 12;
+            this.kryptonTextBox2.Text = "kryptonTextBox2";
+            // 
+            // kryptonTextBox1
+            // 
+            this.kryptonTextBox1.Location = new System.Drawing.Point(17, 368);
+            this.kryptonTextBox1.Name = "kryptonTextBox1";
+            this.kryptonTextBox1.Size = new System.Drawing.Size(120, 27);
+            this.kryptonTextBox1.TabIndex = 11;
+            this.kryptonTextBox1.Text = "kryptonTextBox1";
             // 
             // kryptonCheckBox2
             // 
             this.kryptonCheckBox2.Enabled = false;
-            this.kryptonCheckBox2.Location = new System.Drawing.Point(281, 267);
+            this.kryptonCheckBox2.Location = new System.Drawing.Point(375, 329);
+            this.kryptonCheckBox2.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonCheckBox2.Name = "kryptonCheckBox2";
-            this.kryptonCheckBox2.Size = new System.Drawing.Size(71, 22);
+            this.kryptonCheckBox2.Size = new System.Drawing.Size(86, 26);
             this.kryptonCheckBox2.TabIndex = 10;
             this.kryptonCheckBox2.Values.Text = "Disabled";
             // 
             // kryptonCheckBox1
             // 
-            this.kryptonCheckBox1.Location = new System.Drawing.Point(207, 268);
+            this.kryptonCheckBox1.Location = new System.Drawing.Point(276, 330);
+            this.kryptonCheckBox1.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonCheckBox1.Name = "kryptonCheckBox1";
-            this.kryptonCheckBox1.Size = new System.Drawing.Size(67, 22);
+            this.kryptonCheckBox1.Size = new System.Drawing.Size(82, 26);
             this.kryptonCheckBox1.TabIndex = 9;
             this.kryptonCheckBox1.Values.Text = "Enabled";
             // 
             // kryptonButton2
             // 
             this.kryptonButton2.Enabled = false;
-            this.kryptonButton2.Location = new System.Drawing.Point(110, 268);
+            this.kryptonButton2.Location = new System.Drawing.Point(147, 330);
+            this.kryptonButton2.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonButton2.Name = "kryptonButton2";
-            this.kryptonButton2.Size = new System.Drawing.Size(90, 25);
+            this.kryptonButton2.Size = new System.Drawing.Size(120, 31);
             this.kryptonButton2.TabIndex = 8;
             this.kryptonButton2.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton2.Values.Text = "Disabled";
             // 
             // kryptonButton1
             // 
-            this.kryptonButton1.Location = new System.Drawing.Point(13, 268);
+            this.kryptonButton1.Location = new System.Drawing.Point(17, 330);
+            this.kryptonButton1.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonButton1.Name = "kryptonButton1";
-            this.kryptonButton1.Size = new System.Drawing.Size(90, 25);
+            this.kryptonButton1.Size = new System.Drawing.Size(120, 31);
             this.kryptonButton1.TabIndex = 7;
             this.kryptonButton1.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton1.Values.Text = "Enabled";
@@ -256,22 +389,23 @@
             this.kryptonListView2.Enabled = false;
             this.kryptonListView2.HideSelection = false;
             this.kryptonListView2.Items.AddRange(new System.Windows.Forms.ListViewItem[] {
-            listViewItem41,
-            listViewItem42,
-            listViewItem43,
-            listViewItem44,
-            listViewItem45,
-            listViewItem46,
-            listViewItem47,
-            listViewItem48,
-            listViewItem49,
-            listViewItem50});
+            listViewItem1,
+            listViewItem2,
+            listViewItem3,
+            listViewItem4,
+            listViewItem5,
+            listViewItem6,
+            listViewItem7,
+            listViewItem8,
+            listViewItem9,
+            listViewItem10});
             this.kryptonListView2.ItemStyle = Krypton.Toolkit.ButtonStyle.ListItem;
-            this.kryptonListView2.Location = new System.Drawing.Point(646, 35);
+            this.kryptonListView2.Location = new System.Drawing.Point(861, 43);
+            this.kryptonListView2.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonListView2.Name = "kryptonListView2";
             this.kryptonListView2.OwnerDraw = true;
             this.kryptonListView2.PaletteMode = Krypton.Toolkit.PaletteMode.ProfessionalSystem;
-            this.kryptonListView2.Size = new System.Drawing.Size(121, 226);
+            this.kryptonListView2.Size = new System.Drawing.Size(161, 278);
             this.kryptonListView2.StateCommon.Item.Content.ShortText.MultiLine = Krypton.Toolkit.InheritBool.True;
             this.kryptonListView2.StateCommon.Item.Content.ShortText.MultiLineH = Krypton.Toolkit.PaletteRelativeAlign.Center;
             this.kryptonListView2.StateCommon.Item.Content.ShortText.TextH = Krypton.Toolkit.PaletteRelativeAlign.Center;
@@ -282,22 +416,23 @@
             this.kryptonListView1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(255)))), ((int)(((byte)(255)))));
             this.kryptonListView1.HideSelection = false;
             this.kryptonListView1.Items.AddRange(new System.Windows.Forms.ListViewItem[] {
-            listViewItem51,
-            listViewItem52,
-            listViewItem53,
-            listViewItem54,
-            listViewItem55,
-            listViewItem56,
-            listViewItem57,
-            listViewItem58,
-            listViewItem59,
-            listViewItem60});
+            listViewItem11,
+            listViewItem12,
+            listViewItem13,
+            listViewItem14,
+            listViewItem15,
+            listViewItem16,
+            listViewItem17,
+            listViewItem18,
+            listViewItem19,
+            listViewItem20});
             this.kryptonListView1.ItemStyle = Krypton.Toolkit.ButtonStyle.ListItem;
-            this.kryptonListView1.Location = new System.Drawing.Point(519, 35);
+            this.kryptonListView1.Location = new System.Drawing.Point(692, 43);
+            this.kryptonListView1.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonListView1.Name = "kryptonListView1";
             this.kryptonListView1.OwnerDraw = true;
             this.kryptonListView1.PaletteMode = Krypton.Toolkit.PaletteMode.ProfessionalSystem;
-            this.kryptonListView1.Size = new System.Drawing.Size(121, 226);
+            this.kryptonListView1.Size = new System.Drawing.Size(161, 278);
             this.kryptonListView1.StateCommon.Item.Content.ShortText.MultiLine = Krypton.Toolkit.InheritBool.True;
             this.kryptonListView1.StateCommon.Item.Content.ShortText.MultiLineH = Krypton.Toolkit.PaletteRelativeAlign.Center;
             this.kryptonListView1.StateCommon.Item.Content.ShortText.TextH = Krypton.Toolkit.PaletteRelativeAlign.Center;
@@ -317,9 +452,10 @@
             "8",
             "9",
             "10"});
-            this.kryptonListBox2.Location = new System.Drawing.Point(392, 35);
+            this.kryptonListBox2.Location = new System.Drawing.Point(523, 43);
+            this.kryptonListBox2.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonListBox2.Name = "kryptonListBox2";
-            this.kryptonListBox2.Size = new System.Drawing.Size(120, 226);
+            this.kryptonListBox2.Size = new System.Drawing.Size(160, 278);
             this.kryptonListBox2.TabIndex = 4;
             // 
             // kryptonListBox1
@@ -335,9 +471,10 @@
             "8",
             "9",
             "10"});
-            this.kryptonListBox1.Location = new System.Drawing.Point(266, 35);
+            this.kryptonListBox1.Location = new System.Drawing.Point(355, 43);
+            this.kryptonListBox1.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonListBox1.Name = "kryptonListBox1";
-            this.kryptonListBox1.Size = new System.Drawing.Size(120, 226);
+            this.kryptonListBox1.Size = new System.Drawing.Size(160, 278);
             this.kryptonListBox1.TabIndex = 3;
             // 
             // kryptonCheckedListBox2
@@ -354,9 +491,10 @@
             "8",
             "9",
             "10"});
-            this.kryptonCheckedListBox2.Location = new System.Drawing.Point(139, 35);
+            this.kryptonCheckedListBox2.Location = new System.Drawing.Point(185, 43);
+            this.kryptonCheckedListBox2.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonCheckedListBox2.Name = "kryptonCheckedListBox2";
-            this.kryptonCheckedListBox2.Size = new System.Drawing.Size(120, 226);
+            this.kryptonCheckedListBox2.Size = new System.Drawing.Size(160, 278);
             this.kryptonCheckedListBox2.TabIndex = 2;
             // 
             // kryptonCheckedListBox1
@@ -372,30 +510,136 @@
             "8",
             "9",
             "10"});
-            this.kryptonCheckedListBox1.Location = new System.Drawing.Point(13, 35);
+            this.kryptonCheckedListBox1.Location = new System.Drawing.Point(17, 43);
+            this.kryptonCheckedListBox1.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonCheckedListBox1.Name = "kryptonCheckedListBox1";
-            this.kryptonCheckedListBox1.Size = new System.Drawing.Size(120, 226);
+            this.kryptonCheckedListBox1.Size = new System.Drawing.Size(160, 278);
             this.kryptonCheckedListBox1.TabIndex = 1;
             // 
             // kryptonThemeComboBox1
             // 
             this.kryptonThemeComboBox1.DefaultPalette = Krypton.Toolkit.PaletteMode.ProfessionalSystem;
-            this.kryptonThemeComboBox1.DropDownWidth = 275;
+            this.kryptonThemeComboBox1.DropDownWidth = 367;
             this.kryptonThemeComboBox1.IntegralHeight = false;
-            this.kryptonThemeComboBox1.Location = new System.Drawing.Point(13, 7);
+            this.kryptonThemeComboBox1.Location = new System.Drawing.Point(17, 9);
+            this.kryptonThemeComboBox1.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonThemeComboBox1.Name = "kryptonThemeComboBox1";
-            this.kryptonThemeComboBox1.Size = new System.Drawing.Size(275, 22);
+            this.kryptonThemeComboBox1.Size = new System.Drawing.Size(367, 26);
             this.kryptonThemeComboBox1.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
             this.kryptonThemeComboBox1.TabIndex = 0;
             // 
+            // kryptonDomainUpDown1
+            // 
+            this.kryptonDomainUpDown1.Location = new System.Drawing.Point(17, 402);
+            this.kryptonDomainUpDown1.Name = "kryptonDomainUpDown1";
+            this.kryptonDomainUpDown1.Size = new System.Drawing.Size(120, 26);
+            this.kryptonDomainUpDown1.TabIndex = 21;
+            this.kryptonDomainUpDown1.Text = "kryptonDomainUpDown1";
+            // 
+            // kryptonDomainUpDown2
+            // 
+            this.kryptonDomainUpDown2.Enabled = false;
+            this.kryptonDomainUpDown2.Location = new System.Drawing.Point(147, 402);
+            this.kryptonDomainUpDown2.Name = "kryptonDomainUpDown2";
+            this.kryptonDomainUpDown2.Size = new System.Drawing.Size(120, 26);
+            this.kryptonDomainUpDown2.TabIndex = 22;
+            this.kryptonDomainUpDown2.Text = "kryptonDomainUpDown2";
+            // 
+            // kryptonNumericUpDown1
+            // 
+            this.kryptonNumericUpDown1.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.kryptonNumericUpDown1.Location = new System.Drawing.Point(17, 435);
+            this.kryptonNumericUpDown1.Maximum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            0});
+            this.kryptonNumericUpDown1.Minimum = new decimal(new int[] {
+            0,
+            0,
+            0,
+            0});
+            this.kryptonNumericUpDown1.Name = "kryptonNumericUpDown1";
+            this.kryptonNumericUpDown1.Size = new System.Drawing.Size(120, 26);
+            this.kryptonNumericUpDown1.TabIndex = 23;
+            this.kryptonNumericUpDown1.Value = new decimal(new int[] {
+            0,
+            0,
+            0,
+            0});
+            // 
+            // kryptonNumericUpDown2
+            // 
+            this.kryptonNumericUpDown2.Enabled = false;
+            this.kryptonNumericUpDown2.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.kryptonNumericUpDown2.Location = new System.Drawing.Point(147, 434);
+            this.kryptonNumericUpDown2.Maximum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            0});
+            this.kryptonNumericUpDown2.Minimum = new decimal(new int[] {
+            0,
+            0,
+            0,
+            0});
+            this.kryptonNumericUpDown2.Name = "kryptonNumericUpDown2";
+            this.kryptonNumericUpDown2.Size = new System.Drawing.Size(120, 26);
+            this.kryptonNumericUpDown2.TabIndex = 24;
+            this.kryptonNumericUpDown2.Value = new decimal(new int[] {
+            0,
+            0,
+            0,
+            0});
+            // 
+            // kryptonMaskedTextBox1
+            // 
+            this.kryptonMaskedTextBox1.Location = new System.Drawing.Point(17, 468);
+            this.kryptonMaskedTextBox1.Name = "kryptonMaskedTextBox1";
+            this.kryptonMaskedTextBox1.Size = new System.Drawing.Size(120, 27);
+            this.kryptonMaskedTextBox1.TabIndex = 25;
+            this.kryptonMaskedTextBox1.Text = "kryptonMaskedTextBox1";
+            // 
+            // kryptonMaskedTextBox2
+            // 
+            this.kryptonMaskedTextBox2.Enabled = false;
+            this.kryptonMaskedTextBox2.Location = new System.Drawing.Point(147, 468);
+            this.kryptonMaskedTextBox2.Name = "kryptonMaskedTextBox2";
+            this.kryptonMaskedTextBox2.Size = new System.Drawing.Size(120, 27);
+            this.kryptonMaskedTextBox2.TabIndex = 26;
+            this.kryptonMaskedTextBox2.Text = "kryptonMaskedTextBox2";
+            // 
+            // kryptonTreeView1
+            // 
+            this.kryptonTreeView1.Location = new System.Drawing.Point(809, 332);
+            this.kryptonTreeView1.Name = "kryptonTreeView1";
+            this.kryptonTreeView1.Size = new System.Drawing.Size(99, 96);
+            this.kryptonTreeView1.TabIndex = 27;
+            // 
+            // kryptonTreeView2
+            // 
+            this.kryptonTreeView2.Enabled = false;
+            this.kryptonTreeView2.Location = new System.Drawing.Point(923, 332);
+            this.kryptonTreeView2.Name = "kryptonTreeView2";
+            this.kryptonTreeView2.Size = new System.Drawing.Size(99, 96);
+            this.kryptonTreeView2.TabIndex = 28;
+            // 
             // ControlsTest
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(800, 571);
-            this.CloseBox = false;
+            this.ClientSize = new System.Drawing.Size(1067, 703);
             this.Controls.Add(this.kryptonPanel1);
             this.Controls.Add(this.kryptonRibbon1);
+            this.Margin = new System.Windows.Forms.Padding(4);
             this.Name = "ControlsTest";
             this.Text = "ControlsTest";
             this.Load += new System.EventHandler(this.ControlsTest_Load);
@@ -403,6 +647,14 @@
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).EndInit();
             this.kryptonPanel1.ResumeLayout(false);
             this.kryptonPanel1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonGroupBox2.Panel)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonGroupBox2)).EndInit();
+            this.kryptonGroupBox2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonGroupBox1.Panel)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonGroupBox1)).EndInit();
+            this.kryptonGroupBox1.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel3)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel2)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonThemeComboBox1)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
@@ -441,5 +693,23 @@
         private Krypton.Ribbon.KryptonRibbonGroupLabel kryptonRibbonGroupLabel2;
         private Krypton.Ribbon.KryptonRibbonGroupThemeComboBox kryptonRibbonGroupThemeComboBox1;
         private Krypton.Ribbon.KryptonRibbonGroupThemeComboBox kryptonRibbonGroupThemeComboBox2;
+        private KryptonTextBox kryptonTextBox2;
+        private KryptonTextBox kryptonTextBox1;
+        private KryptonPanel kryptonPanel3;
+        private KryptonPanel kryptonPanel2;
+        private KryptonRadioButton kryptonRadioButton2;
+        private KryptonRadioButton kryptonRadioButton1;
+        private KryptonTrackBar kryptonTrackBar2;
+        private KryptonTrackBar kryptonTrackBar1;
+        private KryptonGroupBox kryptonGroupBox2;
+        private KryptonGroupBox kryptonGroupBox1;
+        private KryptonTreeView kryptonTreeView2;
+        private KryptonTreeView kryptonTreeView1;
+        private KryptonMaskedTextBox kryptonMaskedTextBox2;
+        private KryptonMaskedTextBox kryptonMaskedTextBox1;
+        private KryptonNumericUpDown kryptonNumericUpDown2;
+        private KryptonNumericUpDown kryptonNumericUpDown1;
+        private KryptonDomainUpDown kryptonDomainUpDown2;
+        private KryptonDomainUpDown kryptonDomainUpDown1;
     }
 }


### PR DESCRIPTION
- Ensure that "Precedence" is given to the `Enabled` state of a control, over the `AlwaysActive` highlight state.
- Update TestForm to show Enabled states for affected controls

#1573

![image](https://github.com/Krypton-Suite/Standard-Toolkit/assets/2418812/8fd3eb19-491b-40ff-9bc6-1a838c18a0b7)
