### PR TITLE
- Add `public virtual string Text` to replicate the equivalent of a Winforms base item

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
+* Resolved [#1672](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1672), `KryptonContextMenuItemBase`: does not have a "Text" access AP
 * Resolved [#1686](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1686), `TestForm`: MessageBox "No Close button" is not respected anymore
 * Resolved [#1683](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1683), After #1657 `TestForm` forms still have Toolkit Image strings in the designer files
 * Resolved [#1657](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1657), What is/does "GenericToolkitImages" supposed to do

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuCheckBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuCheckBox.cs
@@ -29,7 +29,6 @@ namespace Krypton.Toolkit
         private bool _autoClose;
         private bool _checked;
         private bool _enabled;
-        private string _text;
         private string? _extraText;
         private Image? _image;
         private Color _imageTransparentColor;
@@ -185,18 +184,10 @@ namespace Krypton.Toolkit
         [Description(@"Main check box text.")]
         [DefaultValue(nameof(CheckBox))]
         [Localizable(true)]
-        public string Text
+        public override string Text
         {
-            get => _text;
-
-            set
-            {
-                if (_text != value)
-                {
-                    _text = value;
-                    OnPropertyChanged(new PropertyChangedEventArgs(nameof(Text)));
-                }
-            }
+            get => base.Text;
+            set => base.Text = value;
         }
 
         /// <summary>
@@ -251,7 +242,6 @@ namespace Krypton.Toolkit
         [Category(@"Appearance")]
         [Description(@"Check box image color to make transparent.")]
         [Localizable(true)]
-        [DisallowNull]
         public Color ImageTransparentColor
         {
             get => _imageTransparentColor;

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuCheckButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuCheckButton.cs
@@ -28,7 +28,6 @@ namespace Krypton.Toolkit
         private bool _autoClose;
         private bool _checked;
         private bool _enabled;
-        private string _text;
         private string _extraText;
         private Image? _image;
         private Color _imageTransparentColor;
@@ -179,18 +178,10 @@ namespace Krypton.Toolkit
         [Description(@"Main check box text.")]
         [DefaultValue(nameof(CheckBox))]
         [Localizable(true)]
-        public string Text
+        public override string Text
         {
-            get => _text;
-
-            set 
-            {
-                if (_text != value)
-                {
-                    _text = value;
-                    OnPropertyChanged(new PropertyChangedEventArgs(nameof(Text)));
-                }
-            }
+            get => base.Text;
+            set => base.Text = value;
         }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuHeading.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuHeading.cs
@@ -24,7 +24,6 @@ namespace Krypton.Toolkit
     public class KryptonContextMenuHeading : KryptonContextMenuItemBase
     {
         #region Instance Fields
-        private string _text;
         private string? _extraText;
         private Image? _image;
         private Color _imageTransparentColor;

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuHeading.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuHeading.cs
@@ -55,7 +55,6 @@ namespace Krypton.Toolkit
         public KryptonContextMenuHeading(string initialText)
         {
             // Default fields
-            _text = initialText;
             _extraText = string.Empty;
             _image = null;
             _imageTransparentColor = GlobalStaticValues.EMPTY_COLOR;
@@ -141,18 +140,10 @@ namespace Krypton.Toolkit
         [Editor(typeof(MultilineStringEditor), typeof(UITypeEditor))]
         [Localizable(true)]
         [DefaultValue(@"Heading")]
-        public string Text
+        public override string Text
         {
-            get => _text;
-
-            set 
-            {
-                if (_text != value)
-                {
-                    _text = value;
-                    OnPropertyChanged(new PropertyChangedEventArgs(nameof(Text)));
-                }
-            }
+            get => base.Text;
+            set => base.Text = value;
         }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuItem.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuItem.cs
@@ -31,7 +31,6 @@ namespace Krypton.Toolkit
         private bool _showShortcutKeys;
         private bool _autoClose;
         private bool _largeKryptonCommandImage;
-        private string _text;
         private string _extraText;
         private string _shortcutKeyDisplayString;
         private Image? _image;
@@ -231,18 +230,10 @@ namespace Krypton.Toolkit
         [DefaultValue(@"MenuItem")]
         [Localizable(true)]
         [Bindable(true)]
-        public string Text
+        public override string Text
         {
-            get => _text;
-
-            set
-            {
-                if (_text != value)
-                {
-                    _text = value;
-                    OnPropertyChanged(new PropertyChangedEventArgs(nameof(Text)));
-                }
-            }
+            get => base.Text;
+            set => base.Text = value;
         }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuItemBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuItemBase.cs
@@ -20,6 +20,7 @@ namespace Krypton.Toolkit
     {
         #region Instance Fields
 
+        protected string _text;
         private bool _visible;
         private ToolTipValues _toolTipValues = new ToolTipValues(null);
         private VisualPopupToolTip? _visualPopupToolTip;
@@ -48,6 +49,7 @@ namespace Krypton.Toolkit
         /// </summary>
         protected KryptonContextMenuItemBase()
         {
+            _text = string.Empty;
             _visible = true;
             ToolTipManager = new ToolTipManager(_toolTipValues);
             ToolTipManager.ShowToolTip += OnShowToolTip;
@@ -134,6 +136,25 @@ namespace Krypton.Toolkit
                 {
                     _visible = value;
                     OnPropertyChanged(new PropertyChangedEventArgs(nameof(Visible)));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets and sets the standard menu item text.
+        /// </summary>
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public virtual string Text
+        {
+            get => _text;
+
+            set
+            {
+                if (_text != value)
+                {
+                    _text = value;
+                    OnPropertyChanged(new PropertyChangedEventArgs(nameof(Text)));
                 }
             }
         }

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuItemBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuItemBase.cs
@@ -20,11 +20,11 @@ namespace Krypton.Toolkit
     {
         #region Instance Fields
 
-        protected string _text;
+        private protected string _text;
         private bool _visible;
-        private ToolTipValues _toolTipValues = new ToolTipValues(null);
+        private ToolTipValues _toolTipValues = new(null);
         private VisualPopupToolTip? _visualPopupToolTip;
-        private IContextMenuProvider _provider;
+        private IContextMenuProvider? _provider;
         #endregion
 
         #region Events
@@ -240,22 +240,24 @@ namespace Krypton.Toolkit
                     _toolTipValues.Image = args.Icon;
 
                     // Create the actual tooltip popup object
-                    var renderer = _provider.ProviderRedirector.Target!.GetRenderer();
-                    _visualPopupToolTip = new VisualPopupToolTip(_provider.ProviderRedirector,
-                        _toolTipValues,
-                        renderer,
-                        PaletteBackStyle.ControlToolTip,
-                        PaletteBorderStyle.ControlToolTip,
-                        CommonHelper.ContentStyleFromLabelStyle(_toolTipValues.ToolTipStyle),
-                        _toolTipValues.ToolTipShadow);
-
-                    _visualPopupToolTip.Disposed += OnVisualPopupToolTipDisposed;
-                    _visualPopupToolTip.ShowRelativeTo(e.Target, e.ControlMousePosition);
+                    if (_provider != null)
+                    {
+                        var renderer = _provider.ProviderRedirector.Target!.GetRenderer();
+                        _visualPopupToolTip = new VisualPopupToolTip(_provider.ProviderRedirector,
+                            _toolTipValues,
+                            renderer,
+                            PaletteBackStyle.ControlToolTip,
+                            PaletteBorderStyle.ControlToolTip,
+                            CommonHelper.ContentStyleFromLabelStyle(_toolTipValues.ToolTipStyle),
+                            _toolTipValues.ToolTipShadow);
+                        _visualPopupToolTip.Disposed += OnVisualPopupToolTipDisposed;
+                        _visualPopupToolTip.ShowRelativeTo(e.Target, e.ControlMousePosition);
+                    }
                 }
             }
         }
 
-        internal void OnCancelToolTip(object? sender, EventArgs e) =>
+        internal void OnCancelToolTip(object? _, EventArgs e) =>
             // Remove any currently showing tooltip
             _visualPopupToolTip?.Dispose();
 

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuLinkLabel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuLinkLabel.cs
@@ -25,7 +25,6 @@ namespace Krypton.Toolkit
     {
         #region Instance Fields
         private bool _autoClose;
-        private string _text;
         private string? _extraText;
         private Image? _image;
         private Color _imageTransparentColor;
@@ -240,18 +239,10 @@ namespace Krypton.Toolkit
         [Description(@"Main link label text.")]
         [DefaultValue(nameof(LinkLabel))]
         [Localizable(true)]
-        public string Text
+        public override string Text
         {
-            get => _text;
-
-            set
-            {
-                if (_text != value)
-                {
-                    _text = value;
-                    OnPropertyChanged(new PropertyChangedEventArgs(nameof(Text)));
-                }
-            }
+            get => base.Text;
+            set => base.Text = value;
         }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuRadioButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuRadioButton.cs
@@ -28,7 +28,6 @@ namespace Krypton.Toolkit
         private bool _autoClose;
         private bool _checked;
         private bool _enabled;
-        private string _text;
         private string? _extraText;
         private Image? _image;
         private Color _imageTransparentColor;
@@ -173,18 +172,10 @@ namespace Krypton.Toolkit
         [Description(@"Main radio button text.")]
         [DefaultValue(nameof(RadioButton))]
         [Localizable(true)]
-        public string Text
+        public override string Text
         {
-            get => _text;
-
-            set 
-            {
-                if (_text != value)
-                {
-                    _text = value;
-                    OnPropertyChanged(new PropertyChangedEventArgs(nameof(Text)));
-                }
-            }
+            get => base.Text;
+            set => base.Text = value;
         }
 
         /// <summary>
@@ -238,7 +229,6 @@ namespace Krypton.Toolkit
         [Category(@"Appearance")]
         [Description(@"Radio button image color to make transparent.")]
         [Localizable(true)]
-        [DisallowNull]
         public Color ImageTransparentColor
         {
             get => _imageTransparentColor;

--- a/Source/Krypton Components/TestForm/BasicToastNotificationTest.cs
+++ b/Source/Krypton Components/TestForm/BasicToastNotificationTest.cs
@@ -23,9 +23,9 @@ namespace TestForm
         private Color _borderColor2;
         private ContentAlignment _titleAlignment;
         private Font _contentFont;
-        private Font _titleFont;
+        private Font? _titleFont;
         private int _countDownSeconds;
-        private KryptonToastNotificationIcon _notificationIcon;
+        private KryptonToastNotificationIcon? _notificationIcon;
         private string _notificationTitleText;
         private string _notificationContentText;
 
@@ -33,13 +33,12 @@ namespace TestForm
 
         public BasicToastNotificationTest()
         {
-
             InitializeComponent();
         }
 
         private void kbtnShow_Click(object sender, EventArgs e)
         {
-            KryptonBasicToastNotificationData notificationData = new KryptonBasicToastNotificationData()
+            var notificationData = new KryptonBasicToastNotificationData()
             {
                 CountDownSeconds = _countDownSeconds,
                 CustomImage = null,
@@ -60,7 +59,7 @@ namespace TestForm
                 UseRtlReading = _useRtlReading
             };
 
-            KryptonBasicToastNotificationData notificationDataWithLocation = new KryptonBasicToastNotificationData()
+            var notificationDataWithLocation = new KryptonBasicToastNotificationData()
             {
                 CountDownSeconds = _countDownSeconds,
                 CustomImage = null,
@@ -108,14 +107,14 @@ namespace TestForm
 
             foreach (var value in Enum.GetValues(typeof(KryptonToastNotificationIcon)))
             {
-                kcmbToastIcon.Items.Add(value.ToString());
+                kcmbToastIcon.Items.Add(value!.ToString());
             }
 
             kcmbToastIcon.SelectedIndex = 8;
 
             foreach (var value in Enum.GetValues(typeof(ContentAlignment)))
             {
-                kcmbToastTitleAlignment.Items.Add(value.ToString());
+                kcmbToastTitleAlignment.Items.Add(value!.ToString());
             }
 
             kcmbToastTitleAlignment.SelectedIndex = 4;
@@ -131,7 +130,7 @@ namespace TestForm
 
         private void kbtnContentFont_Click(object sender, EventArgs e)
         {
-            KryptonFontDialog contentFontDialog = new KryptonFontDialog();
+            var contentFontDialog = new KryptonFontDialog();
 
             if (contentFontDialog.ShowDialog() == DialogResult.OK)
             {

--- a/Source/Krypton Components/TestForm/CustomMessageBoxTest.cs
+++ b/Source/Krypton Components/TestForm/CustomMessageBoxTest.cs
@@ -7,16 +7,6 @@
  */
 #endregion
 
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms;
-
 namespace TestForm
 {
     public partial class CustomMessageBoxTest : KryptonForm

--- a/Source/Krypton Components/TestForm/DataGridViewSetup.cs
+++ b/Source/Krypton Components/TestForm/DataGridViewSetup.cs
@@ -7,7 +7,6 @@
  */
 #endregion
 
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/Source/Krypton Components/TestForm/GlobalUsings.cs
+++ b/Source/Krypton Components/TestForm/GlobalUsings.cs
@@ -10,7 +10,10 @@
 // Global using directives
 
 global using System;
+global using System.Collections;
+global using System.ComponentModel;
 global using System.Drawing;
+global using System.Globalization;
 global using System.Windows.Forms;
 
 global using Krypton.Toolkit;

--- a/Source/Krypton Components/TestForm/InputBoxTest.cs
+++ b/Source/Krypton Components/TestForm/InputBoxTest.cs
@@ -7,16 +7,6 @@
  */
 #endregion
 
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms;
-
 namespace TestForm
 {
     public partial class InputBoxTest : KryptonForm

--- a/Source/Krypton Components/TestForm/LabelsTest.cs
+++ b/Source/Krypton Components/TestForm/LabelsTest.cs
@@ -7,8 +7,6 @@
  */
 #endregion
 
-
-
 namespace TestForm
 {
     public partial class LabelsTest : KryptonForm

--- a/Source/Krypton Components/TestForm/Main.cs
+++ b/Source/Krypton Components/TestForm/Main.cs
@@ -7,7 +7,6 @@
  */
 #endregion
 
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Reflection;
 

--- a/Source/Krypton Components/TestForm/OutlookGridPriceGroup.cs
+++ b/Source/Krypton Components/TestForm/OutlookGridPriceGroup.cs
@@ -7,8 +7,6 @@
  */
 #endregion
 
-using System.Globalization;
-
 namespace TestForm
 {
     public class OutlookGridPriceGroup : OutlookGridDefaultGroup

--- a/Source/Krypton Components/TestForm/OutlookGridTest.cs
+++ b/Source/Krypton Components/TestForm/OutlookGridTest.cs
@@ -8,7 +8,6 @@
 #endregion
 
 using System.Collections.Generic;
-using System.Globalization;
 using System.Xml;
 
 namespace TestForm

--- a/Source/Krypton Components/TestForm/TextBoxEventTest.cs
+++ b/Source/Krypton Components/TestForm/TextBoxEventTest.cs
@@ -7,8 +7,6 @@
  */
 #endregion
 
-using System.ComponentModel;
-
 namespace TestForm
 {
     public partial class TextBoxEventTest : KryptonForm

--- a/Source/Krypton Components/TestForm/ToastNotificationQuickTestForm.cs
+++ b/Source/Krypton Components/TestForm/ToastNotificationQuickTestForm.cs
@@ -7,8 +7,6 @@
  */
 #endregion
 
-using System.Collections;
-
 namespace TestForm
 {
     public partial class ToastNotificationQuickTestForm : KryptonForm

--- a/Source/Krypton Components/TestForm/UserInputToastNotificationTest.cs
+++ b/Source/Krypton Components/TestForm/UserInputToastNotificationTest.cs
@@ -7,8 +7,6 @@
  */
 #endregion
 
-using System.Collections;
-
 namespace TestForm
 {
     public partial class UserInputToastNotificationTest : KryptonForm
@@ -19,7 +17,7 @@ namespace TestForm
 
         private bool _useRTLReading;
 
-        private string _stringResult;
+        private string? _stringResult;
 
         private int _integerResult;
 
@@ -50,7 +48,7 @@ namespace TestForm
 
         private void kbtnShow_Click(object sender, EventArgs e)
         {
-            KryptonUserInputToastNotificationData data = new KryptonUserInputToastNotificationData()
+            var data = new KryptonUserInputToastNotificationData()
             {
                 BorderColor1 = kcbtnBorderColor1.SelectedColor,
                 BorderColor2 = kcbtnBorderColor2.SelectedColor,
@@ -103,7 +101,7 @@ namespace TestForm
                         KryptonMessageBox.Show($"Result = {_stringResult}");
                         break;
                     default:
-                        throw new ArgumentOutOfRangeException();
+                        throw new InvalidEnumArgumentException(@"InputAreaType()");
                 }
             }
             else

--- a/Source/Krypton Components/TestForm/Workspace.cs
+++ b/Source/Krypton Components/TestForm/Workspace.cs
@@ -7,16 +7,6 @@
  */
 #endregion
 
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms;
-
 namespace TestForm
 {
     public partial class WorkspaceTest : KryptonForm


### PR DESCRIPTION
- Add `public virtual string Text` to replicate the equivalent of a Winforms base item

![image](https://github.com/user-attachments/assets/116221e4-cb13-45c4-9c33-0a83d1379b62)

#1672