### PR TITLE
Forward recent fixes for KMbox for V90 - Round 2

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareForm.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareForm.Designer.cs
@@ -54,9 +54,9 @@
             this.kryptonPanel1.Controls.Add(this.tableLayoutPanel1);
             this.kryptonPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonPanel1.Location = new System.Drawing.Point(0, 0);
-            this.kryptonPanel1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.kryptonPanel1.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonPanel1.Name = "kryptonPanel1";
-            this.kryptonPanel1.Size = new System.Drawing.Size(292, 81);
+            this.kryptonPanel1.Size = new System.Drawing.Size(219, 64);
             this.kryptonPanel1.TabIndex = 2;
             // 
             // tableLayoutPanel1
@@ -70,13 +70,13 @@
             this.tableLayoutPanel1.Controls.Add(this.kpnlContentArea, 1, 0);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
-            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(2);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 25F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(292, 81);
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(219, 64);
             this.tableLayoutPanel1.TabIndex = 0;
             // 
             // _panelButtons
@@ -88,11 +88,11 @@
             this._panelButtons.Controls.Add(this._button1);
             this._panelButtons.Controls.Add(this._button2);
             this._panelButtons.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._panelButtons.Location = new System.Drawing.Point(0, 55);
+            this._panelButtons.Location = new System.Drawing.Point(0, 43);
             this._panelButtons.Margin = new System.Windows.Forms.Padding(0);
             this._panelButtons.Name = "_panelButtons";
             this._panelButtons.PanelBackStyle = Krypton.Toolkit.PaletteBackStyle.PanelAlternate;
-            this._panelButtons.Size = new System.Drawing.Size(292, 26);
+            this._panelButtons.Size = new System.Drawing.Size(219, 21);
             this._panelButtons.TabIndex = 0;
             // 
             // _borderEdge
@@ -100,9 +100,9 @@
             this._borderEdge.BorderStyle = Krypton.Toolkit.PaletteBorderStyle.HeaderPrimary;
             this._borderEdge.Dock = System.Windows.Forms.DockStyle.Top;
             this._borderEdge.Location = new System.Drawing.Point(0, 0);
-            this._borderEdge.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this._borderEdge.Margin = new System.Windows.Forms.Padding(2);
             this._borderEdge.Name = "_borderEdge";
-            this._borderEdge.Size = new System.Drawing.Size(292, 1);
+            this._borderEdge.Size = new System.Drawing.Size(219, 1);
             this._borderEdge.Text = "kryptonBorderEdge1";
             // 
             // _button4
@@ -111,12 +111,13 @@
             this._button4.AutoSize = true;
             this._button4.Enabled = false;
             this._button4.IgnoreAltF4 = false;
-            this._button4.Location = new System.Drawing.Point(292, 0);
+            this._button4.Location = new System.Drawing.Point(219, 0);
             this._button4.Margin = new System.Windows.Forms.Padding(0);
-            this._button4.MinimumSize = new System.Drawing.Size(51, 26);
+            this._button4.MinimumSize = new System.Drawing.Size(38, 21);
             this._button4.Name = "_button4";
-            this._button4.Size = new System.Drawing.Size(51, 32);
+            this._button4.Size = new System.Drawing.Size(38, 23);
             this._button4.TabIndex = 2;
+            this._button4.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this._button4.Values.Text = "B4";
             this._button4.Visible = false;
             // 
@@ -126,12 +127,13 @@
             this._button3.AutoSize = true;
             this._button3.Enabled = false;
             this._button3.IgnoreAltF4 = false;
-            this._button3.Location = new System.Drawing.Point(243, 0);
+            this._button3.Location = new System.Drawing.Point(182, 0);
             this._button3.Margin = new System.Windows.Forms.Padding(0);
-            this._button3.MinimumSize = new System.Drawing.Size(51, 26);
+            this._button3.MinimumSize = new System.Drawing.Size(38, 21);
             this._button3.Name = "_button3";
-            this._button3.Size = new System.Drawing.Size(51, 32);
+            this._button3.Size = new System.Drawing.Size(38, 23);
             this._button3.TabIndex = 2;
+            this._button3.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this._button3.Values.Text = "B3";
             this._button3.Visible = false;
             // 
@@ -141,12 +143,13 @@
             this._button1.AutoSize = true;
             this._button1.Enabled = false;
             this._button1.IgnoreAltF4 = false;
-            this._button1.Location = new System.Drawing.Point(141, 0);
+            this._button1.Location = new System.Drawing.Point(106, 0);
             this._button1.Margin = new System.Windows.Forms.Padding(0);
-            this._button1.MinimumSize = new System.Drawing.Size(51, 26);
+            this._button1.MinimumSize = new System.Drawing.Size(38, 21);
             this._button1.Name = "_button1";
-            this._button1.Size = new System.Drawing.Size(51, 32);
+            this._button1.Size = new System.Drawing.Size(38, 23);
             this._button1.TabIndex = 0;
+            this._button1.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this._button1.Values.Text = "B1";
             this._button1.Visible = false;
             // 
@@ -156,12 +159,13 @@
             this._button2.AutoSize = true;
             this._button2.Enabled = false;
             this._button2.IgnoreAltF4 = false;
-            this._button2.Location = new System.Drawing.Point(192, 0);
+            this._button2.Location = new System.Drawing.Point(144, 0);
             this._button2.Margin = new System.Windows.Forms.Padding(0);
-            this._button2.MinimumSize = new System.Drawing.Size(51, 26);
+            this._button2.MinimumSize = new System.Drawing.Size(38, 21);
             this._button2.Name = "_button2";
-            this._button2.Size = new System.Drawing.Size(51, 32);
+            this._button2.Size = new System.Drawing.Size(38, 23);
             this._button2.TabIndex = 1;
+            this._button2.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this._button2.Values.Text = "B2";
             this._button2.Visible = false;
             // 
@@ -169,10 +173,10 @@
             // 
             this._messageIcon.BackColor = System.Drawing.Color.Transparent;
             this._messageIcon.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._messageIcon.Location = new System.Drawing.Point(237, 5);
-            this._messageIcon.Margin = new System.Windows.Forms.Padding(11, 5, 5, 5);
+            this._messageIcon.Location = new System.Drawing.Point(178, 4);
+            this._messageIcon.Margin = new System.Windows.Forms.Padding(8, 4, 4, 4);
             this._messageIcon.Name = "_messageIcon";
-            this._messageIcon.Size = new System.Drawing.Size(44, 45);
+            this._messageIcon.Size = new System.Drawing.Size(33, 35);
             this._messageIcon.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
             this._messageIcon.TabIndex = 0;
             this._messageIcon.TabStop = false;
@@ -181,10 +185,10 @@
             // 
             this.kpnlContentArea.Controls.Add(this.kwlblMessageText);
             this.kpnlContentArea.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.kpnlContentArea.Location = new System.Drawing.Point(4, 4);
-            this.kpnlContentArea.Margin = new System.Windows.Forms.Padding(4);
+            this.kpnlContentArea.Location = new System.Drawing.Point(4, 12);
+            this.kpnlContentArea.Margin = new System.Windows.Forms.Padding(4, 12, 4, 12);
             this.kpnlContentArea.Name = "kpnlContentArea";
