### PR TITLE
1664-Warning-Removal-after-issue-1650

### DIFF
--- a/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecViewAppButton.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecViewAppButton.cs
@@ -78,7 +78,7 @@ namespace Krypton.Ribbon
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">An EventArgs that contains the event data.</param>
-        protected override void OnFinishDelegate(object sender, EventArgs? e) =>
+        protected override void OnFinishDelegate(object? sender, EventArgs? e) =>
             // Ask the button to remove the fixed pressed appearance
             _controller?.RemoveFixed();
         #endregion

--- a/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecViewRibbon.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecViewRibbon.cs
@@ -77,7 +77,7 @@ namespace Krypton.Ribbon
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">An EventArgs that contains the event data.</param>
-        protected override void OnFinishDelegate(object sender, EventArgs? e) =>
+        protected override void OnFinishDelegate(object? sender, EventArgs? e) =>
             // Ask the button to remove the fixed pressed appearance
             _controller?.RemoveFixed();
         #endregion

--- a/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonRibbon.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonRibbon.cs
@@ -1465,7 +1465,7 @@ namespace Krypton.Ribbon
         /// </summary>
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An EventArgs containing event data.</param>
-        protected override void OnButtonSpecChanged(object sender, EventArgs e)
+        protected override void OnButtonSpecChanged(object? sender, EventArgs e)
         {
             // Recreate all the button specs with new values
             TabsArea?.RecreateButtons();

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpec.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpec.cs
@@ -962,7 +962,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">A PropertyChangedEventArgs that contains the event data.</param>
-        protected virtual void OnCommandPropertyChanged(object sender, PropertyChangedEventArgs e)
+        protected virtual void OnCommandPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecAny.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecAny.cs
@@ -331,7 +331,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">A PropertyChangedEventArgs that contains the event data.</param>
-        protected override void OnCommandPropertyChanged(object sender, PropertyChangedEventArgs e)
+        protected override void OnCommandPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             base.OnCommandPropertyChanged(sender, e);
 

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecManagerBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecManagerBase.cs
@@ -809,19 +809,19 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnButtonSpecInserted(object sender, ButtonSpecEventArgs e)
+        private void OnButtonSpecInserted(object? sender, ButtonSpecEventArgs e)
         {
             RecreateAll();
             PerformNeedPaint(true);
         }
 
-        private void OnButtonSpecRemoved(object sender, ButtonSpecEventArgs e)
+        private void OnButtonSpecRemoved(object? sender, ButtonSpecEventArgs e)
         {
             RecreateAll();
             PerformNeedPaint(true);
         }
 
-        private void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void OnPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecView.cs
@@ -309,7 +309,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">An EventArgs that contains the event data.</param>
-        protected virtual void OnFinishDelegate(object sender, EventArgs? e) =>
+        protected virtual void OnFinishDelegate(object? sender, EventArgs? e) =>
             // Ask the button to remove the fixed pressed appearance
             _controller?.RemoveFixed();
 
@@ -362,7 +362,7 @@ namespace Krypton.Toolkit
 
         #region Implementation
 
-        private void OnClick(object sender, MouseEventArgs e)
+        private void OnClick(object? sender, MouseEventArgs e)
         {
             var performFinishDelegate = true;
             // Never show a context menu in design mode
@@ -425,10 +425,10 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnKryptonContextMenuClosed(object sender, ToolStripDropDownClosedEventArgs e)
+        private void OnKryptonContextMenuClosed(object? sender, ToolStripDropDownClosedEventArgs e)
         {
             // Unhook from context menu event, so that it can garbage collected in the future
-            var kcm = (KryptonContextMenu)sender;
+            var kcm = sender as KryptonContextMenu ?? throw new ArgumentNullException(nameof(sender));
             kcm.Closed -= OnKryptonContextMenuClosed;
 
             // Remove the fixed button appearance
@@ -437,7 +437,7 @@ namespace Krypton.Toolkit
 
         private void OnNeedPaint(object? sender, NeedLayoutEventArgs e) => PerformNeedPaint(e.NeedLayout);
 
-        private void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void OnPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuCollections.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuCollections.cs
@@ -140,7 +140,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Private
-        private void OnRadioButtonCheckedChanged(object sender, EventArgs e)
+        private void OnRadioButtonCheckedChanged(object? sender, EventArgs e)
         {
             // Only interested if the button has become checked
             if (sender is KryptonContextMenuRadioButton { Checked: true } radioButton)

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuImageSelect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuImageSelect.cs
@@ -352,7 +352,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnTrackingTick(object sender, EventArgs e)
+        private void OnTrackingTick(object? sender, EventArgs e)
         {
             // If no change in tracking index over last interval
             if (_trackingIndex == _cacheTrackingIndex)

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuItemBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuItemBase.cs
@@ -183,7 +183,7 @@ namespace Krypton.Toolkit
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         internal ToolTipManager? ToolTipManager { get; }
 
-        internal void OnShowToolTip(object sender, ToolTipEventArgs e)
+        internal void OnShowToolTip(object? sender, ToolTipEventArgs e)
         {
             //if (!IsDisposed)
             {
@@ -234,14 +234,14 @@ namespace Krypton.Toolkit
             }
         }
 
-        internal void OnCancelToolTip(object sender, EventArgs e) =>
+        internal void OnCancelToolTip(object? sender, EventArgs e) =>
             // Remove any currently showing tooltip
             _visualPopupToolTip?.Dispose();
 
-        internal void OnVisualPopupToolTipDisposed(object sender, EventArgs e)
+        internal void OnVisualPopupToolTipDisposed(object? sender, EventArgs e)
         {
             // Unhook events from the specific instance that generated event
-            var popupToolTip = (VisualPopupToolTip)sender;
+            var popupToolTip = sender as VisualPopupToolTip ?? throw new ArgumentNullException(nameof(sender));
             popupToolTip.Disposed -= OnVisualPopupToolTipDisposed;
 
             // Not showing a popup page any more

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/ButtonController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/ButtonController.cs
@@ -915,10 +915,10 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnRepeatTimer(object sender, EventArgs e)
+        private void OnRepeatTimer(object? sender, EventArgs e)
         {
             // Modify subsequent repeat timing
-            _t = (System.Windows.Forms.Timer)sender;
+            _t = sender as System.Windows.Forms.Timer ?? throw new ArgumentNullException(nameof(sender));
             _t.Interval = Math.Max(SystemInformation.DoubleClickTime / 4, 100);
             OnClick(new MouseEventArgs(MouseButtons.Left, 1, 0, 0, 0));
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonBreadCrumb.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonBreadCrumb.cs
@@ -589,7 +589,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An EventArgs containing event data.</param>
-        protected override void OnButtonSpecChanged(object sender, EventArgs e)
+        protected override void OnButtonSpecChanged(object? sender, EventArgs e)
         {
             // Recreate all the button specs with new values
             _buttonManager?.RecreateButtons();
@@ -634,7 +634,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnCrumbItemChanged(object sender, PropertyChangedEventArgs e)
+        private void OnCrumbItemChanged(object? sender, PropertyChangedEventArgs e)
         {
             // A change in the selected item hierarchy...
             if (e.PropertyName == "Items")
@@ -661,7 +661,7 @@ namespace Krypton.Toolkit
             PerformNeedPaint(true);
         }
 
-        private void OnShowToolTip(object sender, ToolTipEventArgs e)
+        private void OnShowToolTip(object? sender, ToolTipEventArgs e)
         {
             if (!IsDisposed)
             {
@@ -728,14 +728,14 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnCancelToolTip(object sender, EventArgs e) =>
+        private void OnCancelToolTip(object? sender, EventArgs e) =>
             // Remove any currently showing tooltip
             _visualPopupToolTip?.Dispose();
 
-        private void OnVisualPopupToolTipDisposed(object sender, EventArgs e)
+        private void OnVisualPopupToolTipDisposed(object? sender, EventArgs e)
         {
             // Unhook events from the specific instance that generated event
-            var popupToolTip = (VisualPopupToolTip)sender;
+            var popupToolTip = sender as VisualPopupToolTip ?? throw new ArgumentNullException(nameof(sender));
             popupToolTip.Disposed -= OnVisualPopupToolTipDisposed;
 
             // Not showing a popup page any more

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonButton.cs
@@ -868,7 +868,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">A PropertyChangedEventArgs that contains the event data.</param>
-        protected virtual void OnCommandPropertyChanged(object sender, PropertyChangedEventArgs e)
+        protected virtual void OnCommandPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {
@@ -892,9 +892,9 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnButtonTextChanged(object sender, EventArgs e) => OnTextChanged(EventArgs.Empty);
+        private void OnButtonTextChanged(object? sender, EventArgs e) => OnTextChanged(EventArgs.Empty);
 
-        private void OnButtonClick(object sender, MouseEventArgs e)
+        private void OnButtonClick(object? sender, MouseEventArgs e)
         {
             // Raise the standard click event
             OnClick(EventArgs.Empty);
@@ -903,7 +903,7 @@ namespace Krypton.Toolkit
             OnMouseClick(e);
         }
 
-        private void OnButtonSelect(object sender, MouseEventArgs e)
+        private void OnButtonSelect(object? sender, MouseEventArgs e)
         {
             // Take the focus if allowed
             if (CanFocus)
@@ -974,7 +974,7 @@ namespace Krypton.Toolkit
 
         #region Event Handlers
 
-        private void KryptonContextMenu_Closed(object sender, ToolStripDropDownClosedEventArgs e)
+        private void KryptonContextMenu_Closed(object? sender, ToolStripDropDownClosedEventArgs e)
         {
             if (sender is KryptonContextMenu kcm)
             {
@@ -987,7 +987,7 @@ namespace Krypton.Toolkit
             //} 
         }
 
-        private void ContextMenuStrip_Closing(object sender, ToolStripDropDownClosingEventArgs e)
+        private void ContextMenuStrip_Closing(object? sender, ToolStripDropDownClosingEventArgs e)
         {
             if (sender is ContextMenuStrip cms)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckBox.cs
@@ -669,7 +669,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">A PropertyChangedEventArgs that contains the event data.</param>
-        protected virtual void OnCommandPropertyChanged(object sender, PropertyChangedEventArgs e)
+        protected virtual void OnCommandPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {
@@ -819,9 +819,9 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnCheckBoxTextChanged(object sender, EventArgs e) => OnTextChanged(EventArgs.Empty);
+        private void OnCheckBoxTextChanged(object? sender, EventArgs e) => OnTextChanged(EventArgs.Empty);
 
-        private void OnControllerClick(object sender, EventArgs e) => OnClick(e);
+        private void OnControllerClick(object? sender, EventArgs e) => OnClick(e);
 
         private void UpdateForOrientation()
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckButton.cs
@@ -256,7 +256,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">A PropertyChangedEventArgs that contains the event data.</param>
-        protected override void OnCommandPropertyChanged(object sender, PropertyChangedEventArgs e)
+        protected override void OnCommandPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             Checked = e.PropertyName switch
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckSet.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckSet.cs
@@ -469,26 +469,26 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnCheckedChanging(object sender, CancelEventArgs e)
+        private void OnCheckedChanging(object? sender, CancelEventArgs e)
         {
             // Are we allowed to process the event?
             if (!_ignoreEvents)
             {
                 // Cast to the correct type
-                var checkedButton = (KryptonCheckButton)sender;
+                var checkedButton = sender as KryptonCheckButton ?? throw new ArgumentNullException(nameof(sender));
 
                 // Prevent the checked button becoming unchecked unless AllowUncheck is defined
                 e.Cancel = checkedButton.Checked && !AllowUncheck;
             }
         }
 
-        private void OnCheckedChanged(object sender, EventArgs e)
+        private void OnCheckedChanged(object? sender, EventArgs e)
         {
             // Are we allowed to process the event?
             if (!_ignoreEvents)
             {
                 // Cast to the correct type
-                var checkedButton = (KryptonCheckButton)sender;
+                var checkedButton = sender as KryptonCheckButton ?? throw new ArgumentNullException(nameof(sender));
 
                 if (checkedButton.Checked)
                 {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonColorButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonColorButton.cs
@@ -1096,7 +1096,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">A PropertyChangedEventArgs that contains the event data.</param>
-        protected virtual void OnCommandPropertyChanged(object sender, PropertyChangedEventArgs e)
+        protected virtual void OnCommandPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {
@@ -1141,9 +1141,9 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnButtonTextChanged(object sender, EventArgs e) => OnTextChanged(EventArgs.Empty);
+        private void OnButtonTextChanged(object? sender, EventArgs e) => OnTextChanged(EventArgs.Empty);
 
-        private void OnButtonClick(object sender, MouseEventArgs e)
+        private void OnButtonClick(object? sender, MouseEventArgs e)
         {
             var showingContextMenu = false;
 
@@ -1266,9 +1266,9 @@ namespace Krypton.Toolkit
 
         private void OnContextMenuClosed(object sender, EventArgs e) => ContextMenuClosed();
 
-        private void OnKryptonContextMenuClosed(object sender, EventArgs e)
+        private void OnKryptonContextMenuClosed(object? sender, EventArgs e)
         {
-            var kcm = (KryptonContextMenu)sender;
+            var kcm = sender as KryptonContextMenu ?? throw new ArgumentNullException(nameof(sender));
             kcm.Closed -= OnKryptonContextMenuClosed;
             ContextMenuClosed();
 
@@ -1276,7 +1276,7 @@ namespace Krypton.Toolkit
             HookContextMenuEvents(_kryptonContextMenu!.Items, false);
         }
 
-        private void OnButtonSelect(object sender, MouseEventArgs e)
+        private void OnButtonSelect(object? sender, MouseEventArgs e)
         {
             // Take the focus if allowed
             if (CanFocus)
@@ -1465,13 +1465,13 @@ namespace Krypton.Toolkit
             visible.Visible = previous;
         }
 
-        private void OnColumnsTrackingColor(object sender, ColorEventArgs e) => OnTrackingColor(new ColorEventArgs(e.Color));
+        private void OnColumnsTrackingColor(object? sender, ColorEventArgs e) => OnTrackingColor(new ColorEventArgs(e.Color));
 
-        private void OnColumnsSelectedColorChanged(object sender, ColorEventArgs e) => SelectedColor = e.Color;
+        private void OnColumnsSelectedColorChanged(object? sender, ColorEventArgs e) => SelectedColor = e.Color;
 
-        private void OnClickNoColor(object sender, EventArgs e) => SelectedColor = GlobalStaticValues.EMPTY_COLOR;
+        private void OnClickNoColor(object? sender, EventArgs e) => SelectedColor = GlobalStaticValues.EMPTY_COLOR;
 
-        private void OnClickMoreColors(object sender, EventArgs e)
+        private void OnClickMoreColors(object? sender, EventArgs e)
         {
             // Give user a chance to cancel showing the Krypton more colors dialog
             var cea = new CancelEventArgs();

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonColorDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonColorDialog.cs
@@ -164,7 +164,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void Timer1OnTick(object sender, EventArgs e)
+        private void Timer1OnTick(object? sender, EventArgs e)
         {
             var text = new StringBuilder(6);
             if (PI.GetWindowText(_redEdit.hWnd, text, 4) <= 0)
@@ -182,7 +182,7 @@ namespace Krypton.Toolkit
             _alphaPanel.StateCommon.Color1 = Color.FromArgb(_alphaSlider.Value, red, green, blue);
         }
 
-        private void AlphaSlider_ValueChanged(object sender, EventArgs e)
+        private void AlphaSlider_ValueChanged(object? sender, EventArgs e)
         {
             _alphaSlider.ToolTipValues.Description = _alphaSlider.Value.ToString(CultureInfo.InvariantCulture);
             _alphaLabel.Text = _alphaSlider.ToolTipValues.Description;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -2640,7 +2640,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
-        protected override void OnPaletteNeedPaint(object sender, NeedLayoutEventArgs e)
+        protected override void OnPaletteNeedPaint(object? sender, NeedLayoutEventArgs e)
         {
             base.OnPaletteChanged(e);
             _comboBox.Invalidate();
@@ -2760,7 +2760,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnComboBoxDrawItem(object sender, DrawItemEventArgs e)
+        private void OnComboBoxDrawItem(object? sender, DrawItemEventArgs e)
         {
             Rectangle drawBounds = e.Bounds;
 
@@ -2900,7 +2900,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnComboBoxMeasureItem(object sender, MeasureItemEventArgs e)
+        private void OnComboBoxMeasureItem(object? sender, MeasureItemEventArgs e)
         {
             UpdateContentFromItemIndex(e.Index);
 
@@ -2939,7 +2939,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnComboBoxMouseChange(object sender, EventArgs e)
+        private void OnComboBoxMouseChange(object? sender, EventArgs e)
         {
             // Find new tracking mouse change state
             var tracking = _comboBox.MouseOver || _subclassEdit is { MouseOver: true };
@@ -2966,7 +2966,7 @@ namespace Krypton.Toolkit
             _comboBox.Invalidate();
         }
 
-        private void OnComboBoxGotFocus(object sender, EventArgs e)
+        private void OnComboBoxGotFocus(object? sender, EventArgs e)
         {
             if (DropDownStyle == ComboBoxStyle.DropDown)
             {
@@ -2984,7 +2984,7 @@ namespace Krypton.Toolkit
             _comboBox.Invalidate();
         }
 
-        private void OnComboBoxLostFocus(object sender, EventArgs e)
+        private void OnComboBoxLostFocus(object? sender, EventArgs e)
         {
             if (DropDownStyle == ComboBoxStyle.DropDown)
             {
@@ -2999,28 +2999,28 @@ namespace Krypton.Toolkit
             _comboBox.Invalidate();
         }
 
-        private void OnComboBoxTextChanged(object sender, EventArgs e) => OnTextChanged(e);
+        private void OnComboBoxTextChanged(object? sender, EventArgs e) => OnTextChanged(e);
 
-        private void OnComboBoxTextUpdate(object sender, EventArgs e) => OnTextUpdate(e);
+        private void OnComboBoxTextUpdate(object? sender, EventArgs e) => OnTextUpdate(e);
 
-        private void OnComboBoxSelectionChangeCommitted(object sender, EventArgs e) => OnSelectionChangeCommitted(e);
+        private void OnComboBoxSelectionChangeCommitted(object? sender, EventArgs e) => OnSelectionChangeCommitted(e);
 
-        private void OnComboBoxSelectedIndexChanged(object sender, EventArgs e) => OnSelectedIndexChanged(e);
+        private void OnComboBoxSelectedIndexChanged(object? sender, EventArgs e) => OnSelectedIndexChanged(e);
 
-        private void OnComboBoxDropDownStyleChanged(object sender, EventArgs e) => OnDropDownStyleChanged(e);
+        private void OnComboBoxDropDownStyleChanged(object? sender, EventArgs e) => OnDropDownStyleChanged(e);
 
-        private void OnComboBoxDataSourceChanged(object sender, EventArgs e) => OnDataSourceChanged(e);
+        private void OnComboBoxDataSourceChanged(object? sender, EventArgs e) => OnDataSourceChanged(e);
 
-        private void OnComboBoxDisplayMemberChanged(object sender, EventArgs e) => OnDisplayMemberChanged(e);
+        private void OnComboBoxDisplayMemberChanged(object? sender, EventArgs e) => OnDisplayMemberChanged(e);
 
-        private void OnComboBoxDropDownClosed(object sender, EventArgs e)
+        private void OnComboBoxDropDownClosed(object? sender, EventArgs e)
         {
             _comboBox.Dropped = false;
             Refresh();
             OnDropDownClosed(e);
         }
 
-        private void OnComboBoxDropDown(object sender, EventArgs e)
+        private void OnComboBoxDropDown(object? sender, EventArgs e)
         {
             _comboBox.Dropped = true;
             _hoverIndex = -1;
@@ -3028,27 +3028,27 @@ namespace Krypton.Toolkit
             OnDropDown(e);
         }
 
-        private void OnComboBoxKeyPress(object sender, KeyPressEventArgs e) => OnKeyPress(e);
+        private void OnComboBoxKeyPress(object? sender, KeyPressEventArgs e) => OnKeyPress(e);
 
-        private void OnComboBoxKeyUp(object sender, KeyEventArgs e) => OnKeyUp(e);
+        private void OnComboBoxKeyUp(object? sender, KeyEventArgs e) => OnKeyUp(e);
 
-        private void OnComboBoxKeyDown(object sender, KeyEventArgs e) => OnKeyDown(e);
+        private void OnComboBoxKeyDown(object? sender, KeyEventArgs e) => OnKeyDown(e);
 
-        private void OnComboBoxPreviewKeyDown(object sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
+        private void OnComboBoxPreviewKeyDown(object? sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
 
-        private void OnComboBoxValidated(object sender, EventArgs e) => OnValidated(e);
+        private void OnComboBoxValidated(object? sender, EventArgs e) => OnValidated(e);
 
-        private void OnComboBoxValidating(object sender, CancelEventArgs e) => OnValidating(e);
+        private void OnComboBoxValidating(object? sender, CancelEventArgs e) => OnValidating(e);
 
-        private void OnComboBoxFormat(object sender, ListControlConvertEventArgs e) => OnFormat(e);
+        private void OnComboBoxFormat(object? sender, ListControlConvertEventArgs e) => OnFormat(e);
 
-        private void OnComboBoxFormatInfoChanged(object sender, EventArgs e) => OnFormatInfoChanged(e);
+        private void OnComboBoxFormatInfoChanged(object? sender, EventArgs e) => OnFormatInfoChanged(e);
 
-        private void OnComboBoxFormatStringChanged(object sender, EventArgs e) => OnFormatStringChanged(e);
+        private void OnComboBoxFormatStringChanged(object? sender, EventArgs e) => OnFormatStringChanged(e);
 
-        private void OnComboBoxFormattingEnabledChanged(object sender, EventArgs e) => OnFormattingEnabledChanged(e);
+        private void OnComboBoxFormattingEnabledChanged(object? sender, EventArgs e) => OnFormattingEnabledChanged(e);
 
-        private void OnComboBoxSelectedValueChanged(object sender, EventArgs e)
+        private void OnComboBoxSelectedValueChanged(object? sender, EventArgs e)
         {
             UpdateEditControl();
             PerformNeedPaint(false);
@@ -3056,9 +3056,9 @@ namespace Krypton.Toolkit
             OnSelectedValueChanged(e);
         }
 
-        private void OnComboBoxValueMemberChanged(object sender, EventArgs e) => OnValueMemberChanged(e);
+        private void OnComboBoxValueMemberChanged(object? sender, EventArgs e) => OnValueMemberChanged(e);
 
-        private void OnShowToolTip(object sender, ToolTipEventArgs e)
+        private void OnShowToolTip(object? sender, ToolTipEventArgs e)
         {
             if (!IsDisposed && !Disposing)
             {
@@ -3126,12 +3126,12 @@ namespace Krypton.Toolkit
         }
 
         // Remove any currently showing tooltip
-        private void OnCancelToolTip(object sender, EventArgs e) => _visualPopupToolTip?.Dispose();
+        private void OnCancelToolTip(object? sender, EventArgs e) => _visualPopupToolTip?.Dispose();
 
-        private void OnVisualPopupToolTipDisposed(object sender, EventArgs e)
+        private void OnVisualPopupToolTipDisposed(object? sender, EventArgs e)
         {
             // Unhook events from the specific instance that generated event
-            var popupToolTip = (VisualPopupToolTip)sender;
+            var popupToolTip = sender as VisualPopupToolTip ?? throw new ArgumentNullException(nameof(sender));
             popupToolTip.Disposed -= OnVisualPopupToolTipDisposed;
 
             // Not showing a popup page anymore
@@ -3166,9 +3166,9 @@ namespace Krypton.Toolkit
             tip.ShowCalculatingSize(PointToScreen(point));
         }
 
-        private void OnDoubleClick(object sender, EventArgs e) => base.OnDoubleClick(e);
+        private void OnDoubleClick(object? sender, EventArgs e) => base.OnDoubleClick(e);
 
-        private void OnMouseDoubleClick(object sender, MouseEventArgs e) => base.OnMouseDoubleClick(e);
+        private void OnMouseDoubleClick(object? sender, MouseEventArgs e) => base.OnMouseDoubleClick(e);
 
         internal void UpdateDropDownWidth(Size value) => DropDownWidth = value.Width;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCommandLinkButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCommandLinkButton.cs
@@ -682,7 +682,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">A PropertyChangedEventArgs that contains the event data.</param>
-        protected virtual void OnCommandPropertyChanged(object sender, PropertyChangedEventArgs e)
+        protected virtual void OnCommandPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {
@@ -709,7 +709,7 @@ namespace Krypton.Toolkit
 
         private void OnButtonTextChanged(object sender, EventArgs e) => OnTextChanged(EventArgs.Empty);
 
-        private void OnButtonClick(object sender, MouseEventArgs e)
+        private void OnButtonClick(object? sender, MouseEventArgs e)
         {
             // Raise the standard click event
             OnClick(EventArgs.Empty);
@@ -718,7 +718,7 @@ namespace Krypton.Toolkit
             OnMouseClick(e);
         }
 
-        private void OnButtonSelect(object sender, MouseEventArgs e)
+        private void OnButtonSelect(object? sender, MouseEventArgs e)
         {
             // Take the focus if allowed
             if (CanFocus)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonContextMenu.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonContextMenu.cs
@@ -475,7 +475,7 @@ namespace Krypton.Toolkit
             VisualContextMenu?.PerformNeedPaint(e.NeedLayout);
         }
 
-        private void OnContextMenuDisposed(object sender, EventArgs e)
+        private void OnContextMenuDisposed(object? sender, EventArgs e)
         {
             // Should still be caching a reference to actual display control
             if (VisualContextMenu != null)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
@@ -2954,7 +2954,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">An PaintLayoutEventArgs containing event data.</param>
-        protected override void OnPalettePaint(object sender, PaletteLayoutEventArgs e)
+        protected override void OnPalettePaint(object? sender, PaletteLayoutEventArgs e)
         {
             // Can only generate change events if not suspended
             if (_suspendCount == 0)
@@ -2982,7 +2982,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">An EventArgs containing event data.</param>
-        protected override void OnBasePaletteChanged(object sender, EventArgs e)
+        protected override void OnBasePaletteChanged(object? sender, EventArgs e)
         {
             // Can only generate change events if not suspended
             if (_suspendCount == 0)
@@ -2996,7 +2996,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">An EventArgs containing event data.</param>
-        protected override void OnBaseRendererChanged(object sender, EventArgs e)
+        protected override void OnBaseRendererChanged(object? sender, EventArgs e)
         {
             // Can only generate change events if not suspended
             if (_suspendCount == 0)
@@ -3010,7 +3010,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">An EventArgs containing event data.</param>
-        protected override void OnButtonSpecChanged(object sender, EventArgs e)
+        protected override void OnButtonSpecChanged(object? sender, EventArgs e)
         {
             // Can only generate change events if not suspended
             if (_suspendCount == 0)
@@ -5808,7 +5808,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnMenuToolStatusPaint(object sender, NeedLayoutEventArgs e)
+        private void OnMenuToolStatusPaint(object? sender, NeedLayoutEventArgs e)
         {
             // Only raise the need to paint if painting has not been suspended
             if (_suspendCount == 0)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -869,7 +869,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
-        protected void OnNeedResyncPaint(object sender, NeedLayoutEventArgs e)
+        protected void OnNeedResyncPaint(object? sender, NeedLayoutEventArgs e)
         {
             // Ensure the current cell style values are in sync with the new 
             // palette setting and any state overrides that are defined
@@ -885,7 +885,7 @@ namespace Krypton.Toolkit
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
         /// <exception cref="ArgumentNullException"></exception>
-        protected void OnNeedPaint(object sender, [DisallowNull] NeedLayoutEventArgs e)
+        protected void OnNeedPaint(object? sender, [DisallowNull] NeedLayoutEventArgs e)
         {
             Debug.Assert(e != null);
 
@@ -989,7 +989,7 @@ namespace Krypton.Toolkit
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An EventArgs containing event data.</param>
         /// <exception cref="ArgumentNullException"></exception>
-        protected virtual void OnButtonSpecChanged(object sender, [DisallowNull] EventArgs e)
+        protected virtual void OnButtonSpecChanged(object? sender, [DisallowNull] EventArgs e)
         {
             Debug.Assert(e != null);
 
@@ -2345,17 +2345,17 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnVisualPopupToolTipDisposed(object sender, EventArgs e)
+        private void OnVisualPopupToolTipDisposed(object? sender, EventArgs e)
         {
             // Unhook events from the specific instance that generated event
-            var popupToolTip = (VisualPopupToolTip)sender;
+            var popupToolTip = sender as VisualPopupToolTip ?? throw new ArgumentNullException(nameof(sender));
             popupToolTip.Disposed -= OnVisualPopupToolTipDisposed;
 
             // Not showing a popup page any more
             _visualPopupToolTip = null;
         }
 
-        private void OnTimerTick(object sender, EventArgs e)
+        private void OnTimerTick(object? sender, EventArgs e)
         {
             // Only need a one tick timer
             if (_showTimer != null)
@@ -2599,7 +2599,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnGlobalPaletteChanged(object sender, EventArgs e)
+        private void OnGlobalPaletteChanged(object? sender, EventArgs e)
         {
             // We only care if we are using the global palette
             if (PaletteMode == PaletteMode.Global)
@@ -2617,12 +2617,12 @@ namespace Krypton.Toolkit
 
         private void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e) => OnNeedResyncPaint(Palette!, new NeedLayoutEventArgs(true));
 
-        private void OnSyncPropertyChanged(object sender, EventArgs e) =>
+        private void OnSyncPropertyChanged(object? sender, EventArgs e) =>
             // Ensure the current cell style values are in sync with the new palette 
             // setting and any state overrides that are defined.
             SyncCellStylesWithPalette();
 
-        private void OnSyncBackPropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void OnSyncBackPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             // Only interested in the first color from the background palettes
             if (e.PropertyName == "Color1")
@@ -2635,7 +2635,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Menus
-        private void OnContextMenuStripOpening(object sender, CancelEventArgs e)
+        private void OnContextMenuStripOpening(object? sender, CancelEventArgs e)
         {
             // Get the actual strip instance
             ContextMenuStrip? cms = base.ContextMenuStrip;
@@ -2654,13 +2654,13 @@ namespace Krypton.Toolkit
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public ToolStripRenderer CreateToolStripRenderer() => Renderer?.RenderToolStrip(GetResolvedPalette()!)!;
 
-        private void OnKryptonContextMenuDisposed(object sender, EventArgs e) =>
+        private void OnKryptonContextMenuDisposed(object? sender, EventArgs e) =>
             // When the current krypton context menu is disposed, we should remove 
             // it to prevent it being used again, as that would just throw an exception 
             // because it has been disposed.
             KryptonContextMenu = null;
 
-        private void OnContextMenuClosed(object sender, ToolStripDropDownClosedEventArgs e) => ContextMenuClosed();
+        private void OnContextMenuClosed(object? sender, ToolStripDropDownClosedEventArgs e) => ContextMenuClosed();
 
         /// <summary>
         /// Called when a context menu has just been closed.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDateTimePicker.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDateTimePicker.cs
@@ -1906,7 +1906,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An EventArgs containing event data.</param>
-        protected override void OnButtonSpecChanged(object sender, EventArgs e)
+        protected override void OnButtonSpecChanged(object? sender, EventArgs e)
         {
             // Recreate all the button specs with new values
             _buttonManager?.RecreateButtons();
@@ -1993,7 +1993,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnShowToolTip(object sender, ToolTipEventArgs e)
+        private void OnShowToolTip(object? sender, ToolTipEventArgs e)
         {
             if (!IsDisposed)
             {
@@ -2060,11 +2060,11 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnCheckBoxClick(object sender, EventArgs e) =>
+        private void OnCheckBoxClick(object? sender, EventArgs e) =>
             // Invert the current checked state
             Checked = !Checked;
 
-        private void OnDropDownClick(object sender, EventArgs e)
+        private void OnDropDownClick(object? sender, EventArgs e)
         {
             // Never shown the calendar at design time
             if (!InRibbonDesignMode)
@@ -2168,7 +2168,7 @@ namespace Krypton.Toolkit
             _buttonDropDown.RemoveFixed();
         }
 
-        private void OnMonthCalendarDateChanged(object sender, DateRangeEventArgs e)
+        private void OnMonthCalendarDateChanged(object? sender, DateRangeEventArgs e)
         {
             // Use the newly selected date but the existing time
             var newDt = new DateTime(e.Start.Year, e.Start.Month, e.Start.Day, _dateTime.Hour, _dateTime.Minute,
@@ -2192,10 +2192,10 @@ namespace Krypton.Toolkit
             _dropDownMonthChanged = true;
         }
 
-        private void OnKryptonContextMenuClosed(object sender, EventArgs e)
+        private void OnKryptonContextMenuClosed(object? sender, EventArgs e)
         {
             // Must unhook from menu so it can be garbage collected
-            var kcm = (KryptonContextMenu)sender;
+            var kcm = sender as KryptonContextMenu ?? throw new ArgumentNullException(nameof(sender));
             kcm.Closed -= OnKryptonContextMenuClosed;
 
             // Unhook from month calendar events
@@ -2220,7 +2220,7 @@ namespace Krypton.Toolkit
             kcm.Dispose();
         }
 
-        private void OnUpClick(object sender, EventArgs e)
+        private void OnUpClick(object? sender, EventArgs e)
         {
             // Never operate the control at design time
             if (!InRibbonDesignMode)
@@ -2232,7 +2232,7 @@ namespace Krypton.Toolkit
             _buttonUp.RemoveFixed();
         }
 
-        private void OnDownClick(object sender, EventArgs e)
+        private void OnDownClick(object? sender, EventArgs e)
         {
             // Never operate the control at design time
             if (!InRibbonDesignMode)
@@ -2244,14 +2244,14 @@ namespace Krypton.Toolkit
             _buttonDown.RemoveFixed();
         }
 
-        private void OnCancelToolTip(object sender, EventArgs e) =>
+        private void OnCancelToolTip(object? sender, EventArgs e) =>
             // Remove any currently showing tooltip
             _visualPopupToolTip?.Dispose();
 
-        private void OnVisualPopupToolTipDisposed(object sender, EventArgs e)
+        private void OnVisualPopupToolTipDisposed(object? sender, EventArgs e)
         {
             // Unhook events from the specific instance that generated event
-            var popupToolTip = (VisualPopupToolTip)sender;
+            var popupToolTip = sender as VisualPopupToolTip ?? throw new ArgumentNullException(nameof(sender));
             popupToolTip.Disposed -= OnVisualPopupToolTipDisposed;
 
             // Not showing a popup page any more

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
@@ -1541,7 +1541,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
-        protected override void OnPaletteNeedPaint(object sender, NeedLayoutEventArgs e)
+        protected override void OnPaletteNeedPaint(object? sender, NeedLayoutEventArgs e)
         {
             InvalidateChildren();
             base.OnPaletteChanged(e);
@@ -1874,13 +1874,13 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnDomainUpDownTextChanged(object sender, EventArgs e) => OnTextChanged(e);
+        private void OnDomainUpDownTextChanged(object? sender, EventArgs e) => OnTextChanged(e);
 
-        private void OnDomainUpDownScroll(object sender, ScrollEventArgs e) => OnScroll(e);
+        private void OnDomainUpDownScroll(object? sender, ScrollEventArgs e) => OnScroll(e);
 
-        private void OnDomainUpDownSelectedItemChanged(object sender, EventArgs e) => OnSelectedItemChanged(e);
+        private void OnDomainUpDownSelectedItemChanged(object? sender, EventArgs e) => OnSelectedItemChanged(e);
 
-        private void OnDomainUpDownGotFocus(object sender, EventArgs e)
+        private void OnDomainUpDownGotFocus(object? sender, EventArgs e)
         {
             UpdateStateAndPalettes();
             PerformNeedPaint(true);
@@ -1888,7 +1888,7 @@ namespace Krypton.Toolkit
             base.OnGotFocus(e);
         }
 
-        private void OnDomainUpDownLostFocus(object sender, EventArgs e)
+        private void OnDomainUpDownLostFocus(object? sender, EventArgs e)
         {
             UpdateStateAndPalettes();
             PerformNeedPaint(true);
@@ -1898,19 +1898,19 @@ namespace Krypton.Toolkit
             // ReSharper restore RedundantBaseQualifier
         }
 
-        private void OnDomainUpDownKeyPress(object sender, KeyPressEventArgs e) => OnKeyPress(e);
+        private void OnDomainUpDownKeyPress(object? sender, KeyPressEventArgs e) => OnKeyPress(e);
 
-        private void OnDomainUpDownKeyUp(object sender, KeyEventArgs e) => OnKeyUp(e);
+        private void OnDomainUpDownKeyUp(object? sender, KeyEventArgs e) => OnKeyUp(e);
 
-        private void OnDomainUpDownKeyDown(object sender, KeyEventArgs e) => OnKeyDown(e);
+        private void OnDomainUpDownKeyDown(object? sender, KeyEventArgs e) => OnKeyDown(e);
 
-        private void OnDomainUpDownPreviewKeyDown(object sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
+        private void OnDomainUpDownPreviewKeyDown(object? sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
 
-        private void OnDomainUpDownValidated(object sender, EventArgs e) => OnValidated(e);
+        private void OnDomainUpDownValidated(object? sender, EventArgs e) => OnValidated(e);
 
-        private void OnDomainUpDownValidating(object sender, CancelEventArgs e) => OnValidating(e);
+        private void OnDomainUpDownValidating(object? sender, CancelEventArgs e) => OnValidating(e);
 
-        private void OnShowToolTip(object sender, ToolTipEventArgs e)
+        private void OnShowToolTip(object? sender, ToolTipEventArgs e)
         {
             if (!IsDisposed && !Disposing)
             {
@@ -1977,21 +1977,21 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnCancelToolTip(object sender, EventArgs e) =>
+        private void OnCancelToolTip(object? sender, EventArgs e) =>
             // Remove any currently showing tooltip
             _visualPopupToolTip?.Dispose();
 
-        private void OnVisualPopupToolTipDisposed(object sender, EventArgs e)
+        private void OnVisualPopupToolTipDisposed(object? sender, EventArgs e)
         {
             // Unhook events from the specific instance that generated event
-            var popupToolTip = (VisualPopupToolTip)sender;
+            var popupToolTip = sender as VisualPopupToolTip ?? throw new ArgumentNullException(nameof(sender));
             popupToolTip.Disposed -= OnVisualPopupToolTipDisposed;
 
             // Not showing a popup page any more
             _visualPopupToolTip = null;
         }
 
-        private void OnDomainUpDownMouseChange(object sender, EventArgs e)
+        private void OnDomainUpDownMouseChange(object? sender, EventArgs e)
         {
             // Find new tracking mouse change state
             var tracking = _domainUpDown.MouseOver ||

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDropButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDropButton.cs
@@ -732,7 +732,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">A PropertyChangedEventArgs that contains the event data.</param>
-        protected virtual void OnCommandPropertyChanged(object sender, PropertyChangedEventArgs e)
+        protected virtual void OnCommandPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {
@@ -773,9 +773,9 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnButtonTextChanged(object sender, EventArgs e) => OnTextChanged(EventArgs.Empty);
+        private void OnButtonTextChanged(object? sender, EventArgs e) => OnTextChanged(EventArgs.Empty);
 
-        private void OnButtonClick(object sender, MouseEventArgs e)
+        private void OnButtonClick(object? sender, MouseEventArgs e)
         {
             var showingContextMenu = false;
 
@@ -895,16 +895,16 @@ namespace Krypton.Toolkit
             _ => KryptonContextMenuPositionV.Below
         };
 
-        private void OnContextMenuClosed(object sender, EventArgs e) => ContextMenuClosed();
+        private void OnContextMenuClosed(object? sender, EventArgs e) => ContextMenuClosed();
 
-        private void OnKryptonContextMenuClosed(object sender, EventArgs e)
+        private void OnKryptonContextMenuClosed(object? sender, EventArgs e)
         {
-            var kcm = (KryptonContextMenu)sender;
+            var kcm = sender as KryptonContextMenu ?? throw new ArgumentNullException(nameof(sender));
             kcm.Closed -= OnKryptonContextMenuClosed;
             ContextMenuClosed();
         }
 
-        private void OnButtonSelect(object sender, MouseEventArgs e)
+        private void OnButtonSelect(object? sender, MouseEventArgs e)
         {
             // Take the focus if allowed
             if (CanFocus)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -861,7 +861,7 @@ namespace Krypton.Toolkit
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An EventArgs containing event data.</param>
         /// <exception cref="ArgumentNullException"></exception>
-        protected override void OnButtonSpecChanged(object sender, [DisallowNull] EventArgs e)
+        protected override void OnButtonSpecChanged(object? sender, [DisallowNull] EventArgs e)
         {
             Debug.Assert(e != null);
 
@@ -925,7 +925,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">An EventArgs containing the event data.</param>
-        protected override void OnUseThemeFormChromeBorderWidthChanged(object sender, EventArgs e) =>
+        protected override void OnUseThemeFormChromeBorderWidthChanged(object? sender, EventArgs e) =>
             // Test if we need to change the custom chrome usage
             UpdateUseThemeFormChromeBorderWidthDecision();
 
@@ -1498,7 +1498,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnShowToolTip(object sender, ToolTipEventArgs e)
+        private void OnShowToolTip(object? sender, ToolTipEventArgs e)
         {
             if (!IsDisposed)
             {
@@ -1561,14 +1561,14 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnCancelToolTip(object sender, EventArgs e) =>
+        private void OnCancelToolTip(object? sender, EventArgs e) =>
             // Remove any currently showing tooltip
             _visualPopupToolTip?.Dispose();
 
-        private void OnVisualPopupToolTipDisposed(object sender, EventArgs e)
+        private void OnVisualPopupToolTipDisposed(object? sender, EventArgs e)
         {
             // Unhook events from the specific instance that generated event
-            var popupToolTip = (VisualPopupToolTip)sender;
+            var popupToolTip = sender as VisualPopupToolTip ?? throw new ArgumentNullException(nameof(sender));
             popupToolTip.Disposed -= OnVisualPopupToolTipDisposed;
 
             // Not showing a popup page any more
@@ -1603,7 +1603,7 @@ namespace Krypton.Toolkit
             OnNeedPaint(sender, e);
         }
 
-        private void OnStatusDockChanged(object sender, EventArgs e)
+        private void OnStatusDockChanged(object? sender, EventArgs e)
         {
             if (StatusStripMerging)
             {
@@ -1611,7 +1611,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnStatusVisibleChanged(object sender, EventArgs e)
+        private void OnStatusVisibleChanged(object? sender, EventArgs e)
         {
             if (StatusStripMerging)
             {
@@ -1619,9 +1619,9 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnGlobalUseThemeFormChromeBorderWidthChanged(object sender, EventArgs e) => UpdateUseThemeFormChromeBorderWidthDecision();
+        private void OnGlobalUseThemeFormChromeBorderWidthChanged(object? sender, EventArgs e) => UpdateUseThemeFormChromeBorderWidthDecision();
 
-        private void OnGlobalPaletteChanged(object sender, EventArgs e)
+        private void OnGlobalPaletteChanged(object? sender, EventArgs e)
         {
             // We only care if we are using the global palette
             if (PaletteMode == PaletteMode.Global)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonGroup.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonGroup.cs
@@ -443,7 +443,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnGroupPanelPaint(object sender, NeedLayoutEventArgs e)
+        private void OnGroupPanelPaint(object? sender, NeedLayoutEventArgs e)
         {
             // If the child panel is layout out but not because we are, then it must be
             // laying out because a child has changed visibility/size/etc. If we are an

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonGroupBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonGroupBox.cs
@@ -775,9 +775,9 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnRemoveObscurer(object sender, EventArgs e) => _obscurer?.Uncover();
+        private void OnRemoveObscurer(object? sender, EventArgs e) => _obscurer?.Uncover();
 
-        private void OnValuesTextChanged(object sender, EventArgs e) => OnTextChanged(EventArgs.Empty);
+        private void OnValuesTextChanged(object? sender, EventArgs e) => OnTextChanged(EventArgs.Empty);
 
         private void OnGroupPanelPaint(object sender, NeedLayoutEventArgs e)
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonHeader.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonHeader.cs
@@ -483,7 +483,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An EventArgs containing event data.</param>
-        protected override void OnButtonSpecChanged(object sender, EventArgs e)
+        protected override void OnButtonSpecChanged(object? sender, EventArgs e)
         {
             // Recreate all the button specs with new values
             _buttonManager?.RecreateButtons();
@@ -494,9 +494,9 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnHeaderTextChanged(object sender, EventArgs e) => OnTextChanged(EventArgs.Empty);
+        private void OnHeaderTextChanged(object? sender, EventArgs e) => OnTextChanged(EventArgs.Empty);
 
-        private void OnShowToolTip(object sender, ToolTipEventArgs e)
+        private void OnShowToolTip(object? sender, ToolTipEventArgs e)
         {
             if (!IsDisposed)
             {
@@ -563,14 +563,14 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnCancelToolTip(object sender, EventArgs e) =>
+        private void OnCancelToolTip(object? sender, EventArgs e) =>
             // Remove any currently showing tooltip
             _visualPopupToolTip?.Dispose();
 
-        private void OnVisualPopupToolTipDisposed(object sender, EventArgs e)
+        private void OnVisualPopupToolTipDisposed(object? sender, EventArgs e)
         {
             // Unhook events from the specific instance that generated event
-            var popupToolTip = (VisualPopupToolTip)sender;
+            var popupToolTip = sender as VisualPopupToolTip ?? throw new ArgumentNullException(nameof(sender));
             popupToolTip.Disposed -= OnVisualPopupToolTipDisposed;
 
             // Not showing a popup page any more

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonHeaderGroup.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonHeaderGroup.cs
@@ -1044,7 +1044,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An EventArgs containing event data.</param>
-        protected override void OnButtonSpecChanged(object sender, EventArgs e)
+        protected override void OnButtonSpecChanged(object? sender, EventArgs e)
         {
             // Recreate all the button specs with new values
             _buttonManager.RecreateButtons();
@@ -1055,11 +1055,11 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnRemoveObscurer(object sender, EventArgs e) => _obscurer?.Uncover();
+        private void OnRemoveObscurer(object? sender, EventArgs e) => _obscurer?.Uncover();
 
-        private void OnHeaderGroupTextChanged(object sender, EventArgs e) => OnTextChanged(EventArgs.Empty);
+        private void OnHeaderGroupTextChanged(object? sender, EventArgs e) => OnTextChanged(EventArgs.Empty);
 
-        private void OnShowToolTip(object sender, ToolTipEventArgs e)
+        private void OnShowToolTip(object? sender, ToolTipEventArgs e)
         {
             if (!IsDisposed)
             {
@@ -1127,12 +1127,12 @@ namespace Krypton.Toolkit
         }
 
         // Remove any currently showing tooltip
-        private void OnCancelToolTip(object sender, EventArgs e) => _visualPopupToolTip?.Dispose();
+        private void OnCancelToolTip(object? sender, EventArgs e) => _visualPopupToolTip?.Dispose();
 
-        private void OnVisualPopupToolTipDisposed(object sender, EventArgs e)
+        private void OnVisualPopupToolTipDisposed(object? sender, EventArgs e)
         {
             // Unhook events from the specific instance that generated event
-            var popupToolTip = (VisualPopupToolTip)sender;
+            var popupToolTip = sender as VisualPopupToolTip ?? throw new ArgumentNullException(nameof(sender));
             popupToolTip.Disposed -= OnVisualPopupToolTipDisposed;
 
             // Not showing a popup page anymore
@@ -1140,19 +1140,16 @@ namespace Krypton.Toolkit
         }
 
         // Monitor the button spec being clicked
-        private void OnButtonSpecInserted(object sender, ButtonSpecEventArgs e) => e.ButtonSpec.Click += OnButtonSpecClicked;
+        private void OnButtonSpecInserted(object? sender, ButtonSpecEventArgs e) => e.ButtonSpec.Click += OnButtonSpecClicked;
 
         // Unhook from monitoring the button spec
-        private void OnButtonSpecRemoved(object sender, ButtonSpecEventArgs e) => e.ButtonSpec.Click -= OnButtonSpecClicked;
+        private void OnButtonSpecRemoved(object? sender, ButtonSpecEventArgs e) => e.ButtonSpec.Click -= OnButtonSpecClicked;
 
-        private void OnButtonSpecClicked(object sender, EventArgs e)
+        private void OnButtonSpecClicked(object? sender, EventArgs e)
         {
             // Do we need to automatically switch collapsed modes?
-            if (AutoCollapseArrow)
+            if (AutoCollapseArrow && sender is ButtonSpecHeaderGroup buttonSpec)
             {
-                // Cast to correct type
-                var buttonSpec = (ButtonSpecHeaderGroup)sender;
-
                 // Action depends on the arrow
                 switch (buttonSpec.Type)
                 {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLabel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLabel.cs
@@ -446,7 +446,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">A PropertyChangedEventArgs that contains the event data.</param>
-        protected virtual void OnCommandPropertyChanged(object sender, PropertyChangedEventArgs e)
+        protected virtual void OnCommandPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {
@@ -496,7 +496,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnLabelTextChanged(object sender, EventArgs e) => OnTextChanged(EventArgs.Empty);
+        private void OnLabelTextChanged(object? sender, EventArgs e) => OnTextChanged(EventArgs.Empty);
         #endregion
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLinkLabel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLinkLabel.cs
@@ -287,7 +287,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnControllerClick(object sender, MouseEventArgs e) => OnLinkClicked(new LinkClickedEventArgs(Text));
+        private void OnControllerClick(object? sender, MouseEventArgs e) => OnLinkClicked(new LinkClickedEventArgs(Text));
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLinkWrapLabel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLinkWrapLabel.cs
@@ -810,15 +810,15 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnPaletteNeedPaint(object sender, NeedLayoutEventArgs e) => NeedPaint(e);
+        private void OnPaletteNeedPaint(object? sender, NeedLayoutEventArgs e) => NeedPaint(e);
 
         // Change in base renderer or base palette require we fetch the latest renderer
-        private void OnBaseChanged(object sender, EventArgs e) => Renderer = _palette?.GetRenderer();
+        private void OnBaseChanged(object? sender, EventArgs e) => Renderer = _palette?.GetRenderer();
 
         /// <summary>Called when [global palette changed].</summary>
         /// <param name="sender">The sender.</param>
         /// <param name="e">The <see cref="EventArgs" /> instance containing the event data.</param>
-        private void OnGlobalPaletteChanged(object sender, EventArgs e)
+        private void OnGlobalPaletteChanged(object? sender, EventArgs e)
         {
             // We only care if we are using the global palette
             if (PaletteMode == PaletteMode.Global)
@@ -852,13 +852,13 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnKryptonContextMenuDisposed(object sender, EventArgs e) =>
+        private void OnKryptonContextMenuDisposed(object? sender, EventArgs e) =>
             // When the current krypton context menu is disposed, we should remove 
             // it to prevent it being used again, as that would just throw an exception 
             // because it has been disposed.
             KryptonContextMenu = null;
 
-        private void OnContextMenuClosed(object sender, ToolStripDropDownClosedEventArgs e) => ContextMenuClosed();
+        private void OnContextMenuClosed(object? sender, ToolStripDropDownClosedEventArgs e) => ContextMenuClosed();
 
         private void NeedPaint(bool layout) => NeedPaint(new NeedLayoutEventArgs(layout));
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListBox.cs
@@ -601,7 +601,7 @@ namespace Krypton.Toolkit
             ((KryptonReadOnlyControls)Controls).AddInternal(_listBox);
         }
 
-        private void OnListBoxClick(object sender, EventArgs e) =>
+        private void OnListBoxClick(object? sender, EventArgs e) =>
             // ReSharper disable RedundantBaseQualifier
             base.OnClick(e);
         // ReSharper restore RedundantBaseQualifier
@@ -1323,7 +1323,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
-        protected override void OnPaletteNeedPaint(object sender, NeedLayoutEventArgs e)
+        protected override void OnPaletteNeedPaint(object? sender, NeedLayoutEventArgs e)
         {
             _listBox.RefreshItemSizes();
             base.OnPaletteChanged(e);
@@ -1528,7 +1528,7 @@ namespace Krypton.Toolkit
 
         private IPaletteDouble GetDoubleState() => Enabled ? (IsActive ? StateActive : StateNormal) : StateDisabled;
 
-        private void OnListBoxDrawItem(object sender, DrawItemEventArgs e)
+        private void OnListBoxDrawItem(object? sender, DrawItemEventArgs e)
         {
             // We cannot do anything with an invalid index
             if (e.Index < 0)
@@ -1634,7 +1634,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnListBoxMeasureItem(object sender, MeasureItemEventArgs e)
+        private void OnListBoxMeasureItem(object? sender, MeasureItemEventArgs e)
         {
             UpdateContentFromItemIndex(e.Index);
 
@@ -1666,13 +1666,13 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnListBoxDataSourceChanged(object sender, EventArgs e) => OnDataSourceChanged(e);
+        private void OnListBoxDataSourceChanged(object? sender, EventArgs e) => OnDataSourceChanged(e);
 
-        private void OnListBoxDisplayMemberChanged(object sender, EventArgs e) => OnDisplayMemberChanged(e);
+        private void OnListBoxDisplayMemberChanged(object? sender, EventArgs e) => OnDisplayMemberChanged(e);
 
-        private void OnListBoxValueMemberChanged(object sender, EventArgs e) => OnValueMemberChanged(e);
+        private void OnListBoxValueMemberChanged(object? sender, EventArgs e) => OnValueMemberChanged(e);
 
-        private void OnListBoxSelectedIndexChanged(object sender, EventArgs e)
+        private void OnListBoxSelectedIndexChanged(object? sender, EventArgs e)
         {
             switch (_listBox.SelectionMode)
             {
@@ -1720,22 +1720,22 @@ namespace Krypton.Toolkit
             return left.Where((t, i) => t != right[i]).Any();
         }
 
-        private void OnListBoxSelectedValueChanged(object sender, EventArgs e)
+        private void OnListBoxSelectedValueChanged(object? sender, EventArgs e)
         {
             UpdateStateAndPalettes();
             _listBox.Invalidate();
             OnSelectedValueChanged(e);
         }
 
-        private void OnListBoxFormat(object sender, ListControlConvertEventArgs e) => OnFormat(e);
+        private void OnListBoxFormat(object? sender, ListControlConvertEventArgs e) => OnFormat(e);
 
-        private void OnListBoxFormatInfoChanged(object sender, EventArgs e) => OnFormatInfoChanged(e);
+        private void OnListBoxFormatInfoChanged(object? sender, EventArgs e) => OnFormatInfoChanged(e);
 
-        private void OnListBoxFormatStringChanged(object sender, EventArgs e) => OnFormatStringChanged(e);
+        private void OnListBoxFormatStringChanged(object? sender, EventArgs e) => OnFormatStringChanged(e);
 
-        private void OnListBoxFormattingEnabledChanged(object sender, EventArgs e) => OnFormattingEnabledChanged(e);
+        private void OnListBoxFormattingEnabledChanged(object? sender, EventArgs e) => OnFormattingEnabledChanged(e);
 
-        private void OnListBoxGotFocus(object sender, EventArgs e)
+        private void OnListBoxGotFocus(object? sender, EventArgs e)
         {
             UpdateStateAndPalettes();
             _listBox.Invalidate();
@@ -1743,7 +1743,7 @@ namespace Krypton.Toolkit
             OnGotFocus(e);
         }
 
-        private void OnListBoxLostFocus(object sender, EventArgs e)
+        private void OnListBoxLostFocus(object? sender, EventArgs e)
         {
             UpdateStateAndPalettes();
             _listBox.Invalidate();
@@ -1751,19 +1751,19 @@ namespace Krypton.Toolkit
             OnLostFocus(e);
         }
 
-        private void OnListBoxKeyPress(object sender, KeyPressEventArgs e) => OnKeyPress(e);
+        private void OnListBoxKeyPress(object? sender, KeyPressEventArgs e) => OnKeyPress(e);
 
-        private void OnListBoxKeyUp(object sender, KeyEventArgs e) => OnKeyUp(e);
+        private void OnListBoxKeyUp(object? sender, KeyEventArgs e) => OnKeyUp(e);
 
-        private void OnListBoxKeyDown(object sender, KeyEventArgs e) => OnKeyDown(e);
+        private void OnListBoxKeyDown(object? sender, KeyEventArgs e) => OnKeyDown(e);
 
-        private void OnListBoxPreviewKeyDown(object sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
+        private void OnListBoxPreviewKeyDown(object? sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
 
-        private void OnListBoxValidated(object sender, EventArgs e) => OnValidated(e);
+        private void OnListBoxValidated(object? sender, EventArgs e) => OnValidated(e);
 
-        private void OnListBoxValidating(object sender, CancelEventArgs e) => OnValidating(e);
+        private void OnListBoxValidating(object? sender, CancelEventArgs e) => OnValidating(e);
 
-        private void OnListBoxMouseChange(object sender, EventArgs e)
+        private void OnListBoxMouseChange(object? sender, EventArgs e)
         {
             // Change in tracking state?
             if (_listBox.MouseOver != _trackingMouseEnter)
@@ -1784,9 +1784,9 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnDoubleClick(object sender, EventArgs e) => base.OnDoubleClick(e);
+        private void OnDoubleClick(object? sender, EventArgs e) => base.OnDoubleClick(e);
 
-        private void OnMouseDoubleClick(object sender, MouseEventArgs e) => base.OnMouseDoubleClick(e);
+        private void OnMouseDoubleClick(object? sender, MouseEventArgs e) => base.OnMouseDoubleClick(e);
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListView.cs
@@ -395,7 +395,7 @@ namespace Krypton.Toolkit
             ((KryptonReadOnlyControls)Controls).AddInternal(_listView);
         }
 
-        private void OnListBoxClick(object sender, EventArgs e) => OnClick(e);
+        private void OnListBoxClick(object? sender, EventArgs e) => OnClick(e);
 
         /// <summary>
         /// Clean up any resources being used.
@@ -1345,7 +1345,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnListViewGotFocus(object sender, EventArgs e)
+        private void OnListViewGotFocus(object? sender, EventArgs e)
         {
             UpdateStateAndPalettes();
             _listView.Invalidate();
@@ -1353,7 +1353,7 @@ namespace Krypton.Toolkit
             OnGotFocus(e);
         }
 
-        private void OnListViewLostFocus(object sender, EventArgs e)
+        private void OnListViewLostFocus(object? sender, EventArgs e)
         {
             UpdateStateAndPalettes();
             _listView.Invalidate();

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonManager.cs
@@ -1021,7 +1021,7 @@ namespace Krypton.Toolkit
             UpdateToolStripManager();
         }
 
-        private static void OnPalettePaint(object sender, PaletteLayoutEventArgs e)
+        private static void OnPalettePaint(object? sender, PaletteLayoutEventArgs e)
         {
             // If the color table has changed then need to update tool strip immediately
             if (e.NeedColorTable)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs
@@ -1794,51 +1794,51 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnMaskedTextBoxTextChanged(object sender, EventArgs e) => OnTextChanged(e);
+        private void OnMaskedTextBoxTextChanged(object? sender, EventArgs e) => OnTextChanged(e);
 
-        private void OnMaskedTextBoxTextAlignChanged(object sender, EventArgs e) => OnTextAlignChanged(e);
+        private void OnMaskedTextBoxTextAlignChanged(object? sender, EventArgs e) => OnTextAlignChanged(e);
 
-        private void OnMaskedTextBoxHideSelectionChanged(object sender, EventArgs e) => OnHideSelectionChanged(e);
+        private void OnMaskedTextBoxHideSelectionChanged(object? sender, EventArgs e) => OnHideSelectionChanged(e);
 
-        private void OnMaskedTextBoxModifiedChanged(object sender, EventArgs e) => OnModifiedChanged(e);
+        private void OnMaskedTextBoxModifiedChanged(object? sender, EventArgs e) => OnModifiedChanged(e);
 
-        private void OnMaskedTextBoxReadOnlyChanged(object sender, EventArgs e) => OnReadOnlyChanged(e);
+        private void OnMaskedTextBoxReadOnlyChanged(object? sender, EventArgs e) => OnReadOnlyChanged(e);
 
-        private void OnMaskedMaskChanged(object sender, EventArgs e) => OnMaskChanged(e);
+        private void OnMaskedMaskChanged(object? sender, EventArgs e) => OnMaskChanged(e);
 
-        private void OnMaskedIsOverwriteModeChanged(object sender, EventArgs e) => OnIsOverwriteModeChanged(e);
+        private void OnMaskedIsOverwriteModeChanged(object? sender, EventArgs e) => OnIsOverwriteModeChanged(e);
 
-        private void OnMaskedMaskInputRejected(object sender, MaskInputRejectedEventArgs e) => OnMaskInputRejected(e);
+        private void OnMaskedMaskInputRejected(object? sender, MaskInputRejectedEventArgs e) => OnMaskInputRejected(e);
 
-        private void OnMaskedTypeValidationCompleted(object sender, TypeValidationEventArgs e) => OnTypeValidationCompleted(e);
+        private void OnMaskedTypeValidationCompleted(object? sender, TypeValidationEventArgs e) => OnTypeValidationCompleted(e);
 
-        private void OnMaskedTextBoxGotFocus(object sender, EventArgs e)
+        private void OnMaskedTextBoxGotFocus(object? sender, EventArgs e)
         {
             UpdateStateAndPalettes();
             PerformNeedPaint(true);
             OnGotFocus(e);
         }
 
-        private void OnMaskedTextBoxLostFocus(object sender, EventArgs e)
+        private void OnMaskedTextBoxLostFocus(object? sender, EventArgs e)
         {
             UpdateStateAndPalettes();
             PerformNeedPaint(true);
             OnLostFocus(e);
         }
 
-        private void OnMaskedTextBoxKeyPress(object sender, KeyPressEventArgs e) => OnKeyPress(e);
+        private void OnMaskedTextBoxKeyPress(object? sender, KeyPressEventArgs e) => OnKeyPress(e);
 
-        private void OnMaskedTextBoxKeyUp(object sender, KeyEventArgs e) => OnKeyUp(e);
+        private void OnMaskedTextBoxKeyUp(object? sender, KeyEventArgs e) => OnKeyUp(e);
 
-        private void OnMaskedTextBoxKeyDown(object sender, KeyEventArgs e) => OnKeyDown(e);
+        private void OnMaskedTextBoxKeyDown(object? sender, KeyEventArgs e) => OnKeyDown(e);
 
-        private void OnMaskedTextBoxPreviewKeyDown(object sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
+        private void OnMaskedTextBoxPreviewKeyDown(object? sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
 
-        private void OnMaskedTextBoxValidated(object sender, EventArgs e) => OnValidated(e);
+        private void OnMaskedTextBoxValidated(object? sender, EventArgs e) => OnValidated(e);
 
-        private void OnMaskedTextBoxValidating(object sender, CancelEventArgs e) => OnValidating(e);
+        private void OnMaskedTextBoxValidating(object? sender, CancelEventArgs e) => OnValidating(e);
 
-        private void OnShowToolTip(object sender, ToolTipEventArgs e)
+        private void OnShowToolTip(object? sender, ToolTipEventArgs e)
         {
             if (!IsDisposed && !Disposing)
             {
@@ -1905,24 +1905,24 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnCancelToolTip(object sender, EventArgs e)
+        private void OnCancelToolTip(object? sender, EventArgs e)
         {
             // Remove any currently showing tooltip
             _visualPopupToolTip?.Dispose();
             _visualPopupToolTip = null;
         }
 
-        private void OnVisualPopupToolTipDisposed(object sender, EventArgs e)
+        private void OnVisualPopupToolTipDisposed(object? sender, EventArgs e)
         {
             // Unhook events from the specific instance that generated event
-            var popupToolTip = (VisualPopupToolTip)sender;
+            var popupToolTip = sender as VisualPopupToolTip ?? throw new ArgumentNullException(nameof(sender));
             popupToolTip.Disposed -= OnVisualPopupToolTipDisposed;
 
             // Not showing a popup page any more
             _visualPopupToolTip = null;
         }
 
-        private void OnMaskedTextBoxMouseChange(object sender, EventArgs e)
+        private void OnMaskedTextBoxMouseChange(object? sender, EventArgs e)
         {
             // Change in tracking state?
             if (_maskedTextBox.MouseOver != _trackingMouseEnter)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMonthCalendar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMonthCalendar.cs
@@ -1377,7 +1377,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An EventArgs containing event data.</param>
-        protected override void OnButtonSpecChanged(object sender, EventArgs e)
+        protected override void OnButtonSpecChanged(object? sender, EventArgs e)
         {
             // Recreate all the button specs with new values
             _drawMonths?.RecreateButtons();

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
@@ -1667,7 +1667,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
-        protected override void OnPaletteNeedPaint(object sender, NeedLayoutEventArgs e)
+        protected override void OnPaletteNeedPaint(object? sender, NeedLayoutEventArgs e)
         {
             InvalidateChildren();
             base.OnPaletteChanged(e);
@@ -2007,11 +2007,11 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnNumericUpDownTextChanged(object sender, EventArgs e) => OnTextChanged(e);
+        private void OnNumericUpDownTextChanged(object? sender, EventArgs e) => OnTextChanged(e);
 
-        private void OnNumericUpDownValueChanged(object sender, EventArgs e) => OnValueChanged(e);
+        private void OnNumericUpDownValueChanged(object? sender, EventArgs e) => OnValueChanged(e);
 
-        private void OnNumericUpDownGotFocus(object sender, EventArgs e)
+        private void OnNumericUpDownGotFocus(object? sender, EventArgs e)
         {
             UpdateStateAndPalettes();
             PerformNeedPaint(true);
@@ -2021,7 +2021,7 @@ namespace Krypton.Toolkit
             // ReSharper restore RedundantBaseQualifier
         }
 
-        private void OnNumericUpDownLostFocus(object sender, EventArgs e)
+        private void OnNumericUpDownLostFocus(object? sender, EventArgs e)
         {
             UpdateStateAndPalettes();
             PerformNeedPaint(true);
@@ -2031,19 +2031,19 @@ namespace Krypton.Toolkit
             // ReSharper restore RedundantBaseQualifier
         }
 
-        private void OnNumericUpDownKeyPress(object sender, KeyPressEventArgs e) => OnKeyPress(e);
+        private void OnNumericUpDownKeyPress(object? sender, KeyPressEventArgs e) => OnKeyPress(e);
 
-        private void OnNumericUpDownKeyUp(object sender, KeyEventArgs e) => OnKeyUp(e);
+        private void OnNumericUpDownKeyUp(object? sender, KeyEventArgs e) => OnKeyUp(e);
 
-        private void OnNumericUpDownKeyDown(object sender, KeyEventArgs e) => OnKeyDown(e);
+        private void OnNumericUpDownKeyDown(object? sender, KeyEventArgs e) => OnKeyDown(e);
 
-        private void OnNumericUpDownPreviewKeyDown(object sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
+        private void OnNumericUpDownPreviewKeyDown(object? sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
 
-        private void OnNumericUpDownValidated(object sender, EventArgs e) => OnValidated(e);
+        private void OnNumericUpDownValidated(object? sender, EventArgs e) => OnValidated(e);
 
-        private void OnNumericUpDownValidating(object sender, CancelEventArgs e) => OnValidating(e);
+        private void OnNumericUpDownValidating(object? sender, CancelEventArgs e) => OnValidating(e);
 
-        private void OnShowToolTip(object sender, ToolTipEventArgs e)
+        private void OnShowToolTip(object? sender, ToolTipEventArgs e)
         {
             if (!IsDisposed && !Disposing)
             {
@@ -2110,21 +2110,21 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnCancelToolTip(object sender, EventArgs e) =>
+        private void OnCancelToolTip(object? sender, EventArgs e) =>
             // Remove any currently showing tooltip
             _visualPopupToolTip?.Dispose();
 
-        private void OnVisualPopupToolTipDisposed(object sender, EventArgs e)
+        private void OnVisualPopupToolTipDisposed(object? sender, EventArgs e)
         {
             // Unhook events from the specific instance that generated event
-            var popupToolTip = (VisualPopupToolTip)sender;
+            var popupToolTip = sender as VisualPopupToolTip ?? throw new ArgumentNullException(nameof(sender));
             popupToolTip.Disposed -= OnVisualPopupToolTipDisposed;
 
             // Not showing a popup page anymore
             _visualPopupToolTip = null;
         }
 
-        private void OnNumericUpDownMouseChange(object sender, EventArgs e)
+        private void OnNumericUpDownMouseChange(object? sender, EventArgs e)
         {
             // Find new tracking mouse change state
             var tracking = _numericUpDown.MouseOver ||

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonOutlookGrid.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonOutlookGrid.cs
@@ -911,7 +911,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">The sender.</param>
         /// <param name="e">The <see cref="PaletteLayoutEventArgs"/> instance containing the event data.</param>
-        private void OnPalettePaint(object sender, PaletteLayoutEventArgs e)
+        private void OnPalettePaint(object? sender, PaletteLayoutEventArgs e)
         {
             Invalidate();
         }
@@ -921,7 +921,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">The sender.</param>
         /// <param name="e">The <see cref="EventArgs"/> instance containing the event data.</param>
-        private void OnGlobalPaletteChanged(object sender, EventArgs e)
+        private void OnGlobalPaletteChanged(object? sender, EventArgs e)
         {
             // (5) Unhook events from old palette
             if (_palette != null)
@@ -969,7 +969,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void OnColumnClearSorting(object sender, EventArgs e)
+        private void OnColumnClearSorting(object? sender, EventArgs e)
         {
             if (_colSelected > -1)
             {
@@ -984,7 +984,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void OnColumnSortAscending(object sender, EventArgs e)
+        private void OnColumnSortAscending(object? sender, EventArgs e)
         {
             if (_colSelected > -1)
             {
@@ -1003,7 +1003,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void OnColumnSortDescending(object sender, EventArgs e)
+        private void OnColumnSortDescending(object? sender, EventArgs e)
         {
             if (_colSelected > -1)
             {
@@ -1022,7 +1022,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void OnGroupByThisColumn(object sender, EventArgs e)
+        private void OnGroupByThisColumn(object? sender, EventArgs e)
         {
             if (_colSelected > -1)
             {
@@ -1038,7 +1038,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void OnUnGroupByThisColumn(object sender, EventArgs e)
+        private void OnUnGroupByThisColumn(object? sender, EventArgs e)
         {
             if (_colSelected > -1)
             {
@@ -1049,22 +1049,22 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnGroupCollapse(object sender, EventArgs e)
+        private void OnGroupCollapse(object? sender, EventArgs e)
         {
             OutlookGridColumn col = (OutlookGridColumn)_internalColumns.FindFromColumnIndex(_colSelected)!;
             Collapse(col.Name);
         }
 
-        private void OnGroupExpand(object sender, EventArgs e)
+        private void OnGroupExpand(object? sender, EventArgs e)
         {
             OutlookGridColumn col = (OutlookGridColumn)_internalColumns.FindFromColumnIndex(_colSelected)!;
             Expand(col.Name);
         }
 
-        private void OnSortBySummary(object sender, EventArgs e)
+        private void OnSortBySummary(object? sender, EventArgs e)
         {
 
-            KryptonContextMenuItem item = (KryptonContextMenuItem)sender;
+            var item = sender as KryptonContextMenuItem ?? throw new ArgumentNullException(nameof(sender));
             OutlookGridColumn col = (OutlookGridColumn)_internalColumns.FindFromColumnIndex(_colSelected)!;
             if (col.GroupingType != null)
             {
@@ -1074,9 +1074,9 @@ namespace Krypton.Toolkit
             Fill();
         }
 
-        private void OnGroupIntervalClick(object sender, EventArgs e)
+        private void OnGroupIntervalClick(object? sender, EventArgs e)
         {
-            KryptonContextMenuItem? item = (KryptonContextMenuItem)sender;
+            var item = sender as KryptonContextMenuItem ?? throw new ArgumentNullException(nameof(sender));
             OutlookGridColumn col = (OutlookGridColumn)_internalColumns.FindFromColumnIndex(_colSelected)!;
             if (col.GroupingType != null)
             {
@@ -1093,9 +1093,9 @@ namespace Krypton.Toolkit
             Fill();
         }
 
-        private void OnConditionalFormattingClick(object sender, EventArgs e)
+        private void OnConditionalFormattingClick(object? sender, EventArgs e)
         {
-            KryptonContextMenuImageSelect item = (KryptonContextMenuImageSelect)sender;
+            var item = sender as KryptonContextMenuImageSelect ?? throw new ArgumentNullException(nameof(sender));
             OutlookGridColumn col = (OutlookGridColumn)_internalColumns.FindFromColumnIndex(_colSelected)!;
             ConditionalFormatting? format = _formatConditions.FirstOrDefault(x => x.ColumnName == col.Name);
             ConditionalFormatting newformat = (item.Tag as List<ConditionalFormatting>)![item.SelectedIndex];
@@ -1108,11 +1108,11 @@ namespace Krypton.Toolkit
                 format.FormatType = newformat.FormatType;
                 format.FormatParams = newformat.FormatParams;
             }
-            ((KryptonContextMenuImageSelect)sender).SelectedIndex = -1; //I'm unable to get only one imageselect checked between solid and gradient, so reset the selected image
+            item.SelectedIndex = -1; //I'm unable to get only one imageselect checked between solid and gradient, so reset the selected image
             Fill();
         }
 
-        private void OnTwoColorsCustomClick(object sender, EventArgs e)
+        private void OnTwoColorsCustomClick(object? sender, EventArgs e)
         {
             if (_rightToLeftLayout == RightToLeftLayout.LeftToRight)
             {
@@ -1161,7 +1161,7 @@ namespace Krypton.Toolkit
         }
 
 
-        private void OnThreeColorsCustomClick(object sender, EventArgs e)
+        private void OnThreeColorsCustomClick(object? sender, EventArgs e)
         {
             if (_rightToLeftLayout == RightToLeftLayout.LeftToRight)
             {
@@ -1209,7 +1209,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnBarCustomClick(object sender, EventArgs e)
+        private void OnBarCustomClick(object? sender, EventArgs e)
         {
             if (_rightToLeftLayout == RightToLeftLayout.LeftToRight)
             {
@@ -1257,7 +1257,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnClearConditionalClick(object sender, EventArgs e)
+        private void OnClearConditionalClick(object? sender, EventArgs e)
         {
             OutlookGridColumn col = (OutlookGridColumn)_internalColumns.FindFromColumnIndex(_colSelected)!;
             _formatConditions.RemoveAll(x => x.ColumnName == col.Name);
@@ -1271,9 +1271,9 @@ namespace Krypton.Toolkit
         }
 
 
-        private void OnColumnVisibleCheckedChanged(object sender, EventArgs e)
+        private void OnColumnVisibleCheckedChanged(object? sender, EventArgs e)
         {
-            KryptonContextMenuCheckBox item = (KryptonContextMenuCheckBox)sender;
+            var item = sender as KryptonContextMenuCheckBox ?? throw new ArgumentNullException(nameof(sender));
             Columns[(int)item.Tag!].Visible = item.Checked;
         }
 
@@ -1282,7 +1282,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void OnShowGroupBox(object sender, EventArgs e)
+        private void OnShowGroupBox(object? sender, EventArgs e)
         {
             if (_groupBox != null)
             {
@@ -1295,7 +1295,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void OnHideGroupBox(object sender, EventArgs e)
+        private void OnHideGroupBox(object? sender, EventArgs e)
         {
             if (_groupBox != null)
             {
@@ -1308,7 +1308,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void OnBestFitColumn(object sender, EventArgs e)
+        private void OnBestFitColumn(object? sender, EventArgs e)
         {
             if (_colSelected > -1)
             {
@@ -1323,7 +1323,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void OnBestFitAllColumns(object sender, EventArgs e)
+        private void OnBestFitAllColumns(object? sender, EventArgs e)
         {
             Cursor.Current = Cursors.WaitCursor;
             AutoResizeColumns(DataGridViewAutoSizeColumnsMode.AllCellsExceptHeader);
@@ -1335,7 +1335,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">A OutlookGridColumnEventArgs that contains the event data.</param>
-        private void ColumnSortChangedEvent(object sender, OutlookGridColumnEventArgs e)
+        private void ColumnSortChangedEvent(object? sender, OutlookGridColumnEventArgs e)
         {
             if (e is null)
             {
@@ -1354,7 +1354,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">A OutlookGridColumnEventArgs that contains the event data.</param>
-        private void ColumnGroupAddedEvent(object sender, OutlookGridColumnEventArgs e)
+        private void ColumnGroupAddedEvent(object? sender, OutlookGridColumnEventArgs e)
         {
             GroupColumn(e.Column.Name!, e.Column.SortDirection, null);
             //We fill again the grid with the new Grouping info
@@ -1369,7 +1369,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">A OutlookGridColumnEventArgs that contains the event data.</param>
-        private void ColumnGroupRemovedEvent(object sender, OutlookGridColumnEventArgs e)
+        private void ColumnGroupRemovedEvent(object? sender, OutlookGridColumnEventArgs e)
         {
             UnGroupColumn(e.Column.Name!);
             //We fill again the grid with the new Grouping info
@@ -1384,7 +1384,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">A EventArgs that contains the event data.</param>
-        private void ClearGroupingEvent(object sender, EventArgs e)
+        private void ClearGroupingEvent(object? sender, EventArgs e)
         {
             ClearGroups();
 #if DEBUG
@@ -1397,7 +1397,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">A EventArgs that contains the event data.</param>
-        private void FullCollapseEvent(object sender, EventArgs e)
+        private void FullCollapseEvent(object? sender, EventArgs e)
         {
             CollapseAll();
 #if DEBUG
@@ -1410,7 +1410,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">A EventArgs that contains the event data.</param>
-        private void FullExpandEvent(object sender, EventArgs e)
+        private void FullExpandEvent(object? sender, EventArgs e)
         {
             ExpandAll();
 #if DEBUG
@@ -1423,7 +1423,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void GridGroupExpandEvent(object sender, OutlookGridColumnEventArgs e)
+        private void GridGroupExpandEvent(object? sender, OutlookGridColumnEventArgs e)
         {
             Expand(e.Column.Name);
 #if DEBUG
@@ -1431,7 +1431,7 @@ namespace Krypton.Toolkit
 #endif
         }
 
-        private void GridGroupCollapseEvent(object sender, OutlookGridColumnEventArgs e)
+        private void GridGroupCollapseEvent(object? sender, OutlookGridColumnEventArgs e)
         {
             Collapse(e.Column.Name);
 #if DEBUG
@@ -1439,7 +1439,7 @@ namespace Krypton.Toolkit
 #endif
         }
 
-        private void ColumnGroupIndexChangedEvent(object sender, OutlookGridColumnEventArgs e)
+        private void ColumnGroupIndexChangedEvent(object? sender, OutlookGridColumnEventArgs e)
         {
             //TODO 25/01/2014
             _internalColumns.ChangeGroupIndex(e.Column);
@@ -1450,7 +1450,7 @@ namespace Krypton.Toolkit
 #endif
         }
 
-        private void GroupIntervalClickEvent(object sender, OutlookGridColumnEventArgs e)
+        private void GroupIntervalClickEvent(object? sender, OutlookGridColumnEventArgs e)
         {
             OutlookGridColumn col = (OutlookGridColumn)_internalColumns.FindFromColumnName(e.Column.Name)!;
             (col.GroupingType as OutlookGridDateTimeGroup)!.Interval =
@@ -1461,7 +1461,7 @@ namespace Krypton.Toolkit
 #endif
         }
 
-        private void SortBySummaryCountEvent(object sender, OutlookGridColumnEventArgs e)
+        private void SortBySummaryCountEvent(object? sender, OutlookGridColumnEventArgs e)
         {
             OutlookGridColumn col = (OutlookGridColumn)_internalColumns.FindFromColumnName(e.Column.Name)!;
             if (col.GroupingType != null)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonOutlookGridGroupBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonOutlookGridGroupBox.cs
@@ -531,7 +531,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">A PaletteLayoutEventArgs that contains the event data.</param>
-        private void OnPalettePaint(object sender, PaletteLayoutEventArgs e)
+        private void OnPalettePaint(object? sender, PaletteLayoutEventArgs e)
         {
             Invalidate();
         }
@@ -541,7 +541,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">A EventArgs that contains the event data.</param>
-        private void OnGlobalPaletteChanged(object sender, EventArgs e)
+        private void OnGlobalPaletteChanged(object? sender, EventArgs e)
         {
             // (5) Unhook events from old palette
             if (_palette != null)
@@ -700,7 +700,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">A EventArgs that contains the event data.</param>
-        private void OnHideGroupBox(object sender, EventArgs e)
+        private void OnHideGroupBox(object? sender, EventArgs e)
         {
             Hide();
         }
@@ -710,7 +710,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">A EventArgs that contains the event data.</param>
-        private void OnClearGrouping(object sender, EventArgs e)
+        private void OnClearGrouping(object? sender, EventArgs e)
         {
             OnClearGrouping(new EventArgs());
             _columnsList.Clear();
@@ -722,7 +722,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">A EventArgs that contains the event data.</param>
-        private void OnFullCollapse(object sender, EventArgs e)
+        private void OnFullCollapse(object? sender, EventArgs e)
         {
             OnFullCollapse(new EventArgs());
         }
@@ -732,7 +732,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">A EventArgs that contains the event data.</param>
-        private void OnFullExpand(object sender, EventArgs e)
+        private void OnFullExpand(object? sender, EventArgs e)
         {
             OnFullExpand(new EventArgs());
         }
@@ -742,7 +742,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">A OutlookGridColumnEventArgs that contains the event data.</param>
-        private void OnGroupCollapse(object sender, EventArgs e)
+        private void OnGroupCollapse(object? sender, EventArgs e)
         {
             OnGroupCollapse(new OutlookGridColumnEventArgs(new OutlookGridColumn(_columnsList[_indexselected]?.ColumnName, null, null, SortOrder.None, -1, -1, null)));
         }
@@ -752,7 +752,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">A OutlookGridColumnEventArgs that contains the event data.</param>
-        private void OnGroupExpand(object sender, EventArgs e)
+        private void OnGroupExpand(object? sender, EventArgs e)
         {
             OnGroupExpand(new OutlookGridColumnEventArgs(new OutlookGridColumn(_columnsList[_indexselected]?.ColumnName, null, null, SortOrder.None, -1, -1, null)));
         }
@@ -762,7 +762,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">A EventArgs that contains the event data.</param>
-        private void OnSortAscending(object sender, EventArgs e)
+        private void OnSortAscending(object? sender, EventArgs e)
         {
             //Change the sortOrder in the list
             OutlookGridGroupBoxColumn? col = _columnsList[_indexselected];
@@ -778,7 +778,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">A EventArgs that contains the event data.</param>
-        private void OnSortDescending(object sender, EventArgs e)
+        private void OnSortDescending(object? sender, EventArgs e)
         {
             //Change the sortOrder in the list
             OutlookGridGroupBoxColumn? col = _columnsList[_indexselected];
@@ -794,7 +794,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">A EventArgs that contains the event data.</param>
-        private void OnUngroup(object sender, EventArgs e)
+        private void OnUngroup(object? sender, EventArgs e)
         {
             OutlookGridGroupBoxColumn? col = _columnsList[_indexselected];
             OnColumnGroupRemoved(new OutlookGridColumnEventArgs(new OutlookGridColumn(col!.ColumnName, null, null, SortOrder.None, -1, -1, null)));
@@ -807,9 +807,9 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">A EventArgs that contains the event data.</param>
-        private void OnGroupIntervalClick(object sender, EventArgs e)
+        private void OnGroupIntervalClick(object? sender, EventArgs e)
         {
-            KryptonContextMenuItem item = (KryptonContextMenuItem)sender;
+            var item = sender as KryptonContextMenuItem ?? throw new ArgumentNullException(nameof(sender));
             OutlookGridGroupBoxColumn? col = _columnsList[_indexselected];
             OutlookGridColumn colEvent = new(col!.ColumnName, null, null, SortOrder.None, -1, -1, null)
                 {
@@ -825,9 +825,9 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">A EventArgs that contains the event data.</param>
-        private void OnSortBySummaryCount(object sender, EventArgs e)
+        private void OnSortBySummaryCount(object? sender, EventArgs e)
         {
-            KryptonContextMenuItem item = (KryptonContextMenuItem)sender;
+            var item = sender as KryptonContextMenuItem ?? throw new ArgumentNullException(nameof(sender));
             OutlookGridGroupBoxColumn? col = _columnsList[_indexselected];
             OutlookGridColumn colEvent = new(col!.ColumnName, null, null, SortOrder.None, -1, -1, null)
                 {
@@ -843,7 +843,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">A DragEventArgs that contains the event data.</param>
-        private void KryptonOutlookGridGroupBox_DragDrop(object sender, DragEventArgs e)
+        private void KryptonOutlookGridGroupBox_DragDrop(object? sender, DragEventArgs e)
         {
             string? columnToMove = e.Data?.GetData(typeof(string)) as string;
             string? columnName;
@@ -901,7 +901,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">A DragEventArgs that contains the event data.</param>
-        private void KryptonOutlookGridGroupBox_DragEnter(object sender, DragEventArgs e)
+        private void KryptonOutlookGridGroupBox_DragEnter(object? sender, DragEventArgs e)
         {
             e.Effect = DragDropEffects.Move;
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonProgressBar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonProgressBar.cs
@@ -738,7 +738,7 @@ namespace Krypton.Toolkit
             return path;
         }
 
-        private void OnGlobalPaletteChanged(object sender, EventArgs e)
+        private void OnGlobalPaletteChanged(object? sender, EventArgs e)
         {
             // Unhook events from old palette
             if (_palette != null)
@@ -773,8 +773,8 @@ namespace Krypton.Toolkit
         }
 
         // Palette indicates we might need to repaint, so lets do it
-        private void OnPalettePaint(object sender, PaletteLayoutEventArgs e) => Invalidate();
-        private void OnLabelTextChanged(object sender, EventArgs e) => OnTextChanged(EventArgs.Empty);
+        private void OnPalettePaint(object? sender, PaletteLayoutEventArgs e) => Invalidate();
+        private void OnLabelTextChanged(object? sender, EventArgs e) => OnTextChanged(EventArgs.Empty);
 
         private void StartMarquee()
         {
@@ -784,7 +784,7 @@ namespace Krypton.Toolkit
             _marqueeTimer.Start();
         }
 
-        private void OnMarqueeTick(object sender, EventArgs e)
+        private void OnMarqueeTick(object? sender, EventArgs e)
         {
             _marqueeLocation++;
             if (_marqueeLocation > Maximum)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPropertyGrid.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPropertyGrid.cs
@@ -364,7 +364,7 @@ namespace Krypton.Toolkit
             // Add tree view to the controls collection
             ((KryptonReadOnlyControls)Controls).AddInternal(_propertyGrid);
         }
-        private void OnPropertyGridClick(object sender, EventArgs e) => OnClick(e);
+        private void OnPropertyGridClick(object? sender, EventArgs e) => OnClick(e);
 
         /// <summary>
         /// Clean up any resources being used.
@@ -961,7 +961,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnPropertyGridGotFocus(object sender, EventArgs e)
+        private void OnPropertyGridGotFocus(object? sender, EventArgs e)
         {
             UpdateStateAndPalettes();
             _propertyGrid.Invalidate();
@@ -969,7 +969,7 @@ namespace Krypton.Toolkit
             OnGotFocus(e);
         }
 
-        private void OnPropertyGridLostFocus(object sender, EventArgs e)
+        private void OnPropertyGridLostFocus(object? sender, EventArgs e)
         {
             UpdateStateAndPalettes();
             _propertyGrid.Invalidate();

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRadioButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRadioButton.cs
@@ -636,7 +636,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnRadioButtonTextChanged(object sender, EventArgs e) => OnTextChanged(EventArgs.Empty);
+        private void OnRadioButtonTextChanged(object? sender, EventArgs e) => OnTextChanged(EventArgs.Empty);
 
         private void AutoUpdateOthers()
         {
@@ -666,7 +666,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnControllerClick(object sender, EventArgs e) => OnClick(e);
+        private void OnControllerClick(object? sender, EventArgs e) => OnClick(e);
 
         private void UpdateForOrientation()
         {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
@@ -2110,7 +2110,7 @@ namespace Krypton.Toolkit
 
         private IPaletteTriple GetTripleState() => Enabled ? (IsActive ? StateActive : StateNormal) : StateDisabled;
 
-        private void OnRichTextBoxMouseChange(object sender, EventArgs e)
+        private void OnRichTextBoxMouseChange(object? sender, EventArgs e)
         {
             // Change in tracking state?
             if (_richTextBox.MouseOver != _trackingMouseEnter)
@@ -2131,9 +2131,9 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnRichTextBoxAcceptsTabChanged(object sender, EventArgs e) => OnAcceptsTabChanged(e);
+        private void OnRichTextBoxAcceptsTabChanged(object? sender, EventArgs e) => OnAcceptsTabChanged(e);
 
-        private void OnRichTextBoxTextChanged(object sender, EventArgs e)
+        private void OnRichTextBoxTextChanged(object? sender, EventArgs e)
         {
             if (!string.IsNullOrWhiteSpace(CueHint.CueHintText)
                 && TextLength <= 1)
@@ -2146,51 +2146,51 @@ namespace Krypton.Toolkit
             OnTextChanged(e);
         }
 
-        private void OnRichTextBoxHideSelectionChanged(object sender, EventArgs e) => OnHideSelectionChanged(e);
+        private void OnRichTextBoxHideSelectionChanged(object? sender, EventArgs e) => OnHideSelectionChanged(e);
 
-        private void OnRichTextBoxModifiedChanged(object sender, EventArgs e) => OnModifiedChanged(e);
+        private void OnRichTextBoxModifiedChanged(object? sender, EventArgs e) => OnModifiedChanged(e);
 
-        private void OnRichTextBoxMultilineChanged(object sender, EventArgs e) => OnMultilineChanged(e);
+        private void OnRichTextBoxMultilineChanged(object? sender, EventArgs e) => OnMultilineChanged(e);
 
-        private void OnRichTextBoxReadOnlyChanged(object sender, EventArgs e) => OnReadOnlyChanged(e);
+        private void OnRichTextBoxReadOnlyChanged(object? sender, EventArgs e) => OnReadOnlyChanged(e);
 
-        private void OnRichTextBoxGotFocus(object sender, EventArgs e)
+        private void OnRichTextBoxGotFocus(object? sender, EventArgs e)
         {
             UpdateStateAndPalettes();
             PerformNeedPaint(true);
             OnGotFocus(e);
         }
 
-        private void OnRichTextBoxLostFocus(object sender, EventArgs e)
+        private void OnRichTextBoxLostFocus(object? sender, EventArgs e)
         {
             UpdateStateAndPalettes();
             PerformNeedPaint(true);
             OnLostFocus(e);
         }
 
-        private void OnRichTextBoxKeyPress(object sender, KeyPressEventArgs e) => OnKeyPress(e);
+        private void OnRichTextBoxKeyPress(object? sender, KeyPressEventArgs e) => OnKeyPress(e);
 
-        private void OnRichTextBoxKeyUp(object sender, KeyEventArgs e) => OnKeyUp(e);
+        private void OnRichTextBoxKeyUp(object? sender, KeyEventArgs e) => OnKeyUp(e);
 
-        private void OnRichTextBoxKeyDown(object sender, KeyEventArgs e) => OnKeyDown(e);
+        private void OnRichTextBoxKeyDown(object? sender, KeyEventArgs e) => OnKeyDown(e);
 
-        private void OnRichTextBoxPreviewKeyDown(object sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
+        private void OnRichTextBoxPreviewKeyDown(object? sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
 
-        private void OnRichTextBoxVScroll(object sender, EventArgs e) => OnVScroll(e);
+        private void OnRichTextBoxVScroll(object? sender, EventArgs e) => OnVScroll(e);
 
-        private void OnRichTextBoxHScroll(object sender, EventArgs e) => OnHScroll(e);
+        private void OnRichTextBoxHScroll(object? sender, EventArgs e) => OnHScroll(e);
 
-        private void OnRichTextBoxSelectionChanged(object sender, EventArgs e) => OnSelectionChanged(e);
+        private void OnRichTextBoxSelectionChanged(object? sender, EventArgs e) => OnSelectionChanged(e);
 
-        private void OnRichTextBoxProtected(object sender, EventArgs e) => OnProtected(e);
+        private void OnRichTextBoxProtected(object? sender, EventArgs e) => OnProtected(e);
 
-        private void OnRichTextBoxLinkClicked(object sender, LinkClickedEventArgs e) => OnLinkClicked(e);
+        private void OnRichTextBoxLinkClicked(object? sender, LinkClickedEventArgs e) => OnLinkClicked(e);
 
-        private void OnRichTextBoxValidated(object sender, EventArgs e) => OnValidated(e);
+        private void OnRichTextBoxValidated(object? sender, EventArgs e) => OnValidated(e);
 
-        private void OnRichTextBoxValidating(object sender, CancelEventArgs e) => OnValidating(e);
+        private void OnRichTextBoxValidating(object? sender, CancelEventArgs e) => OnValidating(e);
 
-        private void OnShowToolTip(object sender, ToolTipEventArgs e)
+        private void OnShowToolTip(object? sender, ToolTipEventArgs e)
         {
             if (!IsDisposed && !Disposing)
             {
@@ -2257,14 +2257,14 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnCancelToolTip(object sender, EventArgs e) =>
+        private void OnCancelToolTip(object? sender, EventArgs e) =>
             // Remove any currently showing tooltip
             _visualPopupToolTip?.Dispose();
 
-        private void OnVisualPopupToolTipDisposed(object sender, EventArgs e)
+        private void OnVisualPopupToolTipDisposed(object? sender, EventArgs e)
         {
             // Unhook events from the specific instance that generated event
-            var popupToolTip = (VisualPopupToolTip)sender;
+            var popupToolTip = sender as VisualPopupToolTip ?? throw new ArgumentNullException(nameof(sender));
             popupToolTip.Disposed -= OnVisualPopupToolTipDisposed;
 
             // Not showing a popup page any more

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonScrollBar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonScrollBar.cs
@@ -111,12 +111,14 @@ namespace Krypton.Toolkit
         /// <value>The width of the scroll bar.</value>
         public int ScrollBarWidth
         {
-            get => Width; set => Width = value;
+            get => Width; 
+            set => Width = value;
         }
 
         /// <inheritdoc />
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [AllowNull]
         public override string Text { get; set; }
 
         #endregion
@@ -1166,7 +1168,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">The sender.</param>
         /// <param name="e">An object that contains the event data.</param>
-        private void ProgressTimerTick(object sender, EventArgs e) => ProgressThumb(true);
+        private void ProgressTimerTick(object? sender, EventArgs e) => ProgressThumb(true);
 
         /// <summary>
         /// Resets the scroll status of the scrollbar.
@@ -1443,7 +1445,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnGlobalPaletteChanged(object sender, EventArgs e)
+        private void OnGlobalPaletteChanged(object? sender, EventArgs e)
         {
             if (_palette != null)
             {
@@ -1465,7 +1467,7 @@ namespace Krypton.Toolkit
             Invalidate();
         }
 
-        private void OnPalettePaint(object sender, PaletteLayoutEventArgs e) => Invalidate();
+        private void OnPalettePaint(object? sender, PaletteLayoutEventArgs e) => Invalidate();
 
         #endregion
 
@@ -1586,7 +1588,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">The sender.</param>
         /// <param name="e">The event arguments.</param>
-        private void ScrollHereClick(object sender, EventArgs e)
+        private void ScrollHereClick(object? sender, EventArgs e)
         {
             int thumbSize, thumbPos, arrowSize, size;
 
@@ -1633,42 +1635,42 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">The sender.</param>
         /// <param name="e">The event arguments.</param>
-        private void TopClick(object sender, EventArgs e) => Value = _minimum;
+        private void TopClick(object? sender, EventArgs e) => Value = _minimum;
 
         /// <summary>
         /// Context menu handler.
         /// </summary>
         /// <param name="sender">The sender.</param>
         /// <param name="e">The event arguments.</param>
-        private void BottomClick(object sender, EventArgs e) => Value = _maximum;
+        private void BottomClick(object? sender, EventArgs e) => Value = _maximum;
 
         /// <summary>
         /// Context menu handler.
         /// </summary>
         /// <param name="sender">The sender.</param>
         /// <param name="e">The event arguments.</param>
-        private void LargeUpClick(object sender, EventArgs e) => Value = GetValue(false, true);
+        private void LargeUpClick(object? sender, EventArgs e) => Value = GetValue(false, true);
 
         /// <summary>
         /// Context menu handler.
         /// </summary>
         /// <param name="sender">The sender.</param>
         /// <param name="e">The event arguments.</param>
-        private void LargeDownClick(object sender, EventArgs e) => Value = GetValue(false, false);
+        private void LargeDownClick(object? sender, EventArgs e) => Value = GetValue(false, false);
 
         /// <summary>
         /// Context menu handler.
         /// </summary>
         /// <param name="sender">The sender.</param>
         /// <param name="e">The event arguments.</param>
-        private void SmallUpClick(object sender, EventArgs e) => Value = GetValue(true, true);
+        private void SmallUpClick(object? sender, EventArgs e) => Value = GetValue(true, true);
 
         /// <summary>
         /// Context menu handler.
         /// </summary>
         /// <param name="sender">The sender.</param>
         /// <param name="e">The event arguments.</param>
-        private void SmallDownClick(object sender, EventArgs e) => Value = GetValue(true, false);
+        private void SmallDownClick(object? sender, EventArgs e) => Value = GetValue(true, false);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonSeparator.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonSeparator.cs
@@ -713,7 +713,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnRedrawTick(object sender, EventArgs e)
+        private void OnRedrawTick(object? sender, EventArgs e)
         {
             _redrawTimer?.Stop();
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTableLayoutPanel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTableLayoutPanel.cs
@@ -46,7 +46,7 @@ namespace Krypton.Toolkit
             base.BackgroundImageLayout = ImageLayout.None;
         }
 
-        private void State_PropertyChanged(object sender, PropertyChangedEventArgs e) =>
+        private void State_PropertyChanged(object? sender, PropertyChangedEventArgs e) =>
             // Handle explicit settings to the controls
             BackGroundPanel_Refreshed();
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
@@ -1844,47 +1844,47 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnTextBoxAcceptsTabChanged(object sender, EventArgs e) => OnAcceptsTabChanged(e);
+        private void OnTextBoxAcceptsTabChanged(object? sender, EventArgs e) => OnAcceptsTabChanged(e);
 
-        private void OnTextBoxTextChanged(object sender, EventArgs e) => OnTextChanged(e);
+        private void OnTextBoxTextChanged(object? sender, EventArgs e) => OnTextChanged(e);
 
-        private void OnTextBoxTextAlignChanged(object sender, EventArgs e) => OnTextAlignChanged(e);
+        private void OnTextBoxTextAlignChanged(object? sender, EventArgs e) => OnTextAlignChanged(e);
 
-        private void OnTextBoxHideSelectionChanged(object sender, EventArgs e) => OnHideSelectionChanged(e);
+        private void OnTextBoxHideSelectionChanged(object? sender, EventArgs e) => OnHideSelectionChanged(e);
 
-        private void OnTextBoxModifiedChanged(object sender, EventArgs e) => OnModifiedChanged(e);
+        private void OnTextBoxModifiedChanged(object? sender, EventArgs e) => OnModifiedChanged(e);
 
-        private void OnTextBoxMultilineChanged(object sender, EventArgs e) => OnMultilineChanged(e);
+        private void OnTextBoxMultilineChanged(object? sender, EventArgs e) => OnMultilineChanged(e);
 
-        private void OnTextBoxReadOnlyChanged(object sender, EventArgs e) => OnReadOnlyChanged(e);
+        private void OnTextBoxReadOnlyChanged(object? sender, EventArgs e) => OnReadOnlyChanged(e);
 
-        private void OnTextBoxGotFocus(object sender, EventArgs e)
+        private void OnTextBoxGotFocus(object? sender, EventArgs e)
         {
             UpdateStateAndPalettes();
             PerformNeedPaint(true);
             OnGotFocus(e);
         }
 
-        private void OnTextBoxLostFocus(object sender, EventArgs e)
+        private void OnTextBoxLostFocus(object? sender, EventArgs e)
         {
             UpdateStateAndPalettes();
             PerformNeedPaint(true);
             OnLostFocus(e);
         }
 
-        private void OnTextBoxKeyPress(object sender, KeyPressEventArgs e) => OnKeyPress(e);
+        private void OnTextBoxKeyPress(object? sender, KeyPressEventArgs e) => OnKeyPress(e);
 
-        private void OnTextBoxKeyUp(object sender, KeyEventArgs e) => OnKeyUp(e);
+        private void OnTextBoxKeyUp(object? sender, KeyEventArgs e) => OnKeyUp(e);
 
-        private void OnTextBoxKeyDown(object sender, KeyEventArgs e) => OnKeyDown(e);
+        private void OnTextBoxKeyDown(object? sender, KeyEventArgs e) => OnKeyDown(e);
 
-        private void OnTextBoxPreviewKeyDown(object sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
+        private void OnTextBoxPreviewKeyDown(object? sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
 
-        private void OnTextBoxValidated(object sender, EventArgs e) => OnValidated(e);
+        private void OnTextBoxValidated(object? sender, EventArgs e) => OnValidated(e);
 
-        private void OnTextBoxValidating(object sender, CancelEventArgs e) => OnValidating(e);
+        private void OnTextBoxValidating(object? sender, CancelEventArgs e) => OnValidating(e);
 
-        private void OnShowToolTip(object sender, ToolTipEventArgs e)
+        private void OnShowToolTip(object? sender, ToolTipEventArgs e)
         {
             if (!IsDisposed && !Disposing)
             {
@@ -1958,19 +1958,19 @@ namespace Krypton.Toolkit
         }
 
         // Remove any currently showing tooltip
-        private void OnCancelToolTip(object sender, EventArgs e) => _visualPopupToolTip?.Dispose();
+        private void OnCancelToolTip(object? sender, EventArgs e) => _visualPopupToolTip?.Dispose();
 
-        private void OnVisualPopupToolTipDisposed(object sender, EventArgs e)
+        private void OnVisualPopupToolTipDisposed(object? sender, EventArgs e)
         {
             // Unhook events from the specific instance that generated event
-            var popupToolTip = (VisualPopupToolTip)sender;
+            var popupToolTip = sender as VisualPopupToolTip ?? throw new ArgumentNullException(nameof(sender));
             popupToolTip.Disposed -= OnVisualPopupToolTipDisposed;
 
             // Not showing a popup page any more
             _visualPopupToolTip = null;
         }
 
-        private void OnTextBoxMouseChange(object sender, EventArgs e)
+        private void OnTextBoxMouseChange(object? sender, EventArgs e)
         {
             // Change in tracking state?
             if (_textBox.MouseOver != _trackingMouseEnter)
@@ -1991,13 +1991,13 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnEditorButtonClicked(object sender, EventArgs e) => new MultilineStringEditor1(this).ShowEditor();
+        private void OnEditorButtonClicked(object? sender, EventArgs e) => new MultilineStringEditor1(this).ShowEditor();
 
-        private void OnMouseDoubleClick(object sender, MouseEventArgs e) => base.OnMouseDoubleClick(e);
+        private void OnMouseDoubleClick(object? sender, MouseEventArgs e) => base.OnMouseDoubleClick(e);
 
-        private void OnDoubleClick(object sender, EventArgs e) => base.OnDoubleClick(e);
+        private void OnDoubleClick(object? sender, EventArgs e) => base.OnDoubleClick(e);
 
-        private void OnTextBoxClick(object sender, EventArgs e) =>
+        private void OnTextBoxClick(object? sender, EventArgs e) =>
             // ReSharper disable RedundantBaseQualifier
             base.OnClick(e);
         // ReSharper restore RedundantBaseQualifier

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
@@ -88,7 +88,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Object that intiated the call.</param>
         /// <param name="e">Eventargs object data (not used).</param>
-        private void KryptonManagerGlobalPaletteChanged(object sender, EventArgs e)
+        private void KryptonManagerGlobalPaletteChanged(object? sender, EventArgs e)
         {
             SelectedIndex = CommonHelperThemeSelectors.KryptonManagerGlobalPaletteChanged(_isLocalUpdate, ref _isExternalUpdate, SelectedIndex, Items);
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeListBox.cs
@@ -89,7 +89,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Object that intiated the call.</param>
         /// <param name="e">Eventargs object data (not used).</param>
-        private void KryptonManagerGlobalPaletteChanged(object sender, EventArgs e)
+        private void KryptonManagerGlobalPaletteChanged(object? sender, EventArgs e)
         {
             SelectedIndex = CommonHelperThemeSelectors.KryptonManagerGlobalPaletteChanged(_isLocalUpdate, ref _isExternalUpdate, SelectedIndex, Items);
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTrackBar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTrackBar.cs
@@ -743,9 +743,9 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnDrawValueChanged(object sender, EventArgs e) => OnValueChanged(e);
+        private void OnDrawValueChanged(object? sender, EventArgs e) => OnValueChanged(e);
 
-        private void OnDrawScroll(object sender, EventArgs e) => OnScroll(e);
+        private void OnDrawScroll(object? sender, EventArgs e) => OnScroll(e);
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
@@ -665,7 +665,7 @@ namespace Krypton.Toolkit
             ((KryptonReadOnlyControls)Controls).AddInternal(_treeView);
         }
 
-        private void OnTreeClick(object sender, EventArgs e) => OnClick(e);
+        private void OnTreeClick(object? sender, EventArgs e) => OnClick(e);
 
         /// <summary>
         /// Releases all resources used by the Control. 
@@ -1698,7 +1698,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
-        protected override void OnPaletteNeedPaint(object sender, NeedLayoutEventArgs e)
+        protected override void OnPaletteNeedPaint(object? sender, NeedLayoutEventArgs e)
         {
             UpdateItemHeight();
             base.OnPaletteChanged(e);
@@ -2025,7 +2025,7 @@ namespace Krypton.Toolkit
             return depth * _treeView.Indent;
         }
 
-        private void OnTreeViewDrawNode(object sender, DrawTreeNodeEventArgs e)
+        private void OnTreeViewDrawNode(object? sender, DrawTreeNodeEventArgs e)
         {
             // We cannot do anything without a valid node
             if (e.Node == null)
@@ -2369,7 +2369,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnTreeViewGotFocus(object sender, EventArgs e)
+        private void OnTreeViewGotFocus(object? sender, EventArgs e)
         {
             UpdateStateAndPalettes();
             _treeView.Invalidate();
@@ -2377,7 +2377,7 @@ namespace Krypton.Toolkit
             OnGotFocus(e);
         }
 
-        private void OnTreeViewLostFocus(object sender, EventArgs e)
+        private void OnTreeViewLostFocus(object? sender, EventArgs e)
         {
             UpdateStateAndPalettes();
             _treeView.Invalidate();
@@ -2385,47 +2385,47 @@ namespace Krypton.Toolkit
             OnLostFocus(e);
         }
 
-        private void OnTreeViewKeyPress(object sender, KeyPressEventArgs e) => OnKeyPress(e);
+        private void OnTreeViewKeyPress(object? sender, KeyPressEventArgs e) => OnKeyPress(e);
 
-        private void OnTreeViewKeyUp(object sender, KeyEventArgs e) => OnKeyUp(e);
+        private void OnTreeViewKeyUp(object? sender, KeyEventArgs e) => OnKeyUp(e);
 
-        private void OnTreeViewKeyDown(object sender, KeyEventArgs e) => OnKeyDown(e);
+        private void OnTreeViewKeyDown(object? sender, KeyEventArgs e) => OnKeyDown(e);
 
-        private void OnTreeViewPreviewKeyDown(object sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
+        private void OnTreeViewPreviewKeyDown(object? sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
 
-        private void OnTreeViewValidated(object sender, EventArgs e) => OnValidated(e);
+        private void OnTreeViewValidated(object? sender, EventArgs e) => OnValidated(e);
 
-        private void OnTreeViewValidating(object sender, CancelEventArgs e) => OnValidating(e);
+        private void OnTreeViewValidating(object? sender, CancelEventArgs e) => OnValidating(e);
 
-        private void OnTreeViewNodeMouseHover(object sender, TreeNodeMouseHoverEventArgs e) => OnNodeMouseHover(e);
+        private void OnTreeViewNodeMouseHover(object? sender, TreeNodeMouseHoverEventArgs e) => OnNodeMouseHover(e);
 
-        private void OnTreeViewNodeMouseDoubleClick(object sender, TreeNodeMouseClickEventArgs e) => OnNodeMouseDoubleClick(e);
+        private void OnTreeViewNodeMouseDoubleClick(object? sender, TreeNodeMouseClickEventArgs e) => OnNodeMouseDoubleClick(e);
 
-        private void OnTreeViewNodeMouseClick(object sender, TreeNodeMouseClickEventArgs e) => OnNodeMouseClick(e);
+        private void OnTreeViewNodeMouseClick(object? sender, TreeNodeMouseClickEventArgs e) => OnNodeMouseClick(e);
 
-        private void OnTreeViewItemDrag(object sender, ItemDragEventArgs e) => OnItemDrag(e);
+        private void OnTreeViewItemDrag(object? sender, ItemDragEventArgs e) => OnItemDrag(e);
 
-        private void OnTreeViewBeforeSelect(object sender, TreeViewCancelEventArgs e) => OnBeforeSelect(e);
+        private void OnTreeViewBeforeSelect(object? sender, TreeViewCancelEventArgs e) => OnBeforeSelect(e);
 
-        private void OnTreeViewBeforeLabelEdit(object sender, NodeLabelEditEventArgs e) => OnBeforeLabelEdit(e);
+        private void OnTreeViewBeforeLabelEdit(object? sender, NodeLabelEditEventArgs e) => OnBeforeLabelEdit(e);
 
-        private void OnTreeViewBeforeExpand(object sender, TreeViewCancelEventArgs e) => OnBeforeExpand(e);
+        private void OnTreeViewBeforeExpand(object? sender, TreeViewCancelEventArgs e) => OnBeforeExpand(e);
 
-        private void OnTreeViewBeforeCollapse(object sender, TreeViewCancelEventArgs e) => OnBeforeCollapse(e);
+        private void OnTreeViewBeforeCollapse(object? sender, TreeViewCancelEventArgs e) => OnBeforeCollapse(e);
 
-        private void OnTreeViewBeforeCheck(object sender, TreeViewCancelEventArgs e) => OnBeforeCheck(e);
+        private void OnTreeViewBeforeCheck(object? sender, TreeViewCancelEventArgs e) => OnBeforeCheck(e);
 
-        private void OnTreeViewAfterSelect(object sender, TreeViewEventArgs e) => OnAfterSelect(e);
+        private void OnTreeViewAfterSelect(object? sender, TreeViewEventArgs e) => OnAfterSelect(e);
 
-        private void OnTreeViewAfterLabelEdit(object sender, NodeLabelEditEventArgs e) => OnAfterLabelEdit(e);
+        private void OnTreeViewAfterLabelEdit(object? sender, NodeLabelEditEventArgs e) => OnAfterLabelEdit(e);
 
-        private void OnTreeViewAfterExpand(object sender, TreeViewEventArgs e) => OnAfterExpand(e);
+        private void OnTreeViewAfterExpand(object? sender, TreeViewEventArgs e) => OnAfterExpand(e);
 
-        private void OnTreeViewAfterCollapse(object sender, TreeViewEventArgs e) => OnAfterCollapse(e);
+        private void OnTreeViewAfterCollapse(object? sender, TreeViewEventArgs e) => OnAfterCollapse(e);
 
-        private void OnTreeViewAfterCheck(object sender, TreeViewEventArgs e) => OnAfterCheck(e);
+        private void OnTreeViewAfterCheck(object? sender, TreeViewEventArgs e) => OnAfterCheck(e);
 
-        private void OnTreeViewMouseChange(object sender, EventArgs e)
+        private void OnTreeViewMouseChange(object? sender, EventArgs e)
         {
             // Change in tracking state?
             if (_treeView.MouseOver != _trackingMouseEnter)
@@ -2446,9 +2446,9 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnDoubleClick(object sender, EventArgs e) => base.OnDoubleClick(e);
+        private void OnDoubleClick(object? sender, EventArgs e) => base.OnDoubleClick(e);
 
-        private void OnMouseDoubleClick(object sender, MouseEventArgs e) => base.OnMouseDoubleClick(e);
+        private void OnMouseDoubleClick(object? sender, MouseEventArgs e) => base.OnMouseDoubleClick(e);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonWebBrowser.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonWebBrowser.cs
@@ -125,7 +125,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnContextMenuStripOpening(object sender, CancelEventArgs e)
+        private void OnContextMenuStripOpening(object? sender, CancelEventArgs e)
         {
             // Get the actual strip instance
             ContextMenuStrip? cms = base.ContextMenuStrip;
@@ -185,7 +185,7 @@ namespace Krypton.Toolkit
         }
 
 
-        private void OnKryptonContextMenuDisposed(object sender, EventArgs e) =>
+        private void OnKryptonContextMenuDisposed(object? sender, EventArgs e) =>
             // When the current krypton context menu is disposed, we should remove 
             // it to prevent it being used again, as that would just throw an exception 
             // because it has been disposed.
@@ -226,7 +226,7 @@ namespace Krypton.Toolkit
         /// <summary>Called when there is a change in base renderer or base palette.</summary>
         /// <param name="sender">The sender.</param>
         /// <param name="e">The <see cref="EventArgs" /> instance containing the event data.</param>
-        private void OnBaseChanged(object sender, EventArgs e) =>
+        private void OnBaseChanged(object? sender, EventArgs e) =>
             // Change in base renderer or base palette require we fetch the latest renderer
             _renderer = _palette.GetRenderer();
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonWrapLabel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonWrapLabel.cs
@@ -812,15 +812,15 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnPaletteNeedPaint(object sender, NeedLayoutEventArgs e) => NeedPaint(e);
+        private void OnPaletteNeedPaint(object? sender, NeedLayoutEventArgs e) => NeedPaint(e);
 
         // Change in base renderer or base palette require we fetch the latest renderer
-        private void OnBaseChanged(object sender, EventArgs e) => Renderer = _palette?.GetRenderer()!;
+        private void OnBaseChanged(object? sender, EventArgs e) => Renderer = _palette?.GetRenderer()!;
 
         /// <summary>Called when [global palette changed].</summary>
         /// <param name="sender">The sender.</param>
         /// <param name="e">The <see cref="EventArgs" /> instance containing the event data.</param>
-        private void OnGlobalPaletteChanged(object sender, EventArgs e)
+        private void OnGlobalPaletteChanged(object? sender, EventArgs e)
         {
             // We only care if we are using the global palette
             if (PaletteMode == PaletteMode.Global)
@@ -854,13 +854,13 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnKryptonContextMenuDisposed(object sender, EventArgs e) =>
+        private void OnKryptonContextMenuDisposed(object? sender, EventArgs e) =>
             // When the current krypton context menu is disposed, we should remove 
             // it to prevent it being used again, as that would just throw an exception 
             // because it has been disposed.
             KryptonContextMenu = null;
 
-        private void OnContextMenuClosed(object sender, ToolStripDropDownClosedEventArgs e) => ContextMenuClosed();
+        private void OnContextMenuClosed(object? sender, ToolStripDropDownClosedEventArgs e) => ContextMenuClosed();
 
         private void NeedPaint(bool layout) => NeedPaint(new NeedLayoutEventArgs(layout));
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/CommonDialogHandler.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/CommonDialogHandler.cs
@@ -475,7 +475,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnResizeTimedEvent(object sender, ElapsedEventArgs e)
+        private void OnResizeTimedEvent(object? sender, ElapsedEventArgs e)
         {
             _resizeTimer.Dispose();
             if (_wrapperForm != null)
@@ -491,7 +491,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void FormResize(object sender, EventArgs e)
+        private void FormResize(object? sender, EventArgs e)
         {
             if (_resizeHandle != IntPtr.Zero)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/Basic/LTR/VisualToastNotificationBasicForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/Basic/LTR/VisualToastNotificationBasicForm.cs
@@ -234,7 +234,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void VisualToastNotificationBasicForm_Resize(object sender, EventArgs e)
+        private void VisualToastNotificationBasicForm_Resize(object? sender, EventArgs e)
         {
             WindowState = WindowState switch
             {
@@ -243,9 +243,9 @@ namespace Krypton.Toolkit
             };
         }
 
-        private void VisualToastNotificationBasicForm_GotFocus(object sender, EventArgs e) => kbtnDismiss.Focus();
+        private void VisualToastNotificationBasicForm_GotFocus(object? sender, EventArgs e) => kbtnDismiss.Focus();
 
-        private void VisualToastNotificationBasicForm_LocationChanged(object sender, EventArgs e)
+        private void VisualToastNotificationBasicForm_LocationChanged(object? sender, EventArgs e)
         {
             if (_basicToastNotificationData.ReportToastLocation)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/Basic/LTR/VisualToastNotificationBasicWithProgressBarForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/Basic/LTR/VisualToastNotificationBasicWithProgressBarForm.cs
@@ -215,7 +215,7 @@ namespace Krypton.Toolkit
             itbDismiss.Text = KryptonManager.Strings.ToastNotificationStrings.Dismiss;
         }
 
-        private void VisualToastNotificationBasicWithProgressBarForm_Resize(object sender, EventArgs e)
+        private void VisualToastNotificationBasicWithProgressBarForm_Resize(object? sender, EventArgs e)
         {
             if (WindowState == FormWindowState.Maximized)
             {
@@ -223,12 +223,12 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void VisualToastNotificationBasicWithProgressBarForm_GotFocus(object sender, EventArgs e)
+        private void VisualToastNotificationBasicWithProgressBarForm_GotFocus(object? sender, EventArgs e)
         {
             kbtnDismiss.Focus();
         }
 
-        private void VisualToastNotificationBasicWithProgressBarForm_LocationChanged(object sender, EventArgs e)
+        private void VisualToastNotificationBasicWithProgressBarForm_LocationChanged(object? sender, EventArgs e)
         {
             if (_basicToastNotificationData.ReportToastLocation)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/Basic/RTL/VisualToastNotificationBasicRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/Basic/RTL/VisualToastNotificationBasicRtlAwareForm.cs
@@ -203,7 +203,7 @@ namespace Krypton.Toolkit
             ControlBox = _basicToastNotificationData.ShowCloseBox ?? false;
         }
 
-        private void VisualToastNotificationBasicRtlAwareForm_LocationChanged(object sender, EventArgs e)
+        private void VisualToastNotificationBasicRtlAwareForm_LocationChanged(object? sender, EventArgs e)
         {
             if (_basicToastNotificationData.ReportToastLocation)
             {
@@ -211,7 +211,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void VisualToastNotificationBasicRtlAwareForm_Resize(object sender, EventArgs e)
+        private void VisualToastNotificationBasicRtlAwareForm_Resize(object? sender, EventArgs e)
         {
             if (WindowState == FormWindowState.Maximized)
             {
@@ -219,7 +219,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void VisualToastNotificationBasicRtlAwareForm_GotFocus(object sender, EventArgs e)
+        private void VisualToastNotificationBasicRtlAwareForm_GotFocus(object? sender, EventArgs e)
         {
             kbtnDismiss.Focus();
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/Basic/RTL/VisualToastNotificationBasicWithProgressBarRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/Basic/RTL/VisualToastNotificationBasicWithProgressBarRtlAwareForm.cs
@@ -211,7 +211,7 @@ namespace Krypton.Toolkit
             ControlBox = _basicToastNotificationData.ShowCloseBox ?? false;
         }
 
-        private void VisualToastNotificationBasicWithProgressBarRtlAwareForm_Resize(object sender, EventArgs e)
+        private void VisualToastNotificationBasicWithProgressBarRtlAwareForm_Resize(object? sender, EventArgs e)
         {
             if (WindowState == FormWindowState.Maximized)
             {
@@ -219,7 +219,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void VisualToastNotificationBasicWithProgressBarRtlAwareForm_LocationChanged(object sender, EventArgs e)
+        private void VisualToastNotificationBasicWithProgressBarRtlAwareForm_LocationChanged(object? sender, EventArgs e)
         {
             if (_basicToastNotificationData.ReportToastLocation)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationComboBoxUserInputWithProgressBarForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationComboBoxUserInputWithProgressBarForm.cs
@@ -188,7 +188,7 @@ namespace Krypton.Toolkit
             ControlBox = _data.ShowCloseBox ?? false;
         }
 
-        private void VisualToastNotificationComboBoxUserInputWithProgressBarForm_Resize(object sender, EventArgs e)
+        private void VisualToastNotificationComboBoxUserInputWithProgressBarForm_Resize(object? sender, EventArgs e)
         {
             if (WindowState == FormWindowState.Maximized)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationDateTimeUserInputWithProgressBarForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationDateTimeUserInputWithProgressBarForm.cs
@@ -178,7 +178,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void VisualToastNotificationDateTimeUserInputWithProgressBarForm_Resize(object sender, EventArgs e)
+        private void VisualToastNotificationDateTimeUserInputWithProgressBarForm_Resize(object? sender, EventArgs e)
         {
             if (WindowState == FormWindowState.Maximized)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationDomianUpDownInputWithProgressBarForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationDomianUpDownInputWithProgressBarForm.cs
@@ -178,7 +178,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void VisualToastNotificationDomianUpDownInputWithProgressBarForm_Resize(object sender, EventArgs e)
+        private void VisualToastNotificationDomianUpDownInputWithProgressBarForm_Resize(object? sender, EventArgs e)
         {
             if (WindowState == FormWindowState.Maximized)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationMaskedTextBoxInputWithProgressBarForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationMaskedTextBoxInputWithProgressBarForm.cs
@@ -170,7 +170,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void VisualToastNotificationMaskedTextBoxInputWithProgressBarForm_Resize(object sender, EventArgs e)
+        private void VisualToastNotificationMaskedTextBoxInputWithProgressBarForm_Resize(object? sender, EventArgs e)
         {
             if (WindowState == FormWindowState.Maximized)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationNUDUserInputWithProgressBarForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationNUDUserInputWithProgressBarForm.cs
@@ -174,7 +174,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void VisualToastNotificationNumericUpDownUserInputWithProgressBarForm_Resize(object sender, EventArgs e)
+        private void VisualToastNotificationNumericUpDownUserInputWithProgressBarForm_Resize(object? sender, EventArgs e)
         {
             if (WindowState == FormWindowState.Maximized)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationTextBoxUserInputWithProgressBarForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationTextBoxUserInputWithProgressBarForm.cs
@@ -175,7 +175,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void VisualToastNotificationTextBoxUserInputWithProgressBarForm_Resize(object sender, EventArgs e)
+        private void VisualToastNotificationTextBoxUserInputWithProgressBarForm_Resize(object? sender, EventArgs e)
         {
             if (WindowState == FormWindowState.Maximized)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationDateTimeUserInputRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationDateTimeUserInputRtlAwareForm.cs
@@ -206,7 +206,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void VisualToastNotificationDateTimeUserInputRtlAwareForm_Resize(object sender, EventArgs e)
+        private void VisualToastNotificationDateTimeUserInputRtlAwareForm_Resize(object? sender, EventArgs e)
         {
             if (WindowState == FormWindowState.Maximized)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationDomainUpDownUserInputRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationDomainUpDownUserInputRtlAwareForm.cs
@@ -189,7 +189,7 @@ namespace Krypton.Toolkit
 
         private void itbDismiss_Click(object sender, EventArgs e) => Close();
 
-        private void OnResize(object sender, EventArgs e)
+        private void OnResize(object? sender, EventArgs e)
         {
             if (WindowState == FormWindowState.Maximized)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationMaskedTextBoxUserInputRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationMaskedTextBoxUserInputRtlAwareForm.cs
@@ -197,7 +197,7 @@ namespace Krypton.Toolkit
 
         }
 
-        private void OnResize(object sender, EventArgs e)
+        private void OnResize(object? sender, EventArgs e)
         {
             if (WindowState == FormWindowState.Maximized)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationNUDUserInputRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationNUDUserInputRtlAwareForm.cs
@@ -201,7 +201,7 @@ namespace Krypton.Toolkit
 
         }
 
-        private void OnResize(object sender, EventArgs e)
+        private void OnResize(object? sender, EventArgs e)
         {
             if (WindowState == FormWindowState.Maximized)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationTextBoxUserInputRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationTextBoxUserInputRtlAwareForm.cs
@@ -216,7 +216,7 @@ namespace Krypton.Toolkit
 
         }
 
-        private void OnResize(object sender, EventArgs e)
+        private void OnResize(object? sender, EventArgs e)
         {
             if (WindowState == FormWindowState.Maximized)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationComboBoxUserInputWithProgressBarRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationComboBoxUserInputWithProgressBarRtlAwareForm.cs
@@ -212,7 +212,7 @@ namespace Krypton.Toolkit
 
         }
 
-        private void VisualToastNotificationComboBoxUserInputWithProgressBarRtlAwareForm_Resize(object sender, EventArgs e)
+        private void VisualToastNotificationComboBoxUserInputWithProgressBarRtlAwareForm_Resize(object? sender, EventArgs e)
         {
             if (WindowState == FormWindowState.Maximized)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationDateTimeUserInputWithProgressBarRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationDateTimeUserInputWithProgressBarRtlAwareForm.cs
@@ -189,7 +189,7 @@ namespace Krypton.Toolkit
 
         private void itbDismiss_Click(object sender, EventArgs e) => Close();
 
-        private void VisualToastNotificationDateTimeUserInputWithProgressBarRtlAwareForm_Resize(object sender, EventArgs e)
+        private void VisualToastNotificationDateTimeUserInputWithProgressBarRtlAwareForm_Resize(object? sender, EventArgs e)
         {
             if (WindowState == FormWindowState.Maximized)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationDomainUpDownInputWithProgressBarRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationDomainUpDownInputWithProgressBarRtlAwareForm.cs
@@ -189,7 +189,7 @@ namespace Krypton.Toolkit
 
         private void itbDismiss_Click(object sender, EventArgs e) => Close();
 
-        private void VisualToastNotificationDomainUpDownInputWithProgressBarRtlAwareForm_Resize(object sender, EventArgs e)
+        private void VisualToastNotificationDomainUpDownInputWithProgressBarRtlAwareForm_Resize(object? sender, EventArgs e)
         {
             if (WindowState == FormWindowState.Maximized)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationMaskedTextBoxInputWithProgressBarRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationMaskedTextBoxInputWithProgressBarRtlAwareForm.cs
@@ -181,7 +181,7 @@ namespace Krypton.Toolkit
 
         private void itbDismiss_Click(object sender, EventArgs e) => Close();
 
-        private void VisualToastNotificationMaskedTextBoxInputWithProgressBarRtlAwareForm_Resize(object sender, EventArgs e)
+        private void VisualToastNotificationMaskedTextBoxInputWithProgressBarRtlAwareForm_Resize(object? sender, EventArgs e)
         {
             if (WindowState == FormWindowState.Maximized)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationNUDUserInputWithProgressBarRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationNUDUserInputWithProgressBarRtlAwareForm.cs
@@ -185,7 +185,7 @@ namespace Krypton.Toolkit
 
         private void itbDismiss_Click(object sender, EventArgs e) => Close();
 
-        private void VisualToastNotificationNumericUpDownUserInputWithProgressBarRtlAwareForm_Resize(object sender, EventArgs e)
+        private void VisualToastNotificationNumericUpDownUserInputWithProgressBarRtlAwareForm_Resize(object? sender, EventArgs e)
         {
             if (WindowState == FormWindowState.Maximized)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationTextBoxUserInputWithProgressBarRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationTextBoxUserInputWithProgressBarRtlAwareForm.cs
@@ -186,7 +186,7 @@ namespace Krypton.Toolkit
 
         private void itbDismiss_Click(object sender, EventArgs e) => Close();
 
-        private void VisualToastNotificationTextBoxUserInputWithProgressBarRtlAwareForm_Resize(object sender, EventArgs e)
+        private void VisualToastNotificationTextBoxUserInputWithProgressBarRtlAwareForm_Resize(object? sender, EventArgs e)
         {
             if (WindowState == FormWindowState.Maximized)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContainerControlBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContainerControlBase.cs
@@ -609,7 +609,7 @@ namespace Krypton.Toolkit
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An EventArgs containing event data.</param>
         /// <exception cref="ArgumentNullException"></exception>
-        protected virtual void OnButtonSpecChanged(object sender, [DisallowNull] EventArgs e)
+        protected virtual void OnButtonSpecChanged(object? sender, [DisallowNull] EventArgs e)
         {
             Debug.Assert(e != null);
 
@@ -646,7 +646,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
-        protected virtual void OnPaletteNeedPaint(object sender, NeedLayoutEventArgs e)
+        protected virtual void OnPaletteNeedPaint(object? sender, NeedLayoutEventArgs e)
         {
             // Need to recalculate anything relying on the palette
             DirtyPaletteCounter++;
@@ -983,7 +983,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">An EventArgs that contains the event data.</param>
-        protected virtual void OnGlobalPaletteChanged(object sender, EventArgs e)
+        protected virtual void OnGlobalPaletteChanged(object? sender, EventArgs e)
         {
             // We only care if we are using the global palette
             if (PaletteMode == PaletteMode.Global)
@@ -1105,7 +1105,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnBaseChanged(object sender, EventArgs e) =>
+        private void OnBaseChanged(object? sender, EventArgs e) =>
             // Change in base renderer or base palette require we fetch the latest renderer
             Renderer = _palette?.GetRenderer()!;
 
@@ -1172,7 +1172,7 @@ namespace Krypton.Toolkit
             BeginInvoke(_refreshCall);
         }
 
-        private void OnContextMenuStripOpening(object sender, CancelEventArgs e)
+        private void OnContextMenuStripOpening(object? sender, CancelEventArgs e)
         {
             // Get the actual strip instance
             ContextMenuStrip? cms = base.ContextMenuStrip;
@@ -1181,13 +1181,13 @@ namespace Krypton.Toolkit
             cms!.Renderer = CreateToolStripRenderer();
         }
 
-        private void OnKryptonContextMenuDisposed(object sender, EventArgs e) =>
+        private void OnKryptonContextMenuDisposed(object? sender, EventArgs e) =>
             // When the current krypton context menu is disposed, we should remove 
             // it to prevent it being used again, as that would just throw an exception 
             // because it has been disposed.
             KryptonContextMenu = null;
 
-        private void OnContextMenuClosed(object sender, ToolStripDropDownClosedEventArgs e) => ContextMenuClosed();
+        private void OnContextMenuClosed(object? sender, ToolStripDropDownClosedEventArgs e) => ContextMenuClosed();
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContextMenu.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContextMenu.cs
@@ -410,7 +410,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
-        protected virtual void OnPaletteNeedPaint(object sender, NeedLayoutEventArgs e) =>
+        protected virtual void OnPaletteNeedPaint(object? sender, NeedLayoutEventArgs e) =>
             // Need to recalculate anything relying on the palette
             OnNeedPaint(sender, e);
 
@@ -502,15 +502,15 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnBaseChanged(object sender, EventArgs e) =>
+        private void OnBaseChanged(object? sender, EventArgs e) =>
             // Change in base renderer or base palette require we fetch the latest renderer
             Renderer = _palette!.GetRenderer();
 
-        private void OnProviderClosing(object sender, CancelEventArgs e) => _contextMenu?.OnClosing(e);
+        private void OnProviderClosing(object? sender, CancelEventArgs e) => _contextMenu?.OnClosing(e);
 
-        private void OnProviderClose(object sender, CloseReasonEventArgs e) => _contextMenu?.Close(e.CloseReason);
+        private void OnProviderClose(object? sender, CloseReasonEventArgs e) => _contextMenu?.Close(e.CloseReason);
 
-        private void OnProviderClose(object sender, EventArgs e)
+        private void OnProviderClose(object? sender, EventArgs e)
         {
             // Unhook from event source
             var provider = sender as ContextMenuProvider;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualControlBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualControlBase.cs
@@ -660,7 +660,7 @@ namespace Krypton.Toolkit
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An EventArgs containing event data.</param>
         /// <exception cref="ArgumentNullException"></exception>
-        protected virtual void OnButtonSpecChanged(object sender, [DisallowNull] EventArgs e)
+        protected virtual void OnButtonSpecChanged(object? sender, [DisallowNull] EventArgs e)
         {
             Debug.Assert(e != null);
 
@@ -694,7 +694,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
-        protected virtual void OnPaletteNeedPaint(object sender, NeedLayoutEventArgs e)
+        protected virtual void OnPaletteNeedPaint(object? sender, NeedLayoutEventArgs e)
         {
             // Need to recalculate anything relying on the palette
             DirtyPaletteCounter++;
@@ -1049,7 +1049,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">An EventArgs that contains the event data.</param>
-        protected virtual void OnGlobalPaletteChanged(object sender, EventArgs e)
+        protected virtual void OnGlobalPaletteChanged(object? sender, EventArgs e)
         {
             // We only care if we are using the global palette
             if (PaletteMode == PaletteMode.Global)
@@ -1188,7 +1188,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnBaseChanged(object sender, EventArgs e) =>
+        private void OnBaseChanged(object? sender, EventArgs e) =>
             // Change in base renderer or base palette require we fetch the latest renderer
             Renderer = _palette?.GetRenderer()!;
 
@@ -1255,7 +1255,7 @@ namespace Krypton.Toolkit
             BeginInvoke(_refreshCall);
         }
 
-        private void OnContextMenuStripOpening(object sender, CancelEventArgs e)
+        private void OnContextMenuStripOpening(object? sender, CancelEventArgs e)
         {
             // Get the actual strip instance
             ContextMenuStrip? cms = base.ContextMenuStrip;
@@ -1264,15 +1264,15 @@ namespace Krypton.Toolkit
             cms!.Renderer = CreateToolStripRenderer();
         }
 
-        private void OnKryptonContextMenuDisposed(object sender, EventArgs e) =>
+        private void OnKryptonContextMenuDisposed(object? sender, EventArgs e) =>
             // When the current krypton context menu is disposed, we should remove 
             // it to prevent it being used again, as that would just throw an exception 
             // because it has been disposed.
             KryptonContextMenu = null;
 
-        private void OnContextMenuClosed(object sender, ToolStripDropDownClosedEventArgs e) => ContextMenuClosed();
+        private void OnContextMenuClosed(object? sender, ToolStripDropDownClosedEventArgs e) => ContextMenuClosed();
 
-        private void OnShowToolTip(object sender, ToolTipEventArgs e)
+        private void OnShowToolTip(object? sender, ToolTipEventArgs e)
         {
             if (!IsDisposed)
             {
@@ -1307,14 +1307,14 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnCancelToolTip(object sender, EventArgs e) =>
+        private void OnCancelToolTip(object? sender, EventArgs e) =>
             // Remove any currently showing tooltip
             visualBasePopupToolTip?.Dispose();
 
-        private void OnVisualPopupToolTipDisposed(object sender, EventArgs e)
+        private void OnVisualPopupToolTipDisposed(object? sender, EventArgs e)
         {
             // Unhook events from the specific instance that generated event
-            var popupToolTip = (VisualPopupToolTip)sender;
+            var popupToolTip = sender as VisualPopupToolTip ?? throw new ArgumentNullException(nameof(sender));
             popupToolTip.Disposed -= OnVisualPopupToolTipDisposed;
 
             // Not showing a popup page anymore

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
@@ -945,7 +945,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An EventArgs containing event data.</param>
-        protected virtual void OnButtonSpecChanged(object sender, EventArgs e)
+        protected virtual void OnButtonSpecChanged(object? sender, EventArgs e)
         {
         }
 
@@ -975,7 +975,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">An EventArgs containing the event data.</param>
-        protected virtual void OnUseThemeFormChromeBorderWidthChanged(object sender, EventArgs e)
+        protected virtual void OnUseThemeFormChromeBorderWidthChanged(object? sender, EventArgs e)
         {
         }
 
@@ -985,7 +985,7 @@ namespace Krypton.Toolkit
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
         /// <exception cref="ArgumentNullException"></exception>
-        protected virtual void OnNeedPaint(object sender, [DisallowNull] NeedLayoutEventArgs e)
+        protected virtual void OnNeedPaint(object? sender, [DisallowNull] NeedLayoutEventArgs e)
         {
             Debug.Assert(e != null);
 
@@ -1660,7 +1660,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnGlobalPaletteChanged(object sender, EventArgs e)
+        private void OnGlobalPaletteChanged(object? sender, EventArgs e)
         {
             // We only care if we are using the global palette
             if (PaletteMode == PaletteMode.Global)
@@ -1724,12 +1724,12 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnBaseChanged(object sender, EventArgs e) =>
+        private void OnBaseChanged(object? sender, EventArgs e) =>
             // Change in base renderer or base palette require we fetch the latest renderer
             Renderer = _palette.GetRenderer();// PaletteImageScaler.ScalePalette(FactorDpiX, FactorDpiY, _palette);
 
 #if !NET462
-        private void OnDpiChanged(object sender, DpiChangedEventArgs e) => UpdateDpiFactors();
+        private void OnDpiChanged(object? sender, DpiChangedEventArgs e) => UpdateDpiFactors();
 #endif
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMultilineStringEditor.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMultilineStringEditor.cs
@@ -160,7 +160,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">The control.</param>
         /// <param name="e">The event arguments.</param>
-        private void OnKeyDownTextBox(object sender, KeyEventArgs e)
+        private void OnKeyDownTextBox(object? sender, KeyEventArgs e)
         {
             if (e.KeyCode == Keys.Escape)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPanel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPanel.cs
@@ -755,7 +755,7 @@ namespace Krypton.Toolkit
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An EventArgs containing event data.</param>
         /// <exception cref="ArgumentNullException"></exception>
-        protected virtual void OnButtonSpecChanged(object sender, [DisallowNull] EventArgs e)
+        protected virtual void OnButtonSpecChanged(object? sender, [DisallowNull] EventArgs e)
         {
             Debug.Assert(e is not null);
 
@@ -1139,7 +1139,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnGlobalPaletteChanged(object sender, EventArgs e)
+        private void OnGlobalPaletteChanged(object? sender, EventArgs e)
         {
             // We only care if we are using the global palette
             if (PaletteMode == PaletteMode.Global)
@@ -1158,7 +1158,7 @@ namespace Krypton.Toolkit
 
         private void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e) => PerformNeedPaint(true);
 
-        private void OnContextMenuStripOpening(object sender, CancelEventArgs e)
+        private void OnContextMenuStripOpening(object? sender, CancelEventArgs e)
         {
             // Get the actual strip instance
             ContextMenuStrip? cms = base.ContextMenuStrip;
@@ -1170,13 +1170,13 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnKryptonContextMenuDisposed(object sender, EventArgs e) =>
+        private void OnKryptonContextMenuDisposed(object? sender, EventArgs e) =>
             // When the current krypton context menu is disposed, we should remove 
             // it to prevent it being used again, as that would just throw an exception 
             // because it has been disposed.
             KryptonContextMenu = null;
 
-        private void OnContextMenuClosed(object sender, ToolStripDropDownClosedEventArgs e) => ContextMenuClosed();
+        private void OnContextMenuClosed(object? sender, ToolStripDropDownClosedEventArgs e) => ContextMenuClosed();
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPopupManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPopupManager.cs
@@ -741,7 +741,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnCMSClosed(object sender, ToolStripDropDownClosedEventArgs e)
+        private void OnCMSClosed(object? sender, ToolStripDropDownClosedEventArgs e)
         {
             // Unhook event from object
             var cms = sender as ContextMenuStrip;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualTaskDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualTaskDialog.cs
@@ -1017,7 +1017,7 @@ namespace Krypton.Toolkit
             return requiredSize;
         }
 
-        private void OnRadioButtonCheckedChanged(object sender, EventArgs e)
+        private void OnRadioButtonCheckedChanged(object? sender, EventArgs e)
         {
             var button = sender as KryptonRadioButton;
             _defaultRadioButton = button?.Tag as KryptonTaskDialogCommand;
@@ -1027,7 +1027,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnCommandClicked(object sender, EventArgs e)
+        private void OnCommandClicked(object? sender, EventArgs e)
         {
             Close();
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualTaskDialogForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualTaskDialogForm.cs
@@ -930,7 +930,7 @@ namespace Krypton.Toolkit
             return requiredSize;
         }
 
-        private void OnRadioButtonCheckedChanged(object sender, EventArgs e)
+        private void OnRadioButtonCheckedChanged(object? sender, EventArgs e)
         {
             var button = sender as KryptonRadioButton;
             _defaultRadioButton = button?.Tag as KryptonTaskDialogCommand;
@@ -940,7 +940,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnCommandClicked(object sender, EventArgs e)
+        private void OnCommandClicked(object? sender, EventArgs e)
         {
             Close();
 

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonBorderEdgeActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonBorderEdgeActionList.cs
@@ -150,7 +150,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnOrientationClick(object sender, EventArgs e)
+        private void OnOrientationClick(object? sender, EventArgs e)
         {
             // Cast to the correct type
 

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonCheckButtonActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonCheckButtonActionList.cs
@@ -100,7 +100,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnCheckedClick(object sender, EventArgs e)
+        private void OnCheckedClick(object? sender, EventArgs e)
         {
             // Cast to the correct type
 

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonCustomPaletteBaseActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonCustomPaletteBaseActionList.cs
@@ -70,7 +70,7 @@ namespace Krypton.Toolkit
 
         #region Implementation
 
-        private void OnResetClick(object sender, EventArgs e)
+        private void OnResetClick(object? sender, EventArgs e)
         {
             if (_palette != null)
             {
@@ -85,7 +85,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnPopulateClick(object sender, EventArgs e)
+        private void OnPopulateClick(object? sender, EventArgs e)
         {
             if (_palette != null)
             {
@@ -100,7 +100,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnImportClick(object sender, EventArgs e)
+        private void OnImportClick(object? sender, EventArgs e)
         {
             if (_palette != null)
             {
@@ -109,9 +109,9 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnExportClick(object sender, EventArgs e) => _palette?.ActionListExport();
+        private void OnExportClick(object? sender, EventArgs e) => _palette?.ActionListExport();
 
-        private void OnUpgradePalette(object sender, EventArgs e)
+        private void OnUpgradePalette(object? sender, EventArgs e)
         {
             try
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonHeaderGroupActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonHeaderGroupActionList.cs
@@ -206,7 +206,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnVisibleClick(object sender, EventArgs e)
+        private void OnVisibleClick(object? sender, EventArgs e)
         {
             // Cast to the correct type
             var verb = sender as DesignerVerb;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonLinkLabelActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonLinkLabelActionList.cs
@@ -249,7 +249,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnLinkVisitedClick(object sender, EventArgs e)
+        private void OnLinkVisitedClick(object? sender, EventArgs e)
         {
             // Cast to the correct type
 

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonManagerActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonManagerActionList.cs
@@ -57,7 +57,7 @@ namespace Krypton.Toolkit
 
         #region Implementation
 
-        private void OnReset(object sender, EventArgs e)
+        private void OnReset(object? sender, EventArgs e)
         {
             if (_manager != null)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonSplitContainerActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonSplitContainerActionList.cs
@@ -132,7 +132,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnOrientationClick(object sender, EventArgs e)
+        private void OnOrientationClick(object? sender, EventArgs e)
         {
             // Cast to the correct type
 

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonTrackBarActionList.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Action Lists/KryptonTrackBarActionList.cs
@@ -204,7 +204,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnOrientationClick(object sender, EventArgs e)
+        private void OnOrientationClick(object? sender, EventArgs e)
         {
             // Cast to the correct type
 

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonBreadCrumbDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonBreadCrumbDesigner.cs
@@ -158,7 +158,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnBreadCrumbMouseUp(object sender, MouseEventArgs e)
+        private void OnBreadCrumbMouseUp(object? sender, MouseEventArgs e)
         {
             if ((_breadCrumb != null) && (e.Button == MouseButtons.Left))
             {
@@ -195,7 +195,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnComponentRemoving(object sender, ComponentEventArgs e)
+        private void OnComponentRemoving(object? sender, ComponentEventArgs e)
         {
             // If our control is being removed
             if ((_breadCrumb != null) && (Equals(e.Component, _breadCrumb)))

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonBreadCrumbItemDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonBreadCrumbItemDesigner.cs
@@ -84,7 +84,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnComponentRemoving(object sender, ComponentEventArgs e)
+        private void OnComponentRemoving(object? sender, ComponentEventArgs e)
         {
             // If our item collection is being removed
             if ((_crumbItem != null) && (Equals(e.Component, _crumbItem)))

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonComboBoxDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonComboBoxDesigner.cs
@@ -138,7 +138,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnComboBoxMouseUp(object sender, MouseEventArgs e)
+        private void OnComboBoxMouseUp(object? sender, MouseEventArgs e)
         {
             if (e.Button == MouseButtons.Left)
             {
@@ -175,7 +175,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnComponentRemoving(object sender, ComponentEventArgs e)
+        private void OnComponentRemoving(object? sender, ComponentEventArgs e)
         {
             // If our control is being removed
             if ((_comboBox != null) && (Equals(e.Component, _comboBox)))

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonContextMenuDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonContextMenuDesigner.cs
@@ -101,7 +101,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnComponentRemoving(object sender, ComponentEventArgs e)
+        private void OnComponentRemoving(object? sender, ComponentEventArgs e)
         {
             // If our context menu is being removed
             if ((_contextMenu != null) && (Equals(e.Component, _contextMenu)))

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonContextMenuItemDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonContextMenuItemDesigner.cs
@@ -84,7 +84,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnComponentRemoving(object sender, ComponentEventArgs e)
+        private void OnComponentRemoving(object? sender, ComponentEventArgs e)
         {
             // If our item collection is being removed
             if ((_contextMenuItem != null) && (Equals(e.Component, _contextMenuItem)))

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonContextMenuItemsDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonContextMenuItemsDesigner.cs
@@ -84,7 +84,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnComponentRemoving(object sender, ComponentEventArgs e)
+        private void OnComponentRemoving(object? sender, ComponentEventArgs e)
         {
             // If our item collection is being removed
             if ((_contextMenuItems != null) && (Equals(e.Component, _contextMenuItems)))

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonCustomPaletteBaseDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonCustomPaletteBaseDesigner.cs
@@ -89,7 +89,7 @@ namespace Krypton.Toolkit
 
         #region Implementation
 
-        private void OnUpgrade(object sender, EventArgs e)
+        private void OnUpgrade(object? sender, EventArgs e)
         {
             try
             {
@@ -117,9 +117,9 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnExport(object sender, EventArgs e) => _palette?.ActionListExport();
+        private void OnExport(object? sender, EventArgs e) => _palette?.ActionListExport();
 
-        private void OnImport(object sender, EventArgs e)
+        private void OnImport(object? sender, EventArgs e)
         {
             if (_palette != null)
             {
@@ -128,7 +128,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnPopulate(object sender, EventArgs e)
+        private void OnPopulate(object? sender, EventArgs e)
         {
             if (_palette != null)
             {
@@ -143,7 +143,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnReset(object sender, EventArgs e)
+        private void OnReset(object? sender, EventArgs e)
         {
             if (_palette != null)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonDateTimePickerDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonDateTimePickerDesigner.cs
@@ -157,7 +157,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnDateTimePickerMouseUp(object sender, MouseEventArgs e)
+        private void OnDateTimePickerMouseUp(object? sender, MouseEventArgs e)
         {
             if ((_dateTimePicker != null) && (e.Button == MouseButtons.Left))
             {
@@ -194,7 +194,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnComponentRemoving(object sender, ComponentEventArgs e)
+        private void OnComponentRemoving(object? sender, ComponentEventArgs e)
         {
             // If our control is being removed
             if (Equals(e.Component, _dateTimePicker))

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonDomainUpDownDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonDomainUpDownDesigner.cs
@@ -141,7 +141,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnDomainUpDownMouseUp(object sender, MouseEventArgs e)
+        private void OnDomainUpDownMouseUp(object? sender, MouseEventArgs e)
         {
             if ((_domainUpDown != null) && (e.Button == MouseButtons.Left))
             {
@@ -178,7 +178,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnComponentRemoving(object sender, ComponentEventArgs e)
+        private void OnComponentRemoving(object? sender, ComponentEventArgs e)
         {
             // If our control is being removed
             if ((_domainUpDown != null) && (Equals(e.Component, _domainUpDown)))

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonHeaderDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonHeaderDesigner.cs
@@ -151,7 +151,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnHeaderMouseUp(object sender, MouseEventArgs e)
+        private void OnHeaderMouseUp(object? sender, MouseEventArgs e)
         {
             if ((_header != null) && (e.Button == MouseButtons.Left))
             {
@@ -188,7 +188,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnComponentRemoving(object sender, ComponentEventArgs e)
+        private void OnComponentRemoving(object? sender, ComponentEventArgs e)
         {
             // If our control is being removed
             if ((_header != null) && (Equals(e.Component, _header)))

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonHeaderGroupDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonHeaderGroupDesigner.cs
@@ -199,7 +199,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnHeaderGroupMouseUp(object sender, MouseEventArgs e)
+        private void OnHeaderGroupMouseUp(object? sender, MouseEventArgs e)
         {
             if ((_headerGroup != null) && (e.Button == MouseButtons.Left))
             {
@@ -221,7 +221,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnHeaderGroupDoubleClick(object sender, Point pt)
+        private void OnHeaderGroupDoubleClick(object? sender, Point pt)
         {
             // Get any component associated with the current mouse position
             var component = _headerGroup?.DesignerComponentFromPoint(pt);
@@ -236,7 +236,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnComponentRemoving(object sender, ComponentEventArgs e)
+        private void OnComponentRemoving(object? sender, ComponentEventArgs e)
         {
             // If our control is being removed
             if (Equals(e.Component, _headerGroup))

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonManagerDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonManagerDesigner.cs
@@ -92,14 +92,14 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnComponentChanged(object sender, ComponentChangedEventArgs e) => UpdateVerbStatus();
+        private void OnComponentChanged(object? sender, ComponentChangedEventArgs e) => UpdateVerbStatus();
 
         private void OnComponentRemoving(object sender, ComponentEventArgs e)
         {
             throw new NotImplementedException();
         }
 
-        private void OnReset(object sender, EventArgs e)
+        private void OnReset(object? sender, EventArgs e)
         {
             if (_manager != null)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonMaskedTextBoxDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonMaskedTextBoxDesigner.cs
@@ -147,7 +147,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnMaskedTextBoxMouseUp(object sender, MouseEventArgs e)
+        private void OnMaskedTextBoxMouseUp(object? sender, MouseEventArgs e)
         {
             if ((_maskedTextBox != null) && (e.Button == MouseButtons.Left))
             {
@@ -184,7 +184,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnComponentRemoving(object sender, ComponentEventArgs e)
+        private void OnComponentRemoving(object? sender, ComponentEventArgs e)
         {
             // If our control is being removed
             if (Equals(e.Component, _maskedTextBox))

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonMonthCalendarDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonMonthCalendarDesigner.cs
@@ -180,7 +180,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnCalendarMouseUp(object sender, MouseEventArgs e)
+        private void OnCalendarMouseUp(object? sender, MouseEventArgs e)
         {
             if ((_monthCalendar != null) && (e.Button == MouseButtons.Left))
             {
@@ -217,7 +217,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnComponentRemoving(object sender, ComponentEventArgs e)
+        private void OnComponentRemoving(object? sender, ComponentEventArgs e)
         {
             // If our control is being removed
             if (Equals(e.Component, _monthCalendar))

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonNumericUpDownDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonNumericUpDownDesigner.cs
@@ -141,7 +141,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnNumericUpDownMouseUp(object sender, MouseEventArgs e)
+        private void OnNumericUpDownMouseUp(object? sender, MouseEventArgs e)
         {
             if ((_numericUpDown != null) && (e.Button == MouseButtons.Left))
             {
@@ -178,7 +178,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnComponentRemoving(object sender, ComponentEventArgs e)
+        private void OnComponentRemoving(object? sender, ComponentEventArgs e)
         {
             // If our control is being removed
             if ((_numericUpDown != null) && (Equals(e.Component, _numericUpDown)))

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonRichTextBoxDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonRichTextBoxDesigner.cs
@@ -147,7 +147,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnTextBoxMouseUp(object sender, MouseEventArgs e)
+        private void OnTextBoxMouseUp(object? sender, MouseEventArgs e)
         {
             if ((_richTextBox != null) && (e.Button == MouseButtons.Left))
             {
@@ -184,7 +184,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnComponentRemoving(object sender, ComponentEventArgs e)
+        private void OnComponentRemoving(object? sender, ComponentEventArgs e)
         {
             // If our control is being removed
             if (Equals(e.Component, _richTextBox))

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonSplitterPanelDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonSplitterPanelDesigner.cs
@@ -188,7 +188,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnComponentChanged(object sender, ComponentChangedEventArgs e)
+        private void OnComponentChanged(object? sender, ComponentChangedEventArgs e)
         {
             // Assuming the panel has a parent
             if (_panel?.Parent != null)

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonTextBoxDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonTextBoxDesigner.cs
@@ -147,7 +147,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnTextBoxMouseUp(object sender, MouseEventArgs e)
+        private void OnTextBoxMouseUp(object? sender, MouseEventArgs e)
         {
             if ((_textBox != null) && (e.Button == MouseButtons.Left))
             {
@@ -184,7 +184,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnComponentRemoving(object sender, ComponentEventArgs e)
+        private void OnComponentRemoving(object? sender, ComponentEventArgs e)
         {
             // If our control is being removed
             if ((_textBox != null) && (Equals(e.Component, _textBox)))

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonThemeComboBoxDesigner.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Designers/KryptonThemeComboBoxDesigner.cs
@@ -76,7 +76,7 @@ namespace Krypton.Toolkit
             throw new NotImplementedException();
         }
 
-        private void OnReset(object sender, EventArgs e)
+        private void OnReset(object? sender, EventArgs e)
         {
             if (_themeComboBox != null)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Editors/KryptonBreadCrumbItemsEditor.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Editors/KryptonBreadCrumbItemsEditor.cs
@@ -145,7 +145,7 @@ namespace Krypton.Toolkit
                 #endregion
 
                 #region Implementation
-                private void OnPropertyChanged(object sender, PropertyChangedEventArgs e) =>
+                private void OnPropertyChanged(object? sender, PropertyChangedEventArgs e) =>
                     // Update with correct string for new state
                     Text = Item.ToString();
                 #endregion
@@ -459,7 +459,7 @@ namespace Krypton.Toolkit
             #endregion
 
             #region Implementation
-            private void buttonOK_Click(object sender, EventArgs e)
+            private void buttonOK_Click(object? sender, EventArgs e)
             {
                 // Create an array with all the root items
                 var rootItems = new object[treeView1.Nodes.Count];
@@ -582,7 +582,7 @@ namespace Krypton.Toolkit
                 return null;
             }
 
-            private void buttonMoveUp_Click(object sender, EventArgs e)
+            private void buttonMoveUp_Click(object? sender, EventArgs e)
             {
                 // If we have a selected node
                 MenuTreeNode node = (MenuTreeNode)treeView1.SelectedNode!;
@@ -639,7 +639,7 @@ namespace Krypton.Toolkit
                 UpdatePropertyGrid();
             }
 
-            private void buttonMoveDown_Click(object sender, EventArgs e)
+            private void buttonMoveDown_Click(object? sender, EventArgs e)
             {
                 // If we have a selected node
                 var node = treeView1.SelectedNode as MenuTreeNode;
@@ -682,7 +682,7 @@ namespace Krypton.Toolkit
                 UpdatePropertyGrid();
             }
 
-            private void buttonAddSibling_Click(object sender, EventArgs e)
+            private void buttonAddSibling_Click(object? sender, EventArgs e)
             {
                 KryptonBreadCrumbItem item = (KryptonBreadCrumbItem)CreateInstance(typeof(KryptonBreadCrumbItem));
                 TreeNode newNode = new MenuTreeNode(item);
@@ -720,7 +720,7 @@ namespace Krypton.Toolkit
                 UpdatePropertyGrid();
             }
 
-            private void buttonAddChild_Click(object sender, EventArgs e)
+            private void buttonAddChild_Click(object? sender, EventArgs e)
             {
                 var item = (KryptonBreadCrumbItem)CreateInstance(typeof(KryptonBreadCrumbItem));
                 TreeNode newNode = new MenuTreeNode(item);
@@ -749,7 +749,7 @@ namespace Krypton.Toolkit
                 UpdatePropertyGrid();
             }
 
-            private void buttonDelete_Click(object sender, EventArgs e)
+            private void buttonDelete_Click(object? sender, EventArgs e)
             {
                 TreeNode node = treeView1.SelectedNode!;
 
@@ -778,7 +778,7 @@ namespace Krypton.Toolkit
                 UpdatePropertyGrid();
             }
 
-            private void treeView1_AfterSelect(object sender, TreeViewEventArgs e)
+            private void treeView1_AfterSelect(object? sender, TreeViewEventArgs e)
             {
                 UpdateButtons();
                 UpdatePropertyGrid();

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Other/KryptonSplitContainerGlyph.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Other/KryptonSplitContainerGlyph.cs
@@ -120,7 +120,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnSelectionChanged(object sender, EventArgs e)
+        private void OnSelectionChanged(object? sender, EventArgs e)
         {
             if (_splitContainer is not null && _selectionService is not null)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/UX/KryptonContextMenuCollectionForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/UX/KryptonContextMenuCollectionForm.cs
@@ -103,7 +103,7 @@ namespace Krypton.Toolkit
                     return -1;
                 }
 
-                private void OnPropertyChanged(object sender, PropertyChangedEventArgs e) =>
+                private void OnPropertyChanged(object? sender, PropertyChangedEventArgs e) =>
                     // Update with correct string for new state
                     Text = Item.ToString();
                 #endregion
@@ -685,7 +685,7 @@ namespace Krypton.Toolkit
 
             #region Implementation
 
-            private void buttonOK_Click(object sender, EventArgs e)
+            private void buttonOK_Click(object? sender, EventArgs e)
             {
                 // Create an array with all the root items
                 var rootItems = new object[_treeView.Nodes.Count];
@@ -710,7 +710,7 @@ namespace Krypton.Toolkit
                 Context!.OnComponentChanged();
             }
 
-            private void buttonMoveUp_Click(object sender, EventArgs e)
+            private void buttonMoveUp_Click(object? sender, EventArgs e)
             {
                 // We should have a selected node!
                 if (_treeView.SelectedNode is MenuTreeNode node)
@@ -755,7 +755,7 @@ namespace Krypton.Toolkit
                 UpdatePropertyGrid();
             }
 
-            private void buttonMoveDown_Click(object sender, EventArgs e)
+            private void buttonMoveDown_Click(object? sender, EventArgs e)
             {
                 // We should have a selected node!
                 if (_treeView.SelectedNode is MenuTreeNode node)
@@ -800,31 +800,31 @@ namespace Krypton.Toolkit
                 UpdatePropertyGrid();
             }
 
-            private void buttonAddItem_Click(object sender, EventArgs e) => AddNewItem((KryptonContextMenuItemBase)CreateInstance(typeof(KryptonContextMenuItem)));
+            private void buttonAddItem_Click(object? sender, EventArgs e) => AddNewItem((KryptonContextMenuItemBase)CreateInstance(typeof(KryptonContextMenuItem)));
 
-            private void buttonAddItems_Click(object sender, EventArgs e) => AddNewItem((KryptonContextMenuItemBase)CreateInstance(typeof(KryptonContextMenuItems)));
+            private void buttonAddItems_Click(object? sender, EventArgs e) => AddNewItem((KryptonContextMenuItemBase)CreateInstance(typeof(KryptonContextMenuItems)));
 
-            private void buttonAddHeading_Click(object sender, EventArgs e) => AddNewItem((KryptonContextMenuItemBase)CreateInstance(typeof(KryptonContextMenuHeading)));
+            private void buttonAddHeading_Click(object? sender, EventArgs e) => AddNewItem((KryptonContextMenuItemBase)CreateInstance(typeof(KryptonContextMenuHeading)));
 
-            private void buttonAddMonthCalendar_Click(object sender, EventArgs e) => AddNewItem((KryptonContextMenuItemBase)CreateInstance(typeof(KryptonContextMenuMonthCalendar)));
+            private void buttonAddMonthCalendar_Click(object? sender, EventArgs e) => AddNewItem((KryptonContextMenuItemBase)CreateInstance(typeof(KryptonContextMenuMonthCalendar)));
 
-            private void buttonAddSeparator_Click(object sender, EventArgs e) => AddNewItem((KryptonContextMenuItemBase)CreateInstance(typeof(KryptonContextMenuSeparator)));
+            private void buttonAddSeparator_Click(object? sender, EventArgs e) => AddNewItem((KryptonContextMenuItemBase)CreateInstance(typeof(KryptonContextMenuSeparator)));
 
-            private void buttonAddCheckBox_Click(object sender, EventArgs e) => AddNewItem((KryptonContextMenuItemBase)CreateInstance(typeof(KryptonContextMenuCheckBox)));
+            private void buttonAddCheckBox_Click(object? sender, EventArgs e) => AddNewItem((KryptonContextMenuItemBase)CreateInstance(typeof(KryptonContextMenuCheckBox)));
 
-            private void buttonAddCheckButton_Click(object sender, EventArgs e) => AddNewItem((KryptonContextMenuItemBase)CreateInstance(typeof(KryptonContextMenuCheckButton)));
+            private void buttonAddCheckButton_Click(object? sender, EventArgs e) => AddNewItem((KryptonContextMenuItemBase)CreateInstance(typeof(KryptonContextMenuCheckButton)));
 
-            private void buttonAddRadioButton_Click(object sender, EventArgs e) => AddNewItem((KryptonContextMenuItemBase)CreateInstance(typeof(KryptonContextMenuRadioButton)));
+            private void buttonAddRadioButton_Click(object? sender, EventArgs e) => AddNewItem((KryptonContextMenuItemBase)CreateInstance(typeof(KryptonContextMenuRadioButton)));
 
-            private void buttonAddLinkLabel_Click(object sender, EventArgs e) => AddNewItem((KryptonContextMenuItemBase)CreateInstance(typeof(KryptonContextMenuLinkLabel)));
+            private void buttonAddLinkLabel_Click(object? sender, EventArgs e) => AddNewItem((KryptonContextMenuItemBase)CreateInstance(typeof(KryptonContextMenuLinkLabel)));
 
-            private void buttonAddColorColumns_Click(object sender, EventArgs e) => AddNewItem((KryptonContextMenuItemBase)CreateInstance(typeof(KryptonContextMenuColorColumns)));
+            private void buttonAddColorColumns_Click(object? sender, EventArgs e) => AddNewItem((KryptonContextMenuItemBase)CreateInstance(typeof(KryptonContextMenuColorColumns)));
 
-            private void buttonAddImageSelect_Click(object sender, EventArgs e) => AddNewItem((KryptonContextMenuItemBase)CreateInstance(typeof(KryptonContextMenuImageSelect)));
+            private void buttonAddImageSelect_Click(object? sender, EventArgs e) => AddNewItem((KryptonContextMenuItemBase)CreateInstance(typeof(KryptonContextMenuImageSelect)));
 
-            private void buttonAddComboBox_Click(object sender, EventArgs e) => AddNewItem((KryptonContextMenuItemBase)CreateInstance(typeof(KryptonContextMenuComboBox)));
+            private void buttonAddComboBox_Click(object? sender, EventArgs e) => AddNewItem((KryptonContextMenuItemBase)CreateInstance(typeof(KryptonContextMenuComboBox)));
 
-            private void buttonDelete_Click(object sender, EventArgs e)
+            private void buttonDelete_Click(object? sender, EventArgs e)
             {
                 // We should have a selected node!
                 if (_treeView.SelectedNode is MenuTreeNode node)
@@ -862,7 +862,7 @@ namespace Krypton.Toolkit
                 UpdatePropertyGrid();
             }
 
-            private void SelectionChanged(object sender, TreeViewEventArgs e)
+            private void SelectionChanged(object? sender, TreeViewEventArgs e)
             {
                 UpdateButtons();
                 UpdatePropertyGrid();

--- a/Source/Krypton Components/Krypton.Toolkit/General/BlurManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/BlurManager.cs
@@ -63,7 +63,7 @@ namespace Krypton.Toolkit
 
         #endregion Identity
 
-        private void KryptonFormOnClosing(object sender, /*Cancel*/EventArgs e) => RemoveBlur();
+        private void KryptonFormOnClosing(object? sender, /*Cancel*/EventArgs e) => RemoveBlur();
 
         private void RemoveBlur()
         {
@@ -135,7 +135,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void BlurValuesOnOpacityChanged(object sender, EventArgs e)
+        private void BlurValuesOnOpacityChanged(object? sender, EventArgs e)
         {
             if (_visualBlur != null)
             {
@@ -144,7 +144,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void BlurValues_EnableBlurChanged(object sender, EventArgs e)
+        private void BlurValues_EnableBlurChanged(object? sender, EventArgs e)
         {
             if (!_blurValues.BlurWhenFocusLost)
             {
@@ -152,7 +152,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void DetectIsTopMost(object sender, EventArgs e)
+        private void DetectIsTopMost(object? sender, EventArgs e)
         {
             if ((_visualBlur != null)
                 && IsOverlapped()

--- a/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/HScrollSkin.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/HScrollSkin.cs
@@ -181,7 +181,7 @@ namespace Krypton.Toolkit
         /// <param name="sender"></param>
         /// <param name="e"></param>
         /// <remarks></remarks>
-        public void scrollSkin_ControlAdded(object sender, ControlEventArgs e)
+        public void scrollSkin_ControlAdded(object? sender, ControlEventArgs e)
         {
             if ( e is not null 
                 && e.Control is not null 
@@ -220,12 +220,12 @@ namespace Krypton.Toolkit
         /// <param name="sender"></param>
         /// <param name="e"></param>
         /// <remarks></remarks>
-        private void VScrollBar1_miScroll(object sender, ScrollEventArgs e) => PI.PostMessage(_win.Handle, PI.WM_.HSCROLL, (IntPtr)(PI.SB_.THUMBPOSITION + (0x10000 * VScrollBar1.Value)), IntPtr.Zero);
+        private void VScrollBar1_miScroll(object? sender, ScrollEventArgs e) => PI.PostMessage(_win.Handle, PI.WM_.HSCROLL, (IntPtr)(PI.SB_.THUMBPOSITION + (0x10000 * VScrollBar1.Value)), IntPtr.Zero);
 
         #endregion
 
         #region "   Horizontal Scroll   "
-        private void HScrollBar1_miScroll(object sender, ScrollEventArgs e)
+        private void HScrollBar1_miScroll(object? sender, ScrollEventArgs e)
         {
             if (_win.GetType() == typeof(ListView))
             {
@@ -317,9 +317,9 @@ namespace Krypton.Toolkit
 
         #region "   DGV Scrollbars VisibleChanged   "
 
-        private void HorizontalScrollBar_VisibleChanged(object sender, EventArgs e)
+        private void HorizontalScrollBar_VisibleChanged(object? sender, EventArgs e)
         {
-            var hscroll = (HScrollBar)sender;
+            var hscroll = sender as HScrollBar ?? throw new ArgumentNullException(nameof(sender));
             if (hscroll.Visible)
             {
                 _HScrollBar1.Visible = true;
@@ -330,9 +330,9 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void VerticalScrollBar_VisibleChanged(object sender, EventArgs e)
+        private void VerticalScrollBar_VisibleChanged(object? sender, EventArgs e)
         {
-            var vscroll = (VScrollBar)sender;
+            var vscroll = sender as VScrollBar ?? throw new ArgumentNullException(nameof(sender));
             if (vscroll.Visible)
             {
                 _VScrollBar1.Visible = true;
@@ -347,9 +347,9 @@ namespace Krypton.Toolkit
 
         #region "   DGV Scroll   "
 
-        private void dgv_Scroll(object sender, ScrollEventArgs e)
+        private void dgv_Scroll(object? sender, ScrollEventArgs e)
         {
-            var dgv = (DataGridView)sender;
+            var dgv = sender as DataGridView ?? throw new ArgumentNullException(nameof(sender));
             if (GetDGVScrollbar(ref dgv, out HSB))
             {
                 if (HSB.Visible)
@@ -378,7 +378,7 @@ namespace Krypton.Toolkit
         /// <param name="sender"></param>
         /// <param name="e"></param>
         /// <remarks></remarks>
-        private void win_Resize(object sender, EventArgs e)
+        private void win_Resize(object? sender, EventArgs e)
         {
             VScrollBar1.Size = new Size(0x12, _win.Height); //for the gap 
             VScrollBar1.Left = _win.Right - 0x12;
@@ -542,7 +542,7 @@ namespace Krypton.Toolkit
 
 
         //Krypton Palette Events
-        private void OnGlobalPaletteChanged(object sender, EventArgs e)
+        private void OnGlobalPaletteChanged(object? sender, EventArgs e)
         {
             if (_palette != null)
             {
@@ -561,7 +561,7 @@ namespace Krypton.Toolkit
         }
 
         //Krypton Palette Events
-        private void OnPalettePaint(object sender, PaletteLayoutEventArgs e) => Invalidate();
+        private void OnPalettePaint(object? sender, PaletteLayoutEventArgs e) => Invalidate();
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/ScrollBarExtendedRenderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/ScrollBarExtendedRenderer.cs
@@ -929,7 +929,7 @@ namespace Krypton.Toolkit
 
 
         //Krypton Palette Events
-        private static void OnGlobalPaletteChanged(object sender, EventArgs e)
+        private static void OnGlobalPaletteChanged(object? sender, EventArgs e)
         {
             if (_palette != null)
             {
@@ -951,7 +951,7 @@ namespace Krypton.Toolkit
         }
 
         //Krypton Palette Events
-        private static void OnPalettePaint(object sender, PaletteLayoutEventArgs e)
+        private static void OnPalettePaint(object? sender, PaletteLayoutEventArgs e)
         {
             //Invalidate();
         }

--- a/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/VScrollSkin.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/VScrollSkin.cs
@@ -180,7 +180,7 @@ namespace Krypton.Toolkit
         /// <param name="sender"></param>
         /// <param name="e"></param>
         /// <remarks></remarks>
-        private void scrollSkin_ControlAdded(object sender, ControlEventArgs e)
+        private void scrollSkin_ControlAdded(object? sender, ControlEventArgs e)
         {
             if (e is not null
                 && e.Control is not null
@@ -218,7 +218,7 @@ namespace Krypton.Toolkit
         /// <param name="sender"></param>
         /// <param name="e"></param>
         /// <remarks></remarks>
-        private void VScrollBar1_miScroll(object sender, ScrollEventArgs e)
+        private void VScrollBar1_miScroll(object? sender, ScrollEventArgs e)
         {
             if (_win.GetType() == typeof(ListView))
             {
@@ -342,7 +342,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region "   Horizontal Scroll   "
-        private void HScrollBar1_miScroll(object sender, ScrollEventArgs e)
+        private void HScrollBar1_miScroll(object? sender, ScrollEventArgs e)
         {
             if (_win.GetType() == typeof(ListView))
             {
@@ -428,37 +428,23 @@ namespace Krypton.Toolkit
 
         #region "   DGV Scrollbar VisibleChanged    "
 
-        private void VerticalScrollBar_VisibleChanged(object sender, EventArgs e)
+        private void VerticalScrollBar_VisibleChanged(object? sender, EventArgs e)
         {
-            var vscroll = (VScrollBar)sender;
-            if (vscroll.Visible)
-            {
-                _vScrollBar1.Visible = true;
-            }
-            else
-            {
-                _vScrollBar1.Visible = false;
-            }
+            var vscroll = sender as VScrollBar ?? throw new ArgumentNullException(nameof(sender));
+            _vScrollBar1.Visible = vscroll.Visible;
         }
 
-        private void HorizontalScrollBar_VisibleChanged(object sender, EventArgs e)
+        private void HorizontalScrollBar_VisibleChanged(object? sender, EventArgs e)
         {
-            var hscroll = (HScrollBar)sender;
-            if (hscroll.Visible)
-            {
-                _hScrollBar1.Visible = true;
-            }
-            else
-            {
-                _hScrollBar1.Visible = false;
-            }
+            var hscroll = sender as HScrollBar ?? throw new ArgumentNullException(nameof(sender));
+            _hScrollBar1.Visible = hscroll.Visible;
         }
 
         #endregion
 
         #region "   DGV Scroll   "
 
-        private void dgv_Scroll(object sender, ScrollEventArgs e)
+        private void dgv_Scroll(object? sender, ScrollEventArgs e)
         {
             var dgv = (DataGridView)_win;
             if (GetDGVScrollbar(ref dgv, out VSB))
@@ -501,7 +487,7 @@ namespace Krypton.Toolkit
         /// <param name="sender"></param>
         /// <param name="e"></param>
         /// <remarks></remarks>
-        private void win_Resize(object sender, EventArgs e)
+        private void win_Resize(object? sender, EventArgs e)
         {
             VScrollBar1.Size = new Size(0x12, _win.Height); //for the gap 
             VScrollBar1.Left = _win.Right - 0x12;
@@ -735,7 +721,7 @@ namespace Krypton.Toolkit
 
 
         //Krypton Palette Events
-        private void OnGlobalPaletteChanged(object sender, EventArgs e)
+        private void OnGlobalPaletteChanged(object? sender, EventArgs e)
         {
             if (_palette != null)
             {
@@ -754,7 +740,7 @@ namespace Krypton.Toolkit
         }
 
         //Krypton Palette Events
-        private void OnPalettePaint(object sender, PaletteLayoutEventArgs e) => Invalidate();
+        private void OnPalettePaint(object? sender, PaletteLayoutEventArgs e) => Invalidate();
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/General/ShadowManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/ShadowManager.cs
@@ -85,7 +85,7 @@ namespace Krypton.Toolkit
             && _shadowValues.EnableShadows
             && _parentForm.Visible;
 
-        private void KryptonFormOnClosing(object sender, /*Cancel*/EventArgs e)
+        private void KryptonFormOnClosing(object? sender, /*Cancel*/EventArgs e)
         {
             _allowDrawing = false;
             FlashWindowExListener.FlashEvent -= OnFlashWindowExListenerOnFlashEvent;
@@ -100,7 +100,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void FormLoaded(object sender, EventArgs e)
+        private void FormLoaded(object? sender, EventArgs e)
         {
             _allowDrawing = (LicenseManager.UsageMode != LicenseUsageMode.Designtime)
                             && (Process.GetCurrentProcess().ProcessName != @"devenv");
@@ -126,15 +126,15 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void ShadowValues_ColourChanged(object sender, ColorEventArgs e) => ReCalcBrushes();
+        private void ShadowValues_ColourChanged(object? sender, ColorEventArgs e) => ReCalcBrushes();
 
-        private void ShadowValues_BlurDistanceChanged(object sender, EventArgs e) => ReCalcBrushes();
+        private void ShadowValues_BlurDistanceChanged(object? sender, EventArgs e) => ReCalcBrushes();
 
-        private void ShadowValues_OpacityChanged(object sender, EventArgs e) => ReCalcBrushes();
+        private void ShadowValues_OpacityChanged(object? sender, EventArgs e) => ReCalcBrushes();
 
-        private void ShadowValues_MarginsChanged(object sender, EventArgs e) => SetShadowFormsSizes();
+        private void ShadowValues_MarginsChanged(object? sender, EventArgs e) => SetShadowFormsSizes();
 
-        private void ShadowValues_EnableShadowsChanged(object sender, EventArgs e)
+        private void ShadowValues_EnableShadowsChanged(object? sender, EventArgs e)
         {
             if (!_allowDrawing
                 || _shadowForms == null)

--- a/Source/Krypton Components/Krypton.Toolkit/General/TooltipManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/TooltipManager.cs
@@ -254,7 +254,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnStartTimerTick(object sender, EventArgs e)
+        private void OnStartTimerTick(object? sender, EventArgs e)
         {
             // One tick timer, so always stop
             _startTimer.Stop();
@@ -276,7 +276,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnStopDetectMoveTimerTick(object sender, EventArgs e)
+        private void OnStopDetectMoveTimerTick(object? sender, EventArgs e)
         {
             // One tick timer, so always stop
             _detectMoveTimer.Stop();
@@ -310,7 +310,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnCloseTimerTick(object sender, EventArgs e)
+        private void OnCloseTimerTick(object? sender, EventArgs e)
         {
             // Raises event indicating the tooltip should be removed
             _closeTimer.Stop();

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteButtonSpecs.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteButtonSpecs.cs
@@ -543,7 +543,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">An EventArgs containing event data.</param>
-        protected virtual void OnButtonSpecChanged(object sender, EventArgs e) => ButtonSpecChanged?.Invoke(this, e);
+        protected virtual void OnButtonSpecChanged(object? sender, EventArgs e) => ButtonSpecChanged?.Invoke(this, e);
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/ShellDialogs/FileSaveDialogWrapper.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ShellDialogs/FileSaveDialogWrapper.cs
@@ -59,7 +59,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private protected override void FormResize(object sender, EventArgs e)
+        private protected override void FormResize(object? sender, EventArgs e)
         {
             // Panel controls button placement now (Due to messed up transparency)
             //return;

--- a/Source/Krypton Components/Krypton.Toolkit/ShellDialogs/ShellDialogWrapper.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ShellDialogs/ShellDialogWrapper.cs
@@ -104,7 +104,7 @@ namespace Krypton.Toolkit
         private bool _alreadySetup;
         private protected float _scaleFactor;
 
-        private protected virtual void FormResize(object sender, EventArgs e)
+        private protected virtual void FormResize(object? sender, EventArgs e)
         {
             if (_commonDialogHandler._wrapperForm == null)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/View Base/InternalKryptonStringCollectionEditor.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Base/InternalKryptonStringCollectionEditor.cs
@@ -417,9 +417,9 @@ namespace Krypton.Toolkit
 
         #region Implementation
 
-        private void kbtnCancel_Click(object sender, EventArgs e) => Owner!.DialogResult = DialogResult.Cancel;
+        private void kbtnCancel_Click(object? sender, EventArgs e) => Owner!.DialogResult = DialogResult.Cancel;
 
-        private void kbtnOk_Click(object sender, EventArgs e)
+        private void kbtnOk_Click(object? sender, EventArgs e)
         {
             if (_useTextBox)
             {
@@ -449,21 +449,21 @@ namespace Krypton.Toolkit
             Owner!.DialogResult = DialogResult.OK;
         }
 
-        private void kcRichTextBoxCut_Execute(object sender, EventArgs e) => krtbContents.Cut();
+        private void kcRichTextBoxCut_Execute(object? sender, EventArgs e) => krtbContents.Cut();
 
-        private void kcRichTextBoxCopy_Execute(object sender, EventArgs e) => Clipboard.SetText(krtbContents.Text);
+        private void kcRichTextBoxCopy_Execute(object? sender, EventArgs e) => Clipboard.SetText(krtbContents.Text);
 
-        private void kcRichTextBoxPaste_Execute(object sender, EventArgs e) => krtbContents.Paste();
+        private void kcRichTextBoxPaste_Execute(object? sender, EventArgs e) => krtbContents.Paste();
 
-        private void kcTextBoxCut_Execute(object sender, EventArgs e) => ktxtStringCollection.Cut();
+        private void kcTextBoxCut_Execute(object? sender, EventArgs e) => ktxtStringCollection.Cut();
 
-        private void kcTextBoxCopy_Execute(object sender, EventArgs e) => Clipboard.SetText(ktxtStringCollection.Text);
+        private void kcTextBoxCopy_Execute(object? sender, EventArgs e) => Clipboard.SetText(ktxtStringCollection.Text);
 
-        private void kcTextBoxPaste_Execute(object sender, EventArgs e) => ktxtStringCollection.Paste();
+        private void kcTextBoxPaste_Execute(object? sender, EventArgs e) => ktxtStringCollection.Paste();
 
-        private void kcRichTextBoxSelectAll_Execute(object sender, EventArgs e) => krtbContents.SelectAll();
+        private void kcRichTextBoxSelectAll_Execute(object? sender, EventArgs e) => krtbContents.SelectAll();
 
-        private void kcTextBoxSelectAll_Execute(object sender, EventArgs e) => ktxtStringCollection.SelectAll();
+        private void kcTextBoxSelectAll_Execute(object? sender, EventArgs e) => ktxtStringCollection.SelectAll();
 
         internal void SetContentsArray(string[] contentArray) => _contents = contentArray;
 

--- a/Source/Krypton Components/Krypton.Toolkit/View Base/ViewContextMenuManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Base/ViewContextMenuManager.cs
@@ -834,7 +834,7 @@ namespace Krypton.Toolkit
             return distance;
         }
 
-        private void OnDelayTimerExpire(object sender, EventArgs e)
+        private void OnDelayTimerExpire(object? sender, EventArgs e)
         {
             if (_itemDelayTimer != null)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawDateTimeButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawDateTimeButton.cs
@@ -224,14 +224,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">Event arguments assocaited with the event.</param>
-        protected void OnButtonClick(object sender, MouseEventArgs e) => Click?.Invoke(this, e);
+        protected void OnButtonClick(object? sender, MouseEventArgs e) => Click?.Invoke(this, e);
 
         /// <summary>
         /// Raises the MouseSelect event.
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">Event arguments assocaited with the event.</param>
-        protected void OnButtonMouseSelect(object sender, MouseEventArgs e) => MouseSelect?.Invoke(this, e);
+        protected void OnButtonMouseSelect(object? sender, MouseEventArgs e) => MouseSelect?.Invoke(this, e);
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuCheckBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuCheckBox.cs
@@ -305,7 +305,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Private
-        private void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void OnPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {
@@ -339,7 +339,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnCommandPropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void OnCommandPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {
@@ -356,7 +356,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnClick(object sender, EventArgs e) => KryptonContextMenuCheckBox.PerformClick();
+        private void OnClick(object? sender, EventArgs e) => KryptonContextMenuCheckBox.PerformClick();
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuCheckButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuCheckButton.cs
@@ -292,7 +292,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Private
-        private void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void OnPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {
@@ -325,7 +325,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnCommandPropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void OnCommandPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {
@@ -341,7 +341,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnClick(object sender, EventArgs e) => KryptonContextMenuCheckButton.PerformClick();
+        private void OnClick(object? sender, EventArgs e) => KryptonContextMenuCheckButton.PerformClick();
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuColorBlock.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuColorBlock.cs
@@ -255,7 +255,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Private
-        private void OnClick(object sender, EventArgs e) => KryptonContextMenuColorColumns.SelectedColor = Color;
+        private void OnClick(object? sender, EventArgs e) => KryptonContextMenuColorColumns.SelectedColor = Color;
         #endregion
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuColorColumns.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuColorColumns.cs
@@ -160,7 +160,7 @@ namespace Krypton.Toolkit
             return columns;
         }
 
-        private void OnSelectedColorChanged(object sender, ColorEventArgs e) => _provider.ProviderNeedPaintDelegate(this, new NeedLayoutEventArgs(false));
+        private void OnSelectedColorChanged(object? sender, ColorEventArgs e) => _provider.ProviderNeedPaintDelegate(this, new NeedLayoutEventArgs(false));
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuImageSelectItem.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuImageSelectItem.cs
@@ -176,7 +176,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Private
-        private void OnItemClick(object sender, MouseEventArgs e)
+        private void OnItemClick(object? sender, MouseEventArgs e)
         {
             // Set new selection index
             _imageSelect.SelectedIndex = _imageIndex;

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuItem.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuItem.cs
@@ -580,7 +580,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void OnPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {
@@ -617,7 +617,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnCommandPropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void OnCommandPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {
@@ -635,7 +635,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        internal void OnContextMenuDisposed(object sender, EventArgs e)
+        internal void OnContextMenuDisposed(object? sender, EventArgs e)
         {
             // Should still be caching a reference to actual display control
             if (_contextMenu != null)

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuLinkLabel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuLinkLabel.cs
@@ -261,7 +261,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Private
-        private void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void OnPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {
@@ -292,7 +292,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnCommandPropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void OnCommandPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {
@@ -306,7 +306,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnClick(object sender, EventArgs e) => KryptonContextMenuLinkLabel.PerformClick();
+        private void OnClick(object? sender, EventArgs e) => KryptonContextMenuLinkLabel.PerformClick();
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuRadioButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuRadioButton.cs
@@ -221,18 +221,18 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Private
-        private void OnCheckedChanged(object sender, EventArgs e)
+        private void OnCheckedChanged(object? sender, EventArgs e)
         {
             ViewDrawRadioButton.CheckState = KryptonContextMenuRadioButton.Checked;
             _provider.ProviderNeedPaintDelegate(this, new NeedLayoutEventArgs(false));
         }
 
-        private void OnClick(object sender, EventArgs e) => KryptonContextMenuRadioButton.PerformClick();
+        private void OnClick(object? sender, EventArgs e) => KryptonContextMenuRadioButton.PerformClick();
 
         #endregion
 
         #region Implementation
-        private void OnCommandPropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void OnCommandPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)
             {

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMonth.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMonth.cs
@@ -298,9 +298,9 @@ namespace Krypton.Toolkit
             _numberStack.Visible = showWeekNumbers;
         }
 
-        private void OnNextMonth(object sender, EventArgs e) => _months.NextMonth();
+        private void OnNextMonth(object? sender, EventArgs e) => _months.NextMonth();
 
-        private void OnPrevMonth(object sender, EventArgs e) => _months.PrevMonth();
+        private void OnPrevMonth(object? sender, EventArgs e) => _months.PrevMonth();
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMonthUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMonthUpDown.cs
@@ -169,14 +169,14 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">Event arguments assocaited with the event.</param>
-        protected void OnButtonClick(object sender, MouseEventArgs e) => Click?.Invoke(this, e);
+        protected void OnButtonClick(object? sender, MouseEventArgs e) => Click?.Invoke(this, e);
 
         /// <summary>
         /// Raises the MouseSelect event.
         /// </summary>
         /// <param name="sender">Source of the event.</param>
         /// <param name="e">Event arguments assocaited with the event.</param>
-        protected void OnButtonMouseSelect(object sender, MouseEventArgs e) => MouseSelect?.Invoke(this, e);
+        protected void OnButtonMouseSelect(object? sender, MouseEventArgs e) => MouseSelect?.Invoke(this, e);
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawScrollBar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawScrollBar.cs
@@ -306,7 +306,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnScrollBarChange(object sender, ScrollEventArgs e)
+        private void OnScrollBarChange(object? sender, ScrollEventArgs e)
         {
             // Update with the new scroll value
             _scrollBar!.Value = e.NewValue;

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawToday.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawToday.cs
@@ -103,7 +103,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
-        private void OnClick(object sender, MouseEventArgs e) => Click?.Invoke(this, EventArgs.Empty);
+        private void OnClick(object? sender, MouseEventArgs e) => Click?.Invoke(this, EventArgs.Empty);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutCrumbs.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutCrumbs.cs
@@ -392,7 +392,7 @@ namespace Krypton.Toolkit
             Insert(0, _overflowButton);
         }
 
-        private void OnButtonClick(object sender, MouseEventArgs e)
+        private void OnButtonClick(object? sender, MouseEventArgs e)
         {
             // Only allow a single context menu at a time
             if (!_showingContextMenu)
@@ -482,10 +482,10 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnKryptonContextMenuClosed(object sender, EventArgs e)
+        private void OnKryptonContextMenuClosed(object? sender, EventArgs e)
         {
             // Cast to correct type
-            var kcm = (KryptonContextMenu)sender;
+            var kcm = sender as KryptonContextMenu ?? throw new ArgumentNullException(nameof(sender));
 
             // Unhook from context menu and dispose of it, we only use each menu instance once
             kcm.Closed -= OnKryptonContextMenuClosed;
@@ -499,14 +499,14 @@ namespace Krypton.Toolkit
             _showingContextMenu = false;
         }
 
-        private void OnChildCrumbClick(object sender, EventArgs e)
+        private void OnChildCrumbClick(object? sender, EventArgs e)
         {
             // Make the clicked child crumb the newly selected item
             var childItem = sender as KryptonContextMenuItem;
             _kryptonBreadCrumb.SelectedItem = _menuItemToCrumb[childItem!];
         }
 
-        private void OnOverflowButtonClick(object sender, MouseEventArgs e)
+        private void OnOverflowButtonClick(object? sender, MouseEventArgs e)
         {
             // Only allow a single context menu at a time
             if (!_showingContextMenu)

--- a/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutMonths.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutMonths.cs
@@ -633,7 +633,7 @@ namespace Krypton.Toolkit
         #region Private
         private DateTime JustDay(DateTime dt) => new DateTime(dt.Year, dt.Month, dt.Day);
 
-        private void OnTodayClick(object sender, EventArgs e)
+        private void OnTodayClick(object? sender, EventArgs e)
         {
             // Remove any time information as selecting a date is based only on the day
             DateTime today = Calendar.TodayDate;
@@ -784,7 +784,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnShowToolTip(object sender, ToolTipEventArgs e)
+        private void OnShowToolTip(object? sender, ToolTipEventArgs e)
         {
             if (!IsDisposed)
             {
@@ -847,14 +847,14 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnCancelToolTip(object sender, EventArgs e) =>
+        private void OnCancelToolTip(object? sender, EventArgs e) =>
             // Remove any currently showing tooltip
             _visualPopupToolTip?.Dispose();
 
-        private void OnVisualPopupToolTipDisposed(object sender, EventArgs e)
+        private void OnVisualPopupToolTipDisposed(object? sender, EventArgs e)
         {
             // Unhook events from the specific instance that generated event
-            var popupToolTip = (VisualPopupToolTip)sender;
+            var popupToolTip = sender as VisualPopupToolTip ?? throw new ArgumentNullException(nameof(sender));
             popupToolTip.Disposed -= OnVisualPopupToolTipDisposed;
 
             // Not showing a popup page any more

--- a/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutScrollViewport.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutScrollViewport.cs
@@ -422,7 +422,7 @@ namespace Krypton.Toolkit
         #region Implementation
         private VisualOrientation ViewportOrientation(bool vertical) => vertical ? VisualOrientation.Left : VisualOrientation.Top;
 
-        private void OnScrollVChanged(object sender, EventArgs e)
+        private void OnScrollVChanged(object? sender, EventArgs e)
         {
             // Update viewport with the new scroll offset
             Viewport.SetOffsetV(ScrollbarV.ScrollPosition);
@@ -438,7 +438,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnScrollHChanged(object sender, EventArgs e)
+        private void OnScrollHChanged(object? sender, EventArgs e)
         {
             // Update viewport with the new scroll offset
             Viewport.SetOffsetH(ScrollbarH.ScrollPosition);
@@ -454,7 +454,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnAnimateStep(object sender, EventArgs e) => AnimateStep?.Invoke(sender, e);
+        private void OnAnimateStep(object? sender, EventArgs e) => AnimateStep?.Invoke(sender, e);
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutViewport.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutViewport.cs
@@ -943,7 +943,7 @@ namespace Krypton.Toolkit
             return offset;
         }
 
-        private void OnAnimationTick(object sender, EventArgs e)
+        private void OnAnimationTick(object? sender, EventArgs e)
         {
             // Limit check the animation offset, incase the limits have changed
             _animationOffset.X = Math.Min(Math.Max(_animationOffset.X, _limit.X), 0);


### PR DESCRIPTION
[Issue 1664-Warning-Removal-after-issue-1650-part2](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1664)
- Toolikit warnings removal 
- A couple of other warnings that developed while processing the Toolkit

![compile-results](https://github.com/user-attachments/assets/26a8ed8c-aacd-4eaf-8a78-a53e8a33e007)

MAKE SURE TO UPDATE YOUR ALPHA BASED DEV BRANCHES WHEN THIS HAS BEEN MERGED.