### PR TITLE
- `KryptonPropertyGrid` now uses the State### sets like the rest of t…

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
+* Implemented [#632](https://github.com/Krypton-Suite/Standard-Toolkit/issues/632), **[Breaking Change]** `KryptonPropertyGrid` should have a customisable back colour.
 * Resolved [#1583](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1583), `KryptonThemeComboBox` and `KrpytonThemeListBox` have the wrong designer assigned. Adds the `KryptonStubDesigner` internal class.
 * Resolved [#1564](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1564), Disabled Button Text in Ribbons is not visible in some themes
 * Resolved [#1607](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1607), "MS365 - Black" theme is unreadable

--- a/README.md
+++ b/README.md
@@ -185,6 +185,9 @@ Follow the links to see the different objects and layouts that this framework al
 
 ## V90.## (2024-11-xx - Build 2411 - November 2024)
 There are list of changes that have occurred during the development of the V90.## version
+- [#632](https://github.com/Krypton-Suite/Standard-Toolkit/issues/632), **[Breaking Change]** `KryptonPropertyGrid` should have a customisable back colour.
+   - `KryptonPropertyGrid` now uses the State### sets like the rest of the controls.
+   - Any build breaks in the designers can just be deleted, as the the colouring will be done by the `State####` equivalents
 - [#1435](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1435), **Breaking Change** Take KMB back to the Winform override (Remove Checkbox etc)
 - and [#1432](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1432), **Breaking Change placeholder** Copy `KryptonMessageBox` to `KryptonMessageBoxDep`
   - The introduction of new Parameters elements to the `KryptonMessageBox` is now supported in the `KryptonMessageBoxDep` class

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupComboBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupComboBox.cs
@@ -413,7 +413,7 @@ namespace Krypton.Ribbon
         [Category(@"Appearance")]
         [Description(@"Text associated with the control.")]
         [Editor(typeof(MultilineStringEditor), typeof(UITypeEditor))]
-        public string Text
+        public virtual string Text
         {
             get => ComboBox.Text;
             set => ComboBox.Text = value;
@@ -491,7 +491,7 @@ namespace Krypton.Ribbon
         [Description(@"Controls the appearance and functionality of the KryptonComboBox.")]
         [DefaultValue(typeof(ComboBoxStyle), nameof(DropDown))]
         [RefreshProperties(RefreshProperties.Repaint)]
-        public ComboBoxStyle DropDownStyle
+        public virtual ComboBoxStyle DropDownStyle
         {
             get => ComboBox.DropDownStyle;
             set => ComboBox.DropDownStyle = value;
@@ -589,7 +589,7 @@ namespace Krypton.Ribbon
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         [MergableProperty(false)]
         [Localizable(true)]
-        public ComboBox.ObjectCollection Items => ComboBox.Items;
+        public virtual ComboBox.ObjectCollection Items => ComboBox.Items;
 
         /// <summary>
         /// Gets and sets a value indicating if tooltips should be Displayed for button specs.
@@ -632,7 +632,7 @@ namespace Krypton.Ribbon
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Localizable(true)]
         [Browsable(true)]
-        public AutoCompleteStringCollection AutoCompleteCustomSource
+        public virtual AutoCompleteStringCollection AutoCompleteCustomSource
         {
             get => ComboBox.AutoCompleteCustomSource;
             set => ComboBox.AutoCompleteCustomSource = value;
@@ -645,7 +645,7 @@ namespace Krypton.Ribbon
         [DefaultValue(typeof(AutoCompleteMode), "None")]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Browsable(true)]
-        public AutoCompleteMode AutoCompleteMode
+        public virtual AutoCompleteMode AutoCompleteMode
         {
             get => ComboBox.AutoCompleteMode;
             set => ComboBox.AutoCompleteMode = value;
@@ -658,7 +658,7 @@ namespace Krypton.Ribbon
         [DefaultValue(typeof(AutoCompleteSource), "None")]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Browsable(true)]
-        public AutoCompleteSource AutoCompleteSource
+        public virtual AutoCompleteSource AutoCompleteSource
         {
             get => ComboBox.AutoCompleteSource;
             set => ComboBox.AutoCompleteSource = value;
@@ -671,7 +671,7 @@ namespace Krypton.Ribbon
         [Editor(@"System.Windows.Forms.Design.FormatStringEditor", typeof(UITypeEditor))]
         [MergableProperty(false)]
         [DefaultValue("")]
-        public string FormatString
+        public virtual string FormatString
         {
             get => ComboBox.FormatString;
             set => ComboBox.FormatString = value;
@@ -1109,7 +1109,7 @@ namespace Krypton.Ribbon
 
         private void OnComboBoxSelectionChangeCommitted(object sender, EventArgs e) => OnSelectionChangeCommitted(e);
 
-        private void OnComboBoxSelectedIndexChanged(object sender, EventArgs e) => OnSelectedIndexChanged(e);
+        private protected void OnComboBoxSelectedIndexChanged(object sender, EventArgs e) => OnSelectedIndexChanged(e);
 
         private void OnComboBoxDropDownStyleChanged(object sender, EventArgs e) => OnDropDownStyleChanged(e);
 

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupThemeComboBox.cs
@@ -20,7 +20,7 @@ namespace Krypton.Ribbon
     [DesignTimeVisible(false)]
     [DefaultEvent("SelectedTextChanged")]
     [DefaultProperty(nameof(Text))]
-    public class KryptonRibbonGroupThemeComboBox : KryptonRibbonGroupComboBox, IKryptonThemeSelectorBase
+    public sealed class KryptonRibbonGroupThemeComboBox : KryptonRibbonGroupComboBox, IKryptonThemeSelectorBase
     {
         // TODO: grouped Ribbon controls do expose designers, needs a closer look
 
@@ -42,8 +42,9 @@ namespace Krypton.Ribbon
         #region Identity
 
         /// <summary>Initializes a new instance of the <see cref="KryptonRibbonGroupThemeComboBox" /> class.</summary>
-        public KryptonRibbonGroupThemeComboBox() : base()
+        public KryptonRibbonGroupThemeComboBox()
         {
+            ComboBox.SelectedIndexChanged -= OnComboBoxSelectedIndexChanged;
             _manager = new KryptonManager();
             DropDownStyle = ComboBoxStyle.DropDownList;
 
@@ -55,6 +56,7 @@ namespace Krypton.Ribbon
 
             // React to theme changes from outside this control.
             KryptonManager.GlobalPaletteChanged += KryptonManagerGlobalPaletteChanged;
+            ComboBox.SelectedIndexChanged -= OnComboBoxSelectedIndexChanged;
         }
 
         #endregion
@@ -127,7 +129,7 @@ namespace Krypton.Ribbon
         /// <summary>Gets and sets the text associated with the control.</summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public new string Text
+        public override string Text
         {
             get => base.Text;
             set => base.Text = value;
@@ -136,7 +138,7 @@ namespace Krypton.Ribbon
         /// <summary>Gets or sets the format specifier characters that indicate how a value is to be Displayed.</summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public new string FormatString 
+        public override string FormatString 
         {
             get => base.FormatString;
             set => base.FormatString = value;
@@ -145,7 +147,7 @@ namespace Krypton.Ribbon
         /// <summary>Gets and sets the appearance and functionality of the KryptonComboBox.</summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public new ComboBoxStyle DropDownStyle
+        public override ComboBoxStyle DropDownStyle
         {
             get => base.DropDownStyle;
             set => base.DropDownStyle = value;
@@ -154,12 +156,12 @@ namespace Krypton.Ribbon
         /// <summary>Gets or sets the items in the KryptonComboBox.</summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public new ComboBox.ObjectCollection Items => base.Items;
+        public override ComboBox.ObjectCollection Items => base.Items;
 
         /// <summary>Gets or sets the StringCollection to use when the AutoCompleteSource property is set to CustomSource.</summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public new AutoCompleteStringCollection AutoCompleteCustomSource
+        public override AutoCompleteStringCollection AutoCompleteCustomSource
         {
             get => base.AutoCompleteCustomSource;
             set => base.AutoCompleteCustomSource = value;
@@ -168,7 +170,7 @@ namespace Krypton.Ribbon
         /// <summary>Gets or sets the text completion behavior of the combobox.</summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public new AutoCompleteMode AutoCompleteMode
+        public override AutoCompleteMode AutoCompleteMode
         {
             get => base.AutoCompleteMode;
             set => base.AutoCompleteMode = value;
@@ -177,21 +179,11 @@ namespace Krypton.Ribbon
         /// <summary>Gets or sets the autocomplete source, which can be one of the values from AutoCompleteSource enumeration.</summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public new AutoCompleteSource AutoCompleteSource
+        public override AutoCompleteSource AutoCompleteSource
         {
             get => base.AutoCompleteSource;
             set => base.AutoCompleteSource = value;
         }
-
-        /// <summary>Gets and sets the selected index.</summary>
-        [Browsable(false)]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public new int SelectedIndex 
-        {
-            get => base.SelectedIndex;
-            set => base.SelectedIndex = value;
-        }
-
         #endregion
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListView.cs
@@ -56,7 +56,9 @@ namespace Krypton.Toolkit
             /// <param name="kryptonListView">Reference to owning control.</param>
             public InternalListView(KryptonListView kryptonListView)
             {
-                SetStyle(ControlStyles.ResizeRedraw, true);
+                SetStyle(ControlStyles.ResizeRedraw
+                         | ControlStyles.AllPaintingInWmPaint
+                         | ControlStyles.OptimizedDoubleBuffer, true);
 
                 _kryptonListView = kryptonListView;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPropertyGrid.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPropertyGrid.cs
@@ -1,168 +1,730 @@
 ﻿#region BSD License
 /*
- *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
  *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2021 - 2024. All rights reserved.
- *
  */
 #endregion
+
+// ReSharper disable UnusedMember.Global
+
+// ReSharper disable UnusedMember.Local
+using System.ComponentModel;
 
 namespace Krypton.Toolkit
 {
     ///<summary>A property grid control that supports the Krypton render.</summary>
+    /// /// <seealso cref="PropertyGrid" />
     [Description(@"A property grid control that supports the Krypton render.")]
     [Designer(typeof(KryptonPropertyGridDesigner))]
     [ToolboxBitmap(typeof(PropertyGrid), "ToolboxBitmaps.KryptonPropertyGridVersion2.bmp")]
     [ToolboxItem(true)]
-    public class KryptonPropertyGrid : PropertyGrid
+    public class KryptonPropertyGrid : VisualControlBase,
+        IContainedInputControl
     {
-        #region Variables
-        private PaletteBase? _palette;
+        #region Classes
+        private class InternalPropertyGrid : PropertyGrid
+        {
+            #region Instance Fields
+            private readonly ViewManager? _viewManager;
+            private readonly KryptonPropertyGrid _kryptonPropertyGrid;
+            private readonly IntPtr _screenDC;
+            private bool _mouseOver;
+            #endregion
 
-        private readonly PaletteRedirect? _paletteRedirect;
-        private readonly PaletteInputControlTripleRedirect _stateCommon;
-        private readonly PaletteInputControlTripleStates _stateNormal;
-        private readonly PaletteInputControlTripleStates _stateDisabled;
-        private readonly PaletteInputControlTripleStates _stateActive;
+            #region Events
+            /// <summary>
+            /// Occurs when the mouse enters the InternalListView.
+            /// </summary>
+            public event EventHandler? TrackMouseEnter;
 
+            /// <summary>
+            /// Occurs when the mouse leaves the InternalListView.
+            /// </summary>
+            public event EventHandler? TrackMouseLeave;
+            #endregion
+
+            #region Identity
+            /// <summary>
+            /// Initialize a new instance of the InternalPropertyGrid class.
+            /// </summary>
+            /// <param name="kryptonPropertyGrid">Reference to owning control.</param>
+            public InternalPropertyGrid(KryptonPropertyGrid kryptonPropertyGrid)
+            {
+                SetStyle(ControlStyles.ResizeRedraw
+                    | ControlStyles.AllPaintingInWmPaint
+                    | ControlStyles.OptimizedDoubleBuffer, true);
+                _kryptonPropertyGrid = kryptonPropertyGrid;
+
+                // Create manager and view for drawing the background
+                ViewDrawPanel = new ViewDrawPanel();
+                _viewManager = new ViewManager(this, ViewDrawPanel);
+
+                // ReSharper disable RedundantBaseQualifier
+                base.Size = Size.Empty;
+                //base.BorderStyle = BorderStyle.None;
+                // ReSharper restore RedundantBaseQualifier
+
+                // We need to create and cache a device context compatible with the display
+                _screenDC = PI.CreateCompatibleDC(IntPtr.Zero);
+                ToolStripRenderer = ToolStripManager.Renderer;
+                UseCompatibleTextRendering = false;
+            }
+
+            /// <summary>
+            /// Releases all resources used by the Control. 
+            /// </summary>
+            /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
+            protected override void Dispose(bool disposing)
+            {
+                base.Dispose(disposing);
+                if (_screenDC != IntPtr.Zero)
+                {
+                    PI.DeleteDC(_screenDC);
+                }
+            }
+
+            #endregion
+
+            #region Public
+
+            /// <summary>
+            /// Recreate the window handle.
+            /// </summary>
+            public void Recreate() => RecreateHandle();
+
+            /// <summary>
+            /// Gets access to the contained view draw panel instance.
+            /// </summary>
+            public ViewDrawPanel ViewDrawPanel { get; }
+
+            /// <summary>
+            /// Gets and sets if the mouse is currently over the combo box.
+            /// </summary>
+            public bool MouseOver
+            {
+                get => _mouseOver;
+                set
+                {
+                    // Only interested in changes
+                    if (_mouseOver != value)
+                    {
+                        _mouseOver = value;
+
+                        // Generate appropriate change event
+                        if (_mouseOver)
+                        {
+                            OnTrackMouseEnter(EventArgs.Empty);
+                        }
+                        else
+                        {
+                            OnTrackMouseLeave(EventArgs.Empty);
+                        }
+                    }
+                }
+            }
+            #endregion
+
+            #region Protected
+            /// <summary>Raises the <see cref="E:System.Windows.Forms.Control.SystemColorsChanged" /> event.</summary>
+            /// <param name="e">An <see cref="T:System.EventArgs" /> that contains the event data.</param>
+            protected override void OnSystemColorsChanged(EventArgs e)
+            {
+                // DO nothing, It's Krypton Colours that are in use !
+            }
+
+            /// <summary>
+            /// Raises the Layout event.
+            /// </summary>
+            /// <param name="levent">A LayoutEventArgs containing the event data.</param>
+            protected override void OnLayout(LayoutEventArgs levent)
+            {
+                if (!IsHandleCreated || !Visible)
+                {
+                    return;
+                }
+                base.OnLayout(levent);
+
+                // Ask the panel to layout given our available size
+                using var context =
+                    new ViewLayoutContext(_viewManager, this, _kryptonPropertyGrid, _kryptonPropertyGrid.Renderer);
+                ViewDrawPanel.Layout(context);
+            }
+
+            /// <summary>
+            /// Process Windows-based messages.
+            /// </summary>
+            /// <param name="m">A Windows-based message.</param>
+            protected override void WndProc(ref Message m)
+            {
+                switch (m.Msg)
+                {
+                    case PI.WM_.ERASEBKGND:
+                        // Do not draw the background here, always do it in the paint 
+                        // instead to prevent flicker because of a two stage drawing process
+                        break;
+
+                    case PI.WM_.PRINTCLIENT:
+                    case PI.WM_.PAINT:
+                        WmPaint(ref m);
+                        break;
+
+                    case PI.WM_.VSCROLL:
+                    case PI.WM_.HSCROLL:
+                    case PI.WM_.MOUSEWHEEL:
+                        Invalidate();
+                        base.WndProc(ref m);
+                        break;
+
+                    case PI.WM_.MOUSELEAVE:
+                        if (MouseOver)
+                        {
+                            MouseOver = false;
+                            _kryptonPropertyGrid.PerformNeedPaint(true);
+                            Invalidate();
+                        }
+                        base.WndProc(ref m);
+                        break;
+
+                    case PI.WM_.MOUSEMOVE:
+                        if (!MouseOver)
+                        {
+                            MouseOver = true;
+                            _kryptonPropertyGrid.PerformNeedPaint(true);
+                            Invalidate();
+                        }
+                        base.WndProc(ref m);
+                        break;
+
+                    default:
+                        base.WndProc(ref m);
+                        break;
+                }
+            }
+
+            #endregion
+
+            #region Private
+
+            /// <summary>
+            /// Raises the TrackMouseEnter event.
+            /// </summary>
+            /// <param name="e">An EventArgs containing the event data.</param>
+            private void OnTrackMouseEnter(EventArgs e) => TrackMouseEnter?.Invoke(this, e);
+
+            /// <summary>
+            /// Raises the TrackMouseLeave event.
+            /// </summary>
+            /// <param name="e">An EventArgs containing the event data.</param>
+            private void OnTrackMouseLeave(EventArgs e) => TrackMouseLeave?.Invoke(this, e);
+
+            private void WmPaint(ref Message m)
+            {
+                var ps = new PI.PAINTSTRUCT();
+
+                // Do we need to BeginPaint or just take the given HDC?
+                IntPtr hdc = m.WParam == IntPtr.Zero ? PI.BeginPaint(Handle, ref ps) : m.WParam;
+
+                // Create bitmap that all drawing occurs onto, then we can blit it later to remove flicker
+                Rectangle realRect = CommonHelper.RealClientRectangle(Handle);
+
+                // No point drawing when one of the dimensions is zero
+                if (realRect is { Width: > 0, Height: > 0 })
+                {
+                    IntPtr hBitmap = PI.CreateCompatibleBitmap(hdc, realRect.Width, realRect.Height);
+
+                    // If we managed to get a compatible bitmap
+                    if (hBitmap != IntPtr.Zero)
+                    {
+                        try
+                        {
+                            // Must use the screen device context for the bitmap when drawing into the 
+                            // bitmap otherwise the Opacity and RightToLeftLayout will not work correctly.
+                            PI.SelectObject(_screenDC, hBitmap);
+
+                            // Easier to draw using a graphics instance than a DC!
+                            using (Graphics g = Graphics.FromHdc(_screenDC))
+                            {
+                                // Ask the view element to layout in given space, needs this before a render call
+                                using (var context = new ViewLayoutContext(this, _kryptonPropertyGrid.Renderer))
+                                {
+                                    context.DisplayRectangle = realRect;
+                                    ViewDrawPanel.Layout(context);
+                                }
+
+                                using (var context = new RenderContext(this, _kryptonPropertyGrid, g, realRect,
+                                           _kryptonPropertyGrid.Renderer))
+                                {
+                                    ViewDrawPanel.Render(context);
+                                }
+
+                                // We can only control the background color by using the built in property and not
+                                // by overriding the drawing directly, therefore we can only provide a single color.
+                                Color color1 = ViewDrawPanel.GetPalette().GetBackColor1(ViewDrawPanel.State);
+                                if (color1 != BackColor)
+                                {
+                                    BackColor = color1;
+                                }
+
+                                // Replace given DC with the screen DC for base window proc drawing
+                                IntPtr beforeDC = m.WParam;
+                                m.WParam = _screenDC;
+                                DefWndProc(ref m);
+                                m.WParam = beforeDC;
+                            }
+
+                            // Now blit from the bitmap from the screen to the real dc
+                            PI.BitBlt(hdc, 0, 0, realRect.Width, realRect.Height, _screenDC, 0, 0, PI.SRCCOPY);
+                        }
+                        finally
+                        {
+                            // Delete the temporary bitmap
+                            PI.DeleteObject(hBitmap);
+                        }
+                    }
+                }
+
+                // Do we need to match the original BeginPaint?
+                if (m.WParam == IntPtr.Zero)
+                {
+                    PI.EndPaint(Handle, ref ps);
+                }
+            }
+            #endregion
+        }
 
         #endregion
+
+        #region Instance Fields
+
+        private readonly ViewDrawDocker _drawDockerOuter;
+        private readonly ViewLayoutFill _layoutFill;
+        private readonly InternalPropertyGrid _propertyGrid;
+        private bool? _fixedActive;
+        private readonly IntPtr _screenDC;
+        private bool _mouseOver;
+        private bool _alwaysActive;
+        private bool _forcedLayout;
+        #endregion
+
+        #region Events
+
+        // TODO:
+
+        #endregion
+
 
         #region Constructor
 
         /// <summary>Initializes a new instance of the <see cref="KryptonPropertyGrid" /> class.</summary>
         public KryptonPropertyGrid()
         {
-            SetStyle(ControlStyles.UserPaint
-                     | ControlStyles.OptimizedDoubleBuffer
-                     | ControlStyles.SupportsTransparentBackColor,
-                true);
+            // Contains another control and needs marking as such for validation to work
+            SetStyle(ControlStyles.ContainerControl, true);
+            // Cannot select this control, only the child tree view and does not generate a 
+            SetStyle(ControlStyles.Selectable | ControlStyles.StandardClick, false);
 
-            UpdateStyles();
+            // Default fields
+            base.Padding = new Padding(1);
 
-            // Add Palette Handler
-            if (_palette != null)
-            {
-                _palette.PalettePaint += OnPalettePaint;
-            }
-
-            KryptonManager.GlobalPaletteChanged += OnGlobalPaletteChanged;
-
-            _palette = KryptonManager.CurrentGlobalPalette;
-
-            _paletteRedirect = new PaletteRedirect(_palette);
             // Create the palette provider
-            _stateCommon = new PaletteInputControlTripleRedirect(_paletteRedirect, PaletteBackStyle.InputControlStandalone, PaletteBorderStyle.HeaderCalendar, PaletteContentStyle.LabelNormalPanel, null);
-            _stateDisabled = new PaletteInputControlTripleStates(_stateCommon, null);
-            _stateNormal = new PaletteInputControlTripleStates(_stateCommon, null);
-            _stateActive = new PaletteInputControlTripleStates(_stateCommon, null);
+            StateCommon = new PaletteInputControlTripleRedirect(Redirector, PaletteBackStyle.InputControlStandalone, PaletteBorderStyle.HeaderCalendar, PaletteContentStyle.LabelNormalPanel, null);
+            StateDisabled = new PaletteInputControlTripleStates(StateCommon, NeedPaintDelegate);
+            StateNormal = new PaletteInputControlTripleStates(StateCommon, NeedPaintDelegate);
+            StateActive = new PaletteInputControlTripleStates(StateCommon, NeedPaintDelegate);
 
-            InitColors();
+            // Create the internal list box used for containing content
+            _propertyGrid = new InternalPropertyGrid(this);
+            _propertyGrid.Click += OnPropertyGridClick; // SKC: make sure that the default click is also routed.
+            _propertyGrid.GotFocus += OnPropertyGridGotFocus;
+            _propertyGrid.LostFocus += OnPropertyGridLostFocus;
+
+            _layoutFill = new ViewLayoutFill(_propertyGrid)
+            {
+                DisplayPadding = new Padding(1)
+            };
+
+            // Create inner view for placing inside the drawing docker
+            var drawDockerInner = new ViewLayoutDocker
+            {
+                { _layoutFill, ViewDockStyle.Fill }
+            };
+
+            // Create view for the control border and background
+            _drawDockerOuter = new ViewDrawDocker(StateNormal.Back, StateNormal.Border)
+            {
+                { drawDockerInner, ViewDockStyle.Fill }
+            };
+
+            // Create the view manager instance
+            ViewManager = new ViewManager(this, _drawDockerOuter);
+
+            // We need to create and cache a device context compatible with the display
+            _screenDC = PI.CreateCompatibleDC(IntPtr.Zero);
+
+            // Add tree view to the controls collection
+            ((KryptonReadOnlyControls)Controls).AddInternal(_propertyGrid);
+        }
+        private void OnPropertyGridClick(object sender, EventArgs e) => OnClick(e);
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            if (_screenDC != IntPtr.Zero)
+            {
+                PI.DeleteDC(_screenDC);
+            }
         }
         #endregion
 
         #region Public
-        /// <summary>Refreshes the colours.</summary>
-        public void RefreshColors() => InitColors();
+        /// <summary>
+        /// Gets access to the contained TreeView instance.
+        /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [EditorBrowsable(EditorBrowsableState.Always)]
+        [Browsable(false)]
+        public PropertyGrid PropertyGrid => _propertyGrid;
+
+        /// <summary>
+        /// Gets access to the contained input control.
+        /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [EditorBrowsable(EditorBrowsableState.Always)]
+        [Browsable(false)]
+        public Control ContainedControl => _propertyGrid;
+
+        /// <summary>
+        /// Gets access to the common appearance entries that other states can override.
+        /// </summary>
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining common appearance that other states can override.")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+        public PaletteInputControlTripleRedirect StateCommon { get; }
+        private bool ShouldSerializeStateCommon() => !StateCommon.IsDefault;
+
+        /// <summary>
+        /// Gets access to the disabled appearance entries.
+        /// </summary>
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining disabled appearance.")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+        public PaletteInputControlTripleStates StateDisabled { get; }
+        private bool ShouldSerializeStateDisabled() => !StateDisabled.IsDefault;
+
+        /// <summary>
+        /// Gets access to the normal appearance entries.
+        /// </summary>
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining normal appearance.")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+        public PaletteInputControlTripleStates StateNormal { get; }
+        private bool ShouldSerializeStateNormal() => !StateNormal.IsDefault;
+
+        /// <summary>
+        /// Gets access to the active appearance entries.
+        /// </summary>
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining active appearance.")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+        public PaletteInputControlTripleStates StateActive { get; }
+        private bool ShouldSerializeStateActive() => !StateActive.IsDefault;
+
+
+        /// <summary>
+        /// Gets and sets Determines if the control is always active or only when the mouse is over the control or has focus.
+        /// </summary>
+        [Category(@"Visuals")]
+        [Description(
+            @"Determines if the control is always active or only when the mouse is over the control or has focus.")]
+        [DefaultValue(false)]
+        public bool AlwaysActive
+        {
+            get => _alwaysActive;
+            set
+            {
+                if (_alwaysActive != value)
+                {
+                    _alwaysActive = value;
+                    Invalidate();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Sets the fixed state of the control.
+        /// </summary>
+        /// <param name="active">Should the control be fixed as active.</param>
+        public void SetFixedState(bool active) => _fixedActive = active;
+
+        /// <summary>
+        /// Gets a value indicating if the input control is active.
+        /// </summary>
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool IsActive => _fixedActive ?? DesignMode || AlwaysActive || ContainsFocus || _mouseOver;
+
+        /// <summary>
+        /// Sets input focus to the control.
+        /// </summary>
+        /// <returns>true if the input focus request was successful; otherwise, false.</returns>
+        public new bool Focus() => _propertyGrid.Focus();
+
+        /// <summary>
+        /// Activates the control.
+        /// </summary>
+        public new void Select() => _propertyGrid.Select();
         #endregion
 
-        #region Protected Overrides
-        /// <inheritdoc />
-        protected override void Dispose(bool disposing)
-        {
-            // Unhook from the static events, otherwise we cannot be garbage collected
-            KryptonManager.GlobalPaletteChanged -= OnGlobalPaletteChanged;
+        #region Expose Useful parts
 
-            base.Dispose(disposing);
+        /// <summary>
+        ///  Returns true if the commands pane will be shown for objects
+        ///  that expose verbs.
+        /// </summary>
+        [Category("Appearance")]
+        [DefaultValue(true)]
+        [Description("the commands pane will be shown for objects")]
+        public bool CommandsVisibleIfAvailable
+        {
+            get => _propertyGrid.CommandsVisibleIfAvailable;
+            set => _propertyGrid.CommandsVisibleIfAvailable = value;
         }
+
+        /// <summary>
+        ///  Sets or gets the visibility state of the help pane.
+        /// </summary>
+        [Category("Appearance")]
+        [DefaultValue(true)]
+        [Localizable(true)]
+        [Description("visibility state of the help pane")]
+        public virtual bool HelpVisible
+        {
+            get => _propertyGrid.HelpVisible;
+            set => _propertyGrid.HelpVisible = value;
+        }
+
+        /// <summary>
+        ///  Gets or sets a value that indicates whether OS-specific visual style glyphs are used for the expansion
+        ///  nodes in the grid area.
+        /// </summary>
+        [Category("Appearance")]
+        [Description("indicates whether OS-specific visual style glyphs are used for the expansion nodes in the grid area")]
+        [DefaultValue(true)]
+        public bool CanShowVisualStyleGlyphs
+        {
+            get => _propertyGrid.CanShowVisualStyleGlyphs;
+            set => _propertyGrid.CanShowVisualStyleGlyphs = value;
+        }
+
+        /// <summary>
+        ///  Sets or gets the current property sort type, which can be
+        ///  PropertySort.Categorized or PropertySort.Alphabetical.
+        /// </summary>
+        [Category("Appearance")]
+        [DefaultValue(PropertySort.CategorizedAlphabetical)]
+        [Description("current property sort type")]
+        public PropertySort PropertySort
+        {
+            get => _propertyGrid.PropertySort;
+            set => _propertyGrid.PropertySort = value;
+        }
+
+        internal class SelectedObjectConverter : ReferenceConverter
+        {
+            public SelectedObjectConverter()
+                : base(typeof(IComponent))
+            {
+            }
+        }
+
+        /// <summary>
+        ///  Sets a single object into the grid to be browsed. If multiple objects are being browsed, this property
+        ///  will return the first one in the list. If no objects are selected, null is returned.
+        /// </summary>
+        [Category("Behavior")]
+        [DefaultValue(null)]
+        [Description("")]
+        [TypeConverter(typeof(SelectedObjectConverter))]
+        public object? SelectedObject
+        {
+            get => _propertyGrid.SelectedObject;
+            set => _propertyGrid.SelectedObject = value;
+        }
+
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [AllowNull]
+        public object[] SelectedObjects
+        {
+            get => _propertyGrid.SelectedObjects;
+            set => _propertyGrid.SelectedObjects = value;
+        }
+
+        /// <summary>Gets or sets the background color for the control.</summary>
+        /// <returns>A <see cref="T:System.Drawing.Color" /> that represents the background color of the control. The default is the value of the <see cref="P:System.Windows.Forms.Control.DefaultBackColor" /> property.</returns>
+        [Category("Appearance")]
+        [Description("ControlBackColorDescr")]
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public override Color BackColor
+        {
+            get => base.BackColor;
+            set => base.BackColor = value;
+        }
+
+        /// <summary>Gets or sets the font of the text displayed by the control.</summary>
+        /// <returns>The <see cref="T:System.Drawing.Font" /> to apply to the text displayed by the control. The default is the value of the <see cref="P:System.Windows.Forms.Control.DefaultFont" /> property.</returns>
+        [Category("Appearance")]
+        [AmbientValue(null)]
+        [Description("ControlFontDescr")]
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [AllowNull]
+        public override Font Font
+        {
+            get => base.Font;
+            set => base.Font = value;
+        }
+
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public PropertyTab SelectedTab => _propertyGrid.SelectedTab;
+
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [DisallowNull]
+        public GridItem? SelectedGridItem => _propertyGrid.SelectedGridItem;
+
+        [Category("Appearance")]
+        [Description("PropertyGridLargeButtonsDesc")]
+        [DefaultValue(false)]
+        public bool LargeButtons
+        {
+            get => _propertyGrid.LargeButtons;
+            set => _propertyGrid.LargeButtons = value;
+        }
+
+        /// <summary>
+        ///  Sets or gets the visibility state of the toolStrip.
+        /// </summary>
+        [Category("Appearance")]
+        [DefaultValue(true)]
+        [Description("the visibility state of the toolStrip")]
+        public virtual bool ToolbarVisible
+        {
+            get => _propertyGrid.ToolbarVisible;
+            set => _propertyGrid.ToolbarVisible = value;
+        }
+
+        /// <summary> Collapses all the nodes in the PropertyGrid</summary>
+        public void CollapseAllGridItems() => _propertyGrid.CollapseAllGridItems();
+
+        /// <summary>Expands all the categories in the <see cref="T:System.Windows.Forms.PropertyGrid" />.</summary>
+        public void ExpandAllGridItems() => _propertyGrid.ExpandAllGridItems();
+
+        /// <summary>
+        ///  Refreshes the tabs of the specified <paramref name="tabScope"/>.
+        /// </summary>
+        /// <param name="tabScope">
+        ///  Either <see cref="PropertyTabScope.Component"/> or <see cref="PropertyTabScope.Document"/>.
+        /// </param>
+        /// <remarks>
+        ///  <para>
+        ///   The <see cref="RefreshTabs(PropertyTabScope)"/> method first deletes the property tabs of the specified
+        ///   scope, it then requires the objects and documents to rebuild the tabs.
+        ///  </para>
+        /// </remarks>
+        public void RefreshTabs(PropertyTabScope tabScope) => _propertyGrid.RefreshTabs(tabScope);
+
+        /// <summary>Resets the selected property to its default value.</summary>
+        public void ResetSelectedProperty() => _propertyGrid.ResetSelectedProperty();
         #endregion
 
         #region Krypton
-        // Krypton Palette Events
-        /// <summary>Called when [global palette changed].</summary>
-        /// <param name="sender">The sender.</param>
-        /// <param name="e">The <see cref="EventArgs" /> instance containing the event data.</param>
-        private void OnGlobalPaletteChanged(object sender, EventArgs e)
-        {
-            if (_palette != null)
-            {
-                _palette.PalettePaint -= OnPalettePaint;
-            }
-
-            _palette = KryptonManager.CurrentGlobalPalette;
-            _paletteRedirect!.Target = _palette;
-
-            if (_palette != null)
-            {
-                _palette.PalettePaint += OnPalettePaint;
-                //repaint with new values
-                InitColors();
-            }
-
-            Invalidate();
-        }
-
-        // Krypton Palette Events
-        /// <summary>Called when [palette paint].</summary>
-        /// <param name="sender">The sender.</param>
-        /// <param name="e">The <see cref="PaletteLayoutEventArgs" /> instance containing the event data.</param>
-        private void OnPalettePaint(object sender, PaletteLayoutEventArgs e) => Invalidate();
 
         /// <summary>Initialises the colours.</summary>
-        private void InitColors()
+        private void UpdateStateAndPalettes()
         {
-            ToolStripRenderer = ToolStripManager.Renderer;
-
-            LineColor = _palette!.ColorTable.ToolStripGradientMiddle;
-
-            CategoryForeColor = KryptonManager.CurrentGlobalPalette.ToString().Contains("DarkMode")
-                ? _palette!.ColorTable.MenuStripText
-                : _palette!.ColorTable.ToolStripDropDownBackground;
-
-            var normalFont = _stateNormal.PaletteContent?.GetContentShortTextFont(PaletteState.ContextNormal);
-            var disabledFont = _stateDisabled.PaletteContent?.GetContentShortTextFont(PaletteState.Disabled);
-
-            Font = (Enabled ? normalFont : disabledFont)!;
-            BackColor = _stateNormal.PaletteBack.GetBackColor1(Enabled ? PaletteState.Normal : PaletteState.Disabled);
-
-            var controlsCollection = Controls;
-            var state = PaletteState.ContextNormal;
-            IPaletteTriple triple = _stateNormal;
-            foreach (Control control in controlsCollection)
+            if (!IsDisposed)
             {
-                if (control.Focused)
+                // Attempt to stop Flickering
+                //PI.SendMessage(_propertyGrid.Handle, PI.WM_.SETREDRAW, IntPtr.Zero, IntPtr.Zero);
+
+                var colorTable = KryptonManager.CurrentGlobalPalette.ColorTable;
+                _propertyGrid.LineColor = colorTable.ToolStripGradientMiddle;
+
+                _propertyGrid.CategoryForeColor = KryptonManager.CurrentGlobalPalette.ToString().Contains("DarkMode")
+                    ? colorTable.MenuStripText
+                    : colorTable.ToolStripDropDownBackground;
+
+                var gridState = GetTripleState();
+                _propertyGrid.ViewDrawPanel.SetPalettes(gridState.PaletteBack);
+                _drawDockerOuter.SetPalettes(gridState.PaletteBack, gridState.PaletteBorder!);
+                _drawDockerOuter.Enabled = Enabled;
+                // Find the new state of the main view element
+                PaletteState pState = Enabled
+                    ? (IsActive ? PaletteState.Tracking : PaletteState.Normal)
+                    : PaletteState.Disabled;
+                _propertyGrid.ViewDrawPanel.ElementState = pState;
+                _drawDockerOuter.ElementState = pState;
+
+                var normalFont = gridState.PaletteContent?.GetContentShortTextFont(PaletteState.ContextNormal);
+                var disabledFont = gridState.PaletteContent?.GetContentShortTextFont(PaletteState.Disabled);
+
+                _propertyGrid.Font = (Enabled ? normalFont : disabledFont)!;
+                _propertyGrid.BackColor =
+                    gridState.PaletteBack.GetBackColor1(Enabled ? PaletteState.Normal : PaletteState.Disabled);
+
+                var controlsCollection = _propertyGrid.Controls;
+                foreach (Control control in controlsCollection)
                 {
-                    state = PaletteState.FocusOverride;
-                    triple = _stateActive;
-                    control.Font = _stateActive.PaletteContent?.GetContentShortTextFont(PaletteState.FocusOverride)!;
-                }
-                else if (control.Enabled)
-                {
-                    state = PaletteState.ContextNormal;
-                    triple = _stateNormal;
-                    // Note: tobitege commented out to avoid unrecoverable exception in System.Drawing, when toggling theme back and forth
-                    //control.Font = normalFont!;
-                }
-                else
-                {
-                    state = PaletteState.Disabled;
-                    triple = _stateDisabled;
-                    control.Font = disabledFont!;
+                    PaletteState state;
+                    IPaletteTriple triple;
+                    if (control.Focused)
+                    {
+                        state = PaletteState.FocusOverride;
+                        triple = StateActive;
+                        control.Font = StateActive.PaletteContent?.GetContentShortTextFont(PaletteState.FocusOverride)!;
+                    }
+                    else if (control.Enabled)
+                    {
+                        state = PaletteState.ContextNormal;
+                        triple = StateNormal;
+                        // Note: tobitege commented out to avoid unrecoverable exception in System.Drawing, when toggling theme back and forth
+                        control.Font = normalFont!;
+                    }
+                    else
+                    {
+                        state = PaletteState.Disabled;
+                        triple = StateDisabled;
+                        control.Font = disabledFont!;
+                    }
+
+                    control.ForeColor = triple.PaletteContent!.GetContentShortTextColor1(state);
+                    control.BackColor = triple.PaletteBack.GetBackColor1(state);
                 }
 
-                control.ForeColor = triple.PaletteContent!.GetContentShortTextColor1(state);
-                control.BackColor = triple.PaletteBack.GetBackColor1(state);
+                // Original code caused several themes to have white-on-white text.
+                // This has been tested as working against all schemes and fixes all previously
+                // observed white-on-white/low-contrast colors!
+                // Needed to be moved below the loop!
+                _propertyGrid.HelpForeColor = ContrastColor(_propertyGrid.HelpBackColor);
+                _propertyGrid.ViewForeColor = ContrastColor(_propertyGrid.ViewBackColor);
+                //PI.SendMessage(_propertyGrid.Handle, PI.WM_.SETREDRAW, (IntPtr)PI.BOOL.TRUE, IntPtr.Zero);
+                Invalidate();
             }
-
-            // Original code caused several themes to have white-on-white text.
-            // This has been tested as working against all schemes and fixes all previously
-            // observed white-on-white/low-contrast colors!
-            // Needed to be moved below the loop!
-            HelpForeColor = ContrastColor(HelpBackColor);
-            ViewForeColor = ContrastColor(ViewBackColor);
-
-            Invalidate();
         }
+
+        private IPaletteTriple GetTripleState() => Enabled ? (IsActive ? StateActive : StateNormal) : StateDisabled;
+
 
         private static Color ContrastColor(Color color)
         {
@@ -176,6 +738,259 @@ namespace Krypton.Toolkit
             //  dark colours - white font and vice versa
             return Color.FromArgb(d, d, d);
         }
+
+        #endregion
+
+        #region private
+
+        /// <summary>
+        /// Process Windows-based messages.
+        /// </summary>
+        /// <param name="m">A Windows-based message.</param>
+        protected override void WndProc(ref Message m)
+        {
+            switch (m.Msg)
+            {
+                case PI.WM_.ERASEBKGND:
+                    // Do not draw the background here, always do it in the paint 
+                    // instead to prevent flicker because of a two stage drawing process
+                    break;
+                //case PI.WM_.PRINTCLIENT:
+                //case PI.WM_.PAINT:
+                //    WmPaint(ref m);
+                //    break;
+                case PI.WM_.VSCROLL:
+                case PI.WM_.HSCROLL:
+                case PI.WM_.MOUSEWHEEL:
+                    Invalidate();
+                    base.WndProc(ref m);
+                    break;
+                //case PI.WM_.MOUSEMOVE:// TODO: On Mouse Enter ??
+                //    if (!_mouseOver)
+                //    {
+                //        _mouseOver = true;
+                //        Invalidate();
+                //    }
+                //    base.WndProc(ref m);
+                //    break;
+                // We need to snoop the need to show a context menu
+                case PI.WM_.CONTEXTMENU:
+                    // Only interested in overriding the behaviour when we have a krypton context menu...
+                    if (KryptonContextMenu != null)
+                    {
+                        // Extract the screen mouse position (if might not actually be provided)
+                        var mousePt = new Point(PI.LOWORD(m.LParam), PI.HIWORD(m.LParam));
+
+                        // If keyboard activated, the menu position is centered
+                        if (((int)(long)m.LParam) == -1)
+                        {
+                            mousePt = new Point(Width / 2, Height / 2);
+                        }
+                        else
+                        {
+                            mousePt = PointToClient(mousePt);
+
+                            // Mouse point up and left 1 pixel so that the mouse overlaps the top left corner
+                            // of the showing context menu just like it happens for a ContextMenuStrip.
+                            mousePt.X -= 1;
+                            mousePt.Y -= 1;
+                        }
+
+                        // If the mouse position is within our client area
+                        if (ClientRectangle.Contains(mousePt))
+                        {
+                            // Show the context menu
+                            KryptonContextMenu.Show(this, PointToScreen(mousePt));
+                        }
+                    }
+
+                    break;
+                default:
+                    base.WndProc(ref m);
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Raises the TabStop event.
+        /// </summary>
+        /// <param name="e">An EventArgs that contains the event data.</param>
+        protected override void OnTabStopChanged(EventArgs e)
+        {
+            _propertyGrid.TabStop = TabStop;
+            base.OnTabStopChanged(e);
+        }
+
+        /// <summary>
+        /// Raises the CausesValidationChanged event.
+        /// </summary>
+        /// <param name="e">An EventArgs that contains the event data.</param>
+        protected override void OnCausesValidationChanged(EventArgs e)
+        {
+            _propertyGrid.CausesValidation = CausesValidation;
+            base.OnCausesValidationChanged(e);
+        }
+
+        /// <summary>
+        /// Raises the HandleCreated event.
+        /// </summary>
+        /// <param name="e">An EventArgs containing the event data.</param>
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            // Let base class do standard stuff
+            base.OnHandleCreated(e);
+
+            // Force the font to be set into the text box child control
+            PerformNeedPaint(false);
+
+            // We need a layout to occur before any painting
+            InvokeLayout();
+        }
+
+
+        /// <summary>
+        /// Raises the MouseDown event.
+        /// </summary>
+        /// <param name="e">A MouseEventArgs that contains the event data.</param>
+        protected override void OnMouseDown(MouseEventArgs e)
+        {
+            _mouseOver = false;
+
+            PerformNeedPaint(true);
+
+            _propertyGrid.Invalidate();
+
+            base.OnMouseDown(e);
+        }
+
+        /// <summary>
+        /// Gets the default size of the control.
+        /// </summary>
+        protected override Size DefaultSize => new Size(120, 96);
+
+        /// <inheritdoc/>>
+        protected override void CreateHandle()
+        {
+            base.CreateHandle();
+
+            PI.SetWindowTheme(Handle, @"DarkMode_Explorer", null);
+        }
+
+        /// <summary>
+        /// Force the layout logic to size and position the controls.
+        /// </summary>
+        protected void ForceControlLayout()
+        {
+            if (!IsHandleCreated)
+            {
+                _forcedLayout = true;
+                OnLayout(new LayoutEventArgs(null, null));
+                _forcedLayout = false;
+            }
+        }
+
+        /// <inheritdoc />
+        /// <summary>
+        /// Processes a notification from palette storage of a paint and optional layout required.
+        /// </summary>
+        /// <param name="sender">Source of notification.</param>
+        /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
+        protected override void OnNeedPaint(object? sender, NeedLayoutEventArgs e)
+        {
+            if (IsHandleCreated && !e.NeedLayout)
+            {
+                _propertyGrid.Invalidate();
+            }
+            else
+            {
+                ForceControlLayout();
+            }
+
+            // Update palette to reflect latest state
+            UpdateStateAndPalettes();
+            base.OnNeedPaint(sender, e);
+        }
+
+        /// <summary>
+        /// Raises the Layout event.
+        /// </summary>
+        /// <param name="levent">An EventArgs that contains the event data.</param>
+        protected override void OnLayout(LayoutEventArgs levent)
+        {
+            base.OnLayout(levent);
+
+            // Only use layout logic if control is fully initialized or if being forced
+            // to allow a relayout or if in design mode.
+            if (IsHandleCreated || _forcedLayout || (DesignMode))
+            {
+                Rectangle fillRect = _layoutFill.FillRect;
+                _propertyGrid.SetBounds(fillRect.X, fillRect.Y, fillRect.Width, fillRect.Height);
+            }
+        }
+
+        /// <summary>
+        /// Raises the MouseEnter event.
+        /// </summary>
+        /// <param name="e">An EventArgs that contains the event data.</param>
+        protected override void OnMouseEnter(EventArgs e)
+        {
+            _mouseOver = true;
+            PerformNeedPaint(true);
+            _propertyGrid.Invalidate();
+            base.OnMouseEnter(e);
+        }
+
+        /// <summary>
+        /// Raises the MouseLeave event.
+        /// </summary>
+        /// <param name="e">An EventArgs that contains the event data.</param>
+        protected override void OnMouseLeave(EventArgs e)
+        {
+            _mouseOver = false;
+            PerformNeedPaint(true);
+            _propertyGrid.Invalidate();
+            base.OnMouseLeave(e);
+        }
+
+        /// <inheritdoc />
+        protected override void OnNotifyMessage(Message m)
+        {
+            if (m.Msg != 0x14)
+            {
+                base.OnNotifyMessage(m);
+            }
+        }
+
+        private void OnPropertyGridGotFocus(object sender, EventArgs e)
+        {
+            UpdateStateAndPalettes();
+            _propertyGrid.Invalidate();
+            PerformNeedPaint(true);
+            OnGotFocus(e);
+        }
+
+        private void OnPropertyGridLostFocus(object sender, EventArgs e)
+        {
+            UpdateStateAndPalettes();
+            _propertyGrid.Invalidate();
+            PerformNeedPaint(true);
+            OnLostFocus(e);
+        }
+
+        /// <inheritdoc />
+        protected override void OnEnabledChanged(EventArgs e)
+        {
+            UpdateStateAndPalettes();
+            PerformNeedPaint(true);
+            base.OnEnabledChanged(e);
+        }
+
+        /// <summary>
+        /// Creates a new instance of the control collection for the KryptonTreeView.
+        /// </summary>
+        /// <returns>A new instance of Control.ControlCollection assigned to the control.</returns>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        protected override ControlCollection CreateControlsInstance() => new KryptonReadOnlyControls(this);
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/General/KryptonFormFadeController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/KryptonFormFadeController.cs
@@ -138,7 +138,7 @@ namespace Krypton.Toolkit
         /// </summary>
         private async Task<DialogResult> ShowDialog(float fadeSpeed, FadeCompleted? finished)
         {
-            _parentForm!.BeginInvoke(new Action(() => _showDialogResult.SetResult(_owner!.ShowDialog(_parentForm))));
+            _parentForm!.BeginInvoke(() => _showDialogResult.SetResult(_owner!.ShowDialog(_parentForm)));
 
             _fadeCompleted = finished!;
 

--- a/Source/Krypton Components/Krypton.Toolkit/View Base/InternalKryptonStringCollectionEditor.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Base/InternalKryptonStringCollectionEditor.cs
@@ -116,7 +116,7 @@ namespace Krypton.Toolkit
             kbtnOk.Size = new Size(90, 25);
             kbtnOk.TabIndex = 2;
             kbtnOk.Values.Text = "O&K";
-            kbtnOk.Click += new EventHandler(kbtnOk_Click);
+            kbtnOk.Click += kbtnOk_Click;
             // 
             // kbtnCancel
             // 
@@ -127,7 +127,7 @@ namespace Krypton.Toolkit
             kbtnCancel.Size = new Size(90, 25);
             kbtnCancel.TabIndex = 1;
             kbtnCancel.Values.Text = "C&ancel";
-            kbtnCancel.Click += new EventHandler(kbtnCancel_Click);
+            kbtnCancel.Click += kbtnCancel_Click;
             // 
             // kbEdge
             // 
@@ -186,7 +186,7 @@ namespace Krypton.Toolkit
             // kcRichTextBoxCut
             // 
             kcRichTextBoxCut.Text = "kryptonCommand1";
-            kcRichTextBoxCut.Execute += new EventHandler(kcRichTextBoxCut_Execute);
+            kcRichTextBoxCut.Execute += kcRichTextBoxCut_Execute;
             // 
             // kryptonContextMenuItem2
             // 
@@ -197,7 +197,7 @@ namespace Krypton.Toolkit
             // kcRichTextBoxCopy
             // 
             kcRichTextBoxCopy.Text = "kryptonCommand1";
-            kcRichTextBoxCopy.Execute += new EventHandler(kcRichTextBoxCopy_Execute);
+            kcRichTextBoxCopy.Execute += kcRichTextBoxCopy_Execute;
             // 
             // kryptonContextMenuItem3
             // 
@@ -208,7 +208,7 @@ namespace Krypton.Toolkit
             // kcRichTextBoxPaste
             // 
             kcRichTextBoxPaste.Text = "kryptonCommand1";
-            kcRichTextBoxPaste.Execute += new EventHandler(kcRichTextBoxPaste_Execute);
+            kcRichTextBoxPaste.Execute += kcRichTextBoxPaste_Execute;
             // 
             // kryptonContextMenuItem7
             // 
@@ -219,7 +219,7 @@ namespace Krypton.Toolkit
             // kcRichTextBoxSelectAll
             // 
             kcRichTextBoxSelectAll.Text = "kryptonCommand1";
-            kcRichTextBoxSelectAll.Execute += new EventHandler(kcRichTextBoxSelectAll_Execute);
+            kcRichTextBoxSelectAll.Execute += kcRichTextBoxSelectAll_Execute;
             // 
             // ktxtStringCollection
             // 
@@ -261,7 +261,7 @@ namespace Krypton.Toolkit
             // kcTextBoxCut
             // 
             kcTextBoxCut.Text = "kryptonCommand1";
-            kcTextBoxCut.Execute += new EventHandler(kcTextBoxCut_Execute);
+            kcTextBoxCut.Execute += kcTextBoxCut_Execute;
             // 
             // kryptonContextMenuItem5
             // 
@@ -272,7 +272,7 @@ namespace Krypton.Toolkit
             // kcTextBoxCopy
             // 
             kcTextBoxCopy.Text = "kryptonCommand1";
-            kcTextBoxCopy.Execute += new EventHandler(kcTextBoxCopy_Execute);
+            kcTextBoxCopy.Execute += kcTextBoxCopy_Execute;
             // 
             // kryptonContextMenuItem6
             // 
@@ -283,7 +283,7 @@ namespace Krypton.Toolkit
             // kcTextBoxPaste
             // 
             kcTextBoxPaste.Text = "kryptonCommand1";
-            kcTextBoxPaste.Execute += new EventHandler(kcTextBoxPaste_Execute);
+            kcTextBoxPaste.Execute += kcTextBoxPaste_Execute;
             // 
             // kryptonContextMenuItem8
             // 
@@ -294,7 +294,7 @@ namespace Krypton.Toolkit
             // kcTextBoxSelectAll
             // 
             kcTextBoxSelectAll.Text = "kryptonCommand1";
-            kcTextBoxSelectAll.Execute += new EventHandler(kcTextBoxSelectAll_Execute);
+            kcTextBoxSelectAll.Execute += kcTextBoxSelectAll_Execute;
             // 
             // klblHeader
             // 

--- a/Source/Krypton Components/TestForm/DataGridViewTest.Designer.cs
+++ b/Source/Krypton Components/TestForm/DataGridViewTest.Designer.cs
@@ -84,10 +84,11 @@ namespace TestForm
             // 
             this.kryptonPanel1.Controls.Add(this.kryptonBorderEdge1);
             this.kryptonPanel1.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.kryptonPanel1.Location = new System.Drawing.Point(0, 461);
+            this.kryptonPanel1.Location = new System.Drawing.Point(0, 567);
+            this.kryptonPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.kryptonPanel1.Name = "kryptonPanel1";
             this.kryptonPanel1.PanelBackStyle = Krypton.Toolkit.PaletteBackStyle.PanelAlternate;
-            this.kryptonPanel1.Size = new System.Drawing.Size(1234, 50);
+            this.kryptonPanel1.Size = new System.Drawing.Size(1645, 62);
             this.kryptonPanel1.TabIndex = 0;
             // 
             // kryptonBorderEdge1
@@ -95,8 +96,9 @@ namespace TestForm
             this.kryptonBorderEdge1.BorderStyle = Krypton.Toolkit.PaletteBorderStyle.HeaderSecondary;
             this.kryptonBorderEdge1.Dock = System.Windows.Forms.DockStyle.Top;
             this.kryptonBorderEdge1.Location = new System.Drawing.Point(0, 0);
+            this.kryptonBorderEdge1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.kryptonBorderEdge1.Name = "kryptonBorderEdge1";
-            this.kryptonBorderEdge1.Size = new System.Drawing.Size(1234, 1);
+            this.kryptonBorderEdge1.Size = new System.Drawing.Size(1645, 1);
             this.kryptonBorderEdge1.Text = "kryptonBorderEdge1";
             // 
             // kryptonPanel2
@@ -111,8 +113,9 @@ namespace TestForm
             this.kryptonPanel2.Controls.Add(this.kryptonPropertyGrid1);
             this.kryptonPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonPanel2.Location = new System.Drawing.Point(0, 0);
+            this.kryptonPanel2.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.kryptonPanel2.Name = "kryptonPanel2";
-            this.kryptonPanel2.Size = new System.Drawing.Size(1234, 461);
+            this.kryptonPanel2.Size = new System.Drawing.Size(1645, 567);
             this.kryptonPanel2.TabIndex = 1;
             // 
             // kryptonDataGridView1
@@ -124,10 +127,11 @@ namespace TestForm
             this.kryptonDataGridView1.DataSource = this.dataSet;
             this.kryptonDataGridView1.GridStyles.Style = Krypton.Toolkit.DataGridViewStyle.Mixed;
             this.kryptonDataGridView1.KryptonContextMenu = this.kryptonContextMenu1;
-            this.kryptonDataGridView1.Location = new System.Drawing.Point(13, 12);
+            this.kryptonDataGridView1.Location = new System.Drawing.Point(17, 15);
+            this.kryptonDataGridView1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.kryptonDataGridView1.Name = "kryptonDataGridView1";
             this.kryptonDataGridView1.RowHeadersWidth = 51;
-            this.kryptonDataGridView1.Size = new System.Drawing.Size(870, 252);
+            this.kryptonDataGridView1.Size = new System.Drawing.Size(1160, 310);
             this.kryptonDataGridView1.TabIndex = 2;
             // 
             // dataSet
@@ -234,35 +238,39 @@ namespace TestForm
             // 
             // kryptonLabel1
             // 
-            this.kryptonLabel1.Location = new System.Drawing.Point(342, 272);
+            this.kryptonLabel1.Location = new System.Drawing.Point(456, 335);
+            this.kryptonLabel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.kryptonLabel1.Name = "kryptonLabel1";
-            this.kryptonLabel1.Size = new System.Drawing.Size(263, 24);
+            this.kryptonLabel1.Size = new System.Drawing.Size(295, 26);
             this.kryptonLabel1.TabIndex = 8;
             this.kryptonLabel1.Values.Text = "Right click grid for Krypton Context Menu";
             // 
             // kryptonButton1
             // 
-            this.kryptonButton1.Location = new System.Drawing.Point(11, 395);
+            this.kryptonButton1.Location = new System.Drawing.Point(15, 486);
+            this.kryptonButton1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.kryptonButton1.Name = "kryptonButton1";
-            this.kryptonButton1.Size = new System.Drawing.Size(324, 29);
+            this.kryptonButton1.Size = new System.Drawing.Size(432, 36);
             this.kryptonButton1.TabIndex = 7;
             this.kryptonButton1.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton1.Values.Text = "&Open Programatic Populate";
             // 
             // buttonClearCellColors
             // 
-            this.buttonClearCellColors.Location = new System.Drawing.Point(11, 360);
+            this.buttonClearCellColors.Location = new System.Drawing.Point(15, 443);
+            this.buttonClearCellColors.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.buttonClearCellColors.Name = "buttonClearCellColors";
-            this.buttonClearCellColors.Size = new System.Drawing.Size(324, 29);
+            this.buttonClearCellColors.Size = new System.Drawing.Size(432, 36);
             this.buttonClearCellColors.TabIndex = 6;
             this.buttonClearCellColors.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.buttonClearCellColors.Values.Text = "Clear Cell Colors";
             // 
             // buttonRandomCellColors
             // 
-            this.buttonRandomCellColors.Location = new System.Drawing.Point(12, 326);
+            this.buttonRandomCellColors.Location = new System.Drawing.Point(16, 401);
+            this.buttonRandomCellColors.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.buttonRandomCellColors.Name = "buttonRandomCellColors";
-            this.buttonRandomCellColors.Size = new System.Drawing.Size(324, 29);
+            this.buttonRandomCellColors.Size = new System.Drawing.Size(432, 36);
             this.buttonRandomCellColors.TabIndex = 5;
             this.buttonRandomCellColors.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.buttonRandomCellColors.Values.Text = "Random Cell Colors";
@@ -272,9 +280,10 @@ namespace TestForm
             this.kcmbGridStyle.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.kcmbGridStyle.DropDownWidth = 323;
             this.kcmbGridStyle.IntegralHeight = false;
-            this.kcmbGridStyle.Location = new System.Drawing.Point(13, 299);
+            this.kcmbGridStyle.Location = new System.Drawing.Point(17, 368);
+            this.kcmbGridStyle.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.kcmbGridStyle.Name = "kcmbGridStyle";
-            this.kcmbGridStyle.Size = new System.Drawing.Size(323, 24);
+            this.kcmbGridStyle.Size = new System.Drawing.Size(431, 26);
             this.kcmbGridStyle.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
             this.kcmbGridStyle.TabIndex = 4;
             // 
@@ -283,35 +292,31 @@ namespace TestForm
             this.kryptonThemeComboBox1.DefaultPalette = Krypton.Toolkit.PaletteMode.ProfessionalSystem;
             this.kryptonThemeComboBox1.DropDownWidth = 323;
             this.kryptonThemeComboBox1.IntegralHeight = false;
-            this.kryptonThemeComboBox1.Location = new System.Drawing.Point(13, 271);
+            this.kryptonThemeComboBox1.Location = new System.Drawing.Point(17, 334);
+            this.kryptonThemeComboBox1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.kryptonThemeComboBox1.Name = "kryptonThemeComboBox1";
-            this.kryptonThemeComboBox1.Size = new System.Drawing.Size(323, 24);
+            this.kryptonThemeComboBox1.Size = new System.Drawing.Size(431, 26);
             this.kryptonThemeComboBox1.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
             this.kryptonThemeComboBox1.TabIndex = 3;
             // 
             // kryptonPropertyGrid1
             // 
-            this.kryptonPropertyGrid1.BackColor = System.Drawing.SystemColors.Window;
-            this.kryptonPropertyGrid1.CategoryForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(253)))), ((int)(((byte)(253)))), ((int)(((byte)(253)))));
-            this.kryptonPropertyGrid1.CommandsBackColor = System.Drawing.SystemColors.Window;
-            this.kryptonPropertyGrid1.CommandsForeColor = System.Drawing.SystemColors.ControlText;
-            this.kryptonPropertyGrid1.Font = new System.Drawing.Font("Segoe UI", 10F);
-            this.kryptonPropertyGrid1.HelpBackColor = System.Drawing.SystemColors.Window;
-            this.kryptonPropertyGrid1.HelpForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-            this.kryptonPropertyGrid1.LineColor = System.Drawing.Color.FromArgb(((int)(((byte)(248)))), ((int)(((byte)(248)))), ((int)(((byte)(248)))));
-            this.kryptonPropertyGrid1.Location = new System.Drawing.Point(888, 12);
+            this.kryptonPropertyGrid1.Location = new System.Drawing.Point(1184, 15);
+            this.kryptonPropertyGrid1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.kryptonPropertyGrid1.Name = "kryptonPropertyGrid1";
-            this.kryptonPropertyGrid1.Size = new System.Drawing.Size(334, 429);
+            this.kryptonPropertyGrid1.Padding = new System.Windows.Forms.Padding(1);
+            this.kryptonPropertyGrid1.Size = new System.Drawing.Size(445, 528);
+            this.kryptonPropertyGrid1.StateCommon.Back.Color1 = System.Drawing.Color.Red;
             this.kryptonPropertyGrid1.TabIndex = 2;
-            this.kryptonPropertyGrid1.ViewForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
             // 
             // DataGridViewTest
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1234, 511);
+            this.ClientSize = new System.Drawing.Size(1645, 629);
             this.Controls.Add(this.kryptonPanel2);
             this.Controls.Add(this.kryptonPanel1);
+            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Name = "DataGridViewTest";
             this.Text = "DataGridViewTest";
             this.Load += new System.EventHandler(this.DataGridViewTest_Load);

--- a/Source/Krypton Components/TestForm/ThemeTest.Designer.cs
+++ b/Source/Krypton Components/TestForm/ThemeTest.Designer.cs
@@ -202,23 +202,12 @@ namespace TestForm
             this.kryptonPropertyGrid1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.kryptonPropertyGrid1.BackColor = System.Drawing.Color.White;
-            this.kryptonPropertyGrid1.CategoryForeColor = System.Drawing.Color.White;
-            this.kryptonPropertyGrid1.CommandsBackColor = System.Drawing.Color.White;
-            this.kryptonPropertyGrid1.CommandsForeColor = System.Drawing.Color.White;
-            this.kryptonPropertyGrid1.DisabledItemForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(127)))), ((int)(((byte)(30)))), ((int)(((byte)(57)))), ((int)(((byte)(91)))));
-            this.kryptonPropertyGrid1.Font = new System.Drawing.Font("Segoe UI", 10F);
-            this.kryptonPropertyGrid1.HelpBackColor = System.Drawing.Color.White;
-            this.kryptonPropertyGrid1.HelpForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-            this.kryptonPropertyGrid1.LineColor = System.Drawing.Color.FromArgb(((int)(((byte)(50)))), ((int)(((byte)(50)))), ((int)(((byte)(50)))));
             this.kryptonPropertyGrid1.Location = new System.Drawing.Point(531, 35);
             this.kryptonPropertyGrid1.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonPropertyGrid1.Name = "kryptonPropertyGrid1";
             this.kryptonPropertyGrid1.SelectedObject = this.kryptonManager1;
             this.kryptonPropertyGrid1.Size = new System.Drawing.Size(607, 319);
             this.kryptonPropertyGrid1.TabIndex = 2;
-            this.kryptonPropertyGrid1.ViewBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(134)))), ((int)(((byte)(179)))), ((int)(((byte)(236)))));
-            this.kryptonPropertyGrid1.ViewForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(21)))), ((int)(((byte)(66)))), ((int)(((byte)(139)))));
             // 
             // kryptonManager1
             // 

--- a/Source/Krypton Components/TestForm/TreeViewExample.Designer.cs
+++ b/Source/Krypton Components/TestForm/TreeViewExample.Designer.cs
@@ -142,23 +142,12 @@ namespace TestForm
             // 
             // kryptonPropertyGrid1
             // 
-            this.kryptonPropertyGrid1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(255)))), ((int)(((byte)(255)))));
-            this.kryptonPropertyGrid1.CategoryForeColor = System.Drawing.Color.White;
-            this.kryptonPropertyGrid1.CommandsBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(255)))), ((int)(((byte)(255)))));
-            this.kryptonPropertyGrid1.CommandsForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(30)))), ((int)(((byte)(57)))), ((int)(((byte)(91)))));
-            this.kryptonPropertyGrid1.DisabledItemForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(127)))), ((int)(((byte)(255)))), ((int)(((byte)(255)))), ((int)(((byte)(255)))));
-            this.kryptonPropertyGrid1.Font = new System.Drawing.Font("Segoe UI", 9F);
-            this.kryptonPropertyGrid1.HelpBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(255)))), ((int)(((byte)(255)))));
-            this.kryptonPropertyGrid1.HelpForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-            this.kryptonPropertyGrid1.LineColor = System.Drawing.Color.FromArgb(((int)(((byte)(179)))), ((int)(((byte)(196)))), ((int)(((byte)(216)))));
             this.kryptonPropertyGrid1.Location = new System.Drawing.Point(445, 50);
             this.kryptonPropertyGrid1.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonPropertyGrid1.Name = "kryptonPropertyGrid1";
             this.kryptonPropertyGrid1.SelectedObject = this.ktvTest;
             this.kryptonPropertyGrid1.Size = new System.Drawing.Size(503, 508);
             this.kryptonPropertyGrid1.TabIndex = 2;
-            this.kryptonPropertyGrid1.ViewBackColor = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(255)))), ((int)(((byte)(255)))));
-            this.kryptonPropertyGrid1.ViewForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
             // 
             // ktvTest
             // 


### PR DESCRIPTION
…he controls.

- Fix some issues with the KRibbonThemeComboBox

#632

Note:
![image](https://github.com/user-attachments/assets/c223fe4d-d669-4c34-99e3-449558ea124d)

I have suspicion that warnings from the build are not longer counted (i.e. nullables in the test app abuot the FadeForm etc)

![image](https://github.com/user-attachments/assets/9d2993fe-4f72-4ce8-b8a3-8c418953c788)