-            this.kpnlContentArea.Size = new System.Drawing.Size(224, 47);
+            this.kpnlContentArea.Size = new System.Drawing.Size(166, 19);
             this.kpnlContentArea.TabIndex = 1;
             // 
             // kwlblMessageText
@@ -192,24 +196,24 @@
             this.kwlblMessageText.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kwlblMessageText.InputControlStyle = Krypton.Toolkit.InputControlStyle.PanelClient;
             this.kwlblMessageText.Location = new System.Drawing.Point(0, 0);
-            this.kwlblMessageText.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.kwlblMessageText.Margin = new System.Windows.Forms.Padding(5, 0, 0, 0);
             this.kwlblMessageText.Multiline = true;
             this.kwlblMessageText.Name = "kwlblMessageText";
             this.kwlblMessageText.ReadOnly = true;
-            this.kwlblMessageText.Size = new System.Drawing.Size(224, 47);
+            this.kwlblMessageText.Size = new System.Drawing.Size(166, 19);
             this.kwlblMessageText.StateCommon.Border.DrawBorders = Krypton.Toolkit.PaletteDrawBorders.None;
-            this.kwlblMessageText.TabIndex = 0;
+            this.kwlblMessageText.TabIndex = 2;
+            this.kwlblMessageText.TabStop = false;
             this.kwlblMessageText.Text = "Message Text\r\n.\ttabbed";
             // 
             // VisualMessageBoxRtlAwareForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(292, 81);
+            this.ClientSize = new System.Drawing.Size(219, 64);
             this.Controls.Add(this.kryptonPanel1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.KeyPreview = true;
-            this.Margin = new System.Windows.Forms.Padding(4);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "VisualMessageBoxRtlAwareForm";
@@ -217,7 +221,6 @@
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.TopMost = false;
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).EndInit();
             this.kryptonPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.ResumeLayout(false);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareForm.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareForm.Designer.cs
@@ -38,7 +38,7 @@
             this._button2 = new Krypton.Toolkit.MessageButton();
             this._messageIcon = new System.Windows.Forms.PictureBox();
             this.kpnlContentArea = new Krypton.Toolkit.KryptonPanel();
-            this.kwlblMessageText = new Krypton.Toolkit.KryptonTextBox();
+            this.ktextBoxMessageText = new Krypton.Toolkit.KryptonTextBox();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).BeginInit();
             this.kryptonPanel1.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
@@ -183,7 +183,7 @@
             // 
             // kpnlContentArea
             // 
-            this.kpnlContentArea.Controls.Add(this.kwlblMessageText);
+            this.kpnlContentArea.Controls.Add(this.ktextBoxMessageText);
             this.kpnlContentArea.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kpnlContentArea.Location = new System.Drawing.Point(4, 12);
             this.kpnlContentArea.Margin = new System.Windows.Forms.Padding(4, 12, 4, 12);
@@ -191,20 +191,20 @@
             this.kpnlContentArea.Size = new System.Drawing.Size(166, 19);
             this.kpnlContentArea.TabIndex = 1;
             // 
-            // kwlblMessageText
+            // ktextBoxMessageText
             // 
-            this.kwlblMessageText.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.kwlblMessageText.InputControlStyle = Krypton.Toolkit.InputControlStyle.PanelClient;
-            this.kwlblMessageText.Location = new System.Drawing.Point(0, 0);
-            this.kwlblMessageText.Margin = new System.Windows.Forms.Padding(5, 0, 0, 0);
-            this.kwlblMessageText.Multiline = true;
-            this.kwlblMessageText.Name = "kwlblMessageText";
-            this.kwlblMessageText.ReadOnly = true;
-            this.kwlblMessageText.Size = new System.Drawing.Size(166, 19);
-            this.kwlblMessageText.StateCommon.Border.DrawBorders = Krypton.Toolkit.PaletteDrawBorders.None;
-            this.kwlblMessageText.TabIndex = 2;
-            this.kwlblMessageText.TabStop = false;
-            this.kwlblMessageText.Text = "Message Text\r\n.\ttabbed";
+            this.ktextBoxMessageText.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ktextBoxMessageText.InputControlStyle = Krypton.Toolkit.InputControlStyle.PanelClient;
+            this.ktextBoxMessageText.Location = new System.Drawing.Point(0, 0);
+            this.ktextBoxMessageText.Margin = new System.Windows.Forms.Padding(5, 0, 0, 0);
+            this.ktextBoxMessageText.Multiline = true;
+            this.ktextBoxMessageText.Name = "ktextBoxMessageText";
+            this.ktextBoxMessageText.ReadOnly = true;
+            this.ktextBoxMessageText.Size = new System.Drawing.Size(166, 19);
+            this.ktextBoxMessageText.StateCommon.Border.DrawBorders = Krypton.Toolkit.PaletteDrawBorders.None;
+            this.ktextBoxMessageText.TabIndex = 2;
+            this.ktextBoxMessageText.TabStop = false;
+            this.ktextBoxMessageText.Text = "Message Text\r\n.\ttabbed";
             // 
             // VisualMessageBoxRtlAwareForm
             // 
@@ -247,6 +247,6 @@
         private MessageButton _button2;
         private PictureBox _messageIcon;
         private KryptonPanel kpnlContentArea;
-        private KryptonTextBox kwlblMessageText;
+        private KryptonTextBox ktextBoxMessageText;
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareForm.cs
@@ -49,12 +49,7 @@ namespace Krypton.Toolkit
             bool? showCloseButton)
         {
             // Store incoming values
-            if (text != null && !text.Contains('\n'))
-            {
-                _text = "\r\n"; // \n means that the single line text should align with the icon
-            }
-
-            _text += text;
+            _text = text;
             _caption = caption;
             _buttons = buttons;
             _kryptonMessageBoxIcon = icon;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareForm.cs
@@ -82,7 +82,7 @@ namespace Krypton.Toolkit
             Text = string.IsNullOrEmpty(_caption) 
                 ? string.Empty 
                 : _caption!.Split(Environment.NewLine.ToCharArray())[0];
-            kwlblMessageText.Text = _text;
+            ktextBoxMessageText.Text = _text;
         }
 
         private void UpdateTextExtra(bool? showCtrlCopy)
@@ -485,7 +485,7 @@ namespace Krypton.Toolkit
                 Size scaledMonitorSize = screen!.Bounds.Size;
                 scaledMonitorSize.Width = (int)(scaledMonitorSize.Width * 2 / 3.0f);
                 scaledMonitorSize.Height = (int)(scaledMonitorSize.Height * 0.95f);
-                Font textFont = kwlblMessageText.StateCommon.Content.GetContentShortTextFont(PaletteState.Normal) ?? KryptonManager.CurrentGlobalPalette!.BaseFont;
+                Font textFont = ktextBoxMessageText.StateCommon.Content.GetContentShortTextFont(PaletteState.Normal) ?? KryptonManager.CurrentGlobalPalette!.BaseFont;
                 Font captionFont = KryptonManager.CurrentGlobalPalette.BaseFont;
                 SizeF messageSize = TextRenderer.MeasureText(_text, textFont, scaledMonitorSize);
                 // SKC: Don't forget to add the TextExtra into the calculation
@@ -502,7 +502,7 @@ namespace Krypton.Toolkit
             }
 
             // Calculate the size of the icon area and text area including margins
