### PR TITLE
1624-KryptonTheme-Selectors-default-to-professional-theme

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
+* Resolved [#1624](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1624), Theme Selector controls default to Professional System theme when set to `PaletteMode.Global`. Instead those shoud default to `ThemeManager.DefaultGlobalPalette`.
 * Resolved [#1583](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1583), `KryptonThemeComboBox` and `KrpytonThemeListBox` have the wrong designer assigned. Adds the `KryptonStubDesigner` internal class.
 * Resolved [#1564](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1564), Disabled Button Text in Ribbons is not visible in some themes
 * Resolved [#1607](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1607), "MS365 - Black" theme is unreadable

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupThemeComboBox.cs
@@ -31,7 +31,7 @@ namespace Krypton.Ribbon
         /// <summary> Suppress code execution in the SelectedIndexChanged event handler, when a theme change via the KManager has been performed.</summary>
         private bool _isExternalUpdate = false;
         /// <summary> Backing var for the DefaultPalette property.</summary>
-        private PaletteMode _defaultPalette;
+        private PaletteMode _defaultPalette = PaletteMode.Global;
         /// <summary> Local Krypton Manager instance.</summary>
         private readonly KryptonManager _manager;
         /// <summary> User defined palette.</summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
@@ -21,7 +21,7 @@ namespace Krypton.Toolkit
         /// <summary> Suppress code execution in the SelectedIndexChanged event handler, when a theme change via the KManager has been performed.</summary>
         private bool _isExternalUpdate = false;
         /// <summary> Backing var for the DefaultPalette property.</summary>
-        private PaletteMode _defaultPalette;
+        private PaletteMode _defaultPalette = PaletteMode.Global;
         /// <summary> Local Krypton Manager instance.</summary>
         private readonly KryptonManager _manager;
         /// <summary> User defined palette.</summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeListBox.cs
@@ -22,7 +22,7 @@ namespace Krypton.Toolkit
         /// <summary> Suppress code execution in the SelectedIndexChanged event handler, when a theme change via the KManager has been performed.</summary>
         private bool _isExternalUpdate = false;
         /// <summary> Backing var for the DefaultPalette property.</summary>
-        private PaletteMode _defaultPalette;
+        private PaletteMode _defaultPalette = PaletteMode.Global;
         /// <summary> Local Krypton Manager instance.</summary>
         private readonly KryptonManager _manager;
         /// <summary> User defined palette.</summary>


### PR DESCRIPTION
[Issue 1624-KryptonTheme-Selectors-default-to-professional-theme](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1624)
- _defaultPalette back var needs to be initialized with PaletteMode.Global
- And the change log

![compile-results](https://github.com/user-attachments/assets/a300aa83-8450-43e4-8dd9-d5a4b5f8fc32)
