### PR TITLE
1697-V85-KryptonComboBox-Enabled-and-DropDownStyle-call-order-quirk

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-07-xx - Build 2408 (Patch 2) - July 2024
+* Resolved [#1697](https://github.com/Krypton-Suite/Standard-Toolkit/issues1697), `KryptonComboBox` change in DropDownStyle cripples the control while the control is disabled en reenabled again.
 * Resolved [#1548](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1548), KComboBox DropDown arrow is illegible in certain themes
 * Resolved [#1659](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1659), Solves `KryptonMessageBox` selected text issue, usage of diverse line breaks and sizing issues.
 * Resolved [#1675](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1675), Catastrophic failure wherever `KryptonGroupPanel` is used.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -852,6 +852,11 @@ namespace Krypton.Toolkit
         private int _cachedHeight;
         private int _hoverIndex;
         private float _cornerRoundingRadius;
+
+        // #1697 Work-around
+        // When changing DropDownStyle while the control is disabled the newly selected style was not applied.
+        // _deferredComboBoxStyle caches the selected change which is applied when the control is enabled again.
+        private ComboBoxStyle? _deferredComboBoxStyle;
         #endregion
 
         #region Events
@@ -1179,6 +1184,11 @@ namespace Krypton.Toolkit
 
             // Set `CornerRoundingRadius' to 'GlobalStaticValues.PRIMARY_CORNER_ROUNDING_VALUE' (-1)
             _cornerRoundingRadius = GlobalStaticValues.PRIMARY_CORNER_ROUNDING_VALUE;
+
+            // #1697 Work-around
+            // When changing DropDownStyle while the control is disabled the newly selected style was not applied.
+            // _deferredComboBoxStyle caches the selected change which is applied when the control is enabled again.
+            _deferredComboBoxStyle = null;
         }
 
         /// <summary>
@@ -1595,19 +1605,37 @@ namespace Krypton.Toolkit
         [RefreshProperties(RefreshProperties.Repaint)]
         public ComboBoxStyle DropDownStyle
         {
-            get => _comboBox.DropDownStyle;
+            // #1697 Work-around
+            // When _deferredComboBoxStyle has been set this value takes precedence over _comboBox.DropDownStyle
+            get => _deferredComboBoxStyle.HasValue
+                ? _deferredComboBoxStyle.Value
+                : _comboBox.DropDownStyle;
 
             set
             {
-                if (_comboBox.DropDownStyle != value)
+                // #1697 Work-around
+                // If the _deferredComboBoxStyle has been set and DropDownStyle is changed again while the control is disabled this change has to be recorded.
+                if (_comboBox.DropDownStyle != value || (_deferredComboBoxStyle.HasValue && _deferredComboBoxStyle.Value != value))
                 {
                     if (value == ComboBoxStyle.Simple)
                     {
                         throw new ArgumentOutOfRangeException(nameof(_comboBox.DropDownStyle), @"KryptonComboBox does not support the DropDownStyle.Simple style.");
                     }
 
-                    _comboBox.DropDownStyle = value;
-                    UpdateEditControl();
+                    // #1697 Work-around
+                    // When changing DropDownStyle while the control is disabled the newly selected style was not applied.
+                    // _deferredComboBoxStyle caches the selected change which is applied when the control is enabled again.
+                    if (Enabled)
+                    {
+                        _comboBox.DropDownStyle = value;
+                        UpdateEditControl();
+                    }
+                    else
+                    {
+                        // #1697 Work-around
+                        // If the controls is disabled, record the change in DropDownStyle
+                        _deferredComboBoxStyle = value;
+                    }
                 }
             }
         }
@@ -2365,6 +2393,14 @@ namespace Krypton.Toolkit
 
             // Let base class fire standard event
             base.OnEnabledChanged(e);
+
+            // #1697 Work-around
+            // When changing DropDownStyle while the control is disabled the newly selected style was not applied.
+            if (Enabled && _deferredComboBoxStyle.HasValue)
+            {
+                DropDownStyle = _deferredComboBoxStyle.Value;
+                _deferredComboBoxStyle = null;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
[Issue 1697-V85-KryptonComboBox-Enabled-and-DropDownStyle-call-order-quirk](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1697)
- Implements a work-around for this issue
- And the change log.

![compile-results](https://github.com/user-attachments/assets/d942b0b8-66d1-4dd3-a277-77bded96ca45)