-            Padding textPadding = kwlblMessageText.StateCommon.Content.GetContentPadding(PaletteState.Normal);
+            Padding textPadding = ktextBoxMessageText.StateCommon.Content.GetContentPadding(PaletteState.Normal);
             Padding textAreaAllMargin = Padding.Add(textPadding, kpnlContentArea.Margin);
             Size iconArea = new Size(_messageIcon.Width + _messageIcon.Margin.Left + _messageIcon.Margin.Right,
                 _messageIcon.Height + _messageIcon.Margin.Top + _messageIcon.Margin.Bottom);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareFormDep.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareFormDep.Designer.cs
@@ -38,8 +38,8 @@
             this._button2 = new Krypton.Toolkit.MessageButton();
             this._messageIcon = new System.Windows.Forms.PictureBox();
             this.kpnlContentArea = new Krypton.Toolkit.KryptonPanel();
-            this.kwlblMessageText = new Krypton.Toolkit.KryptonWrapLabel();
             this.klwlblMessageText = new Krypton.Toolkit.KryptonLinkWrapLabel();
+            this.kwlblMessageText = new Krypton.Toolkit.KryptonTextBox();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).BeginInit();
             this.kryptonPanel1.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
@@ -57,7 +57,7 @@
             this.kryptonPanel1.Location = new System.Drawing.Point(0, 0);
             this.kryptonPanel1.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonPanel1.Name = "kryptonPanel1";
-            this.kryptonPanel1.Size = new System.Drawing.Size(219, 124);
+            this.kryptonPanel1.Size = new System.Drawing.Size(219, 64);
             this.kryptonPanel1.TabIndex = 2;
             // 
             // tableLayoutPanel1
@@ -77,7 +77,7 @@
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(219, 124);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(219, 64);
             this.tableLayoutPanel1.TabIndex = 0;
             // 
             // _panelButtons
@@ -89,7 +89,7 @@
             this._panelButtons.Controls.Add(this._button1);
             this._panelButtons.Controls.Add(this._button2);
             this._panelButtons.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._panelButtons.Location = new System.Drawing.Point(0, 103);
+            this._panelButtons.Location = new System.Drawing.Point(0, 43);
             this._panelButtons.Margin = new System.Windows.Forms.Padding(0);
             this._panelButtons.Name = "_panelButtons";
             this._panelButtons.PanelBackStyle = Krypton.Toolkit.PaletteBackStyle.PanelAlternate;
@@ -118,6 +118,7 @@
             this._button4.Name = "_button4";
             this._button4.Size = new System.Drawing.Size(38, 23);
             this._button4.TabIndex = 2;
+            this._button4.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this._button4.Values.Text = "B4";
             this._button4.Visible = false;
             // 
@@ -133,6 +134,7 @@
             this._button3.Name = "_button3";
             this._button3.Size = new System.Drawing.Size(38, 23);
             this._button3.TabIndex = 2;
+            this._button3.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this._button3.Values.Text = "B3";
             this._button3.Visible = false;
             // 
@@ -148,6 +150,7 @@
             this._button1.Name = "_button1";
             this._button1.Size = new System.Drawing.Size(38, 23);
             this._button1.TabIndex = 0;
+            this._button1.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this._button1.Values.Text = "B1";
             this._button1.Visible = false;
             // 
@@ -163,6 +166,7 @@
             this._button2.Name = "_button2";
             this._button2.Size = new System.Drawing.Size(38, 23);
             this._button2.TabIndex = 1;
+            this._button2.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this._button2.Values.Text = "B2";
             this._button2.Visible = false;
             // 
@@ -173,7 +177,7 @@
             this._messageIcon.Location = new System.Drawing.Point(178, 4);
             this._messageIcon.Margin = new System.Windows.Forms.Padding(8, 4, 4, 4);
             this._messageIcon.Name = "_messageIcon";
-            this._messageIcon.Size = new System.Drawing.Size(33, 95);
+            this._messageIcon.Size = new System.Drawing.Size(33, 35);
             this._messageIcon.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
             this._messageIcon.TabIndex = 0;
             this._messageIcon.TabStop = false;
@@ -183,23 +187,11 @@
             this.kpnlContentArea.Controls.Add(this.kwlblMessageText);
             this.kpnlContentArea.Controls.Add(this.klwlblMessageText);
             this.kpnlContentArea.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.kpnlContentArea.Location = new System.Drawing.Point(3, 3);
+            this.kpnlContentArea.Location = new System.Drawing.Point(4, 12);
+            this.kpnlContentArea.Margin = new System.Windows.Forms.Padding(4, 12, 4, 12);
             this.kpnlContentArea.Name = "kpnlContentArea";
-            this.kpnlContentArea.Size = new System.Drawing.Size(168, 97);
+            this.kpnlContentArea.Size = new System.Drawing.Size(166, 19);
             this.kpnlContentArea.TabIndex = 1;
-            // 
-            // kwlblMessageText
-            // 
-            this.kwlblMessageText.AutoSize = false;
-            this.kwlblMessageText.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.kwlblMessageText.Font = new System.Drawing.Font("Segoe UI", 9F);
-            this.kwlblMessageText.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(30)))), ((int)(((byte)(57)))), ((int)(((byte)(91)))));
-            this.kwlblMessageText.LabelStyle = Krypton.Toolkit.LabelStyle.AlternateControl;
-            this.kwlblMessageText.Location = new System.Drawing.Point(0, 0);
-            this.kwlblMessageText.Name = "kwlblMessageText";
-            this.kwlblMessageText.Size = new System.Drawing.Size(168, 97);
-            this.kwlblMessageText.Text = "Message Text";
-            this.kwlblMessageText.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // klwlblMessageText
             // 
@@ -210,15 +202,31 @@
             this.klwlblMessageText.LabelStyle = Krypton.Toolkit.LabelStyle.AlternateControl;
             this.klwlblMessageText.Location = new System.Drawing.Point(0, 0);
             this.klwlblMessageText.Name = "klwlblMessageText";
-            this.klwlblMessageText.Size = new System.Drawing.Size(168, 97);
+            this.klwlblMessageText.Size = new System.Drawing.Size(166, 19);
             this.klwlblMessageText.Text = "Message Text";
             this.klwlblMessageText.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.klwlblMessageText.UseCompatibleTextRendering = false;
+            // 
+            // kwlblMessageText
+            // 
+            this.kwlblMessageText.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.kwlblMessageText.InputControlStyle = Krypton.Toolkit.InputControlStyle.PanelClient;
+            this.kwlblMessageText.Location = new System.Drawing.Point(0, 0);
+            this.kwlblMessageText.Margin = new System.Windows.Forms.Padding(5, 0, 0, 0);
+            this.kwlblMessageText.Multiline = true;
+            this.kwlblMessageText.Name = "kwlblMessageText";
+            this.kwlblMessageText.ReadOnly = true;
+            this.kwlblMessageText.Size = new System.Drawing.Size(166, 19);
+            this.kwlblMessageText.StateCommon.Border.DrawBorders = Krypton.Toolkit.PaletteDrawBorders.None;
+            this.kwlblMessageText.TabIndex = 2;
+            this.kwlblMessageText.TabStop = false;
+            this.kwlblMessageText.Text = "Message Text\r\n.\ttabbed";
             // 
             // VisualMessageBoxRtlAwareFormDep
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(219, 124);
+            this.ClientSize = new System.Drawing.Size(219, 64);
             this.Controls.Add(this.kryptonPanel1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.KeyPreview = true;
@@ -229,7 +237,6 @@
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.TopMost = false;
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).EndInit();
             this.kryptonPanel1.ResumeLayout(false);
             this.tableLayoutPanel1.ResumeLayout(false);
