### PR TITLE
1692 giduac bug inputtext should not be using textlabelcontrol colours

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
+* Resolved [#1692](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1692), Resolves `KryptonMessageBoxes` incompatibility between message text and dark themes.
 * Implemented [#1734](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1734), Add `ForceDesignerDPIUnaware` option
 * Resolved [#1729](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1729), `KryptonCustomPaletteBase` does not implement ##Tracking states
 * Resolved [#1693](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1693), `KryptonCustomPaletteBase` Illegal characters in path

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareForm.cs
@@ -68,6 +68,10 @@ namespace Krypton.Toolkit
             // Default Cursor for the KRTB when the cursors hovers over it
             krtbMessageText.RichTextBox.Cursor = Cursors.Arrow;
 
+            // #1692 text font colour for input controls does not work correct on KMBees when using dark themes.
+            // Set the text colour to the one a control uses.
+            krtbMessageText.StateCommon.Content.Color1 = GlobalStaticValues.KryptonMessageBoxRichTextBoxTextColor;
+
             // Update contents to match requirements
             UpdateText();
             UpdateIcon();

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareFormDep.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareFormDep.cs
@@ -106,6 +106,10 @@ namespace Krypton.Toolkit
             // Default Cursor for the KRTB when the cursors hovers over it
             krtbMessageText.RichTextBox.Cursor = Cursors.Arrow;
 
+            // #1692 text font colour for input controls does not work correct on KMBees when using dark themes.
+            // Set the text colour to the one a control uses.
+            krtbMessageText.StateCommon.Content.Color1 = GlobalStaticValues.KryptonMessageBoxRichTextBoxTextColor;
+
             // Update contents to match requirements
             UpdateText();
             UpdateIcon();

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxForm.cs
@@ -75,6 +75,10 @@ namespace Krypton.Toolkit
             // Default Cursor for the KRTB when the cursors hovers over it
             krtbMessageText.RichTextBox.Cursor = Cursors.Arrow;
 
+            // #1692 text font colour for input controls does not work correct on KMBees when using dark themes.
+            // Set the text colour to the one a control uses.
+            krtbMessageText.StateCommon.Content.Color1 = GlobalStaticValues.KryptonMessageBoxRichTextBoxTextColor;
+
             // Update contents to match requirements
             UpdateText();
             UpdateIcon();

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxFormDep.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxFormDep.cs
@@ -109,6 +109,10 @@ namespace Krypton.Toolkit
             // Default Cursor for the KRTB when the cursors hovers over it
             krtbMessageText.RichTextBox.Cursor = Cursors.Arrow;
 
+            // #1692 text font colour for input controls does not work correct on KMBees when using dark themes.
+            // Set the text colour to the one a control uses.
+            krtbMessageText.StateCommon.Content.Color1 = GlobalStaticValues.KryptonMessageBoxRichTextBoxTextColor;
+
             // Update contents to match requirements
             UpdateText();
             UpdateIcon();

--- a/Source/Krypton Components/Krypton.Toolkit/General/GlobalStaticValues.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/GlobalStaticValues.cs
@@ -372,6 +372,18 @@ namespace Krypton.Toolkit
 
         public static readonly string DEFAULT_LONG_SEED_TEXT = $"BSD 3-Clause License\r\n\r\nCopyright (c) 2017 - {DateTime.Now.Year}, Krypton Suite\r\n\r\nAll rights reserved.\r\n\r\nRedistribution and use in source and binary forms, with or without\r\nmodification, are permitted provided that the following conditions are met:\r\n\r\n1. Redistributions of source code must retain the above copyright notice, this\r\n   list of conditions and the following disclaimer.\r\n\r\n2. Redistributions in binary form must reproduce the above copyright notice,\r\n   this list of conditions and the following disclaimer in the documentation\r\n   and/or other materials provided with the distribution.\r\n\r\n3. Neither the name of the copyright holder nor the names of its\r\n   contributors may be used to endorse or promote products derived from\r\n   this software without specific prior written permission.\r\n\r\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\"\r\nAND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE\r\nIMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\r\nDISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE\r\nFOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL\r\nDAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR\r\nSERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER\r\nCAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,\r\nOR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\r\nOF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.";
 
+        #region Properties
+        /// <summary> 
+        /// KryptonMessageBoxes that use the KRichtTextBox need another color for the text.<br/>
+        /// Set the text colour to the one a non-input control uses.
+        /// </summary>
+        public static Color KryptonMessageBoxRichTextBoxTextColor 
+        {
+            // per ticket #1692
+            get => KryptonManager.CurrentGlobalPalette.GetContentLongTextColor1(PaletteContentStyle.LabelNormalPanel, PaletteState.Normal);
+        }
+        #endregion
+
         #region Methods
         /// <summary>
         /// Helper method that returns a generic message when a variable is null.


### PR DESCRIPTION
[Issue 1692-GIDUAC-bug-inputtext-should-not-be-using-textlabelcontrol-colours](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1692)
- Solves the KMB Richtextbox text color problem.
- And the change log.

![compile-results](https://github.com/user-attachments/assets/0099a412-82c7-415a-9b81-343070e80ac7)
