### PR TITLE
1614-V85-KryptonMessageBox-throws-an-exception-after-Esc-key-is-pressed

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-07-xx - Build 2407 (Patch 1) - July 2024
+* Resolved [#1614](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1614), `KryptonMessageBox` throws an exception after Esc key is pressed.
 * Resolved [#1600](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1600), `KryptonMessageBox` stays on top of other windows.
 * Resolved [#1580](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1580), Changing to certain modes in `KryptonNavigator` can cause a System.NullReferenceException
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMessageBoxForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMessageBoxForm.cs
@@ -702,43 +702,39 @@ namespace Krypton.Toolkit
             {
                 Close();
             }
-            else if (!e.Control
-                     || (e.KeyCode != Keys.C)
-                    )
+            else if (e.KeyData == (Keys.Control | Keys.C))
             {
-                return;
-            }
+                const string DIVIDER = @"---------------------------";
+                const string BUTTON_TEXT_SPACER = @"   ";
+                // Pressing Ctrl+C should copy message text into the clipboard
+                var sb = new StringBuilder();
 
-            const string DIVIDER = @"---------------------------";
-            const string BUTTON_TEXT_SPACER = @"   ";
-            // Pressing Ctrl+C should copy message text into the clipboard
-            var sb = new StringBuilder();
-
-            sb.AppendLine(DIVIDER);
-            sb.AppendLine(Text);
-            sb.AppendLine(DIVIDER);
-            sb.AppendLine(_messageText.Text);
-            sb.AppendLine(DIVIDER);
-            sb.Append(_button1.Text).Append(BUTTON_TEXT_SPACER);
-            if (_button2.Enabled)
-            {
-                sb.Append(_button2.Text).Append(BUTTON_TEXT_SPACER);
-                if (_button3.Enabled)
+                sb.AppendLine(DIVIDER);
+                sb.AppendLine(Text);
+                sb.AppendLine(DIVIDER);
+                sb.AppendLine(_messageText.Text);
+                sb.AppendLine(DIVIDER);
+                sb.Append(_button1.Text).Append(BUTTON_TEXT_SPACER);
+                if (_button2.Enabled)
                 {
-                    sb.Append(_button3.Text).Append(BUTTON_TEXT_SPACER);
+                    sb.Append(_button2.Text).Append(BUTTON_TEXT_SPACER);
+                    if (_button3.Enabled)
+                    {
+                        sb.Append(_button3.Text).Append(BUTTON_TEXT_SPACER);
+                    }
+
+                    if (_button4.Enabled)
+                    {
+                        sb.Append(_button4.Text).Append(BUTTON_TEXT_SPACER);
+                    }
                 }
 
-                if (_button4.Enabled)
-                {
-                    sb.Append(_button4.Text).Append(BUTTON_TEXT_SPACER);
-                }
+                sb.AppendLine(string.Empty);
+                sb.AppendLine(DIVIDER);
+
+                Clipboard.SetText(sb.ToString(), TextDataFormat.Text);
+                Clipboard.SetText(sb.ToString(), TextDataFormat.UnicodeText);
             }
-
-            sb.AppendLine(string.Empty);
-            sb.AppendLine(DIVIDER);
-
-            Clipboard.SetText(sb.ToString(), TextDataFormat.Text);
-            Clipboard.SetText(sb.ToString(), TextDataFormat.UnicodeText);
         }
 
         /// <summary>Setups the action button UI.</summary>


### PR DESCRIPTION
[Issue 1614-KryptonMessageBox-throws-an-exception-after-Esc-key-is-pressed](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1614)

- Move the copying logic inside an `else if` branch to avoid executing the code after Close().
- Use `e.KeyData` for more accurate key combinations.

![image](https://github.com/Krypton-Suite/Standard-Toolkit/assets/18140178/af1a2ac4-6468-45d3-a4fd-9fb2535cc503)