@@ -239,6 +246,7 @@
             ((System.ComponentModel.ISupportInitialize)(this._messageIcon)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.kpnlContentArea)).EndInit();
             this.kpnlContentArea.ResumeLayout(false);
+            this.kpnlContentArea.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -256,6 +264,6 @@
         private PictureBox _messageIcon;
         private KryptonPanel kpnlContentArea;
         private KryptonLinkWrapLabel klwlblMessageText;
-        private KryptonWrapLabel kwlblMessageText;
+        private KryptonTextBox kwlblMessageText;
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareFormDep.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareFormDep.Designer.cs
@@ -38,8 +38,8 @@
             this._button2 = new Krypton.Toolkit.MessageButton();
             this._messageIcon = new System.Windows.Forms.PictureBox();
             this.kpnlContentArea = new Krypton.Toolkit.KryptonPanel();
+            this.ktextBoxMessageText = new Krypton.Toolkit.KryptonTextBox();
             this.klwlblMessageText = new Krypton.Toolkit.KryptonLinkWrapLabel();
-            this.kwlblMessageText = new Krypton.Toolkit.KryptonTextBox();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).BeginInit();
             this.kryptonPanel1.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
@@ -184,7 +184,7 @@
             // 
             // kpnlContentArea
             // 
-            this.kpnlContentArea.Controls.Add(this.kwlblMessageText);
+            this.kpnlContentArea.Controls.Add(this.ktextBoxMessageText);
             this.kpnlContentArea.Controls.Add(this.klwlblMessageText);
             this.kpnlContentArea.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kpnlContentArea.Location = new System.Drawing.Point(4, 12);
@@ -192,6 +192,21 @@
             this.kpnlContentArea.Name = "kpnlContentArea";
             this.kpnlContentArea.Size = new System.Drawing.Size(166, 19);
             this.kpnlContentArea.TabIndex = 1;
+            // 
+            // ktextBoxMessageText
+            // 
+            this.ktextBoxMessageText.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ktextBoxMessageText.InputControlStyle = Krypton.Toolkit.InputControlStyle.PanelClient;
+            this.ktextBoxMessageText.Location = new System.Drawing.Point(0, 0);
+            this.ktextBoxMessageText.Margin = new System.Windows.Forms.Padding(5, 0, 0, 0);
+            this.ktextBoxMessageText.Multiline = true;
+            this.ktextBoxMessageText.Name = "ktextBoxMessageText";
+            this.ktextBoxMessageText.ReadOnly = true;
+            this.ktextBoxMessageText.Size = new System.Drawing.Size(166, 19);
+            this.ktextBoxMessageText.StateCommon.Border.DrawBorders = Krypton.Toolkit.PaletteDrawBorders.None;
+            this.ktextBoxMessageText.TabIndex = 2;
+            this.ktextBoxMessageText.TabStop = false;
+            this.ktextBoxMessageText.Text = "Message Text\r\n.\ttabbed";
             // 
             // klwlblMessageText
             // 
@@ -205,22 +220,6 @@
             this.klwlblMessageText.Size = new System.Drawing.Size(166, 19);
             this.klwlblMessageText.Text = "Message Text";
             this.klwlblMessageText.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.klwlblMessageText.UseCompatibleTextRendering = false;
-            // 
-            // kwlblMessageText
-            // 
-            this.kwlblMessageText.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.kwlblMessageText.InputControlStyle = Krypton.Toolkit.InputControlStyle.PanelClient;
-            this.kwlblMessageText.Location = new System.Drawing.Point(0, 0);
-            this.kwlblMessageText.Margin = new System.Windows.Forms.Padding(5, 0, 0, 0);
-            this.kwlblMessageText.Multiline = true;
-            this.kwlblMessageText.Name = "kwlblMessageText";
-            this.kwlblMessageText.ReadOnly = true;
-            this.kwlblMessageText.Size = new System.Drawing.Size(166, 19);
-            this.kwlblMessageText.StateCommon.Border.DrawBorders = Krypton.Toolkit.PaletteDrawBorders.None;
-            this.kwlblMessageText.TabIndex = 2;
-            this.kwlblMessageText.TabStop = false;
-            this.kwlblMessageText.Text = "Message Text\r\n.\ttabbed";
             // 
             // VisualMessageBoxRtlAwareFormDep
             // 
@@ -264,6 +263,6 @@
         private PictureBox _messageIcon;
         private KryptonPanel kpnlContentArea;
         private KryptonLinkWrapLabel klwlblMessageText;
-        private KryptonTextBox kwlblMessageText;
+        private KryptonTextBox ktextBoxMessageText;
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareFormDep.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareFormDep.cs
@@ -981,7 +981,7 @@ namespace Krypton.Toolkit
                 Size scaledMonitorSize = screen!.Bounds.Size;
                 scaledMonitorSize.Width = (int)(scaledMonitorSize.Width * 2 / 3.0f);
                 scaledMonitorSize.Height = (int)(scaledMonitorSize.Height * 0.95f);
-                Font textFont = kwlblMessageText.StateCommon.Font ?? KryptonManager.CurrentGlobalPalette!.BaseFont;
+                Font textFont = GetMessageTextFont(_contentAreaType);
                 Font captionFont = KryptonManager.CurrentGlobalPalette.BaseFont;
                 SizeF messageSize = TextRenderer.MeasureText(_text, textFont, scaledMonitorSize);
                 // SKC: Don't forget to add the TextExtra into the calculation
@@ -998,7 +998,7 @@ namespace Krypton.Toolkit
             }
 
             // Calculate the size of the icon area and text area including margins
-            Padding textPadding = kwlblMessageText.Padding;
+            Padding textPadding = GetMessageTextPadding(_contentAreaType);
             Padding textAreaAllMargin = Padding.Add(textPadding, kpnlContentArea.Margin);
             Size iconArea = new Size(_messageIcon.Width + _messageIcon.Margin.Left + _messageIcon.Margin.Right,
                 _messageIcon.Height + _messageIcon.Margin.Top + _messageIcon.Margin.Bottom);
@@ -1006,6 +1006,39 @@ namespace Krypton.Toolkit
                 textSize.Height + textAreaAllMargin.Top + textAreaAllMargin.Bottom);
             return new Size(textArea.Width + iconArea.Width,
                 Math.Max(iconArea.Height, textArea.Height));
