### PR TITLE
1644 make datagrid functional in test form

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
+* Resolved [#1646](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1646), `KryptonRibbonGroupThemeComboBox` does not react to index changes anymore.
 * Resolved [#1633](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1633), `KryptonRibbon` - Clicking the Mini QAT Menu Button causes an exception.
 * Resolved [#1624](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1624), Theme Selector controls default to Professional System theme when set to `PaletteMode.Global`. Instead those shoud default to `ThemeManager.DefaultGlobalPalette`.
 * Resolved [#1628](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1628), Some themes do not render the "ToolStrip" Correctly

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupThemeComboBox.cs
@@ -44,7 +44,6 @@ namespace Krypton.Ribbon
         /// <summary>Initializes a new instance of the <see cref="KryptonRibbonGroupThemeComboBox" /> class.</summary>
         public KryptonRibbonGroupThemeComboBox()
         {
-            ComboBox.SelectedIndexChanged -= OnComboBoxSelectedIndexChanged;
             _manager = new KryptonManager();
             DropDownStyle = ComboBoxStyle.DropDownList;
 
@@ -56,7 +55,6 @@ namespace Krypton.Ribbon
 
             // React to theme changes from outside this control.
             KryptonManager.GlobalPaletteChanged += KryptonManagerGlobalPaletteChanged;
-            ComboBox.SelectedIndexChanged -= OnComboBoxSelectedIndexChanged;
         }
 
         #endregion

--- a/Source/Krypton Components/TestForm/DataGridViewTest.cs
+++ b/Source/Krypton Components/TestForm/DataGridViewTest.cs
@@ -33,6 +33,9 @@ namespace TestForm
             dtTestData.Rows.Add(dt, "Mr", "Micheal\r\nSingle\r\nMarried", "(07) 0070-0700", "Divorced", 35, "Press!", false);
             dtTestData.Rows.Add(dt, "Mrs", "Marge has a really long name normally, and this should wrap", "(10) 2311-2311", "Married", 80, "Press!", true);
 
+            kryptonDataGridView1.AutoGenerateColumns = true;
+            kryptonDataGridView1.DataSource = dtTestData;
+
             kryptonPropertyGrid1.SelectedObject = new KryptonDataGridViewProxy(kryptonDataGridView1);
         }
     }


### PR DESCRIPTION
[Issue 1644-Make-Datagrid-functional-in-TestForm](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1644)
- Data Table has been connected to the datagrid.

![compile-results](https://github.com/user-attachments/assets/bb7fbea9-e57f-41a7-85e1-d33c949c9c6c)
