### PR TITLE
1613-V85-KryptonMessageBox-text-is-not-centered-vertically

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-07-xx - Build 2407 (Patch 1) - July 2024
+* Resolved [#1613](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1613), `KryptonMessageBox` text is not centered vertically.
 * Resolved [#1600](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1600), `KryptonMessageBox` stays on top of other windows.
 * Resolved [#1580](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1580), Changing to certain modes in `KryptonNavigator` can cause a System.NullReferenceException
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMessageBoxForm.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMessageBoxForm.Designer.cs
@@ -212,7 +212,7 @@ namespace Krypton.Toolkit
             this._panelContentArea.Controls.Add(this._linkLabelMessageText);
             this._panelContentArea.Dock = System.Windows.Forms.DockStyle.Fill;
             this._panelContentArea.Location = new System.Drawing.Point(64, 4);
-            this._panelContentArea.Margin = new System.Windows.Forms.Padding(4);
+            this._panelContentArea.Margin = new System.Windows.Forms.Padding(4, 12, 4, 12);
             this._panelContentArea.Name = "_panelContentArea";
             this._panelContentArea.Size = new System.Drawing.Size(176, 44);
             this._panelContentArea.TabIndex = 1;


### PR DESCRIPTION
[Issue 1613-KryptonMessageBox-text-is-not-centered-vertically](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1613)

- Increased the top and bottom margin of the panel to fix the referenced issue for single-line texts and also to avoid having the text too close to the borders.

![image](https://github.com/Krypton-Suite/Standard-Toolkit/assets/18140178/2e08d089-eb8d-488b-b653-1cad92467078)
