### PR TITLE
1373-Getting-an-application-crash-when-pressing-the-Delete-key

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
+* Resolved [#1373](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1373), `KT.CommonHelper.CheckContextMenuForShortcut()` handles direct type casts differently from .NET 8.0 onward. Solution courtesy of @Tape-Worm
 * Resolved [#1633](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1633), `KryptonRibbon` - Clicking the Mini QAT Menu Button causes an exception.
 * Resolved [#1624](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1624), Theme Selector controls default to Professional System theme when set to `PaletteMode.Global`. Instead those shoud default to `ThemeManager.DefaultGlobalPalette`.
 * Resolved [#1628](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1628), Some themes do not render the "ToolStrip" Correctly

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,7 +3,6 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
-* Resolved [#1373](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1373), `KT.CommonHelper.CheckContextMenuForShortcut()` handles direct type casts differently from .NET 8.0 onward. Solution courtesy of @Tape-Worm
 * Resolved [#1633](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1633), `KryptonRibbon` - Clicking the Mini QAT Menu Button causes an exception.
 * Resolved [#1624](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1624), Theme Selector controls default to Professional System theme when set to `PaletteMode.Global`. Instead those shoud default to `ThemeManager.DefaultGlobalPalette`.
 * Resolved [#1628](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1628), Some themes do not render the "ToolStrip" Correctly
@@ -134,6 +133,7 @@
 =======
 
 ## 2024-07-xx - Build 2407 (Version 85 - Patch 1) - July 2024
+* Resolved [#1373](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1373), `KT.CommonHelper.CheckContextMenuForShortcut()` handles direct type casts differently from .NET 8.0 onward. Solution courtesy of @Tape-Worm
 * Resolved [#1583](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1583), `KryptonThemeComboBox` and `KrpytonThemeListBox` have the wrong designer assigned. Adds the `KryptonStubDesigner` internal class.
 * Resolved [#1614](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1614), `KryptonMessageBox` throws an exception after Esc key is pressed.
 * Resolved [#1613](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1613), `KryptonMessageBox` text is not centered vertically.

--- a/Source/Krypton Components/Krypton.Toolkit/General/CommonHelper.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/CommonHelper.cs
@@ -150,13 +150,32 @@ namespace Krypton.Toolkit
                 }
 
                 // Get any menu item from context strip that matches the shortcut key combination
-                var shortcuts = _cachedShortcutPI!.GetValue(cms, null) as Hashtable;
+                Hashtable? hashTableShortCuts = _cachedShortcutPI!.GetValue(cms, null) as Hashtable;
+                ToolStripMenuItem? menuItem = null;
+
+                if (hashTableShortCuts is null)
+                {
+                    Dictionary<Keys, ToolStripMenuItem>? dictionaryShortcuts = _cachedShortcutPI!.GetValue(cms, null) as Dictionary<Keys, ToolStripMenuItem>;
+
+                    if (dictionaryShortcuts is not null)
+                    {
+                        dictionaryShortcuts.TryGetValue(keyData, out menuItem);
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                }
+                else
+                {
+                    menuItem = hashTableShortCuts[keyData] as ToolStripMenuItem;
+                }
 
                 // If we found a match...
-                if (shortcuts![keyData] is ToolStripMenuItem menuItem)
+                if (menuItem is not null)
                 {
                     // Get the menu item to process the shortcut
-                    var ret = _cachedShortcutMI!.Invoke(menuItem, [msg, keyData]);
+                    var ret = _cachedShortcutMI!.Invoke(menuItem, new object[] { msg, keyData });
 
                     // Return the 'ProcessCmdKey' result
                     if (ret != null)


### PR DESCRIPTION
[Issue 1373-Getting-an-application-crash-when-pressing-the-Delete-key](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1373)
- `KT.CommonHelper.CheckContextMenuForShortcut()` handles direct type casts differently from .NET 8.0 onward. 
- Solution courtesy of @Tape-Worm
- And the change log

![compile-results](https://github.com/user-attachments/assets/e4692a51-fb50-4667-84a4-3e256235b6a9)
