### PR TITLE
1734-Add-ForceDesignerDPIUnaware-option-repair-testform-csproj

### DIFF
--- a/Source/Krypton Components/TestForm/TestForm.csproj
+++ b/Source/Krypton Components/TestForm/TestForm.csproj
@@ -7,6 +7,8 @@
         <!--https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/warning-waves-->
         <WarningLevel>8</WarningLevel>
         <AnalysisLevel>latest</AnalysisLevel>
+		<UseWindowsForms>true</UseWindowsForms>
+		<LangVersion>preview</LangVersion>
         <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
     </PropertyGroup>
 
@@ -45,7 +47,6 @@
             <Version>4.0.0.0</Version>
             <!-- Designers for the `TFMs != net4` are "Pulled in" via Visual studios ".nuget\packages\microsoft.windowsdesktop.app.ref" -->
         </Reference>
-        <Reference Include="System.Windows.Forms" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
[Issue 1734-Add-ForceDesignerDPIUnaware-option-repair-testform-csproj](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1734)
[Issue Comment](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1734#issuecomment-2303736380)
- Corrects previously unneeded removal of elements fromTestForm.csproj
- No change log since it only affects testform

### IF IT AIN'T BROKE, DON'T FIX IT !!!!

![compile-results](https://github.com/user-attachments/assets/9f10efd9-5ad6-49a7-b6b7-a0b180c122c6)