+        }
+
+        private Font GetMessageTextFont(MessageBoxContentAreaType? contentAreaType)
+        {
+            switch (contentAreaType)
+            {
+                case MessageBoxContentAreaType.Normal:
+                    return kwlblMessageText.StateCommon.Content.GetContentShortTextFont(PaletteState.Normal)
+                        ?? KryptonManager.CurrentGlobalPalette.BaseFont;
+                case MessageBoxContentAreaType.LinkLabel:
+                    klwlblMessageText.UpdateFont();
+                    return klwlblMessageText.Font
+                        ?? KryptonManager.CurrentGlobalPalette.BaseFont;
+                case null:
+                    return KryptonManager.CurrentGlobalPalette.BaseFont;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(contentAreaType), contentAreaType, null);
+            }
+        }
+
+        private Padding GetMessageTextPadding(MessageBoxContentAreaType? contentAreaType)
+        {
+            switch (contentAreaType)
+            {
+                case MessageBoxContentAreaType.Normal:
+                    return kwlblMessageText.StateCommon.Content.GetContentPadding(PaletteState.Normal);
+                case MessageBoxContentAreaType.LinkLabel:
+                    return klwlblMessageText.Padding;
+                case null:
+                    return new Padding(0);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(contentAreaType), contentAreaType, null);
+            }
         }
 
         private Size UpdateButtonsSizing()

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareFormDep.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareFormDep.cs
@@ -149,13 +149,13 @@ namespace Krypton.Toolkit
             switch (contentAreaType)
             {
                 case MessageBoxContentAreaType.Normal:
-                    kwlblMessageText.Text = text;
+                    ktextBoxMessageText.Text = text;
                     break;
                 case MessageBoxContentAreaType.LinkLabel:
                     klwlblMessageText.Text = text;
                     break;
                 case null:
-                    kwlblMessageText.Text = text;
+                    ktextBoxMessageText.Text = text;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(contentAreaType), contentAreaType, null);
@@ -168,7 +168,7 @@ namespace Krypton.Toolkit
 
             if (_contentAreaType == MessageBoxContentAreaType.Normal)
             {
-                kwlblMessageText.Text = _text;
+                ktextBoxMessageText.Text = _text;
             }
             else
             {
@@ -1013,7 +1013,7 @@ namespace Krypton.Toolkit
             switch (contentAreaType)
             {
                 case MessageBoxContentAreaType.Normal:
-                    return kwlblMessageText.StateCommon.Content.GetContentShortTextFont(PaletteState.Normal)
+                    return ktextBoxMessageText.StateCommon.Content.GetContentShortTextFont(PaletteState.Normal)
                         ?? KryptonManager.CurrentGlobalPalette.BaseFont;
                 case MessageBoxContentAreaType.LinkLabel:
                     klwlblMessageText.UpdateFont();
@@ -1031,7 +1031,7 @@ namespace Krypton.Toolkit
             switch (contentAreaType)
             {
                 case MessageBoxContentAreaType.Normal:
-                    return kwlblMessageText.StateCommon.Content.GetContentPadding(PaletteState.Normal);
+                    return ktextBoxMessageText.StateCommon.Content.GetContentPadding(PaletteState.Normal);
                 case MessageBoxContentAreaType.LinkLabel:
                     return klwlblMessageText.Padding;
                 case null:
@@ -1187,17 +1187,17 @@ namespace Krypton.Toolkit
                 case MessageBoxContentAreaType.Normal:
                     klwlblMessageText.Visible = false;
 
-                    kwlblMessageText.Visible = true;
+                    ktextBoxMessageText.Visible = true;
                     break;
                 case MessageBoxContentAreaType.LinkLabel:
                     klwlblMessageText.Visible = true;
 
-                    kwlblMessageText.Visible = false;
+                    ktextBoxMessageText.Visible = false;
                     break;
                 case null:
                     klwlblMessageText.Visible = false;
 
-                    kwlblMessageText.Visible = true;
+                    ktextBoxMessageText.Visible = true;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(contentAreaType), contentAreaType, null);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxForm.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxForm.Designer.cs
@@ -51,7 +51,7 @@ namespace Krypton.Toolkit
             this.kryptonPanel1 = new Krypton.Toolkit.KryptonPanel();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.kpnlContentArea = new Krypton.Toolkit.KryptonPanel();
-            this.kwlblMessageText = new Krypton.Toolkit.KryptonTextBox();
+            this.ktextBoxMessageText = new Krypton.Toolkit.KryptonTextBox();
             ((System.ComponentModel.ISupportInitialize)(this._messageIcon)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this._panelButtons)).BeginInit();
             this._panelButtons.SuspendLayout();
@@ -95,7 +95,7 @@ namespace Krypton.Toolkit
             this._borderEdge.BorderStyle = Krypton.Toolkit.PaletteBorderStyle.HeaderPrimary;
             this._borderEdge.Dock = System.Windows.Forms.DockStyle.Top;
             this._borderEdge.Location = new System.Drawing.Point(0, 0);
-            this._borderEdge.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this._borderEdge.Margin = new System.Windows.Forms.Padding(2);
             this._borderEdge.Name = "_borderEdge";
             this._borderEdge.Size = new System.Drawing.Size(203, 1);
             this._borderEdge.Text = "kryptonBorderEdge1";
@@ -169,7 +169,7 @@ namespace Krypton.Toolkit
             this.kryptonPanel1.Controls.Add(this.tableLayoutPanel1);
             this.kryptonPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonPanel1.Location = new System.Drawing.Point(0, 0);
-            this.kryptonPanel1.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.kryptonPanel1.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonPanel1.Name = "kryptonPanel1";
             this.kryptonPanel1.Size = new System.Drawing.Size(203, 64);
             this.kryptonPanel1.TabIndex = 1;
@@ -185,7 +185,7 @@ namespace Krypton.Toolkit
             this.tableLayoutPanel1.Controls.Add(this.kpnlContentArea, 1, 0);
             this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
-            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(2);
             this.tableLayoutPanel1.Name = "tableLayoutPanel1";
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
@@ -195,28 +195,28 @@ namespace Krypton.Toolkit
             // 
             // kpnlContentArea
             // 
-            this.kpnlContentArea.Controls.Add(this.kwlblMessageText);
+            this.kpnlContentArea.Controls.Add(this.ktextBoxMessageText);
             this.kpnlContentArea.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.kpnlContentArea.Location = new System.Drawing.Point(48, 3);
+            this.kpnlContentArea.Location = new System.Drawing.Point(49, 12);
             this.kpnlContentArea.Margin = new System.Windows.Forms.Padding(4, 12, 4, 12);
             this.kpnlContentArea.Name = "kpnlContentArea";
-            this.kpnlContentArea.Size = new System.Drawing.Size(152, 37);
+            this.kpnlContentArea.Size = new System.Drawing.Size(150, 19);
             this.kpnlContentArea.TabIndex = 1;
             // 
-            // kwlblMessageText
+            // ktextBoxMessageText
             // 
-            this.kwlblMessageText.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.kwlblMessageText.InputControlStyle = Krypton.Toolkit.InputControlStyle.PanelClient;
-            this.kwlblMessageText.Location = new System.Drawing.Point(0, 0);
-            this.kwlblMessageText.Margin = new System.Windows.Forms.Padding(5, 0, 0, 0);
-            this.kwlblMessageText.Multiline = true;
-            this.kwlblMessageText.Name = "kwlblMessageText";
-            this.kwlblMessageText.ReadOnly = true;
-            this.kwlblMessageText.Size = new System.Drawing.Size(152, 37);
-            this.kwlblMessageText.StateCommon.Border.DrawBorders = Krypton.Toolkit.PaletteDrawBorders.None;
-            this.kwlblMessageText.TabIndex = 0;
-            this.kwlblMessageText.TabStop = false;
-            this.kwlblMessageText.Text = "Message Text\r\n.\ttabbed";
+            this.ktextBoxMessageText.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ktextBoxMessageText.InputControlStyle = Krypton.Toolkit.InputControlStyle.PanelClient;
+            this.ktextBoxMessageText.Location = new System.Drawing.Point(0, 0);
+            this.ktextBoxMessageText.Margin = new System.Windows.Forms.Padding(5, 0, 0, 0);
+            this.ktextBoxMessageText.Multiline = true;
+            this.ktextBoxMessageText.Name = "ktextBoxMessageText";
+            this.ktextBoxMessageText.ReadOnly = true;
+            this.ktextBoxMessageText.Size = new System.Drawing.Size(150, 19);
+            this.ktextBoxMessageText.StateCommon.Border.DrawBorders = Krypton.Toolkit.PaletteDrawBorders.None;
+            this.ktextBoxMessageText.TabIndex = 0;
+            this.ktextBoxMessageText.TabStop = false;
+            this.ktextBoxMessageText.Text = "Message Text\r\n.\ttabbed";
             // 
             // VisualMessageBoxForm
             // 
@@ -226,7 +226,7 @@ namespace Krypton.Toolkit
             this.Controls.Add(this.kryptonPanel1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.KeyPreview = true;
-            this.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.Margin = new System.Windows.Forms.Padding(2);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "VisualMessageBoxForm";
@@ -260,6 +260,6 @@ namespace Krypton.Toolkit
         private KryptonPanel kryptonPanel1;
         private TableLayoutPanel tableLayoutPanel1;
         private KryptonPanel kpnlContentArea;
-        private KryptonTextBox kwlblMessageText;
+        private KryptonTextBox ktextBoxMessageText;
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxForm.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxForm.Designer.cs
@@ -198,6 +198,7 @@ namespace Krypton.Toolkit
             this.kpnlContentArea.Controls.Add(this.kwlblMessageText);
             this.kpnlContentArea.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kpnlContentArea.Location = new System.Drawing.Point(48, 3);
+            this.kpnlContentArea.Margin = new System.Windows.Forms.Padding(4, 12, 4, 12);
             this.kpnlContentArea.Name = "kpnlContentArea";
             this.kpnlContentArea.Size = new System.Drawing.Size(152, 37);
             this.kpnlContentArea.TabIndex = 1;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxForm.cs
@@ -54,12 +54,7 @@ namespace Krypton.Toolkit
                                        bool? showCloseButton)
         {
             // Store incoming values
-            if (text != null && !text.Contains('\n'))
-            {
-                _text = "\r\n"; // \n means that the single line text should align with the icon
-            }
-
-            _text += text;
+            _text = text;
             _caption = caption;
             _buttons = buttons;
             _kryptonMessageBoxIcon = icon;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxForm.cs
@@ -89,7 +89,7 @@ namespace Krypton.Toolkit
                 ? string.Empty
                 : _caption!.Split(Environment.NewLine.ToCharArray())[0];
 
-            kwlblMessageText.Text = _text;
+            ktextBoxMessageText.Text = _text;
         }
 
         private void UpdateTextExtra(bool? showCtrlCopy)
@@ -492,7 +492,7 @@ namespace Krypton.Toolkit
                 Size scaledMonitorSize = screen!.Bounds.Size;
                 scaledMonitorSize.Width = (int)(scaledMonitorSize.Width * 2 / 3.0f);
                 scaledMonitorSize.Height = (int)(scaledMonitorSize.Height * 0.95f);
-                Font textFont = kwlblMessageText.StateCommon.Content.GetContentShortTextFont(PaletteState.Normal) ?? KryptonManager.CurrentGlobalPalette!.BaseFont;
+                Font textFont = ktextBoxMessageText.StateCommon.Content.GetContentShortTextFont(PaletteState.Normal) ?? KryptonManager.CurrentGlobalPalette!.BaseFont;
                 Font captionFont = KryptonManager.CurrentGlobalPalette.BaseFont;
                 SizeF messageSize = TextRenderer.MeasureText(_text, textFont, scaledMonitorSize);
                 // SKC: Don't forget to add the TextExtra into the calculation
@@ -509,7 +509,7 @@ namespace Krypton.Toolkit
             }
 
             // Calculate the size of the icon area and text area including margins
