### PR TITLE
1744-Use-the-same-Toolkit-TFMs-on-TestForm

### DIFF
--- a/Source/Krypton Components/TestForm/TestForm.csproj
+++ b/Source/Krypton Components/TestForm/TestForm.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFrameworks>net48;net8.0-windows</TargetFrameworks>
+		<TargetFrameworks>net462;net47;net471;net472;net48;net481;net6.0-windows;net8.0-windows;net9.0-windows</TargetFrameworks>
 		<Nullable>enable</Nullable>
 		<!--https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/warning-waves-->
 		<WarningLevel>8</WarningLevel>


### PR DESCRIPTION
[Issue 1744-Use-the-same-Toolkit-TFMs-on-TestForm](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1744)
- Make TestForm and Toolkit's TFMs equal
- No change log since this is for TestForm

TestForm is not part of the build process. But did a successful TestForm build in VStudio.