### PR TITLE
1600-V85-KryptonMessageBox-stays-on-top-of-other-windows

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-07-xx - Build 2407 (Patch 1) - July 2024
+* Resolved [#1600](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1600), `KryptonMessageBox` stays on top of other windows.
 * Resolved [#1580](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1580), Changing to certain modes in `KryptonNavigator` can cause a System.NullReferenceException
 
 =======

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMessageBoxForm.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMessageBoxForm.Designer.cs
@@ -262,7 +262,7 @@ namespace Krypton.Toolkit
             this.ShowInTaskbar = false;
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.TopMost = true;
+            this.TopMost = false;
             this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.AnyKeyDown);
             ((System.ComponentModel.ISupportInitialize)(this._messageIcon)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this._panelButtons)).EndInit();


### PR DESCRIPTION
[Issue 1600-KryptonMessageBox-stays-on-top-of-other-windows](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1600)
KMessageBox TopMost property set to false.

![compile-results](https://github.com/Krypton-Suite/Standard-Toolkit/assets/96108132/eface0d4-7f6f-4027-a1b6-14e059bfcbef)