-            Padding textPadding = kwlblMessageText.StateCommon.Content.GetContentPadding(PaletteState.Normal);
+            Padding textPadding = ktextBoxMessageText.StateCommon.Content.GetContentPadding(PaletteState.Normal);
             Padding textAreaAllMargin = Padding.Add(textPadding, kpnlContentArea.Margin);
             Size iconArea = new Size(_messageIcon.Width + _messageIcon.Margin.Left + _messageIcon.Margin.Right,
                 _messageIcon.Height + _messageIcon.Margin.Top + _messageIcon.Margin.Bottom);
@@ -612,7 +612,7 @@ namespace Krypton.Toolkit
                 sb.AppendLine(DIVIDER);
                 sb.AppendLine(Text);
                 sb.AppendLine(DIVIDER);
-                sb.AppendLine(kwlblMessageText.Text);
+                sb.AppendLine(ktextBoxMessageText.Text);
                 sb.AppendLine(DIVIDER);
                 sb.Append(_button1.Text).Append(BUTTON_TEXT_SPACER);
                 if (_button2.Enabled)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxFormDep.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxFormDep.Designer.cs
@@ -51,7 +51,7 @@ namespace Krypton.Toolkit
             this.kryptonPanel1 = new Krypton.Toolkit.KryptonPanel();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.kpnlContentArea = new Krypton.Toolkit.KryptonPanel();
-            this.kwlblMessageText = new Krypton.Toolkit.KryptonTextBox();
+            this.ktextBoxMessageText = new Krypton.Toolkit.KryptonTextBox();
             this.klwlblMessageText = new Krypton.Toolkit.KryptonLinkWrapLabel();
             ((System.ComponentModel.ISupportInitialize)(this._messageIcon)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this._panelButtons)).BeginInit();
@@ -196,29 +196,29 @@ namespace Krypton.Toolkit
             // 
             // kpnlContentArea
             // 
-            this.kpnlContentArea.Controls.Add(this.kwlblMessageText);
+            this.kpnlContentArea.Controls.Add(this.ktextBoxMessageText);
             this.kpnlContentArea.Controls.Add(this.klwlblMessageText);
             this.kpnlContentArea.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.kpnlContentArea.Location = new System.Drawing.Point(48, 3);
+            this.kpnlContentArea.Location = new System.Drawing.Point(49, 12);
             this.kpnlContentArea.Margin = new System.Windows.Forms.Padding(4, 12, 4, 12);
             this.kpnlContentArea.Name = "kpnlContentArea";
-            this.kpnlContentArea.Size = new System.Drawing.Size(152, 37);
+            this.kpnlContentArea.Size = new System.Drawing.Size(150, 19);
             this.kpnlContentArea.TabIndex = 1;
             // 
-            // kwlblMessageText
+            // ktextBoxMessageText
             // 
-            this.kwlblMessageText.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.kwlblMessageText.InputControlStyle = Krypton.Toolkit.InputControlStyle.PanelClient;
-            this.kwlblMessageText.Location = new System.Drawing.Point(0, 0);
-            this.kwlblMessageText.Margin = new System.Windows.Forms.Padding(5, 0, 0, 0);
-            this.kwlblMessageText.Multiline = true;
-            this.kwlblMessageText.Name = "kwlblMessageText";
-            this.kwlblMessageText.ReadOnly = true;
-            this.kwlblMessageText.Size = new System.Drawing.Size(152, 37);
-            this.kwlblMessageText.StateCommon.Border.DrawBorders = Krypton.Toolkit.PaletteDrawBorders.None;
-            this.kwlblMessageText.TabIndex = 0;
-            this.kwlblMessageText.TabStop = false;
-            this.kwlblMessageText.Text = "Message Text\r\n.\ttabbed";
+            this.ktextBoxMessageText.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ktextBoxMessageText.InputControlStyle = Krypton.Toolkit.InputControlStyle.PanelClient;
+            this.ktextBoxMessageText.Location = new System.Drawing.Point(0, 0);
+            this.ktextBoxMessageText.Margin = new System.Windows.Forms.Padding(5, 0, 0, 0);
+            this.ktextBoxMessageText.Multiline = true;
+            this.ktextBoxMessageText.Name = "ktextBoxMessageText";
+            this.ktextBoxMessageText.ReadOnly = true;
+            this.ktextBoxMessageText.Size = new System.Drawing.Size(150, 19);
+            this.ktextBoxMessageText.StateCommon.Border.DrawBorders = Krypton.Toolkit.PaletteDrawBorders.None;
+            this.ktextBoxMessageText.TabIndex = 0;
+            this.ktextBoxMessageText.TabStop = false;
+            this.ktextBoxMessageText.Text = "Message Text\r\n.\ttabbed";
             // 
             // klwlblMessageText
             // 
@@ -227,10 +227,9 @@ namespace Krypton.Toolkit
             this.klwlblMessageText.LabelStyle = Krypton.Toolkit.LabelStyle.NormalControl;
             this.klwlblMessageText.Location = new System.Drawing.Point(0, 0);
             this.klwlblMessageText.Name = "klwlblMessageText";
-            this.klwlblMessageText.Size = new System.Drawing.Size(152, 37);
+            this.klwlblMessageText.Size = new System.Drawing.Size(150, 19);
             this.klwlblMessageText.Text = "Message Text";
             this.klwlblMessageText.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.klwlblMessageText.UseCompatibleTextRendering = false;
             // 
             // VisualMessageBoxFormDep
             // 
@@ -275,6 +274,6 @@ namespace Krypton.Toolkit
         private TableLayoutPanel tableLayoutPanel1;
         private KryptonPanel kpnlContentArea;
         private KryptonLinkWrapLabel klwlblMessageText;
-        private KryptonTextBox kwlblMessageText;
+        private KryptonTextBox ktextBoxMessageText;
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxFormDep.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxFormDep.Designer.cs
@@ -70,7 +70,7 @@ namespace Krypton.Toolkit
             this._messageIcon.Location = new System.Drawing.Point(8, 4);
             this._messageIcon.Margin = new System.Windows.Forms.Padding(8, 4, 4, 4);
             this._messageIcon.Name = "_messageIcon";
-            this._messageIcon.Size = new System.Drawing.Size(33, 79);
+            this._messageIcon.Size = new System.Drawing.Size(33, 35);
             this._messageIcon.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
             this._messageIcon.TabIndex = 0;
             this._messageIcon.TabStop = false;
@@ -84,7 +84,7 @@ namespace Krypton.Toolkit
             this._panelButtons.Controls.Add(this._button1);
             this._panelButtons.Controls.Add(this._button2);
             this._panelButtons.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._panelButtons.Location = new System.Drawing.Point(0, 87);
+            this._panelButtons.Location = new System.Drawing.Point(0, 43);
             this._panelButtons.Margin = new System.Windows.Forms.Padding(0);
             this._panelButtons.Name = "_panelButtons";
             this._panelButtons.PanelBackStyle = Krypton.Toolkit.PaletteBackStyle.PanelAlternate;
@@ -172,7 +172,7 @@ namespace Krypton.Toolkit
             this.kryptonPanel1.Location = new System.Drawing.Point(0, 0);
             this.kryptonPanel1.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonPanel1.Name = "kryptonPanel1";
-            this.kryptonPanel1.Size = new System.Drawing.Size(203, 108);
+            this.kryptonPanel1.Size = new System.Drawing.Size(203, 64);
             this.kryptonPanel1.TabIndex = 1;
             // 
             // tableLayoutPanel1
@@ -191,7 +191,7 @@ namespace Krypton.Toolkit
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(203, 108);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(203, 64);
             this.tableLayoutPanel1.TabIndex = 0;
             // 
             // kpnlContentArea
@@ -200,8 +200,9 @@ namespace Krypton.Toolkit
             this.kpnlContentArea.Controls.Add(this.klwlblMessageText);
             this.kpnlContentArea.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kpnlContentArea.Location = new System.Drawing.Point(48, 3);
+            this.kpnlContentArea.Margin = new System.Windows.Forms.Padding(4, 12, 4, 12);
             this.kpnlContentArea.Name = "kpnlContentArea";
-            this.kpnlContentArea.Size = new System.Drawing.Size(152, 81);
+            this.kpnlContentArea.Size = new System.Drawing.Size(152, 37);
             this.kpnlContentArea.TabIndex = 1;
             // 
             // kwlblMessageText
@@ -213,7 +214,7 @@ namespace Krypton.Toolkit
             this.kwlblMessageText.Multiline = true;
             this.kwlblMessageText.Name = "kwlblMessageText";
             this.kwlblMessageText.ReadOnly = true;
-            this.kwlblMessageText.Size = new System.Drawing.Size(152, 81);
+            this.kwlblMessageText.Size = new System.Drawing.Size(152, 37);
             this.kwlblMessageText.StateCommon.Border.DrawBorders = Krypton.Toolkit.PaletteDrawBorders.None;
             this.kwlblMessageText.TabIndex = 0;
             this.kwlblMessageText.TabStop = false;
@@ -226,15 +227,16 @@ namespace Krypton.Toolkit
             this.klwlblMessageText.LabelStyle = Krypton.Toolkit.LabelStyle.NormalControl;
             this.klwlblMessageText.Location = new System.Drawing.Point(0, 0);
             this.klwlblMessageText.Name = "klwlblMessageText";
