### PR TITLE
1583-V85-Adding-control-to-form-causes-universe-not-found-exception

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-07-xx - Build 2407 (Patch 1) - July 2024
+* Resolved [#1583](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1583), `KryptonThemeComboBox` and `KrpytonThemeListBox` have the wrong designer assigned. Adds the `KryptonStubDesigner` internal class.
 * Resolved [#1614](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1614), `KryptonMessageBox` throws an exception after Esc key is pressed.
 * Resolved [#1599](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1599), `KryptonMessageBox` cuts off the last line.
 * Resolved [#1600](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1600), `KryptonMessageBox` stays on top of other windows.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
@@ -14,6 +14,7 @@ namespace Krypton.Toolkit
 {
     /// <summary>Allows the user to change themes using a <see cref="KryptonComboBox"/>.</summary>
     /// <seealso cref="KryptonComboBox" />
+    [Designer(typeof(KryptonStubDesigner))]
     public class KryptonThemeComboBox : KryptonComboBox
     {
         #region Instance Fields

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeListBox.cs
@@ -12,6 +12,7 @@ namespace Krypton.Toolkit
 {
     /// <summary>Allows the user to change themes using a <see cref="KryptonListBox"/>.</summary>
     /// <seealso cref="KryptonListBox" />
+    [Designer(typeof(KryptonStubDesigner))]
     public class KryptonThemeListBox : KryptonListBox
     {
         #region Instance Fields

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonStubDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonStubDesigner.cs
@@ -1,0 +1,19 @@
+﻿#region BSD License
+/*
+ * 
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner(aka Wagnerp), Simon Coghlan(aka Smurf-IV) & (Giduac), et al. 2024 - 2024. All rights reserved. 
+ *  
+ */
+#endregion
+
+namespace Krypton.Toolkit
+{
+    /// <summary>
+    /// A designer stub derived from ControlDesigner with no further functionality.<br/>
+    /// Can be used to add to classes that inherit an unwanted or incompatible designer and disables the inherited action list a control can have at design time.
+    /// </summary>
+    internal class KryptonStubDesigner : ControlDesigner
+    {
+    }
+}


### PR DESCRIPTION
[Issue 1583-V85-Adding-control-to-form-causes-universe-not-found-exception](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1583)
- Adding the KryptonStubDesigner
- Replacing the designer for KThemeComboBox & KThemeListBox
- Updates the change log.

![compile-results](https://github.com/user-attachments/assets/d71c9530-6f58-4a0d-b47c-63fa6eb2c1cd)
