### PR TITLE
1552-VisualMessageBoxForm-throws-exception-when-used-with-custom-theme

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
+* Resolved [#1552](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1552), `KryptonMessageBox` throws an error when using custom theme `Asphalt_v19.xml`.
 * Resolved [#1708](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1708). `KryptonButton` crashes program on invalid type cast.
 * Resolved [#1706](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1706), Restore: `KryptonComboBox` (On Form) does not respect designers `DropDownWidth` setting
 * Resolved [#1704](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1704), Remove properties from `KryptonRichtTextBox`

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
@@ -5631,8 +5631,11 @@ namespace Krypton.Toolkit
             {
                 case PaletteState.Disabled:
                     return panel.StateDisabled;
+               
+                case PaletteState.Tracking: // #1552 KPanel does not implement the tracking state, default to normal
                 case PaletteState.Normal:
                     return panel.StateNormal;
+
                 default:
                     // Should never happen!
                     Debug.Assert(false);


### PR DESCRIPTION
[Issue 1552-VisualMessageBoxForm-throws-exception-when-used-with-custom-theme](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1552)
- Adds missing tracking state to the switch
- And the change log.

![compile-results](https://github.com/user-attachments/assets/64401dcd-7064-4e98-bf72-e5ab6bb44133)