-            this.klwlblMessageText.Size = new System.Drawing.Size(152, 81);
+            this.klwlblMessageText.Size = new System.Drawing.Size(152, 37);
             this.klwlblMessageText.Text = "Message Text";
             this.klwlblMessageText.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.klwlblMessageText.UseCompatibleTextRendering = false;
             // 
             // VisualMessageBoxFormDep
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(203, 108);
+            this.ClientSize = new System.Drawing.Size(203, 64);
             this.Controls.Add(this.kryptonPanel1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.KeyPreview = true;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxFormDep.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxFormDep.cs
@@ -101,7 +101,7 @@ namespace Krypton.Toolkit
 
             // Create the form contents
             InitializeComponent();
-
+            
             // Update contents to match requirements
             UpdateText();
             UpdateIcon();
@@ -1015,7 +1015,7 @@ namespace Krypton.Toolkit
                 Size scaledMonitorSize = screen!.Bounds.Size;
                 scaledMonitorSize.Width = (int)(scaledMonitorSize.Width * 2 / 3.0f);
                 scaledMonitorSize.Height = (int)(scaledMonitorSize.Height * 0.95f);
-                Font textFont = klwlblMessageText.StateCommon.Font ?? KryptonManager.CurrentGlobalPalette.BaseFont; 
+                Font textFont = GetMessageTextFont(_contentAreaType);
                 Font captionFont = KryptonManager.CurrentGlobalPalette.BaseFont;
                 SizeF messageSize = TextRenderer.MeasureText(_text, textFont, scaledMonitorSize);
                 // SKC: Don't forget to add the TextExtra into the calculation
@@ -1032,7 +1032,7 @@ namespace Krypton.Toolkit
             }
 
             // Calculate the size of the icon area and text area including margins
-            Padding textPadding = klwlblMessageText.Padding; //.StateCommon.Content.GetContentPadding(PaletteState.Normal);
+            Padding textPadding = GetMessageTextPadding(_contentAreaType);
             Padding textAreaAllMargin = Padding.Add(textPadding, kpnlContentArea.Margin);
             Size iconArea = new Size(_messageIcon.Width + _messageIcon.Margin.Left + _messageIcon.Margin.Right,
                 _messageIcon.Height + _messageIcon.Margin.Top + _messageIcon.Margin.Bottom);
@@ -1040,6 +1040,39 @@ namespace Krypton.Toolkit
                 textSize.Height + textAreaAllMargin.Top + textAreaAllMargin.Bottom);
             return new Size(textArea.Width + iconArea.Width,
                 Math.Max(iconArea.Height, textArea.Height));
+        }
+
+        private Font GetMessageTextFont(MessageBoxContentAreaType? contentAreaType)
+        {
+            switch (contentAreaType)
+            {
+                case MessageBoxContentAreaType.Normal:
+                    return kwlblMessageText.StateCommon.Content.GetContentShortTextFont(PaletteState.Normal)
+                        ?? KryptonManager.CurrentGlobalPalette.BaseFont;
+                case MessageBoxContentAreaType.LinkLabel:
+                    klwlblMessageText.UpdateFont();
+                    return klwlblMessageText.Font
+                        ?? KryptonManager.CurrentGlobalPalette.BaseFont;
+                case null:
+                    return KryptonManager.CurrentGlobalPalette.BaseFont;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(contentAreaType), contentAreaType, null);
+            }
+        }
+
+        private Padding GetMessageTextPadding(MessageBoxContentAreaType? contentAreaType)
+        {
+            switch (contentAreaType)
+            {
+                case MessageBoxContentAreaType.Normal:
+                    return kwlblMessageText.StateCommon.Content.GetContentPadding(PaletteState.Normal);
+                case MessageBoxContentAreaType.LinkLabel:
+                    return klwlblMessageText.Padding;
+                case null:
+                    return new Padding(0);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(contentAreaType), contentAreaType, null);
+            }
         }
 
         private Size UpdateButtonsSizing()

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxFormDep.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxFormDep.cs
@@ -156,9 +156,9 @@ namespace Krypton.Toolkit
             switch (contentAreaType)
             {
                 case MessageBoxContentAreaType.Normal:
-                    kwlblMessageText.Text = text;
+                    ktextBoxMessageText.Text = text;
 
-                    kwlblMessageText.RightToLeft = options.HasFlag(MessageBoxOptions.RightAlign) ? RightToLeft.Yes :
+                    ktextBoxMessageText.RightToLeft = options.HasFlag(MessageBoxOptions.RightAlign) ? RightToLeft.Yes :
                         options.HasFlag(MessageBoxOptions.RtlReading) ? RightToLeft.Inherit : RightToLeft.No;
                     break;
                 case MessageBoxContentAreaType.LinkLabel:
@@ -172,9 +172,9 @@ namespace Krypton.Toolkit
                             : RightToLeft.No;
                     break;
                 case null:
-                    kwlblMessageText.Text = text;
+                    ktextBoxMessageText.Text = text;
 
-                    kwlblMessageText.RightToLeft = options.HasFlag(MessageBoxOptions.RightAlign) ? RightToLeft.Yes :
+                    ktextBoxMessageText.RightToLeft = options.HasFlag(MessageBoxOptions.RightAlign) ? RightToLeft.Yes :
                         options.HasFlag(MessageBoxOptions.RtlReading) ? RightToLeft.Inherit : RightToLeft.No;
                     break;
                 default:
@@ -188,7 +188,7 @@ namespace Krypton.Toolkit
 
             if (_contentAreaType == MessageBoxContentAreaType.Normal)
             {
-                kwlblMessageText.Text = _text;
+                ktextBoxMessageText.Text = _text;
             }
             else
             {
@@ -1047,7 +1047,7 @@ namespace Krypton.Toolkit
             switch (contentAreaType)
             {
                 case MessageBoxContentAreaType.Normal:
-                    return kwlblMessageText.StateCommon.Content.GetContentShortTextFont(PaletteState.Normal)
+                    return ktextBoxMessageText.StateCommon.Content.GetContentShortTextFont(PaletteState.Normal)
                         ?? KryptonManager.CurrentGlobalPalette.BaseFont;
                 case MessageBoxContentAreaType.LinkLabel:
                     klwlblMessageText.UpdateFont();
@@ -1065,7 +1065,7 @@ namespace Krypton.Toolkit
             switch (contentAreaType)
             {
                 case MessageBoxContentAreaType.Normal:
-                    return kwlblMessageText.StateCommon.Content.GetContentPadding(PaletteState.Normal);
+                    return ktextBoxMessageText.StateCommon.Content.GetContentPadding(PaletteState.Normal);
                 case MessageBoxContentAreaType.LinkLabel:
                     return klwlblMessageText.Padding;
                 case null:
@@ -1221,17 +1221,17 @@ namespace Krypton.Toolkit
                 case MessageBoxContentAreaType.Normal:
                     klwlblMessageText.Visible = false;
 
-                    kwlblMessageText.Visible = true;
+                    ktextBoxMessageText.Visible = true;
                     break;
                 case MessageBoxContentAreaType.LinkLabel:
                     klwlblMessageText.Visible = true;
 
-                    kwlblMessageText.Visible = false;
+                    ktextBoxMessageText.Visible = false;
                     break;
                 case null:
                     klwlblMessageText.Visible = false;
 
-                    kwlblMessageText.Visible = true;
+                    ktextBoxMessageText.Visible = true;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(contentAreaType), contentAreaType, null);


### PR DESCRIPTION
[Issue 1599-KryptonMessageBox-cuts-off-the-last-line](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1599)
[Issue 1613-KryptonMessageBox-text-is-not-centered-vertically](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1613)

- Improve and apply the fixes to all 4 relevant forms.
- Use correct target control (KTextBox or KLinkWrapLabel) for measurements depending on the passed `MessageBoxContentAreaType` argument.

![image](https://github.com/user-attachments/assets/0e062c67-8a42-40f5-b17d-882dc2dc63b6)
