### PR TITLE
1373 v85 getting an application crash when pressing the delete key

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-07-xx - Build 2407 (Patch 1) - July 2024
+* Resolved [#1373](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1373), `KT.CommonHelper.CheckContextMenuForShortcut()` handles direct type casts differently from .NET 8.0 onward. Solution courtesy of @Tape-Worm.
 * Resolved [#1613](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1613), `KryptonMessageBox` text is not centered vertically.
 * Resolved [#1583](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1583), `KryptonThemeComboBox` and `KrpytonThemeListBox` have the wrong designer assigned. Adds the `KryptonStubDesigner` internal class.
 * Resolved [#1614](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1614), `KryptonMessageBox` throws an exception after Esc key is pressed.

--- a/Source/Krypton Components/Krypton.Toolkit/General/CommonHelper.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/CommonHelper.cs
@@ -149,11 +149,29 @@ namespace Krypton.Toolkit
                 }
 
                 // Get any menu item from context strip that matches the shortcut key combination
-                var shortcuts = (Hashtable)_cachedShortcutPI!.GetValue(cms, null);
-                var menuItem = (ToolStripMenuItem)shortcuts[keyData];
+                Hashtable? hashTableShortCuts = _cachedShortcutPI!.GetValue(cms, null) as Hashtable;
+                ToolStripMenuItem? menuItem = null;
+
+                if (hashTableShortCuts is null)
+                {
+                    Dictionary<Keys, ToolStripMenuItem>? dictionaryShortcuts = _cachedShortcutPI!.GetValue(cms, null) as Dictionary<Keys, ToolStripMenuItem>;
+
+                    if (dictionaryShortcuts is not null)
+                    {
+                        dictionaryShortcuts.TryGetValue(keyData, out menuItem);
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                }
+                else
+                {
+                    menuItem = hashTableShortCuts[keyData] as ToolStripMenuItem;
+                }
 
                 // If we found a match...
-                if (menuItem != null)
+                if (menuItem is not null)
                 {
                     // Get the menu item to process the shortcut
                     var ret = _cachedShortcutMI!.Invoke(menuItem, new object[] { msg, keyData });


### PR DESCRIPTION
[Issue 1373-V85-Getting-an-application-crash-when-pressing-the-Delete-key](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1373)
- `KT.CommonHelper.CheckContextMenuForShortcut()` handles direct type casts differently from .NET 8.0 onward. 
- Solution courtesy of @Tape-Worm
- And the change log

![compile-results](https://github.com/user-attachments/assets/9228ff9f-fb01-42a3-b9d4-d94442c74f41)
