### PR TITLE
1700-Add-string-handling-routine-to-CommonHelper

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,7 +3,7 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
-* Implemented [#1700](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1700), Adds a method to `CommonHelper` which normalizes line breaks within a string.
+* Implemented [#1700](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1700), Adds a method to `CommonHelper` which normalizes line breaks within a string, `CommonHelper.NormalizeLineBreaks`.
 * Resolved [#1685](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1685), Theme Selectors `KryptonManagerGlobalPaletteChanged` event sometimes gets fired while the control is not fully initialized.
 * Resolved [#1689](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1689), MessageBox text is "Hard to read" when using "MS 365 dark theme"
 * Resolved [#1672](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1672), `KryptonContextMenuItemBase`: does not have a "Text" access AP

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
+* Implemented [#1700](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1700), Adds a method to `CommonHelper` which normalizes line breaks within a string.
 * Resolved [#1685](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1685), Theme Selectors `KryptonManagerGlobalPaletteChanged` event sometimes gets fired while the control is not fully initialized.
 * Resolved [#1689](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1689), MessageBox text is "Hard to read" when using "MS 365 dark theme"
 * Resolved [#1672](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1672), `KryptonContextMenuItemBase`: does not have a "Text" access AP

--- a/Source/Krypton Components/Krypton.Toolkit/General/CommonHelper.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/CommonHelper.cs
@@ -101,6 +101,42 @@ namespace Krypton.Toolkit
         }
 
         /// <summary>
+        /// Converts line breaks in the string to the system default line break, Environment.NewLine.
+        /// </summary>
+        /// <param name="text">String to process.</param>
+        /// <returns>
+        /// Normalized resultant string.<br/>
+        /// If the input string is an empty string, the input string is returned.
+        /// </returns>
+        public static string NormalizeLineBreaks(string text)
+        {
+            string result = text;
+
+            if (result.Length > 0)
+            {
+                // Convert line breaks to the system provided line break
+                if (!Environment.NewLine.Equals("\r\n"))
+                {
+                    result = Regex.Replace(result, @"\r\n", Environment.NewLine);
+                }
+
+                if (!Environment.NewLine.Equals("\n"))
+                {
+                    // Replaces \n but not \r\n
+                    result = Regex.Replace(result, "(?<!\r)\n", Environment.NewLine);
+                }
+
+                if (!Environment.NewLine.Equals("\r"))
+                {
+                    // Replaces \r but not \r\n
+                    result = Regex.Replace(result, "\r(?!\n)", Environment.NewLine);
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
         /// Gets a string that is guaranteed to be unique.
         /// </summary>
         public static string UniqueString

--- a/Source/Krypton Components/TestForm/CustomMessageBoxTest.cs
+++ b/Source/Krypton Components/TestForm/CustomMessageBoxTest.cs
@@ -169,38 +169,57 @@ namespace TestForm
 
         private void kbtnShow_Click(object sender, EventArgs e)
         {
-            if (!krbIconWinLogo.Checked
-                && !krbIconShield.Checked
-#if NET8_0_OR_GREATER
-#else
-                && !krbButtonsCancelTryContinue.Checked
-#endif
-               )
-            {
-                if (kcbShowHelp.Checked)
-                {
-                    MessageBox.Show(krtbMessageBody.Text, ktxtCaption.Text,
-                        (MessageBoxButtons)_mbButtons,
-                        _mbIcon, MessageBoxDefaultButton.Button1,
-                        _options,
-                        kcbShowHelp.Checked);
-                }
-                else
-                {
-                    MessageBox.Show(this, krtbMessageBody.Text, ktxtCaption.Text,
-                        (MessageBoxButtons)_mbButtons,
-                        _mbIcon, MessageBoxDefaultButton.Button1,
-                        _options);
-                }
-            }
+            string text =
+                "// *****************************************************************************\r\n" +
+                "// BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)\n" +
+                "//  © Component Factory Pty Ltd, 2006-2016, All rights reserved.\n" +
+                "// The software and associated documentation supplied hereunder are the\n" +
+                "//  proprietary information of Component Factory Pty Ltd, 13 Swallows Close,\n" +
+                "//  proprietary\tinformatio\tof\tComponent\tFactory\tPty\tLtd, 13\tSwallows\tClose,\r" +
+                "//  proprietary\tinformatio\tof\tComponent\tFactory\tPty\tLtd, 13\tSwallows\tClose,\r" +
+                "//  proprietary\tinformatio\tof\tComponent\tFactory\tPty\tLtd, 13\tSwallows\tClose,\r" +
+                "//  proprietary\tinformatio\tof\tComponent\tFactory\tPty\tLtd, 13\tSwallows\tClose,\r" +
+                "//  proprietary\tinformatio\tof\tComponent\tFactory\tPty\tLtd, 13\tSwallows\tClose,\r" +
+                "//  proprietary\tinformatio\tof\tComponent\tFactory\tPty\tLtd, 13\tSwallows\tClose,\r" +
+                "//  proprietary\tinformatio\tof\tComponent\tFactory\tPty\tLtd, 13\tSwallows\tClose,\r" +
+                "//  proprietary\tinformatio\tof\tComponent\tFactory\tPty\tLtd, 13\tSwallows\tClose,\r" +
+                "//  proprietary\tinformatio\tof\tComponent\tFactory\tPty\tLtd, 13\tSwallows\tClose,\r" +
+                "//  proprietary\tinformatio\tof\tComponent\tFactory\tPty\tLtd, 13\tSwallows\tClose,\r" +
+                "//  proprietary\tinformatio\tof\tComponent\tFactory\tPty\tLtd, 13\tSwallows\tClose,\r" +
+                "//  proprietary\tinformatio\tof\tComponent\tFactory\tPty\tLtd, 13\tSwallows\tClose,proprietary\tinformatio\tof\tComponent\tFactory\tPty\tLtd, 13\tSwallows\tClose,proprietary\tinformatio\tof\tComponent\tFactory\tPty\tLtd, 13\tSwallows\tClose\n" +
+                "//  proprietary\tinformatio\tof\tComponent\tFactory\tPty\tLtd, 13\tSwallows\tClose,\n" +
+                "//  proprietary\tinformatio\tof\tComponent\tFactory\tPty\tLtd, 13\tSwallows\tClose,\n" +
+                "//  proprietary\tinformatio\tof\tComponent\tFactory\tPty\tLtd, 13\tSwallows\tClose,\n" +
+                "//  proprietary\tinformatio\tof\tComponent\tFactory\tPty\tLtd, 13\tSwallows\tClose,\n" +
+                "//  proprietary\tinformatio\tof\tComponent\tFactory\tPty\tLtd, 13\tSwallows\tClose,\n" +
+                "//  proprietary\tinformatio\tof\tComponent\tFactory\tPty\tLtd, 13\tSwallows\tClose,\n" +
+                "//  proprietary\tinformatio\tof\tComponent\tFactory\tPty\tLtd, 13\tSwallows\tClose,\n" +
+                "//  proprietary\tinformatio\tof\tComponent\tFactory\tPty\tLtd, 13\tSwallows\tClose,\n" +
+                "//  proprietary\tinformatio\tof\tComponent\tFactory\tPty\tLtd, 13\tSwallows\tClose,\n" +
+                "//  proprietary\tinformatio\tof\tComponent\tFactory\tPty\tLtd, 13\tSwallows\tClose,\n" +
+                "//  Mornington,\r\n// Vic 3931,\r// Australia\n// and are supplied subject to licence terms.\n" +
+                "//\n" +
+                "//  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV) 2017 - 2024. All rights reserved. (https://github.com/Krypton-Suite/Standard-Toolkit)\n" +
+                "//  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV) 2017 - 2024. All rights reserved. (https://github.com/Krypton-Suite/Standard-Toolkit)\n" +
+                "//  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV) 2017 - 2024. All rights reserved. (https://github.com/Krypton-Suite/Standard-Toolkit)\n" +
+                "//  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV) 2017 - 2024. All rights reserved. (https://github.com/Krypton-Suite/Standard-Toolkit)\n" +
+                "//  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV) 2017 - 2024. All rights reserved. (https://github.com/Krypton-Suite/Standard-Toolkit)\n" +
+                "//  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV) 2017 - 2024. All rights reserved. (https://github.com/Krypton-Suite/Standard-Toolkit)\n" +
+                "//  Version 4.7.0.0  www.ComponentFactory.com\r\n" +
+                "// *****************************************************************************\r\n";
 
-            var res = KryptonMessageBox.Show(this, krtbMessageBody.Text, ktxtCaption.Text,
+            string s = CommonHelper.NormalizeLineBreaks(text);
+            krtbMessageBody.WordWrap = false;
+            krtbMessageBody.Text = s;
+            this.MaximizeBox = true;
+            this.FormBorderStyle = FormBorderStyle.Sizable;
+            krtbMessageBody.Dock = DockStyle.Fill;
+            var res = KryptonMessageBox.Show(this, s, ktxtCaption.Text,
                 _mbButtons,
                 displayHelpButton: kcbShowHelp.Checked,
                 _kmbIcon, KryptonMessageBoxDefaultButton.Button1,
                 options: _options, kchkShowCtrlCopyText.Checked);
 
-            krtbMessageBody.Text = $@"Krypton DialogResult = {res}";
         }
 
         private void kbtnTestText_Click(object sender, EventArgs e)


### PR DESCRIPTION
[Issue 1700-Add-string-handling-routine-to-CommonHelper](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1700)
Adds the method and the change log.

![compile-results](https://github.com/user-attachments/assets/a7c239e3-ca48-4627-96fa-532ec09818ae)


TestForm/CustomMessageBoxTest.cs was mistakenly committed and deleted from this PR.