### PR TITLE
Fix NullReferenceException in KryptonGroupPanel

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -2,6 +2,11 @@
 
 =======
 
+## 2024-07-xx - Build 2408 (Patch 2) - July 2024
+* Resolved [#1675](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1675), Catastrophic failure wherever `KryptonGroupPanel` is used.
+
+=======
+
 ## 2024-07-22 - Build 2407 (Patch 1) - July 2024
 * Resolved [#1373](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1373), `KT.CommonHelper.CheckContextMenuForShortcut()` handles direct type casts differently from .NET 8.0 onward. Solution courtesy of @Tape-Worm.
 * Resolved [#1613](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1613), `KryptonMessageBox` text is not centered vertically.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonGroupPanel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonGroupPanel.cs
@@ -474,7 +474,7 @@ namespace Krypton.Toolkit
         protected override void OnVisibleChanged(EventArgs e)
         {
             // Note: Why does this throw an exception?
-            VisibleChanged!.Invoke(this, e);
+            VisibleChanged?.Invoke(this, e);
 
             base.OnVisibleChanged(e);
         }


### PR DESCRIPTION
Issue [1675-V85-Catastrophic-failure-wherever-KryptonGroup-is-used](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1675)

Replaced the null-forgiving operator `!` with a null-conditional operator `?.` to prevent throwing a NullReferenceException when the KryptonGroupPanel is about to be shown.

![image](https://github.com/user-attachments/assets/00caf1e9-65bb-47cb-8aa3-3d46a53b2dd0)
