### PR TITLE
1599-V85-KryptonMessageBox-cuts-off-the-last-line

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-07-xx - Build 2407 (Patch 1) - July 2024
+* Resolved [#1599](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1599), `KryptonMessageBox` cuts off the last line.
 * Resolved [#1600](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1600), `KryptonMessageBox` stays on top of other windows.
 * Resolved [#1580](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1580), Changing to certain modes in `KryptonNavigator` can cause a System.NullReferenceException
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMessageBoxForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMessageBoxForm.cs
@@ -582,9 +582,10 @@ namespace Krypton.Toolkit
                 scaledMonitorSize.Width =(int)(scaledMonitorSize.Width * 2 / 3.0f);
                 scaledMonitorSize.Height = (int)(scaledMonitorSize.Height * 0.95f);
                 Font textFont = _messageText.StateCommon.Content.GetContentShortTextFont(PaletteState.Normal);
+                Font captionFont = KryptonManager.CurrentGlobalPalette!.BaseFont;
                 SizeF messageSize = TextRenderer.MeasureText(_text, textFont, scaledMonitorSize);
                 // SKC: Don't forget to add the TextExtra into the calculation
-                SizeF captionSize = TextRenderer.MeasureText($@"{_caption} {TextExtra}", SystemFonts.CaptionFont, scaledMonitorSize);
+                SizeF captionSize = TextRenderer.MeasureText($@"{_caption} {TextExtra}", captionFont, scaledMonitorSize);
 
                 var messageXSize = Math.Max(messageSize.Width, captionSize.Width);
                 // Work out DPI adjustment factor
@@ -596,12 +597,13 @@ namespace Krypton.Toolkit
                 textSize = Size.Ceiling(messageSize);
             }
             
+            // Calculate the size of the icon area and text area including margins
             Padding textPadding = _messageText.StateCommon.Content.GetContentPadding(PaletteState.Normal);
-            Padding textAreaMargin = Padding.Add(textPadding, _panelContentArea.Margin);
+            Padding textAreaAllMargin = Padding.Add(textPadding, _panelContentArea.Margin);
             Size iconArea = new Size(_messageIcon.Width + _messageIcon.Margin.Left + _messageIcon.Margin.Right,
                                      _messageIcon.Height + _messageIcon.Margin.Top + _messageIcon.Margin.Bottom);
-            Size textArea = new Size(textSize.Width + textAreaMargin.Left + textAreaMargin.Right,
-                                     textSize.Height + textAreaMargin.Top + textAreaMargin.Bottom);
+            Size textArea = new Size(textSize.Width + textAreaAllMargin.Left + textAreaAllMargin.Right,
+                                     textSize.Height + textAreaAllMargin.Top + textAreaAllMargin.Bottom);
             return new Size(textArea.Width + iconArea.Width, 
                             Math.Max(iconArea.Height, textArea.Height));
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMessageBoxForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMessageBoxForm.cs
@@ -578,12 +578,13 @@ namespace Krypton.Toolkit
             {
                 // Find size of the label, with a max of 2/3 screen width
                 Screen? screen = showOwner != null ? Screen.FromHandle(showOwner.Handle) : Screen.PrimaryScreen;
-                SizeF scaledMonitorSize = screen.Bounds.Size;
-                scaledMonitorSize.Width *= 2 / 3.0f;
-                scaledMonitorSize.Height *= 0.95f;
-                SizeF messageSize = g.MeasureString(_text, _messageText.Font, scaledMonitorSize);
+                Size scaledMonitorSize = screen.Bounds.Size;
+                scaledMonitorSize.Width =(int)(scaledMonitorSize.Width * 2 / 3.0f);
+                scaledMonitorSize.Height = (int)(scaledMonitorSize.Height * 0.95f);
+                Font textFont = _messageText.StateCommon.Content.GetContentShortTextFont(PaletteState.Normal);
+                SizeF messageSize = TextRenderer.MeasureText(_text, textFont, scaledMonitorSize);
                 // SKC: Don't forget to add the TextExtra into the calculation
-                SizeF captionSize = g.MeasureString($@"{_caption} {TextExtra}", _messageText.Font, scaledMonitorSize);
+                SizeF captionSize = TextRenderer.MeasureText($@"{_caption} {TextExtra}", SystemFonts.CaptionFont, scaledMonitorSize);
 
                 var messageXSize = Math.Max(messageSize.Width, captionSize.Width);
                 // Work out DPI adjustment factor
@@ -592,15 +593,17 @@ namespace Krypton.Toolkit
                 messageSize.Width = messageXSize * factorX;
                 messageSize.Height *= factorY;
 
-                // Always add on ad extra 5 pixels as sometimes the measure size does not draw the last 
-                // character it contains, this ensures there is always definitely enough space for it all
-                messageSize.Width += 5;
                 textSize = Size.Ceiling(messageSize);
             }
-
-            return new Size(textSize.Width + _messageIcon.Width + _messageIcon.Margin.Left + _messageIcon.Margin.Right +
-                            _messageText.Margin.Left + _messageText.Margin.Right,
-                Math.Max(_messageIcon.Height + 10, textSize.Height));
+            
+            Padding textPadding = _messageText.StateCommon.Content.GetContentPadding(PaletteState.Normal);
+            Padding textAreaMargin = Padding.Add(textPadding, _panelContentArea.Margin);
+            Size iconArea = new Size(_messageIcon.Width + _messageIcon.Margin.Left + _messageIcon.Margin.Right,
+                                     _messageIcon.Height + _messageIcon.Margin.Top + _messageIcon.Margin.Bottom);
+            Size textArea = new Size(textSize.Width + textAreaMargin.Left + textAreaMargin.Right,
+                                     textSize.Height + textAreaMargin.Top + textAreaMargin.Bottom);
+            return new Size(textArea.Width + iconArea.Width, 
+                            Math.Max(iconArea.Height, textArea.Height));
         }
 
         private Size UpdateButtonsSizing()


### PR DESCRIPTION
[Issue 1599-KryptonMessageBox-cuts-off-the-last-line](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1599)

- Measure based on the actual font that's used to draw the text.
- Include KTextBox's content padding and container's margin in the calculations.
- Use TextRenderer.MeasureText instead of Graphics.MeasureString for precise measurement.

![image](https://github.com/Krypton-Suite/Standard-Toolkit/assets/18140178/fc518b30-58f8-4063-96cd-1d4f5063a742)

2nd build:
![image](https://github.com/Krypton-Suite/Standard-Toolkit/assets/18140178/7b15d34a-975e-4654-b998-4d8b16341ca3)

