### PR TITLE
1708-KryptonButton-crashes-program-on-invalid-typecast

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
+* Resolved [#1708](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1708). `KryptonButton` crashes program on invalid type cast.
 * Resolved [#1706](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1706), Restore: `KryptonComboBox` (On Form) does not respect designers `DropDownWidth` setting
 * Resolved [#1704](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1704), Remove properties from `KryptonRichtTextBox`
 * Implemented [#1700](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1700), Adds a method to `CommonHelper` which normalizes line breaks within a string, `CommonHelper.NormalizeLineBreaks`.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonButton.cs
@@ -616,7 +616,10 @@ namespace Krypton.Toolkit
                 catch (InvalidEnumArgumentException)
                 {
                     // Is it https://github.com/Krypton-Suite/Standard-Toolkit/issues/728
-                    if (owner is VisualMessageBoxForm)
+                    if (owner is VisualMessageBoxForm 
+                        or VisualMessageBoxFormDep 
+                        or VisualMessageBoxRtlAwareForm 
+                        or VisualMessageBoxRtlAwareFormDep)
                     {
                         // need to gain access to `dialogResult` and set it forcefully
                         FieldInfo? fi = typeof(Form).GetField("dialogResult", BindingFlags.NonPublic | BindingFlags.Instance);


### PR DESCRIPTION
1708-KryptonButton-crashes-program-on-invalid-typecast
Update KButton code
And the change log

![compile-results](https://github.com/user-attachments/assets/680b4acc-c4f2-4c04-a6e0-3842c7eaaad8)
