### PR TITLE
1646-KryptonRibbonGroupThemeComboBox-does-not-react-to-IndexChanged-e…

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
+* Resolved [#1646](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1646), `KryptonRibbonGroupThemeComboBox` does not react to index changes anymore.
 * Resolved [#1633](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1633), `KryptonRibbon` - Clicking the Mini QAT Menu Button causes an exception.
 * Resolved [#1624](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1624), Theme Selector controls default to Professional System theme when set to `PaletteMode.Global`. Instead those shoud default to `ThemeManager.DefaultGlobalPalette`.
 * Resolved [#1628](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1628), Some themes do not render the "ToolStrip" Correctly

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupThemeComboBox.cs
@@ -44,7 +44,6 @@ namespace Krypton.Ribbon
         /// <summary>Initializes a new instance of the <see cref="KryptonRibbonGroupThemeComboBox" /> class.</summary>
         public KryptonRibbonGroupThemeComboBox()
         {
-            ComboBox.SelectedIndexChanged -= OnComboBoxSelectedIndexChanged;
             _manager = new KryptonManager();
             DropDownStyle = ComboBoxStyle.DropDownList;
 
@@ -56,7 +55,6 @@ namespace Krypton.Ribbon
 
             // React to theme changes from outside this control.
             KryptonManager.GlobalPaletteChanged += KryptonManagerGlobalPaletteChanged;
-            ComboBox.SelectedIndexChanged -= OnComboBoxSelectedIndexChanged;
         }
 
         #endregion


### PR DESCRIPTION
[Issue 1646-KryptonRibbonGroupThemeComboBox-does-not-react-to-IndexChanged-events](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1646)
- Removed event detaching statements

![compile-results](https://github.com/user-attachments/assets/d64fef26-b852-4ec9-8a67-e4f47f02a1aa)
