### PR TITLE
1583-Adding-control-to-form-causes-universe-not-found-exception

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,9 +3,10 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
-* Resolved [1607](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1607), "MS365 - Black" theme is unreadable
+* Resolved [#1583](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1583), `KryptonThemeComboBox` and `KrpytonThemeListBox` have the wrong designer assigned. Adds the `KryptonStubDesigner` internal class.
+* Resolved [#1607](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1607), "MS365 - Black" theme is unreadable
 * Resolved [#1581](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1581), **Enhancement** KListview has background problems for disabled view on each "Item" [now with added List and Details Views]
-* Resolved/Implemented [1597](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1597), Use `KryptonUseRTLLayout` to prevent LTR/RTL issues
+* Resolved/Implemented [#1597](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1597), Use `KryptonUseRTLLayout` to prevent LTR/RTL issues
 * Resolved/Implemented [#1601](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1601), Rollback `KryptonPaletteCustomBase` ability to use a single schema
 * Resolved [#1600](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1600), `KryptonMessageBox` and `KryptonMessageBoxDep` stays on top of other windows.
 * Resolved [#1593](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1593), KInputBox is stuck in RTL mode

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
@@ -11,14 +11,9 @@ namespace Krypton.Toolkit
 {
     /// <summary>Allows the user to change themes using a <see cref="KryptonComboBox"/>.</summary>
     /// <seealso cref="KryptonComboBox" />
-    [Designer(typeof(ControlDesigner))]
+    [Designer(typeof(KryptonStubDesigner))]
     public class KryptonThemeComboBox : KryptonComboBox, IKryptonThemeSelectorBase
     {
-        /*
-         * Since their is no suitable designer and the inherited isn't a good match
-         * It's overridden by using the Base class ControlDesigner which effectively removes the designer.
-         */
-
         #region Instance Fields
 
         /// <summary> When we change the palette, Krypton Manager will notify us that there was a change. Since we are changing it that notification can be skipped.</summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeListBox.cs
@@ -12,14 +12,9 @@ namespace Krypton.Toolkit
 {
     /// <summary>Allows the user to change themes using a <see cref="KryptonListBox"/>.</summary>
     /// <seealso cref="KryptonListBox" />
-    [Designer(typeof(ControlDesigner))]
+    [Designer(typeof(KryptonStubDesigner))]
     public class KryptonThemeListBox : KryptonListBox, IKryptonThemeSelectorBase
     {
-        /*
-         * Since their is no suitable designer and the inherited isn't a good match
-         * It's overridden by using the Base class ControlDesigner which effectively removes the designer.
-         */
-
         #region Instance Fields
 
         /// <summary> When we change the palette, Krypton Manager will notify us that there was a change. Since we are changing it that notification can be skipped.</summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonStubDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonStubDesigner.cs
@@ -1,0 +1,19 @@
+﻿#region BSD License
+/*
+ * 
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2024. All rights reserved. 
+ *  
+ */
+#endregion
+
+namespace Krypton.Toolkit
+{
+    /// <summary>
+    /// A designer stub derived from ControlDesigner with no further functionality.<br/>
+    /// Can be used to add to classes that inherit an unwanted or incompatible designer and disables the inherited action list a control can have at design time.
+    /// </summary>
+    internal class KryptonStubDesigner : ControlDesigner
+    {
+    }
+}

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonStubDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonStubDesigner.cs
@@ -2,7 +2,7 @@
 /*
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2024. All rights reserved. 
+ *  Modifications by Peter Wagner(aka Wagnerp), Simon Coghlan(aka Smurf-IV) & (Giduac), et al. 2024 - 2024. All rights reserved. 
  *  
  */
 #endregion


### PR DESCRIPTION
[Issue 1583-Adding-control-to-form-causes-universe-not-found-exception](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1583)
- Adding the KryptonStubDesigner
- Replacing the designer for KThemeComboBox & KThemeListBox
- Updates the change log.

![image](https://github.com/user-attachments/assets/f06f0902-0782-4ab3-9a6d-9f7128ea59ad)
