### PR TITLE
1633-KRibbon-clicking-the-Mini-QAT-Menu-Button-causes-an-exception

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
+* Resolved [#1633](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1633), `KryptonRibbon` - Clicking the Mini QAT Menu Button causes an exception.
 * Resolved [#1624](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1624), Theme Selector controls default to Professional System theme when set to `PaletteMode.Global`. Instead those shoud default to `ThemeManager.DefaultGlobalPalette`.
 * Resolved [#1628](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1628), Some themes do not render the "ToolStrip" Correctly
 * Implemented [#632](https://github.com/Krypton-Suite/Standard-Toolkit/issues/632), **[Breaking Change]** `KryptonPropertyGrid` should have a customisable back colour.

--- a/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonQATMini.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonQATMini.cs
@@ -67,6 +67,9 @@ namespace Krypton.Ribbon
             Add(_border, ViewDockStyle.Fill);
             Add(_extraSeparator, ViewDockStyle.Right);
             Add(_extraButton, ViewDockStyle.Right);
+
+            // OwnerForm property can be intialized after _ribbon has been assigned.
+            OwnerForm ??= _ribbon.FindKryptonForm();
         }
 
         /// <summary>
@@ -289,11 +292,15 @@ namespace Krypton.Ribbon
             // Convert the button rectangle to screen coordinates
             Rectangle screenRect = _ribbon.RectangleToScreen(button.ClientRectangle);
 
-            // If integrated into the caption area
-            // Adjust for the height/width of borders
-            Padding borders = OwnerForm!.RealWindowBorders;
-            screenRect.X -= borders.Left;
-            screenRect.Y -= borders.Top;
+            // Only if the ribbon is on a KForm this adjustment is needed.
+            if (OwnerForm is not null)
+            {
+                // If integrated into the caption area
+                // Adjust for the height/width of borders
+                Padding borders = OwnerForm!.RealWindowBorders;
+                screenRect.X -= borders.Left;
+                screenRect.Y -= borders.Top;
+            }
 
             if (_extraButton is { Overflow: true })
             {
@@ -303,6 +310,7 @@ namespace Krypton.Ribbon
             {
                 _ribbon.DisplayQATCustomizeMenu(screenRect, _borderContents, finishDelegate);
             }
+
         }
         #endregion
     }


### PR DESCRIPTION
[Issue 1633-KRibbon-clicking-the-Mini-QAT-Menu-Button-causes-an-exception](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1633)
- OwnerForm property is initialized from the constructor.
- Method `OnExtraButtonClick` adjusted.
- And the change log.

![compile-results](https://github.com/user-attachments/assets/1026ef6a-6314-4779-91b9-c998d90280ac)
