### PR TITLE
1659-V85-MessageBox-has-selectable-text

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-07-xx - Build 2408 (Patch 2) - July 2024
+* Resolved [#1659](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1659), Solves `KryptonMessageBox` selected text issue, usage of diverse line breaks and sizing issues.
 * Resolved [#1675](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1675), Catastrophic failure wherever `KryptonGroupPanel` is used.
 * Resolved [#1677](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1677), `KryptonComboBox` cuts of text on high DPI.
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMessageBoxForm.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/KryptonMessageBoxForm.Designer.cs
@@ -52,7 +52,7 @@ namespace Krypton.Toolkit
             this.kryptonPanel1 = new Krypton.Toolkit.KryptonPanel();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this._panelContentArea = new Krypton.Toolkit.KryptonPanel();
-            this._messageText = new Krypton.Toolkit.KryptonTextBox();
+            this.krtbMessageText = new Krypton.Toolkit.KryptonRichTextBox();
             this._linkLabelMessageText = new Krypton.Toolkit.KryptonLinkWrapLabel();
             ((System.ComponentModel.ISupportInitialize)(this._messageIcon)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this._panelButtons)).BeginInit();
@@ -208,7 +208,7 @@ namespace Krypton.Toolkit
             // 
             // _panelContentArea
             // 
-            this._panelContentArea.Controls.Add(this._messageText);
+            this._panelContentArea.Controls.Add(this.krtbMessageText);
             this._panelContentArea.Controls.Add(this._linkLabelMessageText);
             this._panelContentArea.Dock = System.Windows.Forms.DockStyle.Fill;
             this._panelContentArea.Location = new System.Drawing.Point(64, 4);
@@ -217,20 +217,22 @@ namespace Krypton.Toolkit
             this._panelContentArea.Size = new System.Drawing.Size(176, 44);
             this._panelContentArea.TabIndex = 1;
             // 
-            // _messageText
+            // krtbMessageText
             // 
-            this._messageText.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._messageText.InputControlStyle = Krypton.Toolkit.InputControlStyle.PanelClient;
-            this._messageText.Location = new System.Drawing.Point(0, 0);
-            this._messageText.Margin = new System.Windows.Forms.Padding(5, 0, 0, 0);
-            this._messageText.Multiline = true;
-            this._messageText.Name = "_messageText";
-            this._messageText.ReadOnly = true;
-            this._messageText.Size = new System.Drawing.Size(176, 44);
-            this._messageText.StateCommon.Border.DrawBorders = Krypton.Toolkit.PaletteDrawBorders.None;
-            this._messageText.TabIndex = 0;
-            this._messageText.TabStop = false;
-            this._messageText.Text = "Message Text\r\n.\ttabbed";
+            this.krtbMessageText.DetectUrls = false;
+            this.krtbMessageText.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.krtbMessageText.InputControlStyle = Krypton.Toolkit.InputControlStyle.PanelClient;
+            this.krtbMessageText.Location = new System.Drawing.Point(0, 0);
+            this.krtbMessageText.Margin = new System.Windows.Forms.Padding(0);
+            this.krtbMessageText.Name = "krtbMessageText";
+            this.krtbMessageText.ReadOnly = true;
+            this.krtbMessageText.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.None;
+            this.krtbMessageText.Size = new System.Drawing.Size(150, 19);
+            this.krtbMessageText.StateCommon.Border.DrawBorders = Krypton.Toolkit.PaletteDrawBorders.None;
+            this.krtbMessageText.TabIndex = 0;
+            this.krtbMessageText.TabStop = false;
+            this.krtbMessageText.Text = "Message Text\n.\ttabbed";
+            this.krtbMessageText.WordWrap = false;
             // 
             // _linkLabelMessageText
             // 
@@ -264,6 +266,7 @@ namespace Krypton.Toolkit
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.TopMost = false;
             this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.AnyKeyDown);
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.OnFormClosed);
             ((System.ComponentModel.ISupportInitialize)(this._messageIcon)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this._panelButtons)).EndInit();
             this._panelButtons.ResumeLayout(false);
@@ -289,6 +292,6 @@ namespace Krypton.Toolkit
         private MessageButton _button5;
         private KryptonPanel _panelContentArea;
         private KryptonLinkWrapLabel _linkLabelMessageText;
-        private KryptonTextBox _messageText;
+        private KryptonRichTextBox krtbMessageText;
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/General/CommonHelper.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/CommonHelper.cs
@@ -11,6 +11,8 @@
 #endregion
 
 // ReSharper disable UnusedMember.Global
+using System.Text.RegularExpressions;
+
 namespace Krypton.Toolkit
 {
     #region Delegates
@@ -97,6 +99,42 @@ namespace Krypton.Toolkit
         {
             [DebuggerStepThrough]
             get => _nextId++;
+        }
+
+        /// <summary>
+        /// Converts line breaks in the string to the system default line break, Environment.NewLine.
+        /// </summary>
+        /// <param name="text">String to process.</param>
+        /// <returns>
+        /// Normalized resultant string.<br/>
+        /// If the input string is an empty string, the input string is returned.
+        /// </returns>
+        public static string NormalizeLineBreaks(string text)
+        {
+            string result = text;
+
+            if (result.Length > 0)
+            {
+                // Convert line breaks to the system provided line break
+                if (!Environment.NewLine.Equals("\r\n"))
+                {
+                    result = Regex.Replace(result, @"\r\n", Environment.NewLine);
+                }
+
+                if (!Environment.NewLine.Equals("\n"))
+                {
+                    // Replaces \n but not \r\n
+                    result = Regex.Replace(result, "(?<!\r)\n", Environment.NewLine);
+                }
+
+                if (!Environment.NewLine.Equals("\r"))
+                {
+                    // Replaces \r but not \r\n
+                    result = Regex.Replace(result, "\r(?!\n)", Environment.NewLine);
+                }
+            }
+
+            return result;
         }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/General/KryptonMessageBoxNativeWindow.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/KryptonMessageBoxNativeWindow.cs
@@ -1,0 +1,36 @@
+﻿#region BSD License
+/*
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2024. All rights reserved. 
+ */
+#endregion
+
+namespace Krypton.Toolkit
+{
+    /// <summary>
+    /// Intercepts unwanted messages on the KryptonRichTextBox used in MessageBox forms
+    /// </summary>
+    internal class KryptonMessageBoxNativeWindow : NativeWindow
+    {
+        private const int WM_SETFOCUS = 0x0007;
+        private const int WM_KILLFOCUS = 0x0008;
+        private const int WM_MOUSEWHEEL = 0x020A;
+
+        protected override void WndProc(ref Message m)
+        {
+            // Prevent the user from entering the control
+            if (m.Msg == WM_SETFOCUS)
+            {
+                m.Msg = WM_KILLFOCUS;
+            }
+
+            // Disable zoom, eat the message
+            if (m.Msg == WM_MOUSEWHEEL)
+            {
+                return;
+            }
+
+            base.WndProc(ref m);
+        }
+    }
+}


### PR DESCRIPTION
[Issue 1659-MessageBox-has-selectable-text](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1659)
- Resolves text selection, incompatibilty between various line breaks and sizing issues. 
- Implements KryptonMessagaBoxNativeWindow
- Implements CommonHelper.NormalizeLineBreaks
- And the change log.

![compile-results](https://github.com/user-attachments/assets/294fc3ca-2337-4ce0-b60b-6bfc48a0f1b9)
