### PR TITLE
- Make the rendering of Graphics paths use `RectangleF`

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
+* Resolved [#1749](https://github.com/Krypton-Suite/Standard-Toolkit/issues1749), Rounded Form borders have "Triangles" in corners.
 * Resolved [#1697](https://github.com/Krypton-Suite/Standard-Toolkit/issues1697), `KryptonComboBox` change in DropDownStyle cripples the control while the control is disabled en reenabled again.
 * Resolved [#1692](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1692), Resolves `KryptonMessageBoxes` incompatibility between message text and dark themes.
 * Implemented [#1734](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1734), Add `ForceDesignerDPIUnaware` option

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
@@ -827,8 +827,7 @@ namespace Krypton.Toolkit
 
             base.OnResize(e);
 
-            if (/*ApplyCustomChrome
-                &&*/ !((MdiParent != null)
+            if (!((MdiParent != null)
                      && CommonHelper.IsFormMaximized(this))
                 )
             {
@@ -880,6 +879,7 @@ namespace Krypton.Toolkit
         //    base.OnPaint(e);
         //}
 
+        ///// <inheritdoc />
         //protected override void OnPaintBackground(PaintEventArgs e)
         //{
         //    if (AcrylicValues.EnableAcrylic)
@@ -888,38 +888,37 @@ namespace Krypton.Toolkit
         //    }
         //}
 
-        /// <inheritdoc />
-        protected override void OnLoad(EventArgs e)
-        {
-            /* FadeValues disabled and moved to extended until proven stable. Further development in V100
-            if (FadeValues.FadingEnabled)
-            {
-                #if NETCOREAPP3_0_OR_GREATER
-                    KryptonFormFadeController.ModernFadeFormIn(FadeValues.Owner ?? this, FadeValues.FadeDuration);
-                #else
-                    KryptonFormFadeController.FadeIn(FadeValues.Owner ?? this, FadeValues.FadeSpeed);
-                #endif
-            }
-            */
-            base.OnLoad(e);
-        }
+        ///// <inheritdoc />
+        //protected override void OnLoad(EventArgs e)
+        //{
+        //    /* FadeValues disabled and moved to extended until proven stable. Further development in V100
+        //    if (FadeValues.FadingEnabled)
+        //    {
+        //        #if NETCOREAPP3_0_OR_GREATER
+        //            KryptonFormFadeController.ModernFadeFormIn(FadeValues.Owner ?? this, FadeValues.FadeDuration);
+        //        #else
+        //            KryptonFormFadeController.FadeIn(FadeValues.Owner ?? this, FadeValues.FadeSpeed);
+        //        #endif
+        //    }
+        //    */
+        //    base.OnLoad(e);
+        //}
 
-        /// <inheritdoc />
-        protected override void OnClosing(CancelEventArgs e)
-        {
-            /* FadeValues disabled and moved to extended until proven stable. Further development in V100
-            if (FadeValues is { FadingEnabled: true, ShouldCloseOnFadeOut: true })
-            {
-                #if NETCOREAPP3_0_OR_GREATER
-                    KryptonFormFadeController.ModernFadeFormOut(FadeValues.Owner ?? this, FadeValues.FadeDuration);
-                #else
-                    KryptonFormFadeController.FadeOut(FadeValues.Owner ?? this, FadeValues.FadeSpeed);
-                #endif
-            }
-            */
-            base.OnClosing(e);
-        }
-
+        ///// <inheritdoc />
+        //protected override void OnClosing(CancelEventArgs e)
+        //{
+        //    /* FadeValues disabled and moved to extended until proven stable. Further development in V100
+        //    if (FadeValues is { FadingEnabled: true, ShouldCloseOnFadeOut: true })
+        //    {
+        //        #if NETCOREAPP3_0_OR_GREATER
+        //            KryptonFormFadeController.ModernFadeFormOut(FadeValues.Owner ?? this, FadeValues.FadeDuration);
+        //        #else
+        //            KryptonFormFadeController.FadeOut(FadeValues.Owner ?? this, FadeValues.FadeSpeed);
+        //        #endif
+        //    }
+        //    */
+        //    base.OnClosing(e);
+        //}
         #endregion
 
         #region Protected Virtual
@@ -1012,13 +1011,8 @@ namespace Krypton.Toolkit
         {
             var processed = false;
 
-            // We do not process the message if on an MDI child, because doing so prevents the 
-            // LayoutMdi call on the parent from working and cascading/tiling the children
-            //if ((m.Msg == (int)PI.WM_NCCALCSIZE) && _themedApp &&
-            //    ((MdiParent == null) || ApplyCustomChrome))
             if (!CommonHelper.IsFormMaximized(this)
                 && _themedApp
-                //&& ((MdiParent == null) || ApplyCustomChrome)
                 )
             {
                 switch (m.Msg)
@@ -1029,7 +1023,7 @@ namespace Krypton.Toolkit
                     case PI.WM_.GETMINMAXINFO:
                         OnWM_GETMINMAXINFO(ref m);
                         /* Setting handled to false enables the application to process its own Min/Max requirements,
-                * as mentioned by jason.bullard (comment from September 22, 2011) on http://gallery.expression.microsoft.com/ZuneWindowBehavior/ */
+                        * as mentioned by jason.bullard (comment from September 22, 2011) on http://gallery.expression.microsoft.com/ZuneWindowBehavior/ */
                         // https://github.com/Krypton-Suite/Standard-Toolkit/issues/459
                         // Still got to call - base - to allow the "application to process its own Min/Max requirements" !!
                         base.WndProc(ref m);

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonOffice2007Renderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonOffice2007Renderer.cs
@@ -734,13 +734,8 @@ namespace Krypton.Toolkit
                            )
                         {
                             // Get the window borders
-
-                            // Finally check that the actual form is using custom chrome
-                            //if (kryptonForm.ApplyCustomChrome)
-                            {
-                                // Extend down into the bottom border
-                                backRect.Height += kryptonForm.RealWindowBorders.Bottom;
-                            }
+                            // Extend down into the bottom border
+                            backRect.Height += kryptonForm.RealWindowBorders.Bottom;
                         }
 
                         // Cannot paint a zero sized area

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonSparkleRenderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonSparkleRenderer.cs
@@ -668,16 +668,11 @@ namespace Krypton.Toolkit
                         )
                     {
                         // Get the window borders
-
-                        // Finally check that the actual form is using custom chrome
-                        //if (kryptonForm.ApplyCustomChrome)
-                        {
-                            // Extend down into the bottom border
-                            Padding borders = kryptonForm.RealWindowBorders;
-                            backRect.Height += borders.Bottom;
-                            backRect.Width += borders.Horizontal;
-                            backRect.X -= borders.Left;
-                        }
+                        // Extend down into the bottom border
+                        Padding borders = kryptonForm.RealWindowBorders;
+                        backRect.Height += borders.Bottom;
+                        backRect.Width += borders.Horizontal;
+                        backRect.X -= borders.Left;
                     }
 
                     // Cannot paint a zero sized area

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonVisualStudio2010With2007Renderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonVisualStudio2010With2007Renderer.cs
@@ -733,13 +733,8 @@ namespace Krypton.Toolkit
                            )
                         {
                             // Get the window borders
-
-                            // Finally check that the actual form is using custom chrome
-                            //if (kryptonForm.ApplyCustomChrome)
-                            {
-                                // Extend down into the bottom border
-                                backRect.Height += kryptonForm.RealWindowBorders.Bottom;
-                            }
+                            // Extend down into the bottom border
+                            backRect.Height += kryptonForm.RealWindowBorders.Bottom;
                         }
 
                         // Cannot paint a zero sized area

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
@@ -92,7 +92,7 @@ namespace Krypton.Toolkit
         private static readonly Blend _ribbonGroup1Blend, _ribbonGroup2Blend, _ribbonGroup3Blend;
         private static readonly Blend _ribbonGroup4Blend, _ribbonGroup5Blend, _ribbonGroup6Blend;
         private static readonly Blend _ribbonGroup7Blend, _ribbonGroup8Blend, _ribbonGroup9Blend;
-        private static readonly Blend _ribbonTabTopBlend, _ribbonAppButtonBlend;
+        private static readonly Blend _ribbonTabTopBlend;//, _ribbonAppButtonBlend;
         private static readonly Blend _dragRoundedInsideBlend;
 
         // Pens
@@ -105,12 +105,12 @@ namespace Krypton.Toolkit
         private static readonly Pen _light2Pen;
         private static readonly Pen _whitenMediumPen;
         //private static readonly Pen _buttonShadowPen;
-        private static readonly Pen _compositionPen;
+        //private static readonly Pen _compositionPen;
 
         // Brushes
         private static readonly SolidBrush _whitenLightBrush;
         private static readonly SolidBrush _whitenLightLBrush;
-        private static readonly SolidBrush _compositionBrush;
+        //private static readonly SolidBrush _compositionBrush;
         private static readonly SolidBrush _buttonBorder1Brush;
         private static readonly SolidBrush _buttonBorder2Brush;
 
@@ -315,11 +315,11 @@ namespace Krypton.Toolkit
                 Positions = [0.0f, 0.2f, 1.0f]
             };
 
-            _ribbonAppButtonBlend = new Blend
-            {
-                Factors = [0.0f, 0.0f, 0.5f, 1.0f, 1.0f],
-                Positions = [0.0f, 0.1f, 0.5f, 0.5f, 1.0f]
-            };
+            //_ribbonAppButtonBlend = new Blend
+            //{
+            //    Factors = [0.0f, 0.0f, 0.5f, 1.0f, 1.0f],
+            //    Positions = [0.0f, 0.1f, 0.5f, 0.5f, 1.0f]
+            //};
 
             _dragRoundedInsideBlend = new Blend
             {
@@ -336,11 +336,11 @@ namespace Krypton.Toolkit
             _light2Pen = new Pen(Color.FromArgb(100, Color.White));
             _whitenMediumPen = new Pen(_whiten128);
             //_buttonShadowPen = new Pen(Color.FromArgb(48, Color.Black));
-            _compositionPen = new Pen(Color.FromArgb(96, Color.Black));
+            //_compositionPen = new Pen(Color.FromArgb(96, Color.Black));
 
             _whitenLightBrush = new SolidBrush(_whiten30);
             _whitenLightLBrush = new SolidBrush(_whiten64);
-            _compositionBrush = new SolidBrush(Color.FromArgb(32, Color.White));
+            //_compositionBrush = new SolidBrush(Color.FromArgb(32, Color.White));
 
             _buttonBorder1Brush = new SolidBrush(Color.FromArgb(20, 52, 59, 64));
             _buttonBorder2Brush = new SolidBrush(Color.FromArgb(70, 52, 59, 64));
@@ -384,7 +384,7 @@ namespace Krypton.Toolkit
             }
 
             // Use the professional renderer but pull colors from the palette
-            KryptonStandardRenderer renderer = new KryptonStandardRenderer(colorPalette.ColorTable)
+            var renderer = new KryptonStandardRenderer(colorPalette.ColorTable)
             {
                 // Setup the need to use rounded corners
                 RoundedEdges = colorPalette.ColorTable.UseRoundedEdges != InheritBool.False
@@ -723,11 +723,6 @@ namespace Krypton.Toolkit
             // Is there anything to actually draw?
             if (rect is { Width: > 0, Height: > 0 } && CommonHelper.HasABorder(borders))
             {
-                // Only use antialiasing if the border is rounded
-                //SmoothingMode smoothMode = paletteBorder.GetBorderRounding(state) > 0 ? SmoothingMode.AntiAlias : SmoothingMode.Default;
-
-                // We want to draw using antialiasing for a nice smooth effect
-                using var hint = new GraphicsHint(context.Graphics, paletteBorder.GetBorderGraphicsHint(state));
                 // Cache commonly used values
                 var borderWidth = paletteBorder.GetBorderWidth(state);
 
@@ -766,7 +761,10 @@ namespace Krypton.Toolkit
                             borderPen.DashPattern = [2, 2];
                         }
 
-                        using var gh = new GraphicsHint(context.Graphics, paletteBorder.GetBorderGraphicsHint(state));
+                        // Only use antialiasing if the border is rounded
+                        PaletteGraphicsHint smoothMode = paletteBorder.GetBorderRounding(state) > 0 ? PaletteGraphicsHint.AntiAlias : paletteBorder.GetBorderGraphicsHint(state);
+                        // We want to draw using antialiasing for a nice smooth effect
+                        using var gh = new GraphicsHint(context.Graphics, smoothMode);
                         context.Graphics.DrawPath(borderPen, borderPath0);
 
                         // Optionally also draw the second path
@@ -788,6 +786,8 @@ namespace Krypton.Toolkit
                         // Use standard helper routine to create appropriate image brush
                         using var borderPen = new Pen(CreateImageBrush(imageRect, borderImage!, borderImageStyle),
                             borderWidth);
+
+                        using var gh = new GraphicsHint(context.Graphics, paletteBorder.GetBorderGraphicsHint(state));
                         context.Graphics.DrawPath(borderPen, borderPath0);
 
                         // Optionally also draw the second path
@@ -1061,9 +1061,12 @@ namespace Krypton.Toolkit
             var displayRect = new Rectangle(Point.Empty, new Size(int.MaxValue, int.MaxValue));
 
             // Track the allocated space in each grid position
-            var allocation = new Size[3, 3] { { Size.Empty, Size.Empty, Size.Empty },
-                                                  { Size.Empty, Size.Empty, Size.Empty },
-                                                  { Size.Empty, Size.Empty, Size.Empty } };
+            var allocation = new Size[3, 3]
+            {
+                { Size.Empty, Size.Empty, Size.Empty },
+                { Size.Empty, Size.Empty, Size.Empty },
+                { Size.Empty, Size.Empty, Size.Empty }
+            };
 
             // Create a memento for storing calculations
             using var memento = new StandardContentMemento();
@@ -1192,9 +1195,12 @@ namespace Krypton.Toolkit
             }
 
             // Track the allocated space in each grid position
-            var allocation = new Size[3, 3] { { Size.Empty, Size.Empty, Size.Empty },
-                                                  { Size.Empty, Size.Empty, Size.Empty },
-                                                  { Size.Empty, Size.Empty, Size.Empty } };
+            var allocation = new Size[3, 3]
+            {
+                { Size.Empty, Size.Empty, Size.Empty },
+                { Size.Empty, Size.Empty, Size.Empty },
+                { Size.Empty, Size.Empty, Size.Empty }
+            };
 
             // Create a memento to return to caller
             var memento = new StandardContentMemento();
@@ -1313,7 +1319,7 @@ namespace Krypton.Toolkit
             Debug.Assert(!context.Control!.IsDisposed);
 
             // Cast the incoming memento to the correct type
-            StandardContentMemento standard = (StandardContentMemento)memento!;
+            var standard = (StandardContentMemento)memento!;
 
             if (standard.DrawImage)
             {
@@ -1488,7 +1494,7 @@ namespace Krypton.Toolkit
         {
             if (memento != null)
             {
-                StandardContentMemento standard = (StandardContentMemento)memento;
+                var standard = (StandardContentMemento)memento;
                 return standard.DrawImage;
             }
             else
@@ -1506,7 +1512,7 @@ namespace Krypton.Toolkit
         {
             if (memento != null)
             {
-                StandardContentMemento standard = (StandardContentMemento)memento;
+                var standard = (StandardContentMemento)memento;
                 return standard.ImageRect;
             }
             else
@@ -1524,7 +1530,7 @@ namespace Krypton.Toolkit
         {
             if (memento != null)
             {
-                StandardContentMemento standard = (StandardContentMemento)memento;
+                var standard = (StandardContentMemento)memento;
                 return standard.DrawShortText;
             }
             else
@@ -1542,7 +1548,7 @@ namespace Krypton.Toolkit
         {
             if (memento != null)
             {
-                StandardContentMemento standard = (StandardContentMemento)memento;
+                var standard = (StandardContentMemento)memento;
                 return standard.ShortTextRect;
             }
             else
@@ -1560,7 +1566,7 @@ namespace Krypton.Toolkit
         {
             if (memento != null)
             {
-                StandardContentMemento standard = (StandardContentMemento)memento;
+                var standard = (StandardContentMemento)memento;
                 return standard.DrawLongText;
             }
             else
@@ -1578,7 +1584,7 @@ namespace Krypton.Toolkit
         {
             if (memento != null)
             {
-                StandardContentMemento standard = (StandardContentMemento)memento;
+                var standard = (StandardContentMemento)memento;
                 return standard.LongTextRect;
             }
             else
@@ -1684,7 +1690,7 @@ namespace Krypton.Toolkit
             // Cache the right to left setting
             var rtl = context.Control!.RightToLeft == RightToLeft.Yes;
 
-            Padding ret = Padding.Empty;
+            var ret = Padding.Empty;
 
             switch (tabBorderStyle)
             {
@@ -1711,7 +1717,7 @@ namespace Krypton.Toolkit
                     break;
                 case TabBorderStyle.SlantEqualNear:
                 case TabBorderStyle.SlantOutsizeNear:
-                    // Calculte the extra needed for the outsize variant
+                    // Calculate the extra needed for the outsize variant
                     var x = tabBorderStyle == TabBorderStyle.SlantOutsizeNear ? SPACING_TAB_OUTSIZE_PADDING : 0;
 
                     switch (orientation)
@@ -1742,7 +1748,7 @@ namespace Krypton.Toolkit
                     break;
                 case TabBorderStyle.SlantEqualFar:
                 case TabBorderStyle.SlantOutsizeFar:
-                    // Calculte the extra needed for the outsize variant
+                    // Calculate the extra needed for the outsize variant
                     var y = tabBorderStyle == TabBorderStyle.SlantOutsizeFar ? SPACING_TAB_OUTSIZE_PADDING : 0;
 
                     switch (orientation)
@@ -1773,7 +1779,7 @@ namespace Krypton.Toolkit
                     break;
                 case TabBorderStyle.SlantEqualBoth:
                 case TabBorderStyle.SlantOutsizeBoth:
-                    // Calculte the extra needed for the outsize variant
+                    // Calculate the extra needed for the outsize variant
                     var z = tabBorderStyle == TabBorderStyle.SlantOutsizeBoth ? SPACING_TAB_OUTSIZE_PADDING : 0;
 
                     ret = new Padding(borderWidth + z + SPACING_TAB_SLANT_PADDING - 1, borderWidth + z,
@@ -1864,8 +1870,7 @@ namespace Krypton.Toolkit
 
             // Use helper to create a border path in middle of the pen
             return CreateTabBorderBackPath(context.Control.RightToLeft, state, false, rect,
-                                           palette.GetBorderWidth(state), tabBorderStyle, orientation,
-                                           palette.GetBorderGraphicsHint(state) == PaletteGraphicsHint.AntiAlias);
+                                           palette.GetBorderWidth(state), tabBorderStyle, orientation);
         }
 
         /// <summary>
@@ -1905,8 +1910,7 @@ namespace Krypton.Toolkit
 
             // Use helper to create a border path in middle of the pen
             return CreateTabBorderBackPath(context.Control.RightToLeft, state, false, rect,
-                                           palette.GetBorderWidth(state), tabBorderStyle, orientation,
-                                           palette.GetBorderGraphicsHint(state) == PaletteGraphicsHint.AntiAlias);
+                                           palette.GetBorderWidth(state), tabBorderStyle, orientation);
         }
 
         /// <summary>
@@ -1946,7 +1950,7 @@ namespace Krypton.Toolkit
             // Is there anything to actually draw?
             if (rect is { Width: > 0, Height: > 0 })
             {
-                // Decide if we need to use anti aliasing for a smoother looking visual
+                // Decide if we need to use antialiasing for a smoother looking visual
                 using var hint = new GraphicsHint(context.Graphics, palette.GetBorderGraphicsHint(state));
                 // Cache commonly used values
                 var borderWidth = palette.GetBorderWidth(state);
@@ -1956,8 +1960,7 @@ namespace Krypton.Toolkit
                 {
                     // Create the path that represents the entire tab border
                     using GraphicsPath borderPath = CreateTabBorderBackPath(context.Control.RightToLeft, state, true, rect,
-                        borderWidth, tabBorderStyle, orientation,
-                        palette.GetBorderGraphicsHint(state) == PaletteGraphicsHint.AntiAlias);
+                        borderWidth, tabBorderStyle, orientation);
                     // Get the rectangle to use when dealing with gradients
                     Rectangle gradientRect = context.GetAlignedRectangle(palette.GetBorderColorAlign(state), rect);
 
@@ -2016,14 +2019,14 @@ namespace Krypton.Toolkit
             VisualOrientation orientation,
             IDisposable? memento)
         {
-            // Note is the incoming state is detailed we are drawing inside a popip
+            // Note is the incoming state is detailed we are drawing inside a popup
             var showingInPopup = (state & PaletteState.FocusOverride) == PaletteState.FocusOverride;
             if (showingInPopup)
             {
                 state &= ~PaletteState.FocusOverride;
             }
 
-            var backColorStyle = palette.GetRibbonBackColorStyle(state);
+            PaletteRibbonColorStyle backColorStyle = palette.GetRibbonBackColorStyle(state);
             switch (backColorStyle)
             {
                 case PaletteRibbonColorStyle.Empty:
@@ -2202,7 +2205,7 @@ namespace Krypton.Toolkit
             Debug.Assert(context != null);
             Debug.Assert(paletteBack != null);
 
-            // Draw inside of the border edge in a lighter version of the border
+            // Draw inside the border edge in a lighter version of the border
             using var drawBrush = new SolidBrush(paletteBack!.GetBackColor1(state));
             context!.Graphics.FillRectangle(drawBrush, displayRect);
         }
@@ -2287,12 +2290,12 @@ namespace Krypton.Toolkit
         }
 
         /// <summary>
-        /// Calculate the requested display size for the check box.
+        /// Calculate the requested display size for the checkbox.
         /// </summary>
         /// <param name="context">Render context.</param>
         /// <param name="palette">Palette for sourcing display values.</param>
         /// <param name="enabled">Should check box be Displayed as enabled.</param>
-        /// <param name="checkState">The checked state of the check box.</param>
+        /// <param name="checkState">The checked state of the checkbox.</param>
         /// <param name="tracking">Should check box be Displayed as hot tracking.</param>
         /// <param name="pressed">Should check box be Displayed as pressed.</param>
         /// <exception cref="ArgumentNullException"></exception>
@@ -2326,7 +2329,7 @@ namespace Krypton.Toolkit
                 // Convert incoming parameters to check box state
                 CheckBoxState state = DiscoverCheckBoxState(enabled, checkState, tracking, pressed);
 
-                // Request the drawing size of the check box glyph
+                // Request the drawing size of the checkbox glyph
                 return CheckBoxRenderer.GetGlyphSize(context.Graphics, state);
             }
             else
@@ -2336,13 +2339,13 @@ namespace Krypton.Toolkit
         }
 
         /// <summary>
-        /// Perform drawing of a check box.
+        /// Perform drawing of a checkbox.
         /// </summary>
         /// <param name="context">Render context.</param>
         /// <param name="displayRect">Display area available for drawing.</param>
         /// <param name="palette">Palette for sourcing display values.</param>
         /// <param name="enabled">Should check box be Displayed as enabled.</param>
-        /// <param name="checkState">The checked state of the check box.</param>
+        /// <param name="checkState">The checked state of the checkbox.</param>
         /// <param name="tracking">Should check box be Displayed as hot tracking.</param>
         /// <param name="pressed">Should check box be Displayed as pressed.</param>
         /// <exception cref="ArgumentNullException"></exception>
@@ -2485,7 +2488,7 @@ namespace Krypton.Toolkit
         }
 
         /// <summary>
-        /// Calculate the requested display size for the drop down button.
+        /// Calculate the requested display size for the drop-down button.
         /// </summary>
         /// <param name="context">Render context.</param>
         /// <param name="palette">Palette for sourcing display values.</param>
@@ -2497,10 +2500,10 @@ namespace Krypton.Toolkit
                                                             VisualOrientation orientation)
         {
             // Grab an image appropriate to the state
-            Image? drawImage = palette?.GetDropDownButtonImage(state);
+            Image? drawImage = palette.GetDropDownButtonImage(state);
 
             // Get the image defined size
-            Size imageSize = Size.Empty;
+            var imageSize = Size.Empty;
             if (drawImage != null)
             {
                 imageSize = drawImage.Size;
@@ -2517,7 +2520,7 @@ namespace Krypton.Toolkit
         }
 
         /// <summary>
-        /// Perform drawing of a drop down button.
+        /// Perform drawing of a drop-down button.
         /// </summary>
         /// <param name="context">Render context.</param>
         /// <param name="displayRect">Display area available for drawing.</param>
@@ -2589,17 +2592,17 @@ namespace Krypton.Toolkit
             var xStart = cellRect.Left + ((cellRect.Right - cellRect.Left - 4) / 2);
             var yStart = cellRect.Top + ((cellRect.Bottom - cellRect.Top - 3) / 2);
 
-            using Pen darkPen = new Pen(c1),
-                lightPen = new Pen(c2);
+            using var darkPen = new Pen(c1);
             context.Graphics.DrawLine(darkPen, xStart, yStart + 3, xStart + 4, yStart + 3);
             context.Graphics.DrawLine(darkPen, xStart + 1, yStart + 2, xStart + 3, yStart + 2);
             context.Graphics.DrawLine(darkPen, xStart + 2, yStart + 2, xStart + 2, yStart + 1);
+            using var lightPen = new Pen(c2);
             context.Graphics.DrawLine(lightPen, xStart + 2, yStart, xStart + 4, yStart + 2);
             context.Graphics.DrawLine(lightPen, xStart + 2, yStart, xStart, yStart + 2);
         }
 
         /// <summary>
-        /// Draw a numeric down button image appropriate for a input control.
+        /// Draw a numeric down button image appropriate for an input control.
         /// </summary>
         /// <param name="context">Render context.</param>
         /// <param name="cellRect">Available drawing rectangle space.</param>
@@ -2632,17 +2635,17 @@ namespace Krypton.Toolkit
             var xStart = cellRect.Left + ((cellRect.Right - cellRect.Left - 4) / 2);
             var yStart = cellRect.Top + ((cellRect.Bottom - cellRect.Top - 3) / 2);
 
-            using Pen darkPen = new Pen(c1),
-                lightPen = new Pen(c2);
+            using var darkPen = new Pen(c1);
             context.Graphics.DrawLine(darkPen, xStart, yStart, xStart + 4, yStart);
             context.Graphics.DrawLine(darkPen, xStart + 1, yStart + 1, xStart + 3, yStart + 1);
             context.Graphics.DrawLine(darkPen, xStart + 2, yStart + 2, xStart + 2, yStart + 1);
+            using var lightPen = new Pen(c2);
             context.Graphics.DrawLine(lightPen, xStart, yStart + 1, xStart + 2, yStart + 3);
             context.Graphics.DrawLine(lightPen, xStart + 2, yStart + 3, xStart + 4, yStart + 1);
         }
 
         /// <summary>
-        /// Draw a drop down grid appropriate for a input control.
+        /// Draw a drop-down grid appropriate for an input control.
         /// </summary>
         /// <param name="context">Render context.</param>
         /// <param name="cellRect">Available drawing rectangle space.</param>
@@ -2675,11 +2678,11 @@ namespace Krypton.Toolkit
             var xStart = cellRect.Left + ((cellRect.Right - cellRect.Left - 4) / 2);
             var yStart = cellRect.Top + ((cellRect.Bottom - cellRect.Top - 3) / 2);
 
-            using Pen darkPen = new Pen(c1),
-                lightPen = new Pen(c2);
+            using var darkPen = new Pen(c1);
             context.Graphics.DrawLine(darkPen, xStart, yStart, xStart + 4, yStart);
             context.Graphics.DrawLine(darkPen, xStart + 1, yStart + 1, xStart + 3, yStart + 1);
             context.Graphics.DrawLine(darkPen, xStart + 2, yStart + 2, xStart + 2, yStart + 1);
+            using var lightPen = new Pen(c2);
             context.Graphics.DrawLine(lightPen, xStart, yStart + 1, xStart + 2, yStart + 3);
             context.Graphics.DrawLine(lightPen, xStart + 2, yStart + 3, xStart + 4, yStart + 1);
         }
@@ -2717,10 +2720,9 @@ namespace Krypton.Toolkit
             {
                 default:
                 case PaletteRibbonShape.Office2007:
-                {
-                    using (Pen darkPen = new Pen(paletteGeneral.GetRibbonGroupDialogDark(state)),
-                           lightPen = new Pen(paletteGeneral.GetRibbonGroupDialogLight(state)))
                     {
+                        using var darkPen = new Pen(paletteGeneral.GetRibbonGroupDialogDark(state));
+                        using var lightPen = new Pen(paletteGeneral.GetRibbonGroupDialogLight(state));
                         context.Graphics.DrawLine(darkPen, displayRect.Left, displayRect.Top + 5, displayRect.Left,
                             displayRect.Top);
                         context.Graphics.DrawLine(darkPen, displayRect.Left, displayRect.Top, displayRect.Left + 5,
@@ -2746,17 +2748,15 @@ namespace Krypton.Toolkit
                         context.Graphics.DrawLine(darkPen, displayRect.Right - 5, displayRect.Bottom - 5,
                             displayRect.Right - 3, displayRect.Bottom - 3);
                     }
-                }
-                break;
+                    break;
                 case PaletteRibbonShape.Office2010:
-                {
-                    var dialogBrush = new LinearGradientBrush(
-                        new RectangleF(displayRect.X - 1, displayRect.Y - 1, displayRect.Width + 2,
-                            displayRect.Height + 2), paletteGeneral.GetRibbonGroupDialogLight(state),
-                        paletteGeneral.GetRibbonGroupDialogDark(state), 45f);
-
-                    using (var dialogPen = new Pen(dialogBrush))
                     {
+                        var dialogBrush = new LinearGradientBrush(
+                            new RectangleF(displayRect.X - 1, displayRect.Y - 1, displayRect.Width + 2,
+                                displayRect.Height + 2), paletteGeneral.GetRibbonGroupDialogLight(state),
+                            paletteGeneral.GetRibbonGroupDialogDark(state), 45f);
+
+                        using var dialogPen = new Pen(dialogBrush);
                         context.Graphics.DrawLine(dialogPen, displayRect.Left, displayRect.Top + 5, displayRect.Left,
                             displayRect.Top);
                         context.Graphics.DrawLine(dialogPen, displayRect.Left, displayRect.Top, displayRect.Left + 5,
@@ -2772,8 +2772,7 @@ namespace Krypton.Toolkit
                         context.Graphics.DrawLine(dialogPen, displayRect.Right - 5, displayRect.Bottom - 5,
                             displayRect.Right - 3, displayRect.Bottom - 3);
                     }
-                }
-                break;
+                    break;
             }
         }
 
@@ -2816,10 +2815,9 @@ namespace Krypton.Toolkit
             {
                 default:
                 case PaletteRibbonShape.Office2007:
-                {
-                    using (Pen darkPen = new Pen(darkColor),
-                           lightPen = new Pen(lightColor))
                     {
+                        using var darkPen = new Pen(darkColor);
+                        using var lightPen = new Pen(lightColor);
                         context.Graphics.DrawLine(darkPen, displayRect.Left, displayRect.Top, displayRect.Left + 4,
                             displayRect.Top);
                         context.Graphics.DrawLine(darkPen, displayRect.Left + 1, displayRect.Top + 1,
@@ -2831,23 +2829,21 @@ namespace Krypton.Toolkit
                         context.Graphics.DrawLine(lightPen, displayRect.Left + 2, displayRect.Top + 3,
                             displayRect.Left + 4, displayRect.Top + 1);
                     }
-                }
-                break;
+                    break;
+
                 case PaletteRibbonShape.Office2010:
-                {
-                    using (var fillBrush = new LinearGradientBrush(
-                               new RectangleF(displayRect.X - 1, displayRect.Y - 1, displayRect.Width + 2,
-                                   displayRect.Height + 2), lightColor, darkColor, 45f))
                     {
-                        context.Graphics.FillPolygon(fillBrush, new Point[]
+                        using var fillBrush = new LinearGradientBrush(
+                            new RectangleF(displayRect.X - 1, displayRect.Y - 1, displayRect.Width + 2,
+                                displayRect.Height + 2), lightColor, darkColor, 45f);
+                        context.Graphics.FillPolygon(fillBrush, new[]
                         {
-                            new Point(displayRect.Left - 1, displayRect.Top - 1),
-                            new Point(displayRect.Left + 2, displayRect.Top + 3),
-                            new Point(displayRect.Left + 5, displayRect.Top)
-                        });
+                        new Point(displayRect.Left - 1, displayRect.Top - 1),
+                        new Point(displayRect.Left + 2, displayRect.Top + 3),
+                        new Point(displayRect.Left + 5, displayRect.Top)
+                    });
                     }
-                }
-                break;
+                    break;
             }
         }
 
@@ -2890,8 +2886,8 @@ namespace Krypton.Toolkit
                 c2 = CommonHelper.ColorToBlackAndWhite(c2);
             }
 
-            using Pen darkPen = new Pen(c1),
-                lightPen = new Pen(c2);
+            using var darkPen = new Pen(c1);
+            using var lightPen = new Pen(c2);
             // TODO: WagnerP - please provide a better way of doing this for Various themes and dpi's
             if (shape == PaletteRibbonShape.Office2010)
             {
@@ -2956,8 +2952,8 @@ namespace Krypton.Toolkit
                 c2 = CommonHelper.ColorToBlackAndWhite(c2);
             }
 
-            using Pen darkPen = new Pen(c1),
-                lightPen = new Pen(c2);
+            using var darkPen = new Pen(c1);
+            using var lightPen = new Pen(c2);
             // TODO: WagnerP - please provide a better way of doing this for Various themes and dpi's
             context.Graphics.DrawLine(darkPen, displayRect.Left, displayRect.Top + 1, displayRect.Left, displayRect.Top + 3);
             context.Graphics.DrawLine(darkPen, displayRect.Left + 1, displayRect.Top + 2, displayRect.Left, displayRect.Top + 3);
@@ -3007,37 +3003,31 @@ namespace Krypton.Toolkit
             {
                 default:
                 case PaletteRibbonShape.Office2007:
-                {
-                    using (Pen darkPen = new Pen(darkColor),
-                           lightPen = new Pen(lightColor))
                     {
+                        using var darkPen = new Pen(darkColor);
+                        using var lightPen = new Pen(lightColor);
                         context.Graphics.DrawLine(lightPen, x, displayRect.Top + 2, x, displayRect.Bottom - 3);
                         context.Graphics.DrawLine(darkPen, x + 1, displayRect.Top + 2, x + 1, displayRect.Bottom - 3);
                     }
-                }
-                break;
+                    break;
+
                 case PaletteRibbonShape.Office2010:
-                {
-                    using (LinearGradientBrush darkBrush =
-                           new LinearGradientBrush(
-                               new RectangleF(displayRect.X, displayRect.Y - 1, displayRect.Width,
-                                   displayRect.Height + 2), Color.FromArgb(72, darkColor), darkColor, 90f),
-                           lightBrush = new LinearGradientBrush(
-                               new RectangleF(displayRect.X - 1, displayRect.Y - 1,
-                                   displayRect.Width + 2, displayRect.Height + 2),
-                               Color.FromArgb(128, lightColor), lightColor, 90f))
                     {
+                        using var darkBrush = new LinearGradientBrush(
+                                    new Rectangle(displayRect.X, displayRect.Y - 1, displayRect.Width,
+                                        displayRect.Height + 2), Color.FromArgb(72, darkColor), darkColor, 90f);
+                        using var lightBrush = new LinearGradientBrush(
+                                new Rectangle(displayRect.X - 1, displayRect.Y - 1,
+                                    displayRect.Width + 2, displayRect.Height + 2),
+                                Color.FromArgb(128, lightColor), lightColor, 90f);
                         darkBrush.SetSigmaBellShape(0.5f);
                         lightBrush.SetSigmaBellShape(0.5f);
 
-                        using (var darkPen = new Pen(darkBrush))
-                        {
-                            context.Graphics.FillRectangle(lightBrush, x, displayRect.Top, 3, displayRect.Height);
-                            context.Graphics.DrawLine(darkPen, x + 1, displayRect.Top, x + 1, displayRect.Bottom - 1);
-                        }
+                        using var darkPen = new Pen(darkBrush);
+                        context.Graphics.FillRectangle(lightBrush, x, displayRect.Top, 3, displayRect.Height);
+                        context.Graphics.DrawLine(darkPen, x + 1, displayRect.Top, x + 1, displayRect.Bottom - 1);
                     }
-                }
-                break;
+                    break;
             }
         }
 
@@ -3269,11 +3259,11 @@ namespace Krypton.Toolkit
 
             if (feedback == PaletteDragFeedback.Rounded)
             {
-                MeasureDragDockingRounded(dragData!, dragDropPalette!);
+                MeasureDragDockingRounded(dragData!);
             }
             else
             {
-                MeasureDragDockingSquares(dragData!, dragDropPalette!);
+                MeasureDragDockingSquares(dragData!);
             }
         }
 
@@ -3356,7 +3346,7 @@ namespace Krypton.Toolkit
                                                   PaletteState state)
         {
             // If the border takes up some visual space
-            if (paletteBorder!.GetBorderWidth(state)! > 0)
+            if (paletteBorder!.GetBorderWidth(state) > 0)
             {
                 // If the border is not being painted then it must be transparent
                 if (paletteBorder.GetBorderDraw(state) == InheritBool.False)
@@ -3438,7 +3428,7 @@ namespace Krypton.Toolkit
 
                 // Draw a marker for each value between min and max
                 var factor = (range == 0) ? float.MinValue : drawRect.Width / range;
-                for (int i = minimum, y = 0 ; i <= maximum ; i += frequency, y += frequency)
+                for (int i = minimum, y = 0; i <= maximum; i += frequency, y += frequency)
                 {
                     var offset = drawRect.X + (factor * y);
                     float top;
@@ -3474,7 +3464,7 @@ namespace Krypton.Toolkit
 
                 // Draw a marker for each value between min and max
                 var factor = (range == 0) ? float.MinValue : drawRect.Height / range;
-                for (int i = minimum, y = 0 ; i <= maximum ; i += frequency, y += frequency)
+                for (int i = minimum, y = 0; i <= maximum; i += frequency, y += frequency)
                 {
                     var offset = drawRect.Y + (factor * y);
                     float left;
@@ -3530,18 +3520,18 @@ namespace Krypton.Toolkit
                 drawRect.Inflate(0, -1);
             }
 
-            using Pen border1Pen = new Pen(elementPalette.GetElementColor1(state)),
-                border2Pen = new Pen(elementPalette.GetElementColor2(state));
+            using var border1Pen = new Pen(elementPalette.GetElementColor1(state));
+            using var border2Pen = new Pen(elementPalette.GetElementColor2(state));
             using var insideBrush = new SolidBrush(elementPalette.GetElementColor3(state));
             if (!volumeControl)
             {
                 context.Graphics.FillRectangle(insideBrush, drawRect.X + 1, drawRect.Y + 1, drawRect.Width - 2, drawRect.Height - 2);
 
-                context.Graphics.DrawLines(border1Pen, new Point[]{
+                context.Graphics.DrawLines(border1Pen, new[]{
                     new Point(drawRect.Right - 1, drawRect.Y), new Point(drawRect.X, drawRect.Y),
                     new Point(drawRect.X, drawRect.Bottom - 1)});
 
-                context.Graphics.DrawLines(border2Pen, new Point[]{
+                context.Graphics.DrawLines(border2Pen, new[]{
                     new Point(drawRect.Right - 1, drawRect.Y + 1), new Point(drawRect.Right - 1, drawRect.Bottom - 1),
                     new Point(drawRect.X + 1, drawRect.Bottom - 1)});
             }
@@ -3550,12 +3540,12 @@ namespace Krypton.Toolkit
                 if (orientation == Orientation.Horizontal)
                 {
                     using var aa = new AntiAlias(context.Graphics);
-                    context.Graphics.FillPolygon(insideBrush, new Point[]{
+                    context.Graphics.FillPolygon(insideBrush, new[]{
                         new Point(drawRect.X, drawRect.Bottom - 2), new Point(drawRect.Right - 1, drawRect.Y),
                         new Point(drawRect.Right - 1, drawRect.Bottom - 1), new Point(drawRect.X, drawRect.Bottom - 1),
                         new Point(drawRect.X, drawRect.Bottom - 2)});
 
-                    context.Graphics.DrawLines(border1Pen, new Point[]{
+                    context.Graphics.DrawLines(border1Pen, new[]{
                         new Point(drawRect.Right - 1, drawRect.Y), new Point(drawRect.Right - 1, drawRect.Bottom - 1),
                         new Point(drawRect.X, drawRect.Bottom - 1), new Point(drawRect.X, drawRect.Bottom - 2),
                         new Point(drawRect.Right - 1, drawRect.Y)});
@@ -3563,12 +3553,12 @@ namespace Krypton.Toolkit
                 else
                 {
                     using var aa = new AntiAlias(context.Graphics);
-                    context.Graphics.FillPolygon(insideBrush, new Point[]{
+                    context.Graphics.FillPolygon(insideBrush, new[]{
                         new Point(drawRect.X + 1, drawRect.Bottom - 1), new Point(drawRect.Right - 1, drawRect.Y + 1),
                         new Point(drawRect.X, drawRect.Y + 1), new Point(drawRect.X, drawRect.Bottom - 1),
                         new Point(drawRect.X + 1, drawRect.Bottom - 1)});
 
-                    context.Graphics.DrawLines(border1Pen, new Point[]{
+                    context.Graphics.DrawLines(border1Pen, new[]{
                         new Point(drawRect.Right - 1, drawRect.Y + 1), new Point(drawRect.X, drawRect.Y + 1),
                         new Point(drawRect.X, drawRect.Bottom - 1), new Point(drawRect.X + 1, drawRect.Bottom - 1),
                         new Point(drawRect.Right - 1, drawRect.Y + 1)});
@@ -3823,34 +3813,35 @@ namespace Krypton.Toolkit
             if (rect is { Width: > 0, Height: > 0 })
             {
                 // Only use a rounding that will fit inside the rect
-                var rounding = Math.Min(borderRounding, Math.Min(rect.Width / 2, rect.Height / 2) - borderWidth);
+                var rounding = Math.Min(borderRounding, Math.Min(rect.Width / 2f, rect.Height / 2f) - borderWidth);
 
                 // Shrink the rect by half the width of the pen, because the pen will 
                 // draw half the distance overlapping each side of the centre anyway.
                 // Unless not drawing into the middle in which case give the outside.
-                var halfBorderWidthTL = middle ? borderWidth / 2 : 0;
+                var halfBorderWidth = middle ? borderWidth / 2f : 0f;
 
+                RectangleF rectF = rect;
                 // Only adjust the edges that are being drawn
                 if (CommonHelper.HasTopBorder(borders))
                 {
-                    rect.Y += halfBorderWidthTL;
-                    rect.Height -= halfBorderWidthTL;
+                    rectF.Y += halfBorderWidth;
+                    rectF.Height -= halfBorderWidth;
                 }
 
                 if (CommonHelper.HasLeftBorder(borders))
                 {
-                    rect.X += halfBorderWidthTL;
-                    rect.Width -= halfBorderWidthTL;
+                    rectF.X += halfBorderWidth;
+                    rectF.Width -= halfBorderWidth;
                 }
 
                 if (CommonHelper.HasBottomBorder(borders))
                 {
-                    rect.Height -= halfBorderWidthTL;
+                    rectF.Height -= halfBorderWidth;
                 }
 
                 if (CommonHelper.HasRightBorder(borders))
                 {
-                    rect.Width -= halfBorderWidthTL;
+                    rectF.Width -= halfBorderWidth;
                 }
 
                 // Find the width/height of the arc box
@@ -3860,7 +3851,7 @@ namespace Krypton.Toolkit
                 // If drawing all the four borders use a single routine
                 if (CommonHelper.HasAllBorders(borders))
                 {
-                    CreateAllBorderBackPath(middle, borderPath, rect, borderWidth, rounding, forBorder, arcLength, arcLength1);
+                    CreateAllBorderBackPath(middle, borderPath, rectF, borderWidth, rounding, forBorder, arcLength, arcLength1);
                 }
                 else
                 {
@@ -3875,12 +3866,12 @@ namespace Krypton.Toolkit
                             // because this is going to be used as a region we need to close the path as well.
                             if (rounding > 0)
                             {
-                                CreateBorderBackPathOnlyClosed(middle, borders, borderPath, rect, arcLength, variant);
+                                CreateBorderBackPathOnlyClosed(middle, borders, borderPath, rectF, arcLength, variant);
                             }
                             else
                             {
-                                // Without rounding we just provide the entire area
-                                borderPath.AddRectangle(rect);
+                                // Without rounding, we just provide the entire area
+                                borderPath.AddRectangle(rectF);
                             }
                         }
                         else
@@ -3890,11 +3881,11 @@ namespace Krypton.Toolkit
 
                             if (rounding > 0)
                             {
-                                CreateBorderBackPathOnly(middle, borders, borderPath, rect, arcLength, variant);
+                                CreateBorderBackPathOnly(middle, borders, borderPath, rectF, arcLength, variant);
                             }
                             else
                             {
-                                CreateBorderBackPathOnly(borders, borderPath, rect, variant);
+                                CreateBorderBackPathOnly(borders, borderPath, rectF, variant);
                             }
                         }
                     }
@@ -3904,12 +3895,12 @@ namespace Krypton.Toolkit
                         // If there is rounding we need to calculate a path that honors the rounding at corners
                         if (rounding > 0)
                         {
-                            CreateBorderBackPathComplete(middle, borders, borderPath, rect, arcLength);
+                            CreateBorderBackPathComplete(middle, borders, borderPath, rectF, arcLength);
                         }
                         else
                         {
                             // Without rounding the complete path is always just the entire area
-                            borderPath.AddRectangle(rect);
+                            borderPath.AddRectangle(rectF);
                         }
                     }
                 }
@@ -3920,7 +3911,7 @@ namespace Krypton.Toolkit
 
         private static void CreateAllBorderBackPath(bool middle,
                                                     GraphicsPath borderPath,
-                                                    Rectangle rect,
+                                                    RectangleF rectF,
                                                     int width,
                                                     float rounding,
                                                     bool forBorder,
@@ -3930,21 +3921,18 @@ namespace Krypton.Toolkit
             // If there is no room for any rounding effect...
             if (rounding <= 0)
             {
-                // If the width is an odd number then need to reduce by 1 in each dimension
-                if (forBorder && middle && ((width % 2) == 1))
-                {
-                    rect.Width--;
-                    rect.Height--;
-                }
+                //// If the width is an odd number then need to reduce by 1 in each dimension
+                //if (forBorder && middle && ((width % 2) == 1))
+                //{
+                //    rectF.Width--;
+                //    rectF.Height--;
+                //}
 
                 // Just add a simple rectangle as a quick way of adding four lines
-                borderPath.AddRectangle(rect);
+                borderPath.AddRectangle(rectF);
             }
             else
             {
-                // We create the path using a floating point rectangle
-                var rectF = new RectangleF(rect.X, rect.Y, rect.Width, rect.Height);
-
                 // If trying to get the outside edge then perform some offsetting so that
                 // when converted to a region it draws nicely inside the path outline
                 if (!middle && ((width % 2) == 1))
@@ -3968,87 +3956,83 @@ namespace Krypton.Toolkit
 
         private static void CreateBorderBackPathOnly(PaletteDrawBorders borders,
                                                      GraphicsPath borderPath,
-                                                     Rectangle rect,
+                                                     RectangleF rectF,
                                                      int variant)
         {
-            // Reduce the width and height by 1 pixel for drawing into rectangle
-            rect.Width--;
-            rect.Height--;
-
             // Add only the border for drawing
             switch (borders)
             {
                 case PaletteDrawBorders.None:
                     break;
                 case PaletteDrawBorders.Top:
-                    borderPath.AddLine(rect.Left - 1, rect.Top, rect.Right + 1, rect.Top);
+                    borderPath.AddLine(rectF.Left - 1, rectF.Top, rectF.Right + 1, rectF.Top);
                     break;
                 case PaletteDrawBorders.Bottom:
-                    borderPath.AddLine(rect.Left - 1, rect.Bottom, rect.Right + 1, rect.Bottom);
+                    borderPath.AddLine(rectF.Left - 1, rectF.Bottom, rectF.Right + 1, rectF.Bottom);
                     break;
                 case PaletteDrawBorders.Left:
-                    borderPath.AddLine(rect.Left, rect.Top - 1, rect.Left, rect.Bottom + 1);
+                    borderPath.AddLine(rectF.Left, rectF.Top - 1, rectF.Left, rectF.Bottom + 1);
                     break;
                 case PaletteDrawBorders.Right:
-                    borderPath.AddLine(rect.Right, rect.Top - 1, rect.Right, rect.Bottom + 1);
+                    borderPath.AddLine(rectF.Right, rectF.Top - 1, rectF.Right, rectF.Bottom + 1);
                     break;
                 case PaletteDrawBorders.TopBottom:
                     if (variant == 0)
                     {
-                        borderPath.AddLine(rect.Left - 1, rect.Top, rect.Right + 1, rect.Top);
+                        borderPath.AddLine(rectF.Left - 1, rectF.Bottom, rectF.Right + 1, rectF.Top);
                     }
                     else
                     {
-                        borderPath.AddLine(rect.Left - 1, rect.Bottom, rect.Right + 1, rect.Bottom);
+                        borderPath.AddLine(rectF.Left - 1, rectF.Bottom, rectF.Right + 1, rectF.Bottom);
                     }
-
                     break;
+
                 case PaletteDrawBorders.LeftRight:
                     if (variant == 0)
                     {
-                        borderPath.AddLine(rect.Left, rect.Top - 1, rect.Left, rect.Bottom + 1);
+                        borderPath.AddLine(rectF.Left, rectF.Top - 1, rectF.Left, rectF.Bottom + 1);
                     }
                     else
                     {
-                        borderPath.AddLine(rect.Right, rect.Top - 1, rect.Right, rect.Bottom + 1);
+                        borderPath.AddLine(rectF.Right, rectF.Top - 1, rectF.Right, rectF.Bottom + 1);
                     }
-
                     break;
+
                 case PaletteDrawBorders.TopLeft:
-                    borderPath.AddLine(rect.Left, rect.Bottom + 1, rect.Left, rect.Top);
-                    borderPath.AddLine(rect.Left, rect.Top, rect.Right + 1, rect.Top);
+                    borderPath.AddLine(rectF.Left, rectF.Bottom + 1, rectF.Left, rectF.Top);
+                    borderPath.AddLine(rectF.Left, rectF.Top, rectF.Right + 1, rectF.Top);
                     break;
                 case PaletteDrawBorders.TopRight:
-                    borderPath.AddLine(rect.Left, rect.Top, rect.Right, rect.Top);
-                    borderPath.AddLine(rect.Right, rect.Top, rect.Right, rect.Bottom + 1);
+                    borderPath.AddLine(rectF.Left, rectF.Top, rectF.Right, rectF.Top);
+                    borderPath.AddLine(rectF.Right, rectF.Top, rectF.Right, rectF.Bottom + 1);
                     break;
                 case PaletteDrawBorders.BottomRight:
-                    borderPath.AddLine(rect.Right, rect.Top - 1, rect.Right, rect.Bottom);
-                    borderPath.AddLine(rect.Right, rect.Bottom, rect.Left - 1, rect.Bottom);
+                    borderPath.AddLine(rectF.Right, rectF.Top - 1, rectF.Right, rectF.Bottom);
+                    borderPath.AddLine(rectF.Right, rectF.Bottom, rectF.Left - 1, rectF.Bottom);
                     break;
                 case PaletteDrawBorders.BottomLeft:
-                    borderPath.AddLine(rect.Right + 1, rect.Bottom, rect.Left, rect.Bottom);
-                    borderPath.AddLine(rect.Left, rect.Bottom, rect.Left, rect.Top - 1);
+                    borderPath.AddLine(rectF.Right + 1, rectF.Bottom, rectF.Left, rectF.Bottom);
+                    borderPath.AddLine(rectF.Left, rectF.Bottom, rectF.Left, rectF.Top - 1);
                     break;
                 case PaletteDrawBorders.TopBottomLeft:
-                    borderPath.AddLine(rect.Right + 1, rect.Bottom, rect.Left, rect.Bottom);
-                    borderPath.AddLine(rect.Left, rect.Bottom, rect.Left, rect.Top);
-                    borderPath.AddLine(rect.Left, rect.Top, rect.Right + 1, rect.Top);
+                    borderPath.AddLine(rectF.Right + 1, rectF.Bottom, rectF.Left, rectF.Bottom);
+                    borderPath.AddLine(rectF.Left, rectF.Bottom, rectF.Left, rectF.Top);
+                    borderPath.AddLine(rectF.Left, rectF.Top, rectF.Right + 1, rectF.Top);
                     break;
                 case PaletteDrawBorders.TopBottomRight:
-                    borderPath.AddLine(rect.Left - 1, rect.Top, rect.Right, rect.Top);
-                    borderPath.AddLine(rect.Right, rect.Top, rect.Right, rect.Bottom);
-                    borderPath.AddLine(rect.Right, rect.Bottom, rect.Left - 1, rect.Bottom);
+                    borderPath.AddLine(rectF.Left - 1, rectF.Top, rectF.Right, rectF.Top);
+                    borderPath.AddLine(rectF.Right, rectF.Top, rectF.Right, rectF.Bottom);
+                    borderPath.AddLine(rectF.Right, rectF.Bottom, rectF.Left - 1, rectF.Bottom);
                     break;
                 case PaletteDrawBorders.TopLeftRight:
-                    borderPath.AddLine(rect.Left, rect.Bottom + 1, rect.Left, rect.Top);
-                    borderPath.AddLine(rect.Left, rect.Top, rect.Right, rect.Top);
-                    borderPath.AddLine(rect.Right, rect.Top, rect.Right, rect.Bottom + 1);
+                    borderPath.AddLine(rectF.Left, rectF.Bottom + 1, rectF.Left, rectF.Top);
+                    borderPath.AddLine(rectF.Left, rectF.Top, rectF.Right, rectF.Top);
+                    borderPath.AddLine(rectF.Right, rectF.Top, rectF.Right, rectF.Bottom + 1);
                     break;
                 case PaletteDrawBorders.BottomLeftRight:
-                    borderPath.AddLine(rect.Right, rect.Top - 1, rect.Right, rect.Bottom);
-                    borderPath.AddLine(rect.Right, rect.Bottom, rect.Left, rect.Bottom);
-                    borderPath.AddLine(rect.Left, rect.Bottom, rect.Left, rect.Top - 1);
+                    borderPath.AddLine(rectF.Right, rectF.Top - 1, rectF.Right, rectF.Bottom);
+                    borderPath.AddLine(rectF.Right, rectF.Bottom, rectF.Left, rectF.Bottom);
+                    borderPath.AddLine(rectF.Left, rectF.Bottom, rectF.Left, rectF.Top - 1);
                     break;
             }
         }
@@ -4056,16 +4040,13 @@ namespace Krypton.Toolkit
         private static void CreateBorderBackPathOnly(bool middle,
                                                      PaletteDrawBorders borders,
                                                      GraphicsPath borderPath,
-                                                     Rectangle rect,
+                                                     RectangleF rectF,
                                                      float arcLength,
                                                      int variant)
         {
-            // Reduce the width and height by 1 pixel for drawing into rectangle
-            rect.Width--;
-            rect.Height--;
-
-            // We create the path using a floating point rectangle
-            var rectF = new RectangleF(rect.X, rect.Y, rect.Width, rect.Height);
+            //// Reduce the width and height by 1 pixel for drawing into rectangle
+            //rect.Width--;
+            //rect.Height--;
 
             // If trying to get the outside edge then perform some offsetting so that
             // when converted to a region it draws nicely inside the path outline
@@ -4083,36 +4064,36 @@ namespace Krypton.Toolkit
                 case PaletteDrawBorders.None:
                     break;
                 case PaletteDrawBorders.Top:
-                    borderPath.AddLine(rect.Left - 1, rect.Top, rect.Right + 1, rect.Top);
+                    borderPath.AddLine(rectF.Left - 1, rectF.Top, rectF.Right + 1, rectF.Top);
                     break;
                 case PaletteDrawBorders.Bottom:
-                    borderPath.AddLine(rect.Left - 1, rect.Bottom, rect.Right + 1, rect.Bottom);
+                    borderPath.AddLine(rectF.Left - 1, rectF.Bottom, rectF.Right + 1, rectF.Bottom);
                     break;
                 case PaletteDrawBorders.Left:
-                    borderPath.AddLine(rect.Left, rect.Top - 1, rect.Left, rect.Bottom + 1);
+                    borderPath.AddLine(rectF.Left, rectF.Top - 1, rectF.Left, rectF.Bottom + 1);
                     break;
                 case PaletteDrawBorders.Right:
-                    borderPath.AddLine(rect.Right, rect.Top - 1, rect.Right, rect.Bottom + 1);
+                    borderPath.AddLine(rectF.Right, rectF.Top - 1, rectF.Right, rectF.Bottom + 1);
                     break;
                 case PaletteDrawBorders.TopBottom:
                     if (variant == 0)
                     {
-                        borderPath.AddLine(rect.Left - 1, rect.Top, rect.Right + 1, rect.Top);
+                        borderPath.AddLine(rectF.Left - 1, rectF.Top, rectF.Right + 1, rectF.Top);
                     }
                     else
                     {
-                        borderPath.AddLine(rect.Left - 1, rect.Bottom, rect.Right + 1, rect.Bottom);
+                        borderPath.AddLine(rectF.Left - 1, rectF.Bottom, rectF.Right + 1, rectF.Bottom);
                     }
 
                     break;
                 case PaletteDrawBorders.LeftRight:
                     if (variant == 0)
                     {
-                        borderPath.AddLine(rect.Left, rect.Top - 1, rect.Left, rect.Bottom + 1);
+                        borderPath.AddLine(rectF.Left, rectF.Top - 1, rectF.Left, rectF.Bottom + 1);
                     }
                     else
                     {
-                        borderPath.AddLine(rect.Right, rect.Top - 1, rect.Right, rect.Bottom + 1);
+                        borderPath.AddLine(rectF.Right, rectF.Top - 1, rectF.Right, rectF.Bottom + 1);
                     }
 
                     break;
@@ -4166,17 +4147,10 @@ namespace Krypton.Toolkit
         private static void CreateBorderBackPathOnlyClosed(bool middle,
                                                            PaletteDrawBorders borders,
                                                            GraphicsPath borderPath,
-                                                           Rectangle rect,
+                                                           RectangleF rectF,
                                                            float arcLength,
                                                            int variant)
         {
-            // Reduce the width and height by 1 pixel for drawing into rectangle
-            rect.Width--;
-            rect.Height--;
-
-            // We create the path using a floating point rectangle
-            var rectF = new RectangleF(rect.X, rect.Y, rect.Width, rect.Height);
-
             // If trying to get the outside edge then perform some offsetting so that
             // when converted to a region it draws nicely inside the path outline
             if (!middle)
@@ -4199,9 +4173,9 @@ namespace Krypton.Toolkit
                 case PaletteDrawBorders.TopBottom:
                 case PaletteDrawBorders.LeftRight:
                     // When using the entire rectangle we do not need to adjust its size
-                    rect.Width++;
-                    rect.Height++;
-                    borderPath.AddRectangle(rect);
+                    rectF.Width++;
+                    rectF.Height++;
+                    borderPath.AddRectangle(rectF);
                     break;
                 case PaletteDrawBorders.TopLeft:
                     borderPath.AddLine(rectF.Left, rectF.Bottom + 1, rectF.Left, rectF.Top + arcLength);
@@ -4257,12 +4231,9 @@ namespace Krypton.Toolkit
         private static void CreateBorderBackPathComplete(bool middle,
                                                          PaletteDrawBorders borders,
                                                          GraphicsPath borderPath,
-                                                         Rectangle rect,
+                                                         RectangleF rectF,
                                                          float arcLength)
         {
-            // We create the path using a floating point rectangle
-            var rectF = new RectangleF(rect.X, rect.Y, rect.Width, rect.Height);
-
             // If trying to get the outside edge then perform some offsetting so that
             // when converted to a region it draws nicely inside the path outline
             if (!middle)
@@ -4283,7 +4254,7 @@ namespace Krypton.Toolkit
                 case PaletteDrawBorders.TopBottom:
                 case PaletteDrawBorders.LeftRight:
                     // Just add a simple rectangle as a quick way of adding four lines
-                    borderPath.AddRectangle(rect);
+                    borderPath.AddRectangle(rectF);
                     break;
                 case PaletteDrawBorders.TopLeft:
                     borderPath.AddLine(rectF.Left, rectF.Bottom, rectF.Left, rectF.Top + arcLength);
@@ -4367,8 +4338,7 @@ namespace Krypton.Toolkit
                                                             Rectangle rect,
                                                             int borderWidth,
                                                             TabBorderStyle tabBorderStyle,
-                                                            VisualOrientation orientation,
-                                                            bool smoothing)
+                                                            VisualOrientation orientation)
         {
             var borderPath = new GraphicsPath();
 
@@ -5040,7 +5010,7 @@ namespace Krypton.Toolkit
                         var x2T = rect.Width / 2;
                         var x6T = rect.Width / 6;
 
-                        borderPath.AddCurve(new Point[]{
+                        borderPath.AddCurve(new[]{
                             new Point(rect.Left, rect.Bottom), new Point(rect.Left + indentW, rect.Top + 5),
                             new Point(rect.Left + x6T, rect.Top + 2), new Point(rect.Left + x2T, rect.Top),
                             new Point(rect.Right - x6T, rect.Top + 2), new Point(rect.Right - indentW, rect.Top + 5),
@@ -5064,7 +5034,7 @@ namespace Krypton.Toolkit
                         var x2B = rect.Width / 2;
                         var x6B = rect.Width / 6;
 
-                        borderPath.AddCurve(new Point[]{
+                        borderPath.AddCurve(new[]{
                             new Point(rect.Left, rect.Top), new Point(rect.Left + indentW, rect.Bottom - 5),
                             new Point(rect.Left + x6B, rect.Bottom - 2), new Point(rect.Left + x2B, rect.Bottom),
                             new Point(rect.Right - x6B, rect.Bottom - 2),
@@ -5088,7 +5058,7 @@ namespace Krypton.Toolkit
                         var y2L = rect.Height / 2;
                         var y6L = rect.Height / 6;
 
-                        borderPath.AddCurve(new Point[]{
+                        borderPath.AddCurve(new[]{
                             new Point(rect.Right, rect.Bottom), new Point(rect.Left + 5, rect.Bottom - indentH),
                             new Point(rect.Left + 2, rect.Bottom - y6L), new Point(rect.Left, rect.Bottom - y2L),
                             new Point(rect.Left + 2, rect.Top + y6L), new Point(rect.Left + 5, rect.Top + indentH),
@@ -5112,7 +5082,7 @@ namespace Krypton.Toolkit
                         var y2R = rect.Height / 2;
                         var y6R = rect.Height / 6;
 
-                        borderPath.AddCurve(new Point[]{
+                        borderPath.AddCurve(new[]{
                             new Point(rect.Left, rect.Bottom), new Point(rect.Right - 5, rect.Bottom - indentH),
                             new Point(rect.Right - 2, rect.Bottom - y6R), new Point(rect.Right, rect.Bottom - y2R),
                             new Point(rect.Right - 2, rect.Top + y6R), new Point(rect.Right - 5, rect.Top + indentH),
@@ -5310,20 +5280,8 @@ namespace Krypton.Toolkit
             RectangleF rectF = path.GetBounds();
 
             // Convert to a pixel aligned rectangle
-            Rectangle rect;
-
             // Do we have any non-integer numbers to convert
-            if ((Math.Round(rectF.X) != rectF.X) ||
-                (Math.Round(rectF.Y) != rectF.Y) ||
-                (Math.Round(rectF.Width) != rectF.Width) ||
-                (Math.Round(rectF.Height) != rectF.Height))
-            {
-                rect = Rectangle.Round(rectF);
-            }
-            else
-            {
-                rect = Rectangle.Truncate(rectF);
-            }
+            var rect = new Rectangle((int)rectF.X, (int)rectF.Y, (int)Math.Ceiling(rectF.Width), (int)Math.Ceiling(rectF.Height));
 
             using Brush backBrush1 = CreateColorBrush(gradientRect, backColor1, backColor1, PaletteColorStyle.Solid, 0f, VisualOrientation.Top),
                 backBrush2 = CreateColorBrush(gradientRect, backColor2, backColor2, PaletteColorStyle.Solid, 0f, VisualOrientation.Top);
@@ -5360,7 +5318,7 @@ namespace Krypton.Toolkit
             }
 
             // Make a copy of the original path, so we can change it
-            GraphicsPath insetPath = (GraphicsPath)path.Clone();
+            var insetPath = (GraphicsPath)path.Clone();
 
             // Offset by 1.5 pixels so the background shows around two of
             // the edges of the background we are about to draw
@@ -5381,7 +5339,7 @@ namespace Krypton.Toolkit
             using (var clip = new Clipping(context.Graphics, path))
             {
                 // Draw the second color as the offset background
-                using var backBrush = CreateColorBrush(gradientRect,
+                using Brush backBrush = CreateColorBrush(gradientRect,
                     backColor2,
                     backColor2,
                     backColorStyle,
@@ -5458,7 +5416,7 @@ namespace Krypton.Toolkit
             rect.X++;
             rect.Y++;
 
-            // Size is smaller in both directions because of off-seting
+            // Size is smaller in both directions because of off-setting
             rect.Width--;
             rect.Height--;
 
@@ -5530,7 +5488,7 @@ namespace Krypton.Toolkit
         {
             using var clip = new Clipping(context.Graphics, path);
             // Use standard helper routine to create appropriate color brush
-            using (var backBrush = CreateColorBrush(gradientRect, backColor1, backColor2,
+            using (Brush backBrush = CreateColorBrush(gradientRect, backColor1, backColor2,
                        backColorStyle, backColorAngle, orientation))
             {
                 context.Graphics.FillPath(backBrush, path);
@@ -5567,13 +5525,13 @@ namespace Krypton.Toolkit
                                        VisualOrientation orientation,
                                        GraphicsPath path)
         {
-            // We want to ignore the ourside pixel edge, so inflate inwards
+            // We want to ignore the outside pixel edge, so inflate inwards
             rect.Inflate(-1, -1);
 
-            // Prevent drawing over that ourside edge
+            // Prevent drawing over that outside edge
             using var clip = new Clipping(context.Graphics, rect);
             // Use standard helper routine to create appropriate color brush
-            using var backBrush = CreateColorBrush(gradientRect, backColor1, backColor2,
+            using Brush backBrush = CreateColorBrush(gradientRect, backColor1, backColor2,
                 PaletteColorStyle.Rounding5, backColorAngle,
                 orientation);
             context.Graphics.FillPath(backBrush, path);
@@ -5589,10 +5547,10 @@ namespace Krypton.Toolkit
                                           VisualOrientation orientation,
                                           GraphicsPath path)
         {
-            // Prevent drawing over that ourside edge
+            // Prevent drawing over that outside edge
             using var clip = new Clipping(context.Graphics, rect);
             // Use standard helper routine to create appropriate color brush
-            using (var backBrush = CreateColorBrush(gradientRect, backColor1, backColor2,
+            using (Brush backBrush = CreateColorBrush(gradientRect, backColor1, backColor2,
                        PaletteColorStyle.Linear, backColorAngle,
                        orientation))
             {
@@ -5676,7 +5634,7 @@ namespace Krypton.Toolkit
         }
 
         private static void AllocateImageSpace([DisallowNull] StandardContentMemento memento,
-            [DisallowNull] IPaletteContent? paletteContent,
+            [DisallowNull] IPaletteContent paletteContent,
             [DisallowNull] IContentValues contentValues,
                                                PaletteState state,
                                                [DisallowNull] Rectangle displayRect,
@@ -5749,14 +5707,14 @@ namespace Krypton.Toolkit
 
         private static void AllocateShortTextSpace(ViewLayoutContext context,
             [DisallowNull] Graphics g,
-                                                   StandardContentMemento memento,
-                                                   [DisallowNull] IPaletteContent? paletteContent,
-                                                   IContentValues contentValues,
-                                                   PaletteState state,
-                                                   Rectangle displayRect,
-                                                   RightToLeft rtl,
-                                                   int spacingGap,
-                                                   ref Size[,] allocation)
+            StandardContentMemento memento,
+            [DisallowNull] IPaletteContent paletteContent,
+            IContentValues contentValues,
+            PaletteState state,
+            Rectangle displayRect,
+            RightToLeft rtl,
+            int spacingGap,
+            ref Size[,] allocation)
         {
             // By default, we cannot draw the text
             memento.DrawShortText = false;
@@ -5833,7 +5791,7 @@ namespace Krypton.Toolkit
         private static void AllocateLongTextSpace(ViewLayoutContext context,
                                                   Graphics? g,
                                                   [DisallowNull] StandardContentMemento memento,
-                                                  [DisallowNull] IPaletteContent? paletteContent,
+                                                  [DisallowNull] IPaletteContent paletteContent,
                                                   IContentValues contentValues,
                                                   PaletteState state,
                                                   Rectangle displayRect,
@@ -5976,11 +5934,11 @@ namespace Krypton.Toolkit
         {
             int[] colWidths = [0, 0, 0];
 
-            for (var col = 0 ; col < 3 ; col++)
+            for (var col = 0; col < 3; col++)
             {
                 if (rowIndex == -1)
                 {
-                    for (var row = 0 ; row < 3 ; row++)
+                    for (var row = 0; row < 3; row++)
                     {
                         // Store the widest cell in each column
                         if (allocation[col, row].Width > colWidths[col])
@@ -6006,9 +5964,9 @@ namespace Krypton.Toolkit
         {
             int[] rowHeights = [0, 0, 0];
 
-            for (var row = 0 ; row < 3 ; row++)
+            for (var row = 0; row < 3; row++)
             {
-                for (var col = 0 ; col < 3 ; col++)
+                for (var col = 0; col < 3; col++)
                 {
                     // Store the Highest cell in each column
                     if (allocation[col, row].Height > rowHeights[row])
@@ -6239,7 +6197,7 @@ namespace Krypton.Toolkit
                                                  int spacingGap,
                                                  ref Rectangle cellRect)
         {
-            Point location = Point.Empty;
+            var location = Point.Empty;
 
             // If drawing from right to left...
             if (rtl == RightToLeft.Yes)
@@ -6381,8 +6339,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void MeasureDragDockingSquares(RenderDragDockingData dragData,
-                                               IPaletteDragDrop dragDropPalette)
+        private void MeasureDragDockingSquares(RenderDragDockingData dragData)
         {
             dragData.DockWindowSize = new Size(88, 88);
 
@@ -6403,8 +6360,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void MeasureDragDockingRounded(RenderDragDockingData dragData,
-                                               IPaletteDragDrop dragDropPalette)
+        private void MeasureDragDockingRounded(RenderDragDockingData dragData)
         {
             dragData.DockWindowSize = new Size(103, 103);
             dragData.RectLeft = new Rectangle(0, 36, 32, 31);
@@ -6505,8 +6461,8 @@ namespace Krypton.Toolkit
             Color borderColor = dragData.ActiveMiddle ? active : border;
             Color insideColor = dragData.ActiveMiddle ? active : inside;
             using var aa = new AntiAlias(context.Graphics);
-            using GraphicsPath borderPath = new GraphicsPath(),
-                insidePath = new GraphicsPath();
+            using var borderPath = new GraphicsPath();
+            using var insidePath = new GraphicsPath();
             // Generate the graphics paths for the border and the inside area which is just inside the border
             Rectangle rect = dragData.RectMiddle;
             var rectInside = new Rectangle(rect.X + 2, rect.Y + 2, rect.Width - 4, rect.Height - 4);
@@ -6540,7 +6496,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void DrawDragDockingMiddleLines(GraphicsPath path, Rectangle rect, int tabExtend) => path.AddLines(new Point[] {
+        private void DrawDragDockingMiddleLines(GraphicsPath path, Rectangle rect, int tabExtend) => path.AddLines(new[] {
                 new Point(rect.X, rect.Bottom - 2), new Point(rect.X, rect.Y + 1), new Point(rect.X + 1, rect.Y),
                 new Point(rect.Right - 1, rect.Y), new Point(rect.Right, rect.Y + 1),
                 new Point(rect.Right, rect.Bottom - 6), new Point(rect.Right - 2, rect.Bottom - 4),
@@ -6593,7 +6549,7 @@ namespace Krypton.Toolkit
                         rect.Y + ((rect.Height - DRAG_ARROW_WIDTH) / 2),
                         DRAG_ARROW_HEIGHT, DRAG_ARROW_WIDTH);
 
-                    innerPath.AddLines(new Point[] {
+                    innerPath.AddLines(new[] {
                         new Point(rect.X + 1, rect.Top + 6), new Point(rect.Right - 1, rect.Top + 1),
                         new Point(rect.Right - 1, rect.Bottom - 2)});
                     break;
@@ -6602,7 +6558,7 @@ namespace Krypton.Toolkit
                         rect.Y + ((rect.Height - DRAG_ARROW_WIDTH) / 2),
                         DRAG_ARROW_HEIGHT, DRAG_ARROW_WIDTH);
 
-                    innerPath.AddLines(new Point[] {
+                    innerPath.AddLines(new[] {
                         new Point(rect.X + 1, rect.Top + 1), new Point(rect.X + 1, rect.Bottom - 2),
                         new Point(rect.Right - 1, rect.Top + 6) });
                     angle = 180f;
@@ -6612,7 +6568,7 @@ namespace Krypton.Toolkit
                         rect.Bottom - DRAG_ARROW_HEIGHT - DRAG_ARROW_GAP - 1,
                         DRAG_ARROW_WIDTH, DRAG_ARROW_HEIGHT);
 
-                    innerPath.AddLines(new Point[] {
+                    innerPath.AddLines(new[] {
                         new Point(rect.X + 1, rect.Bottom), new Point(rect.Right - 1, rect.Bottom),
                         new Point(rect.X + 6, rect.Top + 1) });
                     angle = 90f;
@@ -6622,7 +6578,7 @@ namespace Krypton.Toolkit
                         rect.Top + DRAG_ARROW_GAP,
                         DRAG_ARROW_WIDTH, DRAG_ARROW_HEIGHT);
 
-                    innerPath.AddLines(new Point[] {
+                    innerPath.AddLines(new[] {
                         new Point(rect.X + 2, rect.Top + 1), new Point(rect.Right - 2, rect.Top + 1),
                         new Point(rect.X + 6, rect.Bottom - 1) });
                     angle = 270f;
@@ -6694,17 +6650,16 @@ namespace Krypton.Toolkit
                 throw new ArgumentNullException(nameof(dragData));
             }
 
-            var start = Color.FromArgb(190, 190, 190);
+            Color start = Color.FromArgb(190, 190, 190);
             using var borderPen = new Pen(border);
             using var insideBrush = new SolidBrush(inside);
-            using LinearGradientBrush gradientLL =
-                    new LinearGradientBrush(new Rectangle(-1, -1, 5, 5), start, inside, 0f),
-                gradientTL = new LinearGradientBrush(new Rectangle(-1, 23, 5, 5), start, inside, 90f),
-                gradientCC = new LinearGradientBrush(new Rectangle(24, 25, 5, 5), start, inside, 45f),
-                gradientLT = new LinearGradientBrush(new Rectangle(28, -1, 5, 5), start, inside, 0f),
-                gradientML = new LinearGradientBrush(new Rectangle(22, -1, 5, 5), start, inside, 0f),
-                gradientMT = new LinearGradientBrush(new Rectangle(-1, 22, 5, 5), start, inside, 90f),
-                gradientTT = new LinearGradientBrush(new Rectangle(-1, -1, 5, 5), start, inside, 90f);
+            using var gradientLL = new LinearGradientBrush(new Rectangle(-1, -1, 5, 5), start, inside, 0f);
+            using var gradientTL = new LinearGradientBrush(new Rectangle(-1, 23, 5, 5), start, inside, 90f);
+            using var gradientCC = new LinearGradientBrush(new Rectangle(24, 25, 5, 5), start, inside, 45f);
+            using var gradientLT = new LinearGradientBrush(new Rectangle(28, -1, 5, 5), start, inside, 0f);
+            using var gradientML = new LinearGradientBrush(new Rectangle(22, -1, 5, 5), start, inside, 0f);
+            using var gradientMT = new LinearGradientBrush(new Rectangle(-1, 22, 5, 5), start, inside, 90f);
+            using var gradientTT = new LinearGradientBrush(new Rectangle(-1, -1, 5, 5), start, inside, 90f);
             // Draw all the background cross?
             if (dragData.ShowBack)
             {
@@ -6721,19 +6676,19 @@ namespace Krypton.Toolkit
                 g.FillPolygon(insideBrush, pts);
 
                 // Draw shadow at some of the box edges
-                g.FillPolygon(gradientLL, new Point[] { new Point(1, 57), new Point(1, 30), new Point(4, 33),
+                g.FillPolygon(gradientLL, new[] { new Point(1, 57), new Point(1, 30), new Point(4, 33),
                     new Point(4, 57) });
-                g.FillPolygon(gradientTL, new Point[] { new Point(1, 30), new Point(25, 30), new Point(27, 33),
+                g.FillPolygon(gradientTL, new[] { new Point(1, 30), new Point(25, 30), new Point(27, 33),
                     new Point(3, 33) });
-                g.FillPolygon(gradientCC, new Point[] { new Point(23, 30), new Point(30, 23), new Point(33, 26),
+                g.FillPolygon(gradientCC, new[] { new Point(23, 30), new Point(30, 23), new Point(33, 26),
                     new Point(26, 33) });
-                g.FillPolygon(gradientLT, new Point[] { new Point(30, 1), new Point(30, 24), new Point(33, 26),
+                g.FillPolygon(gradientLT, new[] { new Point(30, 1), new Point(30, 24), new Point(33, 26),
                     new Point(33, 4) });
-                g.FillPolygon(gradientTT, new Point[] { new Point(30, 1), new Point(57, 1), new Point(57, 4),
+                g.FillPolygon(gradientTT, new[] { new Point(30, 1), new Point(57, 1), new Point(57, 4),
                     new Point(33, 4) });
-                g.FillPolygon(gradientLT, new Point[] { new Point(30, 63), new Point(30, 87), new Point(33, 87),
+                g.FillPolygon(gradientLT, new[] { new Point(30, 63), new Point(30, 87), new Point(33, 87),
                     new Point(33, 66) });
-                g.FillPolygon(gradientTL, new Point[] { new Point(63, 30), new Point(87, 30), new Point(87, 33),
+                g.FillPolygon(gradientTL, new[] { new Point(63, 30), new Point(87, 30), new Point(87, 33),
                     new Point(66, 33) });
 
                 // Draw outline in darker colour
@@ -6753,15 +6708,15 @@ namespace Krypton.Toolkit
                 g.FillPolygon(insideBrush, pts);
 
                 // Draw shadow at some of the box edges
-                g.FillPolygon(gradientLL, new Point[] { new Point(1, 57), new Point(1, 30), new Point(4, 33),
+                g.FillPolygon(gradientLL, new[] { new Point(1, 57), new Point(1, 30), new Point(4, 33),
                     new Point(4, 57) });
-                g.FillPolygon(gradientTL, new Point[] { new Point(1, 30), new Point(25, 30), new Point(27, 33),
+                g.FillPolygon(gradientTL, new[] { new Point(1, 30), new Point(25, 30), new Point(27, 33),
                     new Point(3, 33) });
-                g.FillPolygon(gradientCC, new Point[] { new Point(23, 30), new Point(30, 23), new Point(33, 26),
+                g.FillPolygon(gradientCC, new[] { new Point(23, 30), new Point(30, 23), new Point(33, 26),
                     new Point(26, 33) });
-                g.FillPolygon(gradientMT, new Point[] { new Point(30, 24), new Point(57, 24), new Point(60, 27),
+                g.FillPolygon(gradientMT, new[] { new Point(30, 24), new Point(57, 24), new Point(60, 27),
                     new Point(33, 27) });
-                g.FillPolygon(gradientTL, new Point[] { new Point(63, 30), new Point(87, 30), new Point(87, 33),
+                g.FillPolygon(gradientTL, new[] { new Point(63, 30), new Point(87, 30), new Point(87, 33),
                     new Point(66, 33) });
 
                 // Draw outline in darker colour
@@ -6792,15 +6747,15 @@ namespace Krypton.Toolkit
                 // Fill this area with a solid colour
                 g.FillPolygon(insideBrush, pts);
 
-                g.FillPolygon(gradientLT, new Point[] { new Point(30, 1), new Point(30, 24), new Point(33, 26),
+                g.FillPolygon(gradientLT, new[] { new Point(30, 1), new Point(30, 24), new Point(33, 26),
                     new Point(33, 4) });
-                g.FillPolygon(gradientTT, new Point[] { new Point(30, 1), new Point(57, 1), new Point(57, 4),
+                g.FillPolygon(gradientTT, new[] { new Point(30, 1), new Point(57, 1), new Point(57, 4),
                     new Point(33, 4) });
-                g.FillPolygon(gradientCC, new Point[] { new Point(23, 30), new Point(30, 23), new Point(33, 26),
+                g.FillPolygon(gradientCC, new[] { new Point(23, 30), new Point(30, 23), new Point(33, 26),
                     new Point(26, 33) });
-                g.FillPolygon(gradientML, new Point[] { new Point(24, 57), new Point(24, 30), new Point(27, 33),
+                g.FillPolygon(gradientML, new[] { new Point(24, 57), new Point(24, 30), new Point(27, 33),
                     new Point(27, 60) });
-                g.FillPolygon(gradientLT, new Point[] { new Point(30, 63), new Point(30, 87), new Point(33, 87),
+                g.FillPolygon(gradientLT, new[] { new Point(30, 63), new Point(30, 87), new Point(33, 87),
                     new Point(33, 66) });
 
                 // Draw outline in darker colour
@@ -6845,19 +6800,18 @@ namespace Krypton.Toolkit
             Color borderColour = ControlPaint.Dark(activeColor);
 
             // Draw border around the window square
-            using Pen borderPen = new Pen(borderColour),
-                dashPen = new Pen(borderColour),
-                shadow1Pen = new Pen(_190),
-                shadow2Pen = new Pen(_218);
+            using var borderPen = new Pen(borderColour);
+            using var dashPen = new Pen(borderColour);
+            using var shadow1Pen = new Pen(_190);
+            using var shadow2Pen = new Pen(_218);
             // Draw the caption area at top of window
-            using LinearGradientBrush middleBrush =
-                    new LinearGradientBrush(new Rectangle(4, 33, 23, 1), ControlPaint.LightLight(inactiveColor),
-                        activeColor, 0f),
-                bottomBrush = new LinearGradientBrush(new Rectangle(4, 34, 23, 1), ControlPaint.Light(activeColor),
-                    activeColor, 0f),
-                positionBrush = new LinearGradientBrush(new Rectangle(4, 35, 11, 1), Color.FromArgb(160, inactiveColor),
-                    Color.FromArgb(64, inactiveColor), 0f),
-                arrowBrush = new LinearGradientBrush(new Rectangle(18, 40, 5, 8), borderColour,
+            using var middleBrush = new LinearGradientBrush(new Rectangle(4, 33, 23, 1), ControlPaint.LightLight(inactiveColor),
+                        activeColor, 0f);
+            using var bottomBrush = new LinearGradientBrush(new Rectangle(4, 34, 23, 1), ControlPaint.Light(activeColor),
+                    activeColor, 0f);
+            using var positionBrush = new LinearGradientBrush(new Rectangle(4, 35, 11, 1), Color.FromArgb(160, inactiveColor),
+                    Color.FromArgb(64, inactiveColor), 0f);
+            using var arrowBrush = new LinearGradientBrush(new Rectangle(18, 40, 5, 8), borderColour,
                     Color.FromArgb(175, borderColour), 0f);
             // Draw border
             g.DrawLine(borderPen, 4, 33, 4, 53);
@@ -6886,7 +6840,7 @@ namespace Krypton.Toolkit
             g.DrawLine(dashPen, 15, 37, 15, 52);
 
             // Draw the direction arrow
-            g.FillPolygon(arrowBrush, new Point[] { new Point(19, 44), new Point(23, 40), new Point(23, 48),
+            g.FillPolygon(arrowBrush, new[] { new Point(19, 44), new Point(23, 40), new Point(23, 48),
                 new Point(19, 44) });
 
             // If active, then draw highlighted border
@@ -6905,22 +6859,21 @@ namespace Krypton.Toolkit
         {
             if (g is not null)
             {
-                var borderColour = ControlPaint.Dark(activeColor);
+                Color borderColour = ControlPaint.Dark(activeColor);
 
                 // Draw border around the window square
-                using Pen borderPen = new Pen(borderColour),
-                    dashPen = new Pen(borderColour),
-                    shadow1Pen = new Pen(_190),
-                    shadow2Pen = new Pen(_218);
+                using var borderPen = new Pen(borderColour);
+                using var dashPen = new Pen(borderColour);
+                using var shadow1Pen = new Pen(_190);
+                using var shadow2Pen = new Pen(_218);
                 // Draw the caption area at top of window
-                using LinearGradientBrush middleBrush =
-                        new LinearGradientBrush(new Rectangle(60, 33, 23, 1), ControlPaint.LightLight(inactiveColor),
-                            activeColor, 0f),
-                    bottomBrush = new LinearGradientBrush(new Rectangle(60, 34, 23, 1), ControlPaint.Light(activeColor),
-                        activeColor, 0f),
-                    positionBrush = new LinearGradientBrush(new Rectangle(71, 35, 11, 1),
-                        Color.FromArgb(160, inactiveColor), Color.FromArgb(64, inactiveColor), 180f),
-                    arrowBrush = new LinearGradientBrush(new Rectangle(68, 40, 5, 8), borderColour,
+                using var middleBrush = new LinearGradientBrush(new Rectangle(60, 33, 23, 1), ControlPaint.LightLight(inactiveColor),
+                            activeColor, 0f);
+                using var bottomBrush = new LinearGradientBrush(new Rectangle(60, 34, 23, 1), ControlPaint.Light(activeColor),
+                        activeColor, 0f);
+                using var positionBrush = new LinearGradientBrush(new Rectangle(71, 35, 11, 1),
+                        Color.FromArgb(160, inactiveColor), Color.FromArgb(64, inactiveColor), 180f);
+                using var arrowBrush = new LinearGradientBrush(new Rectangle(68, 40, 5, 8), borderColour,
                         Color.FromArgb(175, borderColour), 180f);
                 // Draw border
                 g.DrawLine(borderPen, 60, 33, 60, 53);
@@ -6949,7 +6902,7 @@ namespace Krypton.Toolkit
                 g.DrawLine(dashPen, 72, 37, 72, 52);
 
                 // Draw the direction arrow
-                g.FillPolygon(arrowBrush, new Point[] { new Point(69, 44), new Point(65, 40), new Point(65, 48),
+                g.FillPolygon(arrowBrush, new[] { new Point(69, 44), new Point(65, 40), new Point(65, 48),
                 new Point(69, 44) });
 
                 // If active, then draw highlighted border
@@ -6969,38 +6922,37 @@ namespace Krypton.Toolkit
         {
             if (g is not null)
             {
-                var borderColour = ControlPaint.Dark(activeColor);
+                Color borderColour = ControlPaint.Dark(activeColor);
 
                 // Draw border around the window square
-                using Pen borderPen = new Pen(borderColour),
-                    dashPen = new Pen(borderColour),
-                    shadow1Pen = new Pen(_190),
-                    shadow2Pen = new Pen(_218);
+                using var borderPen = new Pen(borderColour);
+                using var dashPen = new Pen(borderColour);
+                using var shadow1Pen = new Pen(_190);
+                using var shadow2Pen = new Pen(_218);
                 // Draw the caption area at top of window
-                using LinearGradientBrush middleBrush =
-                        new LinearGradientBrush(new Rectangle(33, 5, 20, 1), ControlPaint.LightLight(inactiveColor),
-                            activeColor, 0f),
-                    bottomBrush = new LinearGradientBrush(new Rectangle(33, 6, 20, 1), ControlPaint.Light(activeColor),
-                        activeColor, 0f),
-                    positionBrush = new LinearGradientBrush(new Rectangle(34, 6, 19, 10),
-                        Color.FromArgb(160, inactiveColor), Color.FromArgb(64, inactiveColor), 90f),
-                    arrowBrush = new LinearGradientBrush(new Rectangle(39, 40, 8, 4), borderColour,
+                using var middleBrush = new LinearGradientBrush(new Rectangle(33, 5, 20, 1), ControlPaint.LightLight(inactiveColor),
+                            activeColor, 0f);
+                using var bottomBrush = new LinearGradientBrush(new Rectangle(33, 6, 20, 1), ControlPaint.Light(activeColor),
+                        activeColor, 0f);
+                using var positionBrush = new LinearGradientBrush(new Rectangle(34, 6, 19, 10),
+                        Color.FromArgb(160, inactiveColor), Color.FromArgb(64, inactiveColor), 90f);
+                using var arrowBrush = new LinearGradientBrush(new Rectangle(39, 40, 8, 4), borderColour,
                         Color.FromArgb(175, borderColour), 90f);
                 // Draw border
-                g.DrawLine(borderPen!, 33, 4, 53, 4);
-                g.DrawLine(borderPen!, 53, 4, 53, 27);
-                g.DrawLine(borderPen!, 53, 27, 33, 27);
-                g.DrawLine(borderPen!, 33, 27, 33, 4);
+                g.DrawLine(borderPen, 33, 4, 53, 4);
+                g.DrawLine(borderPen, 53, 4, 53, 27);
+                g.DrawLine(borderPen, 53, 27, 33, 27);
+                g.DrawLine(borderPen, 33, 27, 33, 4);
 
                 // Draw shadows around right and bottom edges
-                g.DrawLine(shadow1Pen!, 34, 28, 54, 28);
-                g.DrawLine(shadow1Pen!, 54, 5, 54, 28);
-                g.DrawLine(shadow2Pen!, 35, 29, 55, 29);
-                g.DrawLine(shadow2Pen!, 55, 6, 55, 29);
+                g.DrawLine(shadow1Pen, 34, 28, 54, 28);
+                g.DrawLine(shadow1Pen, 54, 5, 54, 28);
+                g.DrawLine(shadow2Pen, 35, 29, 55, 29);
+                g.DrawLine(shadow2Pen, 55, 6, 55, 29);
 
                 // Draw the caption area
-                g.FillRectangle(middleBrush!, 34, 5, 19, 1);
-                g.FillRectangle(bottomBrush!, 34, 6, 19, 1);
+                g.FillRectangle(middleBrush, 34, 5, 19, 1);
+                g.FillRectangle(bottomBrush, 34, 6, 19, 1);
 
                 // Draw client area
                 g.FillRectangle(SystemBrushes.Window!, 34, 7, 19, 20);
@@ -7013,15 +6965,15 @@ namespace Krypton.Toolkit
                 g.DrawLine(dashPen, 35, 15, 53, 15);
 
                 // Draw the direction arrow
-                g.FillPolygon(arrowBrush, new Point[] { new Point(43, 18), new Point(47, 23), new Point(39, 23),
+                g.FillPolygon(arrowBrush, new[] { new Point(43, 18), new Point(47, 23), new Point(39, 23),
                 new Point(43, 18) });
 
                 // If active, then draw highlighted border
                 if (dragData.ActiveTop)
                 {
-                    g.DrawLine(borderPen!, 29, 0, 29, 23);
-                    g.DrawLine(borderPen!, 57, 0, 57, 23);
-                    g.DrawLine(borderPen!, 29, 0, 57, 0);
+                    g.DrawLine(borderPen, 29, 0, 29, 23);
+                    g.DrawLine(borderPen, 57, 0, 57, 23);
+                    g.DrawLine(borderPen, 29, 0, 57, 0);
                 }
             }
         }
@@ -7031,62 +6983,60 @@ namespace Krypton.Toolkit
                                                   Color inactiveColor,
                                                   RenderDragDockingData dragData)
         {
-
             if (g is not null)
             {
-                var borderColour = ControlPaint.Dark(activeColor);
+                Color borderColour = ControlPaint.Dark(activeColor);
 
                 // Draw border around the window square
-                using Pen borderPen = new Pen(borderColour),
-                    dashPen = new Pen(borderColour),
-                    shadow1Pen = new Pen(_190),
-                    shadow2Pen = new Pen(_218);
+                using var borderPen = new Pen(borderColour);
+                using var dashPen = new Pen(borderColour);
+                using var shadow1Pen = new Pen(_190);
+                using var shadow2Pen = new Pen(_218);
                 // Draw the caption area at top of window
-                using LinearGradientBrush middleBrush =
-                        new LinearGradientBrush(new Rectangle(33, 61, 20, 1), ControlPaint.LightLight(inactiveColor),
-                            activeColor, 0f),
-                    bottomBrush = new LinearGradientBrush(new Rectangle(33, 62, 20, 1), ControlPaint.Light(activeColor),
-                        activeColor, 0f),
-                    positionBrush = new LinearGradientBrush(new Rectangle(34, 72, 19, 11),
-                        Color.FromArgb(160, inactiveColor), Color.FromArgb(64, inactiveColor), 270f),
-                    arrowBrush = new LinearGradientBrush(new Rectangle(39, 66, 8, 4), borderColour,
+                using var middleBrush = new LinearGradientBrush(new Rectangle(33, 61, 20, 1), ControlPaint.LightLight(inactiveColor),
+                            activeColor, 0f);
+                using var bottomBrush = new LinearGradientBrush(new Rectangle(33, 62, 20, 1), ControlPaint.Light(activeColor),
+                        activeColor, 0f);
+                using var positionBrush = new LinearGradientBrush(new Rectangle(34, 72, 19, 11),
+                        Color.FromArgb(160, inactiveColor), Color.FromArgb(64, inactiveColor), 270f);
+                using var arrowBrush = new LinearGradientBrush(new Rectangle(39, 66, 8, 4), borderColour,
                         Color.FromArgb(175, borderColour), 270f);
                 // Draw border
-                g.DrawLine(borderPen!, 33, 60, 53, 60);
-                g.DrawLine(borderPen!, 53, 60, 53, 83);
-                g.DrawLine(borderPen!, 53, 83, 33, 83);
-                g.DrawLine(borderPen!, 33, 83, 33, 60);
+                g.DrawLine(borderPen, 33, 60, 53, 60);
+                g.DrawLine(borderPen, 53, 60, 53, 83);
+                g.DrawLine(borderPen, 53, 83, 33, 83);
+                g.DrawLine(borderPen, 33, 83, 33, 60);
 
                 // Draw shadows around right and bottom edges
-                g.DrawLine(shadow1Pen!, 34, 84, 54, 84);
-                g.DrawLine(shadow1Pen!, 54, 61, 54, 84);
-                g.DrawLine(shadow2Pen!, 35, 85, 55, 85);
-                g.DrawLine(shadow2Pen!, 55, 61, 55, 85);
+                g.DrawLine(shadow1Pen, 34, 84, 54, 84);
+                g.DrawLine(shadow1Pen, 54, 61, 54, 84);
+                g.DrawLine(shadow2Pen, 35, 85, 55, 85);
+                g.DrawLine(shadow2Pen, 55, 61, 55, 85);
 
                 // Draw the caption area
-                g.FillRectangle(middleBrush!, 34, 61, 19, 1);
-                g.FillRectangle(bottomBrush!, 34, 62, 19, 1);
+                g.FillRectangle(middleBrush, 34, 61, 19, 1);
+                g.FillRectangle(bottomBrush, 34, 62, 19, 1);
 
                 // Draw client area
                 g.FillRectangle(SystemBrushes.Window!, 34, 63, 19, 20);
 
                 // Draw docking edge indicator
-                g.FillRectangle(positionBrush!, 34, 73, 19, 10);
+                g.FillRectangle(positionBrush, 34, 73, 19, 10);
 
                 // Draw a dashed line down the middle
                 dashPen.DashStyle = DashStyle.Dot;
                 g.DrawLine(dashPen, 35, 73, 53, 73);
 
                 // Draw the direction arrow
-                g.FillPolygon(arrowBrush, new Point[] { new Point(43, 71), new Point(47, 67), new Point(40, 67),
+                g.FillPolygon(arrowBrush, new[] { new Point(43, 71), new Point(47, 67), new Point(40, 67),
                 new Point(43, 71) });
 
                 // If active, then draw highlighted border
                 if (dragData.ActiveBottom)
                 {
-                    g.DrawLine(borderPen!, 29, 63, 29, 87);
-                    g.DrawLine(borderPen!, 57, 63, 57, 87);
-                    g.DrawLine(borderPen!, 29, 87, 57, 87);
+                    g.DrawLine(borderPen, 29, 63, 29, 87);
+                    g.DrawLine(borderPen, 57, 63, 57, 87);
+                    g.DrawLine(borderPen, 29, 87, 57, 87);
                 }
             }
         }
@@ -7098,13 +7048,13 @@ namespace Krypton.Toolkit
         {
             if (g is not null)
             {
-                var borderColour = ControlPaint.Dark(activeColor);
+                Color borderColour = ControlPaint.Dark(activeColor);
 
                 // Draw border around the window square
-                using Pen borderPen = new Pen(borderColour),
-                    dashPen = new Pen(borderColour),
-                    shadow1Pen = new Pen(_190),
-                    shadow2Pen = new Pen(_218);
+                using var borderPen = new Pen(borderColour);
+                using var dashPen = new Pen(borderColour);
+                using var shadow1Pen = new Pen(_190);
+                using var shadow2Pen = new Pen(_218);
                 // Draw the caption area at top of window
                 using (LinearGradientBrush middleBrush =
                        new LinearGradientBrush(new Rectangle(32, 34, 21, 1), ControlPaint.LightLight(inactiveColor),
@@ -7113,67 +7063,67 @@ namespace Krypton.Toolkit
                            activeColor, 0f))
                 {
                     // Draw border
-                    g.DrawLine(borderPen!, 32, 32, 54, 32);
-                    g.DrawLine(borderPen!, 32, 32, 32, 53);
-                    g.DrawLine(borderPen!, 32, 53, 33, 54);
-                    g.DrawLine(borderPen!, 33, 54, 41, 54);
-                    g.DrawLine(borderPen!, 41, 54, 42, 52);
-                    g.DrawLine(borderPen!, 42, 52, 42, 50);
-                    g.DrawLine(borderPen!, 42, 50, 54, 50);
-                    g.DrawLine(borderPen!, 54, 32, 54, 53);
-                    g.DrawLine(borderPen!, 54, 53, 53, 54);
-                    g.DrawLine(borderPen!, 53, 54, 49, 54);
-                    g.DrawLine(borderPen!, 49, 54, 48, 53);
-                    g.DrawLine(borderPen!, 48, 53, 48, 50);
-                    g.DrawLine(borderPen!, 48, 53, 47, 54);
-                    g.DrawLine(borderPen!, 47, 54, 43, 54);
-                    g.DrawLine(borderPen!, 43, 54, 42, 53);
+                    g.DrawLine(borderPen, 32, 32, 54, 32);
+                    g.DrawLine(borderPen, 32, 32, 32, 53);
+                    g.DrawLine(borderPen, 32, 53, 33, 54);
+                    g.DrawLine(borderPen, 33, 54, 41, 54);
+                    g.DrawLine(borderPen, 41, 54, 42, 52);
+                    g.DrawLine(borderPen, 42, 52, 42, 50);
+                    g.DrawLine(borderPen, 42, 50, 54, 50);
+                    g.DrawLine(borderPen, 54, 32, 54, 53);
+                    g.DrawLine(borderPen, 54, 53, 53, 54);
+                    g.DrawLine(borderPen, 53, 54, 49, 54);
+                    g.DrawLine(borderPen, 49, 54, 48, 53);
+                    g.DrawLine(borderPen, 48, 53, 48, 50);
+                    g.DrawLine(borderPen, 48, 53, 47, 54);
+                    g.DrawLine(borderPen, 47, 54, 43, 54);
+                    g.DrawLine(borderPen, 43, 54, 42, 53);
 
                     // Draw the caption area
-                    g.FillRectangle(middleBrush!, 33, 33, 21, 1);
-                    g.FillRectangle(bottomBrush!, 33, 34, 21, 1);
+                    g.FillRectangle(middleBrush, 33, 33, 21, 1);
+                    g.FillRectangle(bottomBrush, 33, 34, 21, 1);
 
                     // Draw the client area
-                    g.FillRectangle(SystemBrushes.Window!, 33, 35, 21, 15);
-                    g.FillRectangle(SystemBrushes.Window!, 33, 50, 9, 3);
-                    g.FillRectangle(SystemBrushes.Window!, 33, 53, 9, 1);
-                    g.FillRectangle(SystemBrushes.Window!, 43, 51, 5, 3);
-                    g.FillRectangle(SystemBrushes.Window!, 49, 51, 5, 3);
+                    g.FillRectangle(SystemBrushes.Window, 33, 35, 21, 15);
+                    g.FillRectangle(SystemBrushes.Window, 33, 50, 9, 3);
+                    g.FillRectangle(SystemBrushes.Window, 33, 53, 9, 1);
+                    g.FillRectangle(SystemBrushes.Window, 43, 51, 5, 3);
+                    g.FillRectangle(SystemBrushes.Window, 49, 51, 5, 3);
 
                     // Fill the inner indicator area
                     using (var innerBrush = new SolidBrush(Color.FromArgb(64, inactiveColor)))
                     {
-                        g.FillRectangle(innerBrush!, 34, 36, 19, 13);
-                        g.FillRectangle(innerBrush!, 34, 49, 7, 3);
-                        g.FillRectangle(innerBrush!, 35, 52, 5, 1);
+                        g.FillRectangle(innerBrush, 34, 36, 19, 13);
+                        g.FillRectangle(innerBrush, 34, 49, 7, 3);
+                        g.FillRectangle(innerBrush, 35, 52, 5, 1);
                     }
 
                     // Draw outline of the indicator area
                     dashPen.DashStyle = DashStyle.Dot;
-                    g.DrawLine(dashPen!, 34, 37, 34, 52);
-                    g.DrawLine(dashPen!, 35, 52, 40, 52);
-                    g.DrawLine(dashPen!, 40, 51, 40, 49);
-                    g.DrawLine(dashPen!, 40, 51, 40, 48);
-                    g.DrawLine(dashPen!, 41, 48, 53, 48);
-                    g.DrawLine(dashPen!, 52, 47, 52, 36);
-                    g.DrawLine(dashPen!, 35, 36, 52, 36);
+                    g.DrawLine(dashPen, 34, 37, 34, 52);
+                    g.DrawLine(dashPen, 35, 52, 40, 52);
+                    g.DrawLine(dashPen, 40, 51, 40, 49);
+                    g.DrawLine(dashPen, 40, 51, 40, 48);
+                    g.DrawLine(dashPen, 41, 48, 53, 48);
+                    g.DrawLine(dashPen, 52, 47, 52, 36);
+                    g.DrawLine(dashPen, 35, 36, 52, 36);
 
                     // Draw right han side shadow
-                    g.DrawLine(shadow1Pen!, 55, 33, 55, 53);
-                    g.DrawLine(shadow2Pen!, 56, 34, 56, 53);
-                    g.DrawLine(shadow1Pen!, 33, 55, 53, 55);
-                    g.DrawLine(shadow1Pen!, 53, 55, 55, 53);
-                    g.DrawLine(shadow2Pen!, 34, 56, 53, 56);
-                    g.DrawLine(shadow2Pen!, 53, 56, 56, 53);
+                    g.DrawLine(shadow1Pen, 55, 33, 55, 53);
+                    g.DrawLine(shadow2Pen, 56, 34, 56, 53);
+                    g.DrawLine(shadow1Pen, 33, 55, 53, 55);
+                    g.DrawLine(shadow1Pen, 53, 55, 55, 53);
+                    g.DrawLine(shadow2Pen, 34, 56, 53, 56);
+                    g.DrawLine(shadow2Pen, 53, 56, 56, 53);
                 }
 
                 // If active, then draw highlighted border
                 if (dragData.ActiveMiddle)
                 {
-                    g.DrawLine(borderPen!, 23, 29, 29, 23);
-                    g.DrawLine(borderPen!, 57, 23, 63, 29);
-                    g.DrawLine(borderPen!, 63, 57, 57, 63);
-                    g.DrawLine(borderPen!, 23, 57, 29, 63);
+                    g.DrawLine(borderPen, 23, 29, 29, 23);
+                    g.DrawLine(borderPen, 57, 23, 63, 29);
+                    g.DrawLine(borderPen, 63, 57, 57, 63);
+                    g.DrawLine(borderPen, 23, 57, 29, 63);
                 }
             }
         }
@@ -7291,7 +7241,7 @@ namespace Krypton.Toolkit
 
                 using (var aa = new AntiAlias(context.Graphics))
                 {
-                    // Draw the outside of the entire border line
+                    // Draw the outside of the entire borderline
                     context.Graphics.DrawPath(cache.OutsidePen!, cache.OutsidePath!);
 
                     // Draw the highlighting inside border
@@ -7461,11 +7411,11 @@ namespace Krypton.Toolkit
                     shadowPath.AddLine(rect.Right - 4, rect.Bottom, rect.Right, rect.Bottom - 3);
                     shadowPath.AddLine(rect.Right, rect.Bottom - 3, rect.Right, rect.Top + 3);
 
-                    LinearGradientBrush insideBrush = new LinearGradientBrush(rect, Color.Transparent, c2, 95f);
+                    var insideBrush = new LinearGradientBrush(rect, Color.Transparent, c2, 95f);
                     cache.InsidePen = new Pen(insideBrush);
 
-                    Rectangle rectGradient = new Rectangle(rect.Left - 1, rect.Top, rect.Width + 2, rect.Height + 1);
-                    LinearGradientBrush shadowBrush = new LinearGradientBrush(rectGradient, _darken8, _darken38, 90f);
+                    var rectGradient = new Rectangle(rect.Left - 1, rect.Top, rect.Width + 2, rect.Height + 1);
+                    var shadowBrush = new LinearGradientBrush(rectGradient, _darken8, _darken38, 90f);
                     cache.ShadowPen = new Pen(shadowBrush);
 
                     cache.FillBrush = new LinearGradientBrush(rect, Color.White, _242, 90f)
@@ -7486,14 +7436,14 @@ namespace Krypton.Toolkit
                 context.Graphics.FillPath(cache.FillBrush!, cache.OutsidePath!);
 
                 // Clip drawing to the outside border
-                using (Clipping clip = new Clipping(context.Graphics, cache.OutsidePath!))
+                using (var clip = new Clipping(context.Graphics, cache.OutsidePath!))
                 {
                     context.Graphics.FillPath(cache.FillTopBrush!, cache.OutsidePath!);
                 }
 
-                using (AntiAlias aa = new AntiAlias(context.Graphics))
+                using (var aa = new AntiAlias(context.Graphics))
                 {
-                    // Draw the outside of the entire border line
+                    // Draw the outside of the entire borderline
                     context.Graphics.DrawPath(cache.OutsidePen!, cache.OutsidePath!);
 
                     // Draw the highlighting inside border
@@ -7586,7 +7536,7 @@ namespace Krypton.Toolkit
                 }
 
                 // Draw the actual border
-                using (AntiAlias aa = new AntiAlias(context.Graphics))
+                using (var aa = new AntiAlias(context.Graphics))
                 {
                     context.Graphics.DrawPath(cache.OutsidePen!, cache.OutsidePath!);
                 }
@@ -7621,15 +7571,15 @@ namespace Krypton.Toolkit
                                                             MementoRibbonTabTracking2007 cache)
         {
             // Create path for a curved border around the tab
-            GraphicsPath outsidePath = new GraphicsPath();
+            var outsidePath = new GraphicsPath();
             outsidePath.AddLine(rect.Left + 1, rect.Bottom - 2, rect.Left + 1, rect.Top + 1.5f);
             outsidePath.AddLine(rect.Left + 1, rect.Top + 1.5f, rect.Left + 3, rect.Top);
             outsidePath.AddLine(rect.Left + 3, rect.Top, rect.Right - 4, rect.Top);
             outsidePath.AddLine(rect.Right - 4, rect.Top, rect.Right - 2, rect.Top + 1.5f);
             outsidePath.AddLine(rect.Right - 2, rect.Top + 1.5f, rect.Right - 2, rect.Bottom - 2);
 
-            // Create path for the top hightlight line
-            GraphicsPath topPath = new GraphicsPath();
+            // Create path for the top highlight line
+            var topPath = new GraphicsPath();
             topPath.AddLine(rect.Left + 3, rect.Top + 2, rect.Left + 4, rect.Top + 1);
             topPath.AddLine(rect.Left + 4, rect.Top + 1, rect.Right - 5, rect.Top + 1);
             topPath.AddLine(rect.Right - 5, rect.Top + 1, rect.Right - 4, rect.Top + 2);
@@ -7640,8 +7590,8 @@ namespace Krypton.Toolkit
             var half2 = full - half1;
             cache.Half1Rect = new Rectangle(rect.Left + 3, rect.Top + 2, rect.Width - 6, half1);
             cache.Half2Rect = new Rectangle(rect.Left + 3, rect.Top + 2 + half1, rect.Width - 6, half2);
-            Rectangle fullRect = new Rectangle(rect.Left + 3, rect.Top + 2, rect.Width - 6, half1 + half2);
-            RectangleF half1RectF = new RectangleF(cache.Half1Rect.Left - 1, cache.Half1Rect.Top - 0.5f,
+            var fullRect = new Rectangle(rect.Left + 3, rect.Top + 2, rect.Width - 6, half1 + half2);
+            var half1RectF = new RectangleF(cache.Half1Rect.Left - 1, cache.Half1Rect.Top - 0.5f,
                 cache.Half1Rect.Width + 2, cache.Half1Rect.Height + 1);
             cache.Half2RectF = new RectangleF(cache.Half2Rect.Left - 1, cache.Half2Rect.Top - 0.5f, cache.Half2Rect.Width + 2, cache.Half2Rect.Height + 1);
 
@@ -7657,10 +7607,10 @@ namespace Krypton.Toolkit
             cache.Half2Brush = new SolidBrush(Color.FromArgb(85, c2));
 
             // Create ellipse information for lightening the bottom half
-            cache.EllipseRect = new RectangleF(fullRect.Left - (fullRect.Width / 8), fullRect.Top, fullRect.Width * 1.25f, fullRect.Height);
+            cache.EllipseRect = new RectangleF(fullRect.Left - (fullRect.Width / 8f), fullRect.Top, fullRect.Width * 1.25f, fullRect.Height);
 
             // Cannot draw a path that contains a zero sized element
-            GraphicsPath ellipsePath = new GraphicsPath();
+            var ellipsePath = new GraphicsPath();
             if (cache.EllipseRect is { Width: > 0, Height: > 0 })
             {
                 ellipsePath.AddEllipse(cache.EllipseRect);
@@ -7668,14 +7618,14 @@ namespace Krypton.Toolkit
                 {
                     CenterColor = Color.FromArgb(92, Color.White)
                 };
-                PointF centerPoint = new PointF(cache.EllipseRect.Left + (cache.EllipseRect.Width / 2),
+                var centerPoint = new PointF(cache.EllipseRect.Left + (cache.EllipseRect.Width / 2),
                     cache.EllipseRect.Top + (cache.EllipseRect.Height / 2));
                 cache.EllipseBrush.CenterPoint = centerPoint;
                 cache.EllipseBrush.SurroundColors = [Color.Transparent];
             }
 
-            RectangleF vertRectF = new RectangleF(rect.Left - 1, rect.Top + 2, rect.Width + 2, rect.Height - 2);
-            RectangleF horzRectF = new RectangleF(rect.Left + 1, rect.Top, rect.Width - 2, rect.Height);
+            var vertRectF = new RectangleF(rect.Left - 1, rect.Top + 2, rect.Width + 2, rect.Height - 2);
+            var horzRectF = new RectangleF(rect.Left + 1, rect.Top, rect.Width - 2, rect.Height);
             cache.OutsideBrush = new LinearGradientBrush(vertRectF, Color.Transparent, _whiten128, 90f)
             {
                 Blend = _ribbonOutBlend
@@ -7703,7 +7653,7 @@ namespace Krypton.Toolkit
                                                                 MementoRibbonTabTracking2007 cache,
                                                                 Graphics? g)
         {
-            if (g is not null && cache is not null)
+            if (g is not null)
             {
                 g.FillRectangle(cache.OutsideBrush!, rect.Left, rect.Top + 3, 1, rect.Height - 4);
                 g.FillRectangle(cache.InsideBrush!, rect.Left + 2, rect.Top + 3, 1, rect.Height - 4);
@@ -7720,15 +7670,15 @@ namespace Krypton.Toolkit
                                                          MementoRibbonTabTracking2007 cache)
         {
             // Create path for a curved border around the tab
-            GraphicsPath outsidePath = new GraphicsPath();
+            var outsidePath = new GraphicsPath();
             outsidePath.AddLine(rect.Right - 2, rect.Bottom - 2, rect.Left + 1.5f, rect.Bottom - 2);
             outsidePath.AddLine(rect.Left + 1.5f, rect.Bottom - 2, rect.Left, rect.Bottom - 4);
             outsidePath.AddLine(rect.Left, rect.Bottom - 4, rect.Left, rect.Top + 3);
             outsidePath.AddLine(rect.Left, rect.Top + 3, rect.Left + 1.5f, rect.Top + 1);
             outsidePath.AddLine(rect.Left + 1.5f, rect.Top + 1, rect.Right - 2, rect.Top + 1);
 
-            // Create path for the top hightlight line
-            GraphicsPath topPath = new GraphicsPath();
+            // Create path for the top highlight line
+            var topPath = new GraphicsPath();
             topPath.AddLine(rect.Left + 2, rect.Bottom - 4, rect.Left + 1, rect.Bottom - 5);
             topPath.AddLine(rect.Left + 1, rect.Bottom - 5, rect.Left + 1, rect.Top + 4);
             topPath.AddLine(rect.Left + 1, rect.Top + 4, rect.Left + 2, rect.Top + 3);
@@ -7739,8 +7689,8 @@ namespace Krypton.Toolkit
             var half2 = full - half1;
             cache.Half1Rect = new Rectangle(rect.Left + 2, rect.Top + 3, half1, rect.Height - 6);
             cache.Half2Rect = new Rectangle(rect.Left + 2 + half1, rect.Top + 3, half2, rect.Height - 6);
-            Rectangle fullRect = new Rectangle(rect.Left + 2, rect.Top + 3, half1 + half2, rect.Height - 6);
-            RectangleF half1RectF = new RectangleF(cache.Half1Rect.Left - 0.5f, cache.Half1Rect.Top - 1f,
+            var fullRect = new Rectangle(rect.Left + 2, rect.Top + 3, half1 + half2, rect.Height - 6);
+            var half1RectF = new RectangleF(cache.Half1Rect.Left - 0.5f, cache.Half1Rect.Top - 1f,
                 cache.Half1Rect.Width + 1, cache.Half1Rect.Height + 2);
             cache.Half2RectF = new RectangleF(cache.Half2Rect.Left - 0.5f, cache.Half2Rect.Top - 1f, cache.Half2Rect.Width + 1, cache.Half2Rect.Height + 2);
 
@@ -7755,10 +7705,10 @@ namespace Krypton.Toolkit
             cache.Half1LightBrush = new LinearGradientBrush(half1RectF, Color.FromArgb(28, Color.White), Color.FromArgb(125, Color.White), 180f);
             cache.Half2Brush = new SolidBrush(Color.FromArgb(85, c2));
 
-            // Create ellipse information for lightening the bottom hald
-            cache.EllipseRect = new RectangleF(fullRect.Left, fullRect.Top - (fullRect.Width / 8), fullRect.Width, fullRect.Height * 1.25f);
+            // Create ellipse information for lightening the bottom half
+            cache.EllipseRect = new RectangleF(fullRect.Left, fullRect.Top - (fullRect.Width / 8f), fullRect.Width, fullRect.Height * 1.25f);
 
-            GraphicsPath ellipsePath = new GraphicsPath();
+            var ellipsePath = new GraphicsPath();
             // Cannot draw a path that contains a zero sized element
             if (cache.EllipseRect is { Width: > 0, Height: > 0 })
             {
@@ -7767,14 +7717,14 @@ namespace Krypton.Toolkit
                 {
                     CenterColor = Color.FromArgb(48, Color.White)
                 };
-                PointF centerPoint = new PointF(cache.EllipseRect.Left + (cache.EllipseRect.Width / 2),
+                var centerPoint = new PointF(cache.EllipseRect.Left + (cache.EllipseRect.Width / 2),
                     cache.EllipseRect.Top + (cache.EllipseRect.Height / 2));
                 cache.EllipseBrush.CenterPoint = centerPoint;
                 cache.EllipseBrush.SurroundColors = [Color.Transparent];
             }
 
-            RectangleF vertRectF = new RectangleF(rect.Left + 2, rect.Top - 1, rect.Width - 2, rect.Height + 2);
-            RectangleF horzRectF = new RectangleF(rect.Left, rect.Top + 1, rect.Width, rect.Height - 2);
+            var vertRectF = new RectangleF(rect.Left + 2, rect.Top - 1, rect.Width - 2, rect.Height + 2);
+            var horzRectF = new RectangleF(rect.Left, rect.Top + 1, rect.Width, rect.Height - 2);
             cache.OutsideBrush = new LinearGradientBrush(vertRectF, Color.Transparent, _whiten128, 180f)
             {
                 Blend = _ribbonOutBlend
@@ -7819,15 +7769,15 @@ namespace Krypton.Toolkit
                                                               MementoRibbonTabTracking2007 cache)
         {
             // Create path for a curved border around the tab
-            GraphicsPath outsidePath = new GraphicsPath();
+            var outsidePath = new GraphicsPath();
             outsidePath.AddLine(rect.Left + 1, rect.Bottom - 2, rect.Right - 2.5f, rect.Bottom - 2);
             outsidePath.AddLine(rect.Right - 2.5f, rect.Bottom - 2, rect.Right - 1, rect.Bottom - 4);
             outsidePath.AddLine(rect.Right - 1, rect.Bottom - 4, rect.Right - 1, rect.Top + 3);
             outsidePath.AddLine(rect.Right - 1, rect.Top + 3, rect.Right - 2.5f, rect.Top + 1);
             outsidePath.AddLine(rect.Right - 2.5f, rect.Top + 1, rect.Left + 1, rect.Top + 1);
 
-            // Create path for the top hightlight line
-            GraphicsPath topPath = new GraphicsPath();
+            // Create path for the top highlight line
+            var topPath = new GraphicsPath();
             topPath.AddLine(rect.Right - 3, rect.Bottom - 4, rect.Right - 2, rect.Bottom - 5);
             topPath.AddLine(rect.Right - 2, rect.Bottom - 5, rect.Right - 2, rect.Top + 4);
             topPath.AddLine(rect.Right - 2, rect.Top + 4, rect.Right - 3, rect.Top + 3);
@@ -7838,9 +7788,9 @@ namespace Krypton.Toolkit
             var half2 = full - half1;
             cache.Half1Rect = new Rectangle(rect.Right - 2 - half1, rect.Top + 3, half1, rect.Height - 6);
             cache.Half2Rect = new Rectangle(rect.Right - 2 - half1 - half2, rect.Top + 3, half2, rect.Height - 6);
-            Rectangle fullRect = new Rectangle(rect.Right - 2 - half1 - half2, rect.Top + 3, half1 + half2,
+            var fullRect = new Rectangle(rect.Right - 2 - half1 - half2, rect.Top + 3, half1 + half2,
                 rect.Height - 6);
-            RectangleF half1RectF = new RectangleF(cache.Half1Rect.Left - 0.5f, cache.Half1Rect.Top - 1f,
+            var half1RectF = new RectangleF(cache.Half1Rect.Left - 0.5f, cache.Half1Rect.Top - 1f,
                 cache.Half1Rect.Width + 1, cache.Half1Rect.Height + 2);
             cache.Half2RectF = new RectangleF(cache.Half2Rect.Left - 0.5f, cache.Half2Rect.Top - 1f, cache.Half2Rect.Width + 1, cache.Half2Rect.Height + 2);
 
@@ -7855,10 +7805,10 @@ namespace Krypton.Toolkit
             cache.Half1LightBrush = new LinearGradientBrush(half1RectF, Color.FromArgb(28, Color.White), Color.FromArgb(125, Color.White), 0f);
             cache.Half2Brush = new SolidBrush(Color.FromArgb(85, c2));
 
-            // Create ellipse information for lightening the bottom hald
-            cache.EllipseRect = new RectangleF(fullRect.Left, fullRect.Top - (fullRect.Width / 8), fullRect.Width, fullRect.Height * 1.25f);
+            // Create ellipse information for lightening the bottom half
+            cache.EllipseRect = new RectangleF(fullRect.Left, fullRect.Top - (fullRect.Width / 8f), fullRect.Width, fullRect.Height * 1.25f);
 
-            GraphicsPath ellipsePath = new GraphicsPath();
+            var ellipsePath = new GraphicsPath();
             // Cannot draw a path that contains a zero sized element
             if (cache.EllipseRect is { Width: > 0, Height: > 0 })
             {
@@ -7867,14 +7817,14 @@ namespace Krypton.Toolkit
                 {
                     CenterColor = Color.FromArgb(48, Color.White)
                 };
-                PointF centerPoint = new PointF(cache.EllipseRect.Left + (cache.EllipseRect.Width / 2),
+                var centerPoint = new PointF(cache.EllipseRect.Left + (cache.EllipseRect.Width / 2),
                     cache.EllipseRect.Top + (cache.EllipseRect.Height / 2));
                 cache.EllipseBrush.CenterPoint = centerPoint;
                 cache.EllipseBrush.SurroundColors = [Color.Transparent];
             }
 
-            RectangleF vertRectF = new RectangleF(rect.Left, rect.Top - 1, rect.Width - 2, rect.Height + 2);
-            RectangleF horzRectF = new RectangleF(rect.Left, rect.Top + 1, rect.Width, rect.Height - 2);
+            var vertRectF = new RectangleF(rect.Left, rect.Top - 1, rect.Width - 2, rect.Height + 2);
+            var horzRectF = new RectangleF(rect.Left, rect.Top + 1, rect.Width, rect.Height - 2);
             cache.OutsideBrush = new LinearGradientBrush(vertRectF, Color.Transparent, _whiten128, 0f)
             {
                 Blend = _ribbonOutBlend
@@ -7919,15 +7869,15 @@ namespace Krypton.Toolkit
                                                                MementoRibbonTabTracking2007 cache)
         {
             // Create path for a curved border around the tab
-            GraphicsPath outsidePath = new GraphicsPath();
+            var outsidePath = new GraphicsPath();
             outsidePath.AddLine(rect.Left + 1, rect.Top + 1, rect.Left + 1, rect.Bottom - 2.5f);
             outsidePath.AddLine(rect.Left + 1, rect.Bottom - 2.5f, rect.Left + 3, rect.Bottom - 1);
             outsidePath.AddLine(rect.Left + 3, rect.Bottom - 1, rect.Right - 4, rect.Bottom - 1);
             outsidePath.AddLine(rect.Right - 4, rect.Bottom - 1, rect.Right - 2, rect.Bottom - 2.5f);
             outsidePath.AddLine(rect.Right - 2, rect.Bottom - 2.5f, rect.Right - 2, rect.Top + 1);
 
-            // Create path for the bottom hightlight line
-            GraphicsPath topPath = new GraphicsPath();
+            // Create path for the bottom highlight line
+            var topPath = new GraphicsPath();
             topPath.AddLine(rect.Left + 3, rect.Bottom - 3, rect.Left + 4, rect.Bottom - 2);
             topPath.AddLine(rect.Left + 4, rect.Bottom - 2, rect.Right - 5, rect.Bottom - 2);
             topPath.AddLine(rect.Right - 5, rect.Bottom - 2, rect.Right - 4, rect.Bottom - 3);
@@ -7938,9 +7888,9 @@ namespace Krypton.Toolkit
             var half2 = full - half1;
             cache.Half1Rect = new Rectangle(rect.Left + 3, rect.Bottom - 2 - half1, rect.Width - 6, half1);
             cache.Half2Rect = new Rectangle(rect.Left + 3, rect.Bottom - 2 - half1 - half2, rect.Width - 6, half2);
-            Rectangle fullRect = new Rectangle(rect.Left + 3, rect.Bottom - 2 - half1 - half2, rect.Width - 6,
+            var fullRect = new Rectangle(rect.Left + 3, rect.Bottom - 2 - half1 - half2, rect.Width - 6,
                 half1 + half2);
-            RectangleF half1RectF = new RectangleF(cache.Half1Rect.Left - 1, cache.Half1Rect.Top - 0.5f,
+            var half1RectF = new RectangleF(cache.Half1Rect.Left - 1, cache.Half1Rect.Top - 0.5f,
                 cache.Half1Rect.Width + 2, cache.Half1Rect.Height + 1);
             cache.Half2RectF = new RectangleF(cache.Half2Rect.Left - 1, cache.Half2Rect.Top - 0.5f, cache.Half2Rect.Width + 2, cache.Half2Rect.Height + 1);
 
@@ -7955,10 +7905,10 @@ namespace Krypton.Toolkit
             cache.Half1LightBrush = new LinearGradientBrush(half1RectF, Color.FromArgb(28, Color.White), Color.FromArgb(125, Color.White), 270f);
             cache.Half2Brush = new SolidBrush(Color.FromArgb(85, c2));
 
-            // Create ellipse information for lightening the bottom hald
-            cache.EllipseRect = new RectangleF(fullRect.Left - (fullRect.Width / 8), fullRect.Top, fullRect.Width * 1.25f, fullRect.Height);
+            // Create ellipse information for lightening the bottom half
+            cache.EllipseRect = new RectangleF(fullRect.Left - (fullRect.Width / 8f), fullRect.Top, fullRect.Width * 1.25f, fullRect.Height);
 
-            GraphicsPath ellipsePath = new GraphicsPath();
+            var ellipsePath = new GraphicsPath();
             // Cannot draw a path that contains a zero sized element
             if (cache.EllipseRect is { Width: > 0, Height: > 0 })
             {
@@ -7967,14 +7917,14 @@ namespace Krypton.Toolkit
                 {
                     CenterColor = Color.FromArgb(92, Color.White)
                 };
-                PointF centerPoint = new PointF(cache.EllipseRect.Left + (cache.EllipseRect.Width / 2),
+                var centerPoint = new PointF(cache.EllipseRect.Left + (cache.EllipseRect.Width / 2),
                     cache.EllipseRect.Bottom - (cache.EllipseRect.Height / 2));
                 cache.EllipseBrush.CenterPoint = centerPoint;
                 cache.EllipseBrush.SurroundColors = [Color.Transparent];
             }
 
-            RectangleF vertRectF = new RectangleF(rect.Left - 1, rect.Top, rect.Width + 2, rect.Height - 2);
-            RectangleF horzRectF = new RectangleF(rect.Left + 1, rect.Top, rect.Width - 2, rect.Height);
+            var vertRectF = new RectangleF(rect.Left - 1, rect.Top, rect.Width + 2, rect.Height - 2);
+            var horzRectF = new RectangleF(rect.Left + 1, rect.Top, rect.Width - 2, rect.Height);
             cache.OutsideBrush = new LinearGradientBrush(vertRectF, Color.Transparent, _whiten128, 270f)
             {
                 Blend = _ribbonOutBlend
@@ -8091,7 +8041,7 @@ namespace Krypton.Toolkit
                 context.Graphics.FillPath(cache.OutsideBrush!, cache.OutsidePath!);
 
                 // Draw the border
-                using (AntiAlias aa = new AntiAlias(context.Graphics))
+                using (var aa = new AntiAlias(context.Graphics))
                 {
                     context.Graphics.DrawPath(cache.OutsidePen!, cache.BorderPath!);
                 }
@@ -8110,9 +8060,9 @@ namespace Krypton.Toolkit
                                                             Color c3, Color c4,
                                                             MementoRibbonTabTracking2010 cache)
         {
-            GraphicsPath borderPath = new GraphicsPath();
-            GraphicsPath outsidePath = new GraphicsPath();
-            GraphicsPath insidePath = new GraphicsPath();
+            var borderPath = new GraphicsPath();
+            var outsidePath = new GraphicsPath();
+            var insidePath = new GraphicsPath();
 
             // Create path for a border pen
             borderPath.AddLine(rect.Left, rect.Bottom - 2, rect.Left, rect.Top + 1.75f);
@@ -8121,7 +8071,7 @@ namespace Krypton.Toolkit
             borderPath.AddLine(rect.Right - 2, rect.Top, rect.Right - 1, rect.Top + 1.75f);
             borderPath.AddLine(rect.Right - 1, rect.Top + 1.75f, rect.Right - 1, rect.Bottom - 2);
 
-            // Create path for a inside fill
+            // Create path for an inside fill
             outsidePath.AddLine(rect.Left, rect.Bottom - 1, rect.Left, rect.Top + 1.5f);
             outsidePath.AddLine(rect.Left, rect.Top + 1.5f, rect.Left + 1, rect.Top);
             outsidePath.AddLine(rect.Left + 1, rect.Top, rect.Right - 2, rect.Top);
@@ -8157,9 +8107,9 @@ namespace Krypton.Toolkit
                                                                Color c3, Color c4,
                                                                MementoRibbonTabTracking2010 cache)
         {
-            GraphicsPath borderPath = new GraphicsPath();
-            GraphicsPath outsidePath = new GraphicsPath();
-            GraphicsPath insidePath = new GraphicsPath();
+            var borderPath = new GraphicsPath();
+            var outsidePath = new GraphicsPath();
+            var insidePath = new GraphicsPath();
 
             // Create path for a border pen
             borderPath.AddLine(rect.Left, rect.Top, rect.Left, rect.Bottom - 2.75f);
@@ -8168,7 +8118,7 @@ namespace Krypton.Toolkit
             borderPath.AddLine(rect.Right - 2, rect.Bottom - 1, rect.Right - 1, rect.Bottom - 2.75f);
             borderPath.AddLine(rect.Right - 1, rect.Bottom - 2.75f, rect.Right - 1, rect.Top);
 
-            // Create path for a inside fill
+            // Create path for an inside fill
             outsidePath.AddLine(rect.Left, rect.Top, rect.Left, rect.Bottom - 2.5f);
             outsidePath.AddLine(rect.Left, rect.Bottom - 2.5f, rect.Left + 1, rect.Bottom - 1);
             outsidePath.AddLine(rect.Left + 1, rect.Bottom - 1, rect.Right - 2, rect.Bottom - 1);
@@ -8203,9 +8153,9 @@ namespace Krypton.Toolkit
                                                              Color c3, Color c4,
                                                              MementoRibbonTabTracking2010 cache)
         {
-            GraphicsPath borderPath = new GraphicsPath();
-            GraphicsPath outsidePath = new GraphicsPath();
-            GraphicsPath insidePath = new GraphicsPath();
+            var borderPath = new GraphicsPath();
+            var outsidePath = new GraphicsPath();
+            var insidePath = new GraphicsPath();
 
             // Create path for a border pen
             borderPath.AddLine(rect.Right - 1, rect.Top, rect.Left + 1.75f, rect.Top);
@@ -8214,7 +8164,7 @@ namespace Krypton.Toolkit
             borderPath.AddLine(rect.Left, rect.Bottom - 2.5f, rect.Left + 1.75f, rect.Bottom - 1);
             borderPath.AddLine(rect.Left + 1.75f, rect.Bottom - 1, rect.Right - 1, rect.Bottom - 1);
 
-            // Create path for a inside fill
+            // Create path for an inside fill
             outsidePath.AddLine(rect.Right - 1, rect.Top, rect.Left + 1.75f, rect.Top);
             outsidePath.AddLine(rect.Left + 1.75f, rect.Top, rect.Left, rect.Top + 1);
             outsidePath.AddLine(rect.Left, rect.Top + 1, rect.Left, rect.Bottom - 2.5f);
@@ -8250,9 +8200,9 @@ namespace Krypton.Toolkit
                                                               Color c3, Color c4,
                                                               MementoRibbonTabTracking2010 cache)
         {
-            GraphicsPath borderPath = new GraphicsPath();
-            GraphicsPath outsidePath = new GraphicsPath();
-            GraphicsPath insidePath = new GraphicsPath();
+            var borderPath = new GraphicsPath();
+            var outsidePath = new GraphicsPath();
+            var insidePath = new GraphicsPath();
 
             // Create path for a border pen
             borderPath.AddLine(rect.Left, rect.Top, rect.Right - 2.75f, rect.Top);
@@ -8261,7 +8211,7 @@ namespace Krypton.Toolkit
             borderPath.AddLine(rect.Right - 1, rect.Bottom - 2.5f, rect.Right - 2.75f, rect.Bottom - 1);
             borderPath.AddLine(rect.Right - 2.75f, rect.Bottom - 1, rect.Left, rect.Bottom - 1);
 
-            // Create path for a inside fill
+            // Create path for an inside fill
             outsidePath.AddLine(rect.Left, rect.Top, rect.Right - 2.75f, rect.Top);
             outsidePath.AddLine(rect.Right - 2.75f, rect.Top, rect.Right - 1, rect.Top + 1);
             outsidePath.AddLine(rect.Right - 1, rect.Top + 1, rect.Right - 1, rect.Bottom - 2.5f);
@@ -8363,7 +8313,7 @@ namespace Krypton.Toolkit
                 context.Graphics.FillPath(cache.OutsideBrush!, cache.OutsidePath!);
 
                 // Draw the border
-                using (AntiAlias aa = new AntiAlias(context.Graphics))
+                using (var aa = new AntiAlias(context.Graphics))
                 {
                     context.Graphics.DrawPath(cache.OutsidePen!, cache.BorderPath!);
                 }
@@ -8382,9 +8332,9 @@ namespace Krypton.Toolkit
                                                          Color c3, Color c4,
                                                          MementoRibbonTabTracking2010 cache)
         {
-            GraphicsPath borderPath = new GraphicsPath();
-            GraphicsPath outsidePath = new GraphicsPath();
-            GraphicsPath insidePath = new GraphicsPath();
+            var borderPath = new GraphicsPath();
+            var outsidePath = new GraphicsPath();
+            var insidePath = new GraphicsPath();
 
             // Create path for a border pen
             borderPath.AddLine(rect.Left, rect.Bottom - 1, rect.Left + 1, rect.Bottom - 2);
@@ -8395,7 +8345,7 @@ namespace Krypton.Toolkit
             borderPath.AddLine(rect.Right - 2, rect.Top + 1.75f, rect.Right - 2, rect.Bottom - 2);
             borderPath.AddLine(rect.Right - 2, rect.Bottom - 2, rect.Right - 1, rect.Bottom - 1);
 
-            // Create path for a inside fill
+            // Create path for an inside fill
             outsidePath.AddLine(rect.Left, rect.Bottom, rect.Left + 1, rect.Bottom - 1);
             outsidePath.AddLine(rect.Left + 1, rect.Bottom - 1, rect.Left + 1, rect.Top + 1.5f);
             outsidePath.AddLine(rect.Left + 1, rect.Top + 1.5f, rect.Left + 2, rect.Top);
@@ -8435,9 +8385,9 @@ namespace Krypton.Toolkit
                                                             Color c3, Color c4,
                                                             MementoRibbonTabTracking2010 cache)
         {
-            GraphicsPath borderPath = new GraphicsPath();
-            GraphicsPath outsidePath = new GraphicsPath();
-            GraphicsPath insidePath = new GraphicsPath();
+            var borderPath = new GraphicsPath();
+            var outsidePath = new GraphicsPath();
+            var insidePath = new GraphicsPath();
 
             // Create path for a border pen
             borderPath.AddLine(rect.Left, rect.Top, rect.Left + 1, rect.Top + 1);
@@ -8448,7 +8398,7 @@ namespace Krypton.Toolkit
             borderPath.AddLine(rect.Right - 2, rect.Bottom - 2.75f, rect.Right - 2, rect.Top + 1);
             borderPath.AddLine(rect.Right - 2, rect.Top + 1, rect.Right - 1, rect.Top);
 
-            // Create path for a inside fill
+            // Create path for an inside fill
             outsidePath.AddLine(rect.Left, rect.Top, rect.Left + 1, rect.Top);
             outsidePath.AddLine(rect.Left + 1, rect.Top, rect.Left + 1, rect.Bottom - 2.5f);
             outsidePath.AddLine(rect.Left + 1, rect.Bottom - 2.5f, rect.Left + 2, rect.Bottom - 1);
@@ -8487,9 +8437,9 @@ namespace Krypton.Toolkit
                                                           Color c3, Color c4,
                                                           MementoRibbonTabTracking2010 cache)
         {
-            GraphicsPath borderPath = new GraphicsPath();
-            GraphicsPath outsidePath = new GraphicsPath();
-            GraphicsPath insidePath = new GraphicsPath();
+            var borderPath = new GraphicsPath();
+            var outsidePath = new GraphicsPath();
+            var insidePath = new GraphicsPath();
 
             // Create path for a border pen
             borderPath.AddLine(rect.Right - 1, rect.Top - 1, rect.Right - 2, rect.Top);
@@ -8500,7 +8450,7 @@ namespace Krypton.Toolkit
             borderPath.AddLine(rect.Left + 1.75f, rect.Bottom - 2, rect.Right - 2, rect.Bottom - 2);
             borderPath.AddLine(rect.Right - 2, rect.Bottom - 2, rect.Right - 1, rect.Bottom - 1);
 
-            // Create path for a inside fill
+            // Create path for an inside fill
             outsidePath.AddLine(rect.Right, rect.Top, rect.Left + 1.75f, rect.Top);
             outsidePath.AddLine(rect.Left + 1.75f, rect.Top, rect.Left, rect.Top + 1);
             outsidePath.AddLine(rect.Left, rect.Top + 1, rect.Left, rect.Bottom - 2.5f);
@@ -8538,9 +8488,9 @@ namespace Krypton.Toolkit
                                                            Color c3, Color c4,
                                                            MementoRibbonTabTracking2010 cache)
         {
-            GraphicsPath borderPath = new GraphicsPath();
-            GraphicsPath outsidePath = new GraphicsPath();
-            GraphicsPath insidePath = new GraphicsPath();
+            var borderPath = new GraphicsPath();
+            var outsidePath = new GraphicsPath();
+            var insidePath = new GraphicsPath();
 
             // Create path for a border pen
             borderPath.AddLine(rect.Left, rect.Top - 1, rect.Left + 1, rect.Top);
@@ -8551,7 +8501,7 @@ namespace Krypton.Toolkit
             borderPath.AddLine(rect.Right - 2.75f, rect.Bottom - 2, rect.Left + 1, rect.Bottom - 2);
             borderPath.AddLine(rect.Left + 1, rect.Bottom - 2, rect.Left, rect.Bottom - 1);
 
-            // Create path for a inside fill
+            // Create path for an inside fill
             outsidePath.AddLine(rect.Left, rect.Top, rect.Right - 2.75f, rect.Top);
             outsidePath.AddLine(rect.Right - 2.75f, rect.Top, rect.Right - 1, rect.Top + 1);
             outsidePath.AddLine(rect.Right - 1, rect.Top + 1, rect.Right - 1, rect.Bottom - 2.5f);
@@ -8654,7 +8604,7 @@ namespace Krypton.Toolkit
                 }
 
                 // Draw the border over the edge of the inside color
-                using (AntiAlias aa = new AntiAlias(context.Graphics))
+                using (var aa = new AntiAlias(context.Graphics))
                 {
                     context.Graphics.DrawPath(cache.OutsidePen!, cache.OutsidePath!);
                 }
@@ -8665,7 +8615,7 @@ namespace Krypton.Toolkit
                 // Cannot draw a path that contains a zero sized element
                 if (cache.EllipseRect is { Width: > 0, Height: > 0 })
                 {
-                    context.Graphics.FillRectangle(cache.EllipseBrush!, cache.FullRect!);
+                    context.Graphics.FillRectangle(cache.EllipseBrush!, cache.FullRect);
                 }
             }
 
@@ -8679,9 +8629,9 @@ namespace Krypton.Toolkit
                                                        Color c1, Color c2, Color insideColor,
                                                        MementoRibbonTabGlowing cache)
         {
-            GraphicsPath outsidePath = new GraphicsPath();
-            GraphicsPath topPath = new GraphicsPath();
-            GraphicsPath ellipsePath = new GraphicsPath();
+            var outsidePath = new GraphicsPath();
+            var topPath = new GraphicsPath();
+            var ellipsePath = new GraphicsPath();
 
             // Create path for a curved border around the tab
             outsidePath.AddLine(rect.Left, rect.Bottom - 2, rect.Left, rect.Top + 1.5f);
@@ -8700,13 +8650,13 @@ namespace Krypton.Toolkit
             topPath.AddLine(rect.Right - 2, rect.Top + 2 + q4, rect.Right - 2, rect.Top + 2);
             topPath.AddLine(rect.Right - 2, rect.Top + 2, rect.Right - 3, rect.Top + 1);
 
-            RectangleF topRectF = new RectangleF(rect.Left, rect.Top, rect.Width, q4 + 5);
+            var topRectF = new RectangleF(rect.Left, rect.Top, rect.Width, q4 + 5);
             cache.TopBrush = new LinearGradientBrush(topRectF, c1, Color.Transparent, 90f);
 
-            var ellipseWidth = (int)(rect.Width * 1.2f);
-            var ellipseHeight = (int)(rect.Height * 0.4f);
+            var ellipseWidth = rect.Width * 1.2f;
+            var ellipseHeight = rect.Height * 0.4f;
             cache.FullRect = new RectangleF(rect.Left + 1, rect.Top + 1, rect.Width - 3, rect.Height - 2);
-            cache.EllipseRect = new RectangleF(rect.Left - ((ellipseWidth - rect.Width) / 2), rect.Bottom - ellipseHeight, ellipseWidth, ellipseHeight * 2);
+            cache.EllipseRect = new RectangleF(rect.Left - ((ellipseWidth - rect.Width) / 2f), rect.Bottom - ellipseHeight, ellipseWidth, ellipseHeight * 2);
 
             // Cannot draw a path that contains a zero sized element
             if (cache.EllipseRect is { Width: > 0, Height: > 0 })
@@ -8716,7 +8666,7 @@ namespace Krypton.Toolkit
                 {
                     CenterColor = c2
                 };
-                PointF centerPoint = new PointF(cache.EllipseRect.Left + (cache.EllipseRect.Width / 2),
+                var centerPoint = new PointF(cache.EllipseRect.Left + (cache.EllipseRect.Width / 2),
                     cache.EllipseRect.Top + (cache.EllipseRect.Height / 2));
                 cache.EllipseBrush.CenterPoint = centerPoint;
                 cache.EllipseBrush.SurroundColors = [Color.Transparent];
@@ -8737,9 +8687,9 @@ namespace Krypton.Toolkit
                                                         Color c1, Color c2, Color insideColor,
                                                         MementoRibbonTabGlowing cache)
         {
-            GraphicsPath outsidePath = new GraphicsPath();
-            GraphicsPath topPath = new GraphicsPath();
-            GraphicsPath ellipsePath = new GraphicsPath();
+            var outsidePath = new GraphicsPath();
+            var topPath = new GraphicsPath();
+            var ellipsePath = new GraphicsPath();
 
             // Create path for a curved border around the tab
             outsidePath.AddLine(rect.Right - 2, rect.Bottom - 1, rect.Left + 1.5f, rect.Bottom - 1);
@@ -8758,13 +8708,13 @@ namespace Krypton.Toolkit
             topPath.AddLine(rect.Left + 2 + q4, rect.Top + 1, rect.Left + 2, rect.Top + 2);
             topPath.AddLine(rect.Left + 2, rect.Top + 2, rect.Left + 1, rect.Top + 2);
 
-            RectangleF topRectF = new RectangleF(rect.Left, rect.Top, q4 + 5, rect.Height);
+            var topRectF = new RectangleF(rect.Left, rect.Top, q4 + 5, rect.Height);
             cache.TopBrush = new LinearGradientBrush(topRectF, c1, Color.Transparent, 0f);
 
-            var ellipseWidth = (int)(rect.Width * 0.4f);
-            var ellipseHeight = (int)(rect.Height * 1.2f);
+            var ellipseWidth = (rect.Width * 0.4f);
+            var ellipseHeight = (rect.Height * 1.2f);
             cache.FullRect = new RectangleF(rect.Left + 1, rect.Top + 2, rect.Width - 2, rect.Height - 3);
-            cache.EllipseRect = new RectangleF(rect.Right - ellipseWidth, rect.Top - ((ellipseHeight - rect.Height) / 2), ellipseWidth * 2, ellipseHeight);
+            cache.EllipseRect = new RectangleF(rect.Right - ellipseWidth, rect.Top - ((ellipseHeight - rect.Height) / 2f), ellipseWidth * 2, ellipseHeight);
 
             // Cannot draw a path that contains a zero sized element
             if (cache.EllipseRect is { Width: > 0, Height: > 0 })
@@ -8774,7 +8724,7 @@ namespace Krypton.Toolkit
                 {
                     CenterColor = c2
                 };
-                PointF centerPoint = new PointF(cache.EllipseRect.Left + (cache.EllipseRect.Width / 2),
+                var centerPoint = new PointF(cache.EllipseRect.Left + (cache.EllipseRect.Width / 2),
                     cache.EllipseRect.Top + (cache.EllipseRect.Height / 2));
                 cache.EllipseBrush.CenterPoint = centerPoint;
                 cache.EllipseBrush.SurroundColors = [Color.Transparent];
@@ -8795,9 +8745,9 @@ namespace Krypton.Toolkit
                                                          Color c1, Color c2, Color insideColor,
                                                          MementoRibbonTabGlowing cache)
         {
-            GraphicsPath outsidePath = new GraphicsPath();
-            GraphicsPath topPath = new GraphicsPath();
-            GraphicsPath ellipsePath = new GraphicsPath();
+            var outsidePath = new GraphicsPath();
+            var topPath = new GraphicsPath();
+            var ellipsePath = new GraphicsPath();
 
             // Create path for a curved border around the tab
             outsidePath.AddLine(rect.Left + 1, rect.Bottom - 1, rect.Right - 2.5f, rect.Bottom - 1);
@@ -8816,13 +8766,13 @@ namespace Krypton.Toolkit
             topPath.AddLine(rect.Right - 2 - q4, rect.Top + 1, rect.Right - 2, rect.Top + 2);
             topPath.AddLine(rect.Right - 2, rect.Top + 2, rect.Right - 1, rect.Top + 2);
 
-            RectangleF topRectF = new RectangleF(rect.Right - q4 - 5, rect.Top, q4 + 5, rect.Height);
+            var topRectF = new RectangleF(rect.Right - q4 - 5, rect.Top, q4 + 5, rect.Height);
             cache.TopBrush = new LinearGradientBrush(topRectF, c1, Color.Transparent, 180f);
 
-            var ellipseWidth = (int)(rect.Width * 0.4f);
-            var ellipseHeight = (int)(rect.Height * 1.2f);
+            var ellipseWidth = (rect.Width * 0.4f);
+            var ellipseHeight = (rect.Height * 1.2f);
             cache.FullRect = new RectangleF(rect.Left + 1, rect.Top + 2, rect.Width - 2, rect.Height - 3);
-            cache.EllipseRect = new RectangleF(rect.Left - ellipseWidth, rect.Top - ((ellipseHeight - rect.Height) / 2), ellipseWidth * 2, ellipseHeight);
+            cache.EllipseRect = new RectangleF(rect.Left - ellipseWidth, rect.Top - ((ellipseHeight - rect.Height) / 2f), ellipseWidth * 2, ellipseHeight);
 
             // Cannot draw a path that contains a zero sized element
             if (cache.EllipseRect is { Width: > 0, Height: > 0 })
@@ -8832,8 +8782,8 @@ namespace Krypton.Toolkit
                 {
                     CenterColor = c2
                 };
-                PointF centerPoint = new PointF(cache.EllipseRect.Left + (cache.EllipseRect.Width / 2),
-                    cache.EllipseRect.Top + (cache.EllipseRect.Height / 2));
+                var centerPoint = new PointF(cache.EllipseRect.Left + (cache.EllipseRect.Width / 2f),
+                    cache.EllipseRect.Top + (cache.EllipseRect.Height / 2f));
                 cache.EllipseBrush.CenterPoint = centerPoint;
                 cache.EllipseBrush.SurroundColors = [Color.Transparent];
             }
@@ -8853,9 +8803,9 @@ namespace Krypton.Toolkit
                                                           Color c1, Color c2, Color insideColor,
                                                           MementoRibbonTabGlowing cache)
         {
-            GraphicsPath outsidePath = new GraphicsPath();
-            GraphicsPath topPath = new GraphicsPath();
-            GraphicsPath ellipsePath = new GraphicsPath();
+            var outsidePath = new GraphicsPath();
+            var topPath = new GraphicsPath();
+            var ellipsePath = new GraphicsPath();
 
             // Create path for a curved border around the tab
             outsidePath.AddLine(rect.Left, rect.Top + 1, rect.Left, rect.Bottom - 2.5f);
@@ -8874,13 +8824,13 @@ namespace Krypton.Toolkit
             topPath.AddLine(rect.Right - 2, rect.Bottom - 2 - q4, rect.Right - 2, rect.Bottom - 2);
             topPath.AddLine(rect.Right - 2, rect.Bottom - 2, rect.Right - 3, rect.Bottom - 1);
 
-            RectangleF topRectF = new RectangleF(rect.Left, rect.Bottom - 6 - q4, rect.Width, q4 + 5);
+            var topRectF = new RectangleF(rect.Left, rect.Bottom - 6 - q4, rect.Width, q4 + 5);
             cache.TopBrush = new LinearGradientBrush(topRectF, c1, Color.Transparent, 270f);
 
-            var ellipseWidth = (int)(rect.Width * 1.2f);
-            var ellipseHeight = (int)(rect.Height * 0.4f);
+            var ellipseWidth = (rect.Width * 1.2f);
+            var ellipseHeight = (rect.Height * 0.4f);
             cache.FullRect = new RectangleF(rect.Left + 1, rect.Top + 1, rect.Width - 3, rect.Height - 2);
-            cache.EllipseRect = new RectangleF(rect.Left - ((ellipseWidth - rect.Width) / 2), rect.Top - ellipseHeight, ellipseWidth, ellipseHeight * 2);
+            cache.EllipseRect = new RectangleF(rect.Left - ((ellipseWidth - rect.Width) / 2f), rect.Top - ellipseHeight, ellipseWidth, ellipseHeight * 2);
 
             // Cannot draw a path that contains a zero sized element
             if (cache.EllipseRect is { Width: > 0, Height: > 0 })
@@ -8890,8 +8840,8 @@ namespace Krypton.Toolkit
                 {
                     CenterColor = c2
                 };
-                PointF centerPoint = new PointF(cache.EllipseRect.Left + (cache.EllipseRect.Width / 2),
-                    cache.EllipseRect.Bottom - 1 - (cache.EllipseRect.Height / 2));
+                var centerPoint = new PointF(cache.EllipseRect.Left + (cache.EllipseRect.Width / 2f),
+                    cache.EllipseRect.Bottom - 1 - (cache.EllipseRect.Height / 2f));
                 cache.EllipseBrush.CenterPoint = centerPoint;
                 cache.EllipseBrush.SurroundColors = [Color.Transparent];
             }
@@ -8972,7 +8922,7 @@ namespace Krypton.Toolkit
                 context.Graphics.FillPath(cache.InsideBrush!, cache.OutsidePath!);
 
                 // Draw the actual border
-                using (AntiAlias aa = new AntiAlias(context.Graphics))
+                using (var aa = new AntiAlias(context.Graphics))
                 {
                     context.Graphics.DrawPath(cache.OutsidePen!, cache.OutsidePath!);
                 }
@@ -9007,7 +8957,7 @@ namespace Krypton.Toolkit
                                                             Color c4, Color c5,
                                                             MementoRibbonTabSelected2007? cache)
         {
-            GraphicsPath outsidePath = new GraphicsPath();
+            var outsidePath = new GraphicsPath();
 
             // Create path for a curved dark border around the tab
             outsidePath.AddLine(rect.Left, rect.Bottom - 2, rect.Left + 1, rect.Bottom - 3);
@@ -9019,7 +8969,7 @@ namespace Krypton.Toolkit
             outsidePath.AddLine(rect.Right - 2, rect.Bottom - 3, rect.Right - 1, rect.Bottom - 2);
 
             cache!.CenterRect = new Rectangle(rect.Left + 4, rect.Top + 4, rect.Width - 8, rect.Height - 4);
-            RectangleF centerRectF = new RectangleF(cache.CenterRect.Left - 1, cache.CenterRect.Top - 1,
+            var centerRectF = new Rectangle(cache.CenterRect.Left - 1, cache.CenterRect.Top - 1,
                 cache.CenterRect.Width + 2, cache.CenterRect.Height + 2);
             cache.CenterBrush = new LinearGradientBrush(centerRectF, c4, c5, 90f);
             cache.OutsidePath = outsidePath;
@@ -9039,7 +8989,7 @@ namespace Krypton.Toolkit
                 g.DrawLine(cache.InsidePen!, rect.Left + 2, rect.Bottom - 2, rect.Right - 3, rect.Bottom - 2);
                 g.DrawLine(cache.CenterPen!, rect.Left + 3, rect.Bottom - 1, rect.Right - 4, rect.Bottom - 1);
 
-                using AntiAlias aa = new AntiAlias(g);
+                using var aa = new AntiAlias(g);
                 // Draw a line on the inside of the left and right border edges
                 g.DrawLine(cache.MiddlePen!, rect.Left + 2, rect.Bottom - 3, rect.Left + 2, rect.Top + 2);
                 g.DrawLine(cache.MiddlePen!, rect.Right - 1.5f, rect.Bottom - 1, rect.Right - 3, rect.Bottom - 3);
@@ -9047,10 +8997,10 @@ namespace Krypton.Toolkit
                 g.DrawLine(cache.MiddlePen!, rect.Left + 0.5f, rect.Bottom - 1, rect.Left + 2, rect.Bottom - 3);
 
                 // Draw shadow lines on the outside of the left and right edges
-                g.DrawLine(_paleShadowPen!, rect.Left - 1, rect.Bottom - 2, rect.Left - 1, rect.Top + 8);
-                g.DrawLine(_lightShadowPen!, rect.Left, rect.Bottom - 3, rect.Left, rect.Top + 5);
-                g.DrawLine(_darkShadowPen!, rect.Right - 1, rect.Bottom - 3, rect.Right - 1, rect.Top + 3);
-                g.DrawLine(_mediumShadowPen!, rect.Right, rect.Bottom - 2, rect.Right, rect.Top + 7);
+                g.DrawLine(_paleShadowPen, rect.Left - 1, rect.Bottom - 2, rect.Left - 1, rect.Top + 8);
+                g.DrawLine(_lightShadowPen, rect.Left, rect.Bottom - 3, rect.Left, rect.Top + 5);
+                g.DrawLine(_darkShadowPen, rect.Right - 1, rect.Bottom - 3, rect.Right - 1, rect.Top + 3);
+                g.DrawLine(_mediumShadowPen, rect.Right, rect.Bottom - 2, rect.Right, rect.Top + 7);
             }
         }
 
@@ -9061,7 +9011,7 @@ namespace Krypton.Toolkit
                                                              Color c4, Color c5,
                                                              MementoRibbonTabSelected2007? cache)
         {
-            GraphicsPath outsidePath = new GraphicsPath();
+            var outsidePath = new GraphicsPath();
 
             // Create path for a curved dark border around the tab
             outsidePath.AddLine(rect.Right - 2, rect.Bottom - 1, rect.Right - 3, rect.Bottom - 2);
@@ -9073,7 +9023,7 @@ namespace Krypton.Toolkit
             outsidePath.AddLine(rect.Right - 3, rect.Top + 1, rect.Right - 1, rect.Top);
 
             cache!.CenterRect = new Rectangle(rect.Left + 4, rect.Top + 4, rect.Width - 4, rect.Height - 8);
-            RectangleF centerRectF = new RectangleF(cache.CenterRect.Left - 1, cache.CenterRect.Top - 1,
+            var centerRectF = new Rectangle(cache.CenterRect.Left - 1, cache.CenterRect.Top - 1,
                 cache.CenterRect.Width + 2, cache.CenterRect.Height + 2);
             cache.CenterBrush = new LinearGradientBrush(centerRectF, c4, c5, 0f);
             cache.OutsidePath = outsidePath;
@@ -9093,7 +9043,7 @@ namespace Krypton.Toolkit
                 g.DrawLine(cache.InsidePen!, rect.Right - 2, rect.Bottom - 3, rect.Right - 2, rect.Top + 2);
                 g.DrawLine(cache.CenterPen!, rect.Right - 1, rect.Bottom - 4, rect.Right - 1, rect.Top + 3);
 
-                using AntiAlias aa = new AntiAlias(g);
+                using var aa = new AntiAlias(g);
                 // Draw a line on the inside of the left and right border edges
                 g.DrawLine(cache.MiddlePen!, rect.Right - 1, rect.Bottom - 1.5f, rect.Right - 3, rect.Bottom - 3);
                 g.DrawLine(cache.MiddlePen!, rect.Right - 3, rect.Bottom - 3, rect.Left + 2, rect.Bottom - 3);
@@ -9101,10 +9051,10 @@ namespace Krypton.Toolkit
                 g.DrawLine(cache.MiddlePen!, rect.Right - 3, rect.Top + 2, rect.Left + 2, rect.Top + 2);
 
                 // Draw shadow lines on the outside of the left and right edges
-                g.DrawLine(_paleShadowPen!, rect.Right - 2, rect.Bottom, rect.Left + 8, rect.Bottom);
-                g.DrawLine(_lightShadowPen!, rect.Right - 3, rect.Bottom - 1, rect.Left + 5, rect.Bottom - 1);
-                g.DrawLine(_darkShadowPen!, rect.Right - 3, rect.Top, rect.Left + 3, rect.Top);
-                g.DrawLine(_mediumShadowPen!, rect.Right - 2, rect.Top - 1, rect.Left + 7, rect.Top - 1);
+                g.DrawLine(_paleShadowPen, rect.Right - 2, rect.Bottom, rect.Left + 8, rect.Bottom);
+                g.DrawLine(_lightShadowPen, rect.Right - 3, rect.Bottom - 1, rect.Left + 5, rect.Bottom - 1);
+                g.DrawLine(_darkShadowPen, rect.Right - 3, rect.Top, rect.Left + 3, rect.Top);
+                g.DrawLine(_mediumShadowPen, rect.Right - 2, rect.Top - 1, rect.Left + 7, rect.Top - 1);
             }
         }
 
@@ -9115,7 +9065,7 @@ namespace Krypton.Toolkit
                                                               Color c4, Color c5,
                                                               MementoRibbonTabSelected2007? cache)
         {
-            GraphicsPath outsidePath = new GraphicsPath();
+            var outsidePath = new GraphicsPath();
 
             // Create path for a curved dark border around the tab
             outsidePath.AddLine(rect.Left + 1, rect.Bottom - 1, rect.Left + 2, rect.Bottom - 2);
@@ -9127,7 +9077,7 @@ namespace Krypton.Toolkit
             outsidePath.AddLine(rect.Left + 2, rect.Top + 1, rect.Left, rect.Top);
 
             cache!.CenterRect = new Rectangle(rect.Left, rect.Top + 4, rect.Width - 4, rect.Height - 8);
-            RectangleF centerRectF = new RectangleF(cache.CenterRect.Left - 1, cache.CenterRect.Top - 1,
+            var centerRectF = new RectangleF(cache.CenterRect.Left - 1, cache.CenterRect.Top - 1,
                 cache.CenterRect.Width + 2, cache.CenterRect.Height + 2);
             cache.CenterBrush = new LinearGradientBrush(centerRectF, c4, c5, 180f);
             cache.OutsidePath = outsidePath;
@@ -9147,7 +9097,7 @@ namespace Krypton.Toolkit
                 g.DrawLine(cache.InsidePen!, rect.Left + 1, rect.Bottom - 3, rect.Left + 1, rect.Top + 2);
                 g.DrawLine(cache.CenterPen!, rect.Left, rect.Bottom - 4, rect.Left, rect.Top + 3);
 
-                using AntiAlias aa = new AntiAlias(g);
+                using var aa = new AntiAlias(g);
                 // Draw a line on the inside of the left and right border edges
                 g.DrawLine(cache.MiddlePen!, rect.Left, rect.Bottom - 1.5f, rect.Left + 2, rect.Bottom - 3);
                 g.DrawLine(cache.MiddlePen!, rect.Left + 2, rect.Bottom - 3, rect.Right - 3, rect.Bottom - 3);
@@ -9169,7 +9119,7 @@ namespace Krypton.Toolkit
                                                                Color c4, Color c5,
                                                                MementoRibbonTabSelected2007? cache)
         {
-            GraphicsPath outsidePath = new GraphicsPath();
+            var outsidePath = new GraphicsPath();
 
             // Create path for a curved dark border around the tab
             outsidePath.AddLine(rect.Left, rect.Top + 1, rect.Left + 1, rect.Top + 2);
@@ -9181,7 +9131,7 @@ namespace Krypton.Toolkit
             outsidePath.AddLine(rect.Right - 2, rect.Top + 2, rect.Right - 1, rect.Top + 1);
 
             cache!.CenterRect = new Rectangle(rect.Left + 4, rect.Top, rect.Width - 8, rect.Height - 4);
-            RectangleF centerRectF = new RectangleF(cache.CenterRect.Left - 1, cache.CenterRect.Top - 1,
+            var centerRectF = new Rectangle(cache.CenterRect.Left - 1, cache.CenterRect.Top - 1,
                 cache.CenterRect.Width + 2, cache.CenterRect.Height + 2);
             cache.CenterBrush = new LinearGradientBrush(centerRectF, c4, c5, 270f);
             cache.OutsidePath = outsidePath;
@@ -9201,7 +9151,7 @@ namespace Krypton.Toolkit
                 g.DrawLine(cache.InsidePen!, rect.Left + 2, rect.Top + 1, rect.Right - 3, rect.Top + 1);
                 g.DrawLine(cache.CenterPen!, rect.Left + 3, rect.Top, rect.Right - 4, rect.Top);
 
-                using AntiAlias aa = new AntiAlias(g);
+                using var aa = new AntiAlias(g);
                 // Draw a line on the inside of the left and right border edges
                 g.DrawLine(cache.MiddlePen!, rect.Left + 0.5f, rect.Top, rect.Left + 2, rect.Top + 2);
                 g.DrawLine(cache.MiddlePen!, rect.Left + 2, rect.Top + 2, rect.Left + 2, rect.Bottom - 3);
@@ -9209,10 +9159,10 @@ namespace Krypton.Toolkit
                 g.DrawLine(cache.MiddlePen!, rect.Right - 3, rect.Top + 2, rect.Right - 3, rect.Bottom - 3);
 
                 // Draw shadow lines on the outside of the left and right edges
-                g.DrawLine(_paleShadowPen!, rect.Left - 1, rect.Top + 1, rect.Left - 1, rect.Bottom - 9);
-                g.DrawLine(_lightShadowPen!, rect.Left, rect.Top + 2, rect.Left, rect.Bottom - 6);
-                g.DrawLine(_darkShadowPen!, rect.Right - 1, rect.Top + 2, rect.Right - 1, rect.Bottom - 4);
-                g.DrawLine(_mediumShadowPen!, rect.Right, rect.Top + 1, rect.Right, rect.Bottom - 8);
+                g.DrawLine(_paleShadowPen, rect.Left - 1, rect.Top + 1, rect.Left - 1, rect.Bottom - 9);
+                g.DrawLine(_lightShadowPen, rect.Left, rect.Top + 2, rect.Left, rect.Bottom - 6);
+                g.DrawLine(_darkShadowPen, rect.Right - 1, rect.Top + 2, rect.Right - 1, rect.Bottom - 4);
+                g.DrawLine(_mediumShadowPen, rect.Right, rect.Top + 1, rect.Right, rect.Bottom - 8);
             }
         }
 
@@ -9296,7 +9246,7 @@ namespace Krypton.Toolkit
                     context.Graphics.FillPath(cache.InsideBrush!, cache.InsidePath!);
                 }
 
-                using (AntiAlias aa = new AntiAlias(context.Graphics))
+                using (var aa = new AntiAlias(context.Graphics))
                 {
                     context.Graphics.DrawPath(cache.OutsidePen!, cache.OutsidePath!);
                 }
@@ -9328,8 +9278,8 @@ namespace Krypton.Toolkit
                                                             Color c2, Color c3, Color c5,
                                                             MementoRibbonTabSelected2010 cache)
         {
-            GraphicsPath outsidePath = new GraphicsPath();
-            GraphicsPath insidePath = new GraphicsPath();
+            var outsidePath = new GraphicsPath();
+            var insidePath = new GraphicsPath();
 
             // Create path for a curved dark border around the tab
             outsidePath.AddLine(rect.Left, rect.Bottom - 2, rect.Left + 1, rect.Bottom - 3);
@@ -9340,7 +9290,7 @@ namespace Krypton.Toolkit
             outsidePath.AddLine(rect.Right - 2, rect.Top + 1, rect.Right - 2, rect.Bottom - 3);
             outsidePath.AddLine(rect.Right - 2, rect.Bottom - 3, rect.Right - 1, rect.Bottom - 2);
 
-            RectangleF centerRectF = new RectangleF(rect.Left - 1, rect.Top - 1, rect.Width + 2, rect.Height + 2);
+            var centerRectF = new Rectangle(rect.Left - 1, rect.Top - 1, rect.Width + 2, rect.Height + 2);
             cache.CenterBrush = new LinearGradientBrush(centerRectF, c2, c3, 90f)
             {
                 Blend = _ribbonTabSelected1Blend
@@ -9362,7 +9312,7 @@ namespace Krypton.Toolkit
             insidePath.AddLine(rect.Right - 2, rect.Top + 1, rect.Right - 2, rect.Bottom - 3);
             insidePath.AddLine(rect.Right - 2, rect.Bottom - 3, rect.Right - 1, rect.Bottom - 2);
 
-            RectangleF insideRectF = new RectangleF(rect.Left - 1, rect.Top - 1, rect.Width + 2, rect.Height + 2);
+            var insideRectF = new Rectangle(rect.Left - 1, rect.Top - 1, rect.Width + 2, rect.Height + 2);
             cache.InsideBrush = new LinearGradientBrush(insideRectF, Color.FromArgb(32, c5), Color.Transparent, 90f)
             {
                 Blend = _ribbonTabSelected2Blend
@@ -9383,7 +9333,7 @@ namespace Krypton.Toolkit
                 g.DrawLine(cache.CenterPen!, rect.Left + 2, rect.Bottom - 2, rect.Right - 3, rect.Bottom - 2);
                 g.DrawLine(cache.CenterPen!, rect.Left + 1, rect.Bottom - 1, rect.Right - 2, rect.Bottom - 1);
 
-                using AntiAlias aa = new AntiAlias(g);
+                using var aa = new AntiAlias(g);
                 // Draw shadow lines on the outside of the left and right edges
                 g.DrawLine(_mediumShadowPen, rect.Left, rect.Bottom - 3, rect.Left, rect.Top + 2);
                 g.DrawLine(_mediumShadowPen, rect.Right - 1, rect.Bottom - 3, rect.Right - 1, rect.Top + 2);
@@ -9397,8 +9347,8 @@ namespace Krypton.Toolkit
                                                              Color c2, Color c3, Color c5,
                                                              MementoRibbonTabSelected2010 cache)
         {
-            GraphicsPath outsidePath = new GraphicsPath();
-            GraphicsPath insidePath = new GraphicsPath();
+            var outsidePath = new GraphicsPath();
+            var insidePath = new GraphicsPath();
 
             // Create path for a curved dark border around the tab
             outsidePath.AddLine(rect.Right - 2, rect.Bottom - 1, rect.Right - 2, rect.Bottom - 2);
@@ -9409,7 +9359,7 @@ namespace Krypton.Toolkit
             outsidePath.AddLine(rect.Left + 1, rect.Top + 1, rect.Right - 2, rect.Top + 1);
             outsidePath.AddLine(rect.Right - 2, rect.Top + 1, rect.Right - 2, rect.Top);
 
-            RectangleF centerRectF = new RectangleF(rect.Left - 1, rect.Top - 1, rect.Width + 2, rect.Height + 2);
+            var centerRectF = new Rectangle(rect.Left - 1, rect.Top - 1, rect.Width + 2, rect.Height + 2);
             cache.CenterBrush = new LinearGradientBrush(centerRectF, c2, c3, 0f)
             {
                 Blend = _ribbonTabSelected1Blend
@@ -9431,7 +9381,7 @@ namespace Krypton.Toolkit
             insidePath.AddLine(rect.Left + 1, rect.Top + 1, rect.Right - 2, rect.Top + 1);
             insidePath.AddLine(rect.Right - 2, rect.Top + 1, rect.Right - 2, rect.Top);
 
-            RectangleF insideRectF = new RectangleF(rect.Left - 1, rect.Top - 1, rect.Width + 2, rect.Height + 2);
+            var insideRectF = new Rectangle(rect.Left - 1, rect.Top - 1, rect.Width + 2, rect.Height + 2);
             cache.InsideBrush = new LinearGradientBrush(insideRectF, Color.FromArgb(32, c5), Color.Transparent, 0f)
             {
                 Blend = _ribbonTabSelected2Blend
@@ -9452,10 +9402,10 @@ namespace Krypton.Toolkit
                 g.DrawLine(cache.CenterPen!, rect.Right - 2, rect.Bottom - 3, rect.Right - 2, rect.Top + 2);
                 g.DrawLine(cache.CenterPen!, rect.Right - 1, rect.Bottom - 2, rect.Right - 1, rect.Top + 1);
 
-                using AntiAlias aa = new AntiAlias(g);
+                using var aa = new AntiAlias(g);
                 // Draw shadow lines on the outside of the top and bottom edges
-                g.DrawLine(_mediumShadowPen!, rect.Right - 3, rect.Bottom - 1, rect.Left + 3, rect.Bottom - 1);
-                g.DrawLine(_mediumShadowPen!, rect.Right - 3, rect.Top, rect.Left + 3, rect.Top);
+                g.DrawLine(_mediumShadowPen, rect.Right - 3, rect.Bottom - 1, rect.Left + 3, rect.Bottom - 1);
+                g.DrawLine(_mediumShadowPen, rect.Right - 3, rect.Top, rect.Left + 3, rect.Top);
             }
         }
 
@@ -9466,8 +9416,8 @@ namespace Krypton.Toolkit
                                                               Color c2, Color c3, Color c5,
                                                               MementoRibbonTabSelected2010 cache)
         {
-            GraphicsPath outsidePath = new GraphicsPath();
-            GraphicsPath insidePath = new GraphicsPath();
+            var outsidePath = new GraphicsPath();
+            var insidePath = new GraphicsPath();
 
             // Create path for a curved dark border around the tab
             outsidePath.AddLine(rect.Left + 1, rect.Bottom - 1, rect.Left + 1, rect.Bottom - 2);
@@ -9478,7 +9428,7 @@ namespace Krypton.Toolkit
             outsidePath.AddLine(rect.Right - 2, rect.Top + 1, rect.Left + 1, rect.Top + 1);
             outsidePath.AddLine(rect.Left + 1, rect.Top + 1, rect.Left + 1, rect.Top);
 
-            RectangleF centerRectF = new RectangleF(rect.Left - 1, rect.Top - 1, rect.Width + 2, rect.Height + 2);
+            var centerRectF = new Rectangle(rect.Left - 1, rect.Top - 1, rect.Width + 2, rect.Height + 2);
             cache.CenterBrush = new LinearGradientBrush(centerRectF, c2, c3, 180f)
             {
                 Blend = _ribbonTabSelected1Blend
@@ -9499,7 +9449,7 @@ namespace Krypton.Toolkit
             insidePath.AddLine(rect.Right - 2, rect.Top + 1, rect.Left + 1, rect.Top + 1);
             insidePath.AddLine(rect.Left + 1, rect.Top + 1, rect.Left + 1, rect.Top);
 
-            RectangleF insideRectF = new RectangleF(rect.Left - 1, rect.Top - 1, rect.Width + 2, rect.Height + 2);
+            var insideRectF = new Rectangle(rect.Left - 1, rect.Top - 1, rect.Width + 2, rect.Height + 2);
             cache.InsideBrush = new LinearGradientBrush(insideRectF, Color.FromArgb(32, c5), Color.Transparent, 180f)
             {
                 Blend = _ribbonTabSelected2Blend
@@ -9521,10 +9471,10 @@ namespace Krypton.Toolkit
                 g.DrawLine(cache.CenterPen!, rect.Left + 1, rect.Bottom - 3, rect.Left + 1, rect.Top + 2);
                 g.DrawLine(cache.CenterPen!, rect.Left, rect.Bottom - 2, rect.Left, rect.Top + 1);
 
-                using AntiAlias aa = new AntiAlias(g);
+                using var aa = new AntiAlias(g);
                 // Draw shadow lines on the outside of the top and bottom edges
-                g.DrawLine(_mediumShadowPen!, rect.Left + 2, rect.Bottom - 1, rect.Right - 4, rect.Bottom - 1);
-                g.DrawLine(_mediumShadowPen!, rect.Left + 2, rect.Top, rect.Right - 4, rect.Top);
+                g.DrawLine(_mediumShadowPen, rect.Left + 2, rect.Bottom - 1, rect.Right - 4, rect.Bottom - 1);
+                g.DrawLine(_mediumShadowPen, rect.Left + 2, rect.Top, rect.Right - 4, rect.Top);
             }
         }
 
@@ -9535,8 +9485,8 @@ namespace Krypton.Toolkit
                                                                Color c2, Color c3, Color c5,
                                                                MementoRibbonTabSelected2010 cache)
         {
-            GraphicsPath outsidePath = new GraphicsPath();
-            GraphicsPath insidePath = new GraphicsPath();
+            var outsidePath = new GraphicsPath();
+            var insidePath = new GraphicsPath();
 
             // Create path for a curved dark border around the tab
             outsidePath.AddLine(rect.Left, rect.Top + 1, rect.Left + 1, rect.Top + 1);
@@ -9547,7 +9497,7 @@ namespace Krypton.Toolkit
             outsidePath.AddLine(rect.Right - 2, rect.Bottom - 3, rect.Right - 2, rect.Top + 1);
             outsidePath.AddLine(rect.Right - 2, rect.Top + 1, rect.Right - 1, rect.Top + 1);
 
-            RectangleF centerRectF = new RectangleF(rect.Left - 1, rect.Top - 1, rect.Width + 2, rect.Height + 2);
+            var centerRectF = new Rectangle(rect.Left - 1, rect.Top - 1, rect.Width + 2, rect.Height + 2);
             cache.CenterBrush = new LinearGradientBrush(centerRectF, c2, c3, 270f)
             {
                 Blend = _ribbonTabSelected1Blend
@@ -9568,7 +9518,7 @@ namespace Krypton.Toolkit
             insidePath.AddLine(rect.Right - 2, rect.Bottom - 3, rect.Right - 2, rect.Top + 1);
             insidePath.AddLine(rect.Right - 2, rect.Top + 1, rect.Right - 1, rect.Top + 1);
 
-            RectangleF insideRectF = new RectangleF(rect.Left - 1, rect.Top - 1, rect.Width + 2, rect.Height + 2);
+            var insideRectF = new Rectangle(rect.Left - 1, rect.Top - 1, rect.Width + 2, rect.Height + 2);
             cache.InsideBrush = new LinearGradientBrush(insideRectF, Color.FromArgb(32, c5), Color.Transparent, 270f)
             {
                 Blend = _ribbonTabSelected2Blend
@@ -9591,9 +9541,10 @@ namespace Krypton.Toolkit
 
                 using var aa = new AntiAlias(g);
                 // Draw shadow lines on the outside of the left and right edges
-                g.DrawLine(_mediumShadowPen!, rect.Left, rect.Top + 2, rect.Left, rect.Bottom - 4);
-                g.DrawLine(_mediumShadowPen!, rect.Right - 1, rect.Top + 2, rect.Right - 1, rect.Bottom - 4);
-        } }
+                g.DrawLine(_mediumShadowPen, rect.Left, rect.Top + 2, rect.Left, rect.Bottom - 4);
+                g.DrawLine(_mediumShadowPen, rect.Right - 1, rect.Top + 2, rect.Right - 1, rect.Bottom - 4);
+            }
+        }
 
         /// <summary>
         /// Internal rendering method.
@@ -9659,11 +9610,11 @@ namespace Krypton.Toolkit
                 }
 
                 // Fill the interior using a gradient brush
-                context.Graphics.FillRectangle(Brushes.White!, cache.InteriorRect!);
-                context.Graphics.FillRectangle(cache.InsideBrush!, cache.InteriorRect!);
+                context.Graphics.FillRectangle(Brushes.White, cache.InteriorRect);
+                context.Graphics.FillRectangle(cache.InsideBrush!, cache.InteriorRect);
 
                 // Draw the actual border
-                using (AntiAlias aa = new AntiAlias(context.Graphics))
+                using (var aa = new AntiAlias(context.Graphics))
                 {
                     context.Graphics.DrawPath(cache.OutsidePen!, cache.OutsidePath!);
                 }
@@ -9695,7 +9646,7 @@ namespace Krypton.Toolkit
                                                                Color c2,
                                                                MementoRibbonTabContextSelected? cache)
         {
-            GraphicsPath outsidePath = new GraphicsPath();
+            var outsidePath = new GraphicsPath();
 
             // Create path for a curved dark border around the tab
             outsidePath.AddLine(rect.Left, rect.Bottom - 2, rect.Left + 1, rect.Bottom - 3);
@@ -9706,10 +9657,8 @@ namespace Krypton.Toolkit
             outsidePath.AddLine(rect.Right - 2, rect.Top + 1.5f, rect.Right - 2, rect.Bottom - 3);
             outsidePath.AddLine(rect.Right - 2, rect.Bottom - 3, rect.Right - 1, rect.Bottom - 2);
 
-            LinearGradientBrush leftBrush =
-                new LinearGradientBrush(rect, Color.FromArgb(125, c2), Color.FromArgb(67, c2), 90f);
-            LinearGradientBrush rightBrush =
-                new LinearGradientBrush(rect, Color.FromArgb(16, c2), Color.FromArgb(67, c2), 90f);
+            var leftBrush = new LinearGradientBrush(rect, Color.FromArgb(125, c2), Color.FromArgb(67, c2), 90f);
+            var rightBrush = new LinearGradientBrush(rect, Color.FromArgb(16, c2), Color.FromArgb(67, c2), 90f);
             cache!.LeftPen = new Pen(leftBrush);
             cache.RightPen = new Pen(rightBrush);
 
@@ -9741,7 +9690,7 @@ namespace Krypton.Toolkit
                 g.DrawLine(cache.BottomInnerPen!, rect.Left + 2, rect.Bottom - 2, rect.Left + 1, rect.Bottom - 1);
                 g.DrawLine(Pens.White, rect.Right - 3, rect.Bottom - 2, rect.Right - 2, rect.Bottom - 1);
                 g.DrawLine(cache.BottomInnerPen!, rect.Right - 3, rect.Bottom - 2, rect.Right - 2, rect.Bottom - 1);
-                g.DrawLine(Pens.White!, rect.Left + 1, rect.Bottom - 2, rect.Left, rect.Bottom - 1);
+                g.DrawLine(Pens.White, rect.Left + 1, rect.Bottom - 2, rect.Left, rect.Bottom - 1);
                 g.DrawLine(cache.BottomOuterPen!, rect.Left + 1, rect.Bottom - 2, rect.Left, rect.Bottom - 1);
                 g.DrawLine(Pens.White, rect.Right - 2, rect.Bottom - 2, rect.Right - 1, rect.Bottom - 1);
                 g.DrawLine(cache.BottomOuterPen!, rect.Right - 2, rect.Bottom - 2, rect.Right - 1, rect.Bottom - 1);
@@ -9755,7 +9704,7 @@ namespace Krypton.Toolkit
                                                                 Color c2,
                                                                 MementoRibbonTabContextSelected? cache)
         {
-            GraphicsPath outsidePath = new GraphicsPath();
+            var outsidePath = new GraphicsPath();
 
             // Create path for a curved dark border around the tab
             outsidePath.AddLine(rect.Right - 2, rect.Bottom - 1, rect.Right - 3, rect.Bottom - 2);
@@ -9766,10 +9715,8 @@ namespace Krypton.Toolkit
             outsidePath.AddLine(rect.Left + 1.5f, rect.Top + 1, rect.Right - 3, rect.Top + 1);
             outsidePath.AddLine(rect.Right - 3, rect.Top + 1, rect.Right - 2, rect.Top);
 
-            LinearGradientBrush leftBrush =
-                new LinearGradientBrush(rect, Color.FromArgb(125, c2), Color.FromArgb(67, c2), 0f);
-            LinearGradientBrush rightBrush =
-                new LinearGradientBrush(rect, Color.FromArgb(16, c2), Color.FromArgb(67, c2), 0f);
+            var leftBrush = new LinearGradientBrush(rect, Color.FromArgb(125, c2), Color.FromArgb(67, c2), 0f);
+            var rightBrush = new LinearGradientBrush(rect, Color.FromArgb(16, c2), Color.FromArgb(67, c2), 0f);
             cache!.LeftPen = new Pen(leftBrush);
             cache.RightPen = new Pen(rightBrush);
 
@@ -9787,7 +9734,7 @@ namespace Krypton.Toolkit
         {
             if (g is not null && cache is not null)
             {
-                g.DrawLine(Pens.White!, rect.Left + 3, rect.Bottom - 3, rect.Left + 3, rect.Top + 2);
+                g.DrawLine(Pens.White, rect.Left + 3, rect.Bottom - 3, rect.Left + 3, rect.Top + 2);
                 g.DrawLine(cache.L3!, rect.Left + 3, rect.Bottom - 3, rect.Left + 3, rect.Top + 2);
                 g.DrawLine(Pens.White, rect.Left + 2, rect.Bottom - 3, rect.Left + 2, rect.Top + 2);
                 g.DrawLine(cache.L2!, rect.Left + 2, rect.Bottom - 3, rect.Left + 2, rect.Top + 2);
@@ -9797,13 +9744,13 @@ namespace Krypton.Toolkit
                 // Draw the inside left, right and then bottom borders
                 g.DrawLine(cache.LeftPen!, rect.Left + 4, rect.Bottom - 3, rect.Right - 3, rect.Bottom - 3);
                 g.DrawLine(cache.RightPen!, rect.Left + 2, rect.Top + 2, rect.Right - 3, rect.Top + 2);
-                g.DrawLine(Pens.White!, rect.Right - 2, rect.Bottom - 3, rect.Right - 1, rect.Bottom - 2);
+                g.DrawLine(Pens.White, rect.Right - 2, rect.Bottom - 3, rect.Right - 1, rect.Bottom - 2);
                 g.DrawLine(cache.BottomInnerPen!, rect.Right - 2, rect.Bottom - 3, rect.Right - 1, rect.Bottom - 2);
-                g.DrawLine(Pens.White!, rect.Right - 2, rect.Top + 2, rect.Right - 1, rect.Top + 1);
+                g.DrawLine(Pens.White, rect.Right - 2, rect.Top + 2, rect.Right - 1, rect.Top + 1);
                 g.DrawLine(cache.BottomInnerPen!, rect.Right - 2, rect.Top + 2, rect.Right - 1, rect.Top + 1);
-                g.DrawLine(Pens.White!, rect.Right - 2, rect.Bottom - 2, rect.Right - 1, rect.Bottom - 1);
+                g.DrawLine(Pens.White, rect.Right - 2, rect.Bottom - 2, rect.Right - 1, rect.Bottom - 1);
                 g.DrawLine(cache.BottomOuterPen!, rect.Right - 2, rect.Bottom - 2, rect.Right - 1, rect.Bottom - 1);
-                g.DrawLine(Pens.White!, rect.Right - 2, rect.Top + 1, rect.Right - 1, rect.Top);
+                g.DrawLine(Pens.White, rect.Right - 2, rect.Top + 1, rect.Right - 1, rect.Top);
                 g.DrawLine(cache.BottomOuterPen!, rect.Right - 2, rect.Top + 1, rect.Right - 1, rect.Top);
             }
         }
@@ -9815,7 +9762,7 @@ namespace Krypton.Toolkit
                                                                  Color c2,
                                                                  MementoRibbonTabContextSelected? cache)
         {
-            GraphicsPath outsidePath = new GraphicsPath();
+            var outsidePath = new GraphicsPath();
 
             // Create path for a curved dark border around the tab
             outsidePath.AddLine(rect.Left + 1, rect.Bottom - 1, rect.Left + 2, rect.Bottom - 2);
@@ -9826,10 +9773,8 @@ namespace Krypton.Toolkit
             outsidePath.AddLine(rect.Right - 2.5f, rect.Top + 1, rect.Left + 2, rect.Top + 1);
             outsidePath.AddLine(rect.Left + 2, rect.Top + 1, rect.Left + 1, rect.Top);
 
-            LinearGradientBrush leftBrush =
-                new LinearGradientBrush(rect, Color.FromArgb(125, c2), Color.FromArgb(67, c2), 180f);
-            LinearGradientBrush rightBrush =
-                new LinearGradientBrush(rect, Color.FromArgb(16, c2), Color.FromArgb(67, c2), 180f);
+            var leftBrush = new LinearGradientBrush(rect, Color.FromArgb(125, c2), Color.FromArgb(67, c2), 180f);
+            var rightBrush = new LinearGradientBrush(rect, Color.FromArgb(16, c2), Color.FromArgb(67, c2), 180f);
             cache!.LeftPen = new Pen(leftBrush);
             cache.RightPen = new Pen(rightBrush);
 
@@ -9847,23 +9792,23 @@ namespace Krypton.Toolkit
         {
             if (g is not null && cache is not null)
             {
-                g.DrawLine(Pens.White!, rect.Right - 4, rect.Bottom - 3, rect.Right - 4, rect.Top + 2);
+                g.DrawLine(Pens.White, rect.Right - 4, rect.Bottom - 3, rect.Right - 4, rect.Top + 2);
                 g.DrawLine(cache.L3!, rect.Right - 4, rect.Bottom - 3, rect.Right - 4, rect.Top + 2);
-                g.DrawLine(Pens.White!, rect.Right - 3, rect.Bottom - 3, rect.Right - 3, rect.Top + 2);
+                g.DrawLine(Pens.White, rect.Right - 3, rect.Bottom - 3, rect.Right - 3, rect.Top + 2);
                 g.DrawLine(cache.L2!, rect.Right - 3, rect.Bottom - 3, rect.Right - 3, rect.Top + 2);
-                g.DrawLine(Pens.White!, rect.Right - 2, rect.Bottom - 4, rect.Right - 2, rect.Top + 3);
+                g.DrawLine(Pens.White, rect.Right - 2, rect.Bottom - 4, rect.Right - 2, rect.Top + 3);
                 g.DrawLine(cache.L1!, rect.Right - 2, rect.Bottom - 4, rect.Right - 2, rect.Top + 3);
 
                 // Draw the inside left, right and then bottom borders
                 g.DrawLine(cache.LeftPen!, rect.Right - 5, rect.Bottom - 3, rect.Left + 2, rect.Bottom - 3);
                 g.DrawLine(cache.RightPen!, rect.Right - 3, rect.Top + 2, rect.Left + 2, rect.Top + 2);
-                g.DrawLine(Pens.White!, rect.Left + 1, rect.Bottom - 3, rect.Left, rect.Bottom - 2);
+                g.DrawLine(Pens.White, rect.Left + 1, rect.Bottom - 3, rect.Left, rect.Bottom - 2);
                 g.DrawLine(cache.BottomInnerPen!, rect.Left + 1, rect.Bottom - 3, rect.Left, rect.Bottom - 2);
-                g.DrawLine(Pens.White!, rect.Left + 1, rect.Top + 2, rect.Left, rect.Top + 1);
+                g.DrawLine(Pens.White, rect.Left + 1, rect.Top + 2, rect.Left, rect.Top + 1);
                 g.DrawLine(cache.BottomInnerPen!, rect.Left + 1, rect.Top + 2, rect.Left, rect.Top + 1);
-                g.DrawLine(Pens.White!, rect.Left + 1, rect.Bottom - 2, rect.Left, rect.Bottom - 1);
+                g.DrawLine(Pens.White, rect.Left + 1, rect.Bottom - 2, rect.Left, rect.Bottom - 1);
                 g.DrawLine(cache.BottomOuterPen!, rect.Left + 1, rect.Bottom - 2, rect.Left, rect.Bottom - 1);
-                g.DrawLine(Pens.White!, rect.Left + 1, rect.Top + 1, rect.Left, rect.Top);
+                g.DrawLine(Pens.White, rect.Left + 1, rect.Top + 1, rect.Left, rect.Top);
                 g.DrawLine(cache.BottomOuterPen!, rect.Left + 1, rect.Top + 1, rect.Left, rect.Top);
             }
         }
@@ -9875,7 +9820,7 @@ namespace Krypton.Toolkit
                                                                   Color c2,
                                                                   MementoRibbonTabContextSelected? cache)
         {
-            GraphicsPath outsidePath = new GraphicsPath();
+            var outsidePath = new GraphicsPath();
 
             // Create path for a curved dark border around the tab
             outsidePath.AddLine(rect.Left, rect.Top + 1, rect.Left + 1, rect.Top + 2);
@@ -9886,10 +9831,8 @@ namespace Krypton.Toolkit
             outsidePath.AddLine(rect.Right - 2, rect.Bottom - 2.5f, rect.Right - 2, rect.Top + 2);
             outsidePath.AddLine(rect.Right - 2, rect.Top + 2, rect.Right - 1, rect.Top + 1);
 
-            LinearGradientBrush leftBrush =
-                new LinearGradientBrush(rect, Color.FromArgb(125, c2), Color.FromArgb(67, c2), 270f);
-            LinearGradientBrush rightBrush =
-                new LinearGradientBrush(rect, Color.FromArgb(16, c2), Color.FromArgb(67, c2), 270f);
+            var leftBrush = new LinearGradientBrush(rect, Color.FromArgb(125, c2), Color.FromArgb(67, c2), 270f);
+            var rightBrush = new LinearGradientBrush(rect, Color.FromArgb(16, c2), Color.FromArgb(67, c2), 270f);
             cache!.LeftPen = new Pen(leftBrush);
             cache.RightPen = new Pen(rightBrush);
 
@@ -9907,23 +9850,23 @@ namespace Krypton.Toolkit
         {
             if (cache is not null && g is not null)
             {
-                g.DrawLine(Pens.White!, rect.Left + 2, rect.Bottom - 4, rect.Right - 3, rect.Bottom - 4);
+                g.DrawLine(Pens.White, rect.Left + 2, rect.Bottom - 4, rect.Right - 3, rect.Bottom - 4);
                 g.DrawLine(cache.L3!, rect.Left + 2, rect.Bottom - 4, rect.Right - 3, rect.Bottom - 4);
-                g.DrawLine(Pens.White!, rect.Left + 2, rect.Bottom - 3, rect.Right - 3, rect.Bottom - 3);
+                g.DrawLine(Pens.White, rect.Left + 2, rect.Bottom - 3, rect.Right - 3, rect.Bottom - 3);
                 g.DrawLine(cache.L2!, rect.Left + 2, rect.Bottom - 3, rect.Right - 3, rect.Bottom - 3);
-                g.DrawLine(Pens.White!, rect.Left + 3, rect.Bottom - 2, rect.Right - 4, rect.Bottom - 2);
+                g.DrawLine(Pens.White, rect.Left + 3, rect.Bottom - 2, rect.Right - 4, rect.Bottom - 2);
                 g.DrawLine(cache.L1!, rect.Left + 3, rect.Bottom - 2, rect.Right - 4, rect.Bottom - 2);
 
                 // Draw the inside left, right and then bottom borders
                 g.DrawLine(cache.LeftPen!, rect.Left + 2, rect.Bottom - 5, rect.Left + 2, rect.Top + 2);
                 g.DrawLine(cache.RightPen!, rect.Right - 3, rect.Bottom - 3, rect.Right - 3, rect.Top + 2);
-                g.DrawLine(Pens.White!, rect.Left + 2, rect.Top + 1, rect.Left + 1, rect.Top);
+                g.DrawLine(Pens.White, rect.Left + 2, rect.Top + 1, rect.Left + 1, rect.Top);
                 g.DrawLine(cache.BottomInnerPen!, rect.Left + 2, rect.Top + 1, rect.Left + 1, rect.Top);
-                g.DrawLine(Pens.White!, rect.Right - 3, rect.Top + 1, rect.Right - 2, rect.Top);
+                g.DrawLine(Pens.White, rect.Right - 3, rect.Top + 1, rect.Right - 2, rect.Top);
                 g.DrawLine(cache.BottomInnerPen!, rect.Right - 3, rect.Top + 1, rect.Right - 2, rect.Top);
-                g.DrawLine(Pens.White!, rect.Left + 1, rect.Top + 1, rect.Left, rect.Top);
+                g.DrawLine(Pens.White, rect.Left + 1, rect.Top + 1, rect.Left, rect.Top);
                 g.DrawLine(cache.BottomOuterPen!, rect.Left + 1, rect.Top + 1, rect.Left, rect.Top);
-                g.DrawLine(Pens.White!, rect.Right - 2, rect.Top + 1, rect.Right - 1, rect.Top);
+                g.DrawLine(Pens.White, rect.Right - 2, rect.Top + 1, rect.Right - 1, rect.Top);
                 g.DrawLine(cache.BottomOuterPen!, rect.Right - 2, rect.Top + 1, rect.Right - 1, rect.Top);
             }
         }
@@ -10022,8 +9965,8 @@ namespace Krypton.Toolkit
                                                          Color c4, Color c5,
                                                          MementoRibbonTabHighlight cache)
         {
-            RectangleF hF = new RectangleF(rect.Left - 2, rect.Top - 1, rect.Width + 4, 6);
-            RectangleF vF = new RectangleF(rect.Left - 2, rect.Top + 1, rect.Width + 4, rect.Height - 1);
+            var hF = new Rectangle(rect.Left - 2, rect.Top - 1, rect.Width + 4, 6);
+            var vF = new Rectangle(rect.Left - 2, rect.Top + 1, rect.Width + 4, rect.Height - 1);
             cache.TopBorderBrush = new LinearGradientBrush(hF, Color.FromArgb(48, c5), Color.FromArgb(64, c5), 90f);
             cache.BorderVertBrush = new LinearGradientBrush(vF, c5, c4, 90f);
             cache.OutsideVertBrush = new LinearGradientBrush(vF, Color.FromArgb(48, c5), c5, 90f);
@@ -10040,7 +9983,7 @@ namespace Krypton.Toolkit
                                                              Graphics? g,
                                                              bool alternate)
         {
-            if (cache is not null && g is not null)
+            if (g is not null)
             {
                 g.FillRectangle(cache.TopBorderBrush!, rect.Left - 1, rect.Top - 1, rect.Width + 2, 4);
                 g.DrawLine(cache.InnerVertPen!, rect.Left + 2, rect.Bottom - 2, rect.Left + 2, rect.Top + 3);
@@ -10074,8 +10017,8 @@ namespace Krypton.Toolkit
                                                           Color c4, Color c5,
                                                           MementoRibbonTabHighlight cache)
         {
-            RectangleF hF = new RectangleF(rect.Left - 1, rect.Top - 2, 6, rect.Height - 4);
-            RectangleF vF = new RectangleF(rect.Left + 1, rect.Top - 2, rect.Width - 1, rect.Height - 4);
+            var hF = new Rectangle(rect.Left - 1, rect.Top - 2, 6, rect.Height - 4);
+            var vF = new Rectangle(rect.Left + 1, rect.Top - 2, rect.Width - 1, rect.Height - 4);
             cache.TopBorderBrush = new LinearGradientBrush(hF, Color.FromArgb(48, c5), Color.FromArgb(64, c5), 0f);
             cache.BorderVertBrush = new LinearGradientBrush(vF, c5, c4, 0f);
             cache.OutsideVertBrush = new LinearGradientBrush(vF, Color.FromArgb(48, c5), c5, 0f);
@@ -10092,7 +10035,7 @@ namespace Krypton.Toolkit
                                                               Graphics? g,
                                                               bool alternate)
         {
-            if (cache is not null && g is not null)
+            if (g is not null)
             {
                 g.FillRectangle(cache.TopBorderBrush!, rect.Left - 1, rect.Top - 1, 4, rect.Height + 2);
                 g.DrawLine(cache.InnerVertPen!, rect.Right - 2, rect.Bottom - 3, rect.Left + 3, rect.Bottom - 3);
@@ -10126,8 +10069,8 @@ namespace Krypton.Toolkit
                                                            Color c4, Color c5,
                                                            MementoRibbonTabHighlight cache)
         {
-            RectangleF hF = new RectangleF(rect.Right - 6, rect.Top - 2, 6, rect.Height - 4);
-            RectangleF vF = new RectangleF(rect.Left, rect.Top - 2, rect.Width - 1, rect.Height - 4);
+            var hF = new Rectangle(rect.Right - 6, rect.Top - 2, 6, rect.Height - 4);
+            var vF = new Rectangle(rect.Left, rect.Top - 2, rect.Width - 1, rect.Height - 4);
             cache.TopBorderBrush = new LinearGradientBrush(hF, Color.FromArgb(48, c5), Color.FromArgb(64, c5), 180f);
             cache.BorderVertBrush = new LinearGradientBrush(vF, c5, c4, 180f);
             cache.OutsideVertBrush = new LinearGradientBrush(vF, Color.FromArgb(48, c5), c5, 180f);
@@ -10144,7 +10087,7 @@ namespace Krypton.Toolkit
                                                                Graphics? g,
                                                                bool alternate)
         {
-            if (cache is not null && g is not null)
+            if (g is not null)
             {
                 g.FillRectangle(cache.TopBorderBrush!, rect.Right - 4, rect.Top - 1, 4, rect.Height + 2);
                 g.DrawLine(cache.InnerVertPen!, rect.Left + 1, rect.Bottom - 3, rect.Right - 4, rect.Bottom - 3);
@@ -10178,8 +10121,8 @@ namespace Krypton.Toolkit
                                                             Color c4, Color c5,
                                                             MementoRibbonTabHighlight cache)
         {
-            RectangleF hF = new RectangleF(rect.Left - 2, rect.Bottom - 6, rect.Width + 4, 6);
-            RectangleF vF = new RectangleF(rect.Left - 2, rect.Top, rect.Width + 4, rect.Height - 1);
+            var hF = new Rectangle(rect.Left - 2, rect.Bottom - 6, rect.Width + 4, 6);
+            var vF = new Rectangle(rect.Left - 2, rect.Top, rect.Width + 4, rect.Height - 1);
             cache.TopBorderBrush = new LinearGradientBrush(hF, Color.FromArgb(48, c5), Color.FromArgb(64, c5), 270f);
             cache.BorderVertBrush = new LinearGradientBrush(vF, c5, c4, 270f);
             cache.OutsideVertBrush = new LinearGradientBrush(vF, Color.FromArgb(48, c5), c5, 270f);
@@ -10196,7 +10139,7 @@ namespace Krypton.Toolkit
                                                         Graphics? g,
                                                         bool alternate)
         {
-            if (cache is not null && g is not null)
+            if (g is not null)
             {
                 g.FillRectangle(cache.TopBorderBrush!, rect.Left - 1, rect.Bottom - 3, rect.Width + 2, 4);
                 g.DrawLine(cache.InnerVertPen!, rect.Left + 2, rect.Top + 1, rect.Left + 2, rect.Bottom - 4);
@@ -10260,16 +10203,16 @@ namespace Krypton.Toolkit
                     // Dispose of existing values
                     cache.Dispose();
 
-                    Rectangle borderRect = new Rectangle(rect.X - 1, rect.Y - 1, rect.Width + 2, rect.Height + 2);
+                    var borderRect = new Rectangle(rect.X - 1, rect.Y - 1, rect.Width + 2, rect.Height + 2);
                     cache.FillRect = new Rectangle(rect.X + 1, rect.Y, rect.Width - 2, rect.Height - 1);
 
-                    LinearGradientBrush borderBrush = new LinearGradientBrush(borderRect, c1, Color.Transparent, 270f)
+                    var borderBrush = new LinearGradientBrush(borderRect, c1, Color.Transparent, 270f)
                     {
                         Blend = _ribbonGroup5Blend
                     };
                     cache.BorderPen = new Pen(borderBrush);
 
-                    LinearGradientBrush underlineBrush =
+                    var underlineBrush =
                         new LinearGradientBrush(borderRect, Color.Transparent, Color.FromArgb(200, c2), 0f)
                         {
                             Blend = _ribbonGroup7Blend
@@ -10282,7 +10225,7 @@ namespace Krypton.Toolkit
                     };
                 }
 
-                // Draw the left and right border lines
+                // Draw the left and right borderlines
                 context.Graphics.DrawLine(cache.BorderPen!, rect.X, rect.Y, rect.X, rect.Bottom - 1);
                 context.Graphics.DrawLine(cache.BorderPen!, rect.Right - 1, rect.Y, rect.Right - 1, rect.Bottom - 1);
 
@@ -10357,7 +10300,7 @@ namespace Krypton.Toolkit
                     cache.RectUpperGlow = new RectangleF
                     {
                         Width = rect.Width - 4,
-                        Height = rect.Height / 8
+                        Height = rect.Height / 8f
                     };
                     cache.RectUpperGlow.Y = rect.Y + ((rect.Height - cache.RectUpperGlow.Height) / 2);
                     cache.RectUpperGlow.X = rect.X + ((rect.Width - cache.RectUpperGlow.Width) / 2);
@@ -10366,7 +10309,7 @@ namespace Krypton.Toolkit
                     cache.BrushLower = new LinearGradientBrush(cache.RectLower, Color.Transparent, Color.Transparent, LinearGradientMode.Horizontal);
                 }
 
-                using AntiAlias aa = new AntiAlias(context.Graphics);
+                using var aa = new AntiAlias(context.Graphics);
                 DrawRibbonAppButtonBorder1(context.Graphics, cache);
                 DrawRibbonAppButtonUpperHalf(context.Graphics, cache, state, topDark, bottomDark, topLight, topMedium, trackBorderAsPressed);
                 DrawRibbonAppButtonLowerHalf(context.Graphics, cache, state, bottomDark, bottomLight, bottomMedium);
@@ -10403,7 +10346,6 @@ namespace Krypton.Toolkit
                                                             Color topMedium,
                                                             bool trackBorderAsPressed)
         {
-
             if (g is not null)
             {
                 var pressed = state == PaletteState.Pressed;
@@ -10421,7 +10363,7 @@ namespace Krypton.Toolkit
                     Color[] colorsUpperHalf = [topDark, topMedium, topLight, topLight, topMedium, topDark];
                     float[] posUpperHalf = [0.0f, 0.2f, 0.4f, 0.6f, 0.8f, 1.0f];
 
-                    ColorBlend blendUpperHalf = new ColorBlend
+                    var blendUpperHalf = new ColorBlend
                     {
                         Colors = colorsUpperHalf,
                         Positions = posUpperHalf
@@ -10446,7 +10388,7 @@ namespace Krypton.Toolkit
                     c2 = topDark;
                 }
 
-                using LinearGradientBrush brushUpper2 =
+                using var brushUpper2 =
                     new LinearGradientBrush(memento!.Rect, c1, c2, LinearGradientMode.Vertical);
                 g.FillPie(brushUpper2, memento.Rect.X, memento.Rect.Y, memento.Rect.Width, memento.Rect.Height, 180, 180);
             }
@@ -10470,13 +10412,13 @@ namespace Krypton.Toolkit
                     ? [0.0f, 0.3f, 0.5f, 0.5f, 0.7f, 1.0f]
                     : new[] { 0.0f, 0.2f, 0.4f, 0.6f, 0.8f, 1.0f };
 
-                ColorBlend blendLowerHalf = new ColorBlend
+                var blendLowerHalf = new ColorBlend
                 {
                     Colors = colorsLowerHalf,
                     Positions = posLowerHalf
                 };
 
-                memento!.BrushLower!.InterpolationColors = blendLowerHalf;
+                memento.BrushLower!.InterpolationColors = blendLowerHalf;
                 g.FillPie(memento.BrushLower, memento.RectLower.X, memento.RectLower.Y, memento.RectLower.Width, memento.RectLower.Height, 0, 180);
             }
         }
@@ -10493,10 +10435,10 @@ namespace Krypton.Toolkit
 
             if (g is not null && memento is not null)
             {
-                using LinearGradientBrush brushBottomGlow = new LinearGradientBrush(memento.RectBottomGlow,
+                using var brushBottomGlow = new LinearGradientBrush(memento.RectBottomGlow,
                     Color.FromArgb(50, Color.White), Color.FromArgb(30, Color.White), LinearGradientMode.Vertical);
                 RectangleF rectBottomGlow = memento.RectBottomGlow;
-                rectBottomGlow.X = memento.Rect.X + ((memento.Rect.Width - rectBottomGlow.Width) / 2);
+                rectBottomGlow.X = memento.Rect.X + ((memento.Rect.Width - rectBottomGlow.Width) / 2f);
                 rectBottomGlow.Y = memento.Rect.Y + (memento.Rect.Height - rectBottomGlow.Height - 2);
 
                 if (state != PaletteState.Pressed)
@@ -10508,12 +10450,12 @@ namespace Krypton.Toolkit
                 {
                     rectBottomGlow.Height = memento.Rect.Height * 0.2f;
                     rectBottomGlow.Width = memento.Rect.Width * 0.4f;
-                    rectBottomGlow.X = memento.Rect.X + ((memento.Rect.Width - rectBottomGlow.Width) / 2);
+                    rectBottomGlow.X = memento.Rect.X + ((memento.Rect.Width - rectBottomGlow.Width) / 2f);
                     rectBottomGlow.Y = memento.Rect.Y + (memento.Rect.Height - rectBottomGlow.Height);
 
-                    using GraphicsPath path = new GraphicsPath();
+                    using var path = new GraphicsPath();
                     path.AddEllipse(rectBottomGlow);
-                    using PathGradientBrush pathGradient = new PathGradientBrush(path);
+                    using var pathGradient = new PathGradientBrush(path);
                     pathGradient.CenterColor = topLight;
                     pathGradient.SurroundColors = [Color.FromArgb(100, bottomLight)];
                     g.FillEllipse(pathGradient, rectBottomGlow);
@@ -10542,7 +10484,7 @@ namespace Krypton.Toolkit
                     mediumTransparency = 200;
                 }
 
-                using LinearGradientBrush brushUpperGlow = new LinearGradientBrush(memento.RectUpperGlow, Color.Transparent,
+                using var brushUpperGlow = new LinearGradientBrush(memento.RectUpperGlow, Color.Transparent,
                     Color.Transparent, LinearGradientMode.Horizontal);
                 Color[] colorsUpperGlow =
                 [
@@ -10556,7 +10498,7 @@ namespace Krypton.Toolkit
 
                 float[] posUpperGlow = [0.0f, 0.2f, 0.4f, 0.6f, 0.8f, 1.0f];
 
-                ColorBlend blendUpperGlow = new ColorBlend
+                var blendUpperGlow = new ColorBlend
                 {
                     Colors = colorsUpperGlow,
                     Positions = posUpperGlow
@@ -10602,12 +10544,12 @@ namespace Krypton.Toolkit
                     borderGlowColor = _whiten120;
                 }
 
-                using (Pen p = new Pen(borderGlowColor))
+                using (var p = new Pen(borderGlowColor))
                 {
                     g.DrawEllipse(p, memento.BorderMain1);
                 }
 
-                using (Pen p = new Pen(Color.FromArgb(100, 52, 59, 64)))
+                using (var p = new Pen(Color.FromArgb(100, 52, 59, 64)))
                 {
                     g.DrawEllipse(p, memento.Rect);
                 }
@@ -10615,12 +10557,12 @@ namespace Krypton.Toolkit
                 if (pressed)
                 {
                     borderGlowColor = _whiten60;
-                    using Pen p = new Pen(borderGlowColor);
+                    using var p = new Pen(borderGlowColor);
                     g.DrawEllipse(p, memento.BorderMain3);
                 }
 
                 borderGlowColor = pressed ? _whiten50 : _whiten80;
-                using (Pen p = new Pen(borderGlowColor))
+                using (var p = new Pen(borderGlowColor))
                 {
                     g.DrawArc(p, memento.BorderMain2, 180, 180);
                 }
@@ -10628,13 +10570,13 @@ namespace Krypton.Toolkit
                 if (!pressed)
                 {
                     borderGlowColor = _whiten30;
-                    using Pen p = new Pen(borderGlowColor);
+                    using var p = new Pen(borderGlowColor);
                     g.DrawArc(p, memento.BorderMain4, 180, 180);
                 }
 
                 if (tracking && !pressed)
                 {
-                    using Pen p = new Pen(Color.FromArgb(100, borderGlowColor));
+                    using var p = new Pen(Color.FromArgb(100, borderGlowColor));
                     g.DrawEllipse(p, memento.Rect);
                 }
             }
@@ -10699,6 +10641,7 @@ namespace Krypton.Toolkit
                             cache.InsideFillBrush.SetSigmaBellShape(0.33f);
                             cache.HighlightBrush!.CenterColor = Color.FromArgb(64, Color.White);
                             break;
+
                         case PaletteState.Tracking:
                             cache.BorderBrush = new SolidBrush(bottomColor);
                             cache.InsideFillBrush = new LinearGradientBrush(new RectangleF(rect.X, rect.Y + 1, rect.Width, rect.Height),
@@ -10709,6 +10652,7 @@ namespace Krypton.Toolkit
                             cache.InsideFillBrush.SetSigmaBellShape(0.33f);
                             cache.HighlightBrush!.CenterColor = Color.FromArgb(100, Color.White);
                             break;
+
                         case PaletteState.Tracking | PaletteState.FocusOverride:
                             cache.BorderBrush = new SolidBrush(ControlPaint.LightLight(bottomColor));
                             cache.InsideFillBrush = new LinearGradientBrush(new RectangleF(rect.X, rect.Y + 1, rect.Width, rect.Height),
@@ -10719,6 +10663,7 @@ namespace Krypton.Toolkit
                             cache.InsideFillBrush.SetSigmaBellShape(0.33f);
                             cache.HighlightBrush!.CenterColor = ControlPaint.LightLight(bottomColor);
                             break;
+
                         case PaletteState.Pressed:
                             cache.BorderBrush = new SolidBrush(CommonHelper.MergeColors(topColor, 0.5f, bottomColor, 0.5f));
                             cache.InsideFillBrush = new LinearGradientBrush(new RectangleF(rect.X, rect.Y + 1, rect.Width, rect.Height),
@@ -10797,13 +10742,13 @@ namespace Krypton.Toolkit
                     // Dispose of existing values
                     cache.Dispose();
 
-                    GraphicsPath trackingPath = new GraphicsPath();
+                    var trackingPath = new GraphicsPath();
                     trackingPath.AddEllipse(rect with { Y = rect.Y + (rect.Height / 2), Width = rect.Width - 3 });
                     cache.TrackHighlightBrush = new PathGradientBrush(trackingPath)
                     {
                         SurroundColors = [Color.Transparent],
                         CenterColor = cache.C3,//(dark ? (rect.Width > 50 ? _whiten60 : _whiten45) : _whiten160),
-                        CenterPoint = new PointF(rect.X + ((rect.Width - 3) / 2), rect.Height)
+                        CenterPoint = new PointF(rect.X + ((rect.Width - 3) / 2f), rect.Height)
                     };
 
                     //cache.topBrush = new LinearGradientBrush(topRectF, c1, Color.Transparent, 90f);
@@ -10837,7 +10782,6 @@ namespace Krypton.Toolkit
 
             return memento;
         }
-
 
         /// <summary>
         /// Internal rendering method.
@@ -10878,10 +10822,10 @@ namespace Krypton.Toolkit
                     // Dispose of existing values
                     cache.Dispose();
 
-                    GraphicsPath solidPath = new GraphicsPath();
-                    GraphicsPath insidePath = new GraphicsPath();
-                    GraphicsPath outsidePath = new GraphicsPath();
-                    GraphicsPath lightPath = new GraphicsPath();
+                    var solidPath = new GraphicsPath();
+                    var insidePath = new GraphicsPath();
+                    var outsidePath = new GraphicsPath();
+                    var lightPath = new GraphicsPath();
 
                     // Create the rounded complete border
                     solidPath.AddLine(rect.Left + 2, rect.Top, rect.Right - 4, rect.Top);
@@ -10913,8 +10857,8 @@ namespace Krypton.Toolkit
                     lightPath.AddLine(rect.Left + 1, rect.Bottom - 4, rect.Left + 1, rect.Top + 2);
                     lightPath.AddLine(rect.Left + 1, rect.Top + 2, rect.Left + 2, rect.Top + 1);
 
-                    RectangleF solidRectF = new RectangleF(rect.Left - 1, rect.Top - 1, rect.Width + 2, rect.Height + 2);
-                    LinearGradientBrush solidBrush = new LinearGradientBrush(solidRectF, c1, c2, 90f);
+                    var solidRectF = new Rectangle(rect.Left - 1, rect.Top - 1, rect.Width + 2, rect.Height + 2);
+                    var solidBrush = new LinearGradientBrush(solidRectF, c1, c2, 90f);
                     cache.SolidPen = new Pen(solidBrush);
 
                     cache.BackRect = new Rectangle(rect.Left + 2, rect.Top + 1, rect.Width - 4, rect.Height - 4);
@@ -10930,12 +10874,12 @@ namespace Krypton.Toolkit
                     context.Graphics.FillRectangle(lightInside ? _whitenLightLBrush : _whitenLightBrush, cache.BackRect);
                 }
 
-                using (AntiAlias aa = new AntiAlias(context.Graphics))
+                using (var aa = new AntiAlias(context.Graphics))
                 {
                     // Draw the solid border
                     context.Graphics.DrawPath(cache.SolidPen!, cache.SolidPath!);
 
-                    // Do now draw the inside and outside paths if ligtening the inside anyway
+                    // Do now draw the inside and outside paths if lightening the inside anyway
                     if (!lightInside)
                     {
                         // Draw the two areas that make a lighter shadow to the right and bottom of border
@@ -10998,7 +10942,7 @@ namespace Krypton.Toolkit
                     // Dispose of existing values
                     cache.Dispose();
 
-                    RectangleF rectF = new RectangleF(rect.X - 1, rect.Y - 1, rect.Width + 2, rect.Height + 2);
+                    var rectF = new RectangleF(rect.X - 1, rect.Y - 1, rect.Width + 2, rect.Height + 2);
                     cache.TotalBrush = new LinearGradientBrush(rectF, c2, c1, 90f);
 
                     cache.InnerBrush = new LinearGradientBrush(rectF, c4, c3, 90f);
@@ -11077,7 +11021,7 @@ namespace Krypton.Toolkit
                     // Dispose of existing values
                     cache.Dispose();
 
-                    GraphicsPath titlePath = new GraphicsPath();
+                    var titlePath = new GraphicsPath();
 
                     // Create the rounded bottom edge to fit inside a group border
                     titlePath.AddLine(rect.Left, rect.Top, rect.Right - 1, rect.Top);
@@ -11087,7 +11031,7 @@ namespace Krypton.Toolkit
                     titlePath.AddLine(rect.Left + 2, rect.Bottom - 1, rect.Left, rect.Bottom - 3);
                     titlePath.AddLine(rect.Left, rect.Bottom - 3, rect.Left, rect.Top);
 
-                    RectangleF rectF = new RectangleF(rect.Left - 0.5f, rect.Top - 0.5f, rect.Width + 1,
+                    var rectF = new RectangleF(rect.Left - 0.5f, rect.Top - 0.5f, rect.Width + 1,
                         rect.Height + 1);
                     cache.TitleBrush = new LinearGradientBrush(rectF, c1, c2, 90f);
                     cache.TitlePath = titlePath;
@@ -11140,8 +11084,8 @@ namespace Krypton.Toolkit
                     // Dispose of existing values
                     cache.Dispose();
 
-                    GraphicsPath solidPath = new GraphicsPath();
-                    GraphicsPath insidePath = new GraphicsPath();
+                    var solidPath = new GraphicsPath();
+                    var insidePath = new GraphicsPath();
 
                     // Create the rounded complete border
                     solidPath.AddLine(rect.Left + 1.25f, rect.Top, rect.Right - 2, rect.Top);
@@ -11163,11 +11107,10 @@ namespace Krypton.Toolkit
                     insidePath.AddLine(rect.Left + 1, rect.Bottom - 3, rect.Left + 1, rect.Top + 2);
                     insidePath.AddLine(rect.Left + 1, rect.Top + 2, rect.Left + 2, rect.Top + 1);
 
-                    RectangleF solidRectF = new RectangleF(rect.Left - 1, rect.Top - 1, rect.Width + 2, rect.Height + 2);
-                    RectangleF insideRectF = new RectangleF(rect.Left, rect.Top, rect.Width, rect.Height);
-
-                    LinearGradientBrush solidBrush = new LinearGradientBrush(solidRectF, c1, c2, 90f);
-                    LinearGradientBrush insideBrush = new LinearGradientBrush(insideRectF, c3, c4, 90f);
+                    var solidRectF = new RectangleF(rect.Left - 1, rect.Top - 1, rect.Width + 2, rect.Height + 2);
+                    var insideRectF = new RectangleF(rect.Left, rect.Top, rect.Width, rect.Height);
+                    var solidBrush = new LinearGradientBrush(solidRectF, c1, c2, 90f);
+                    var insideBrush = new LinearGradientBrush(insideRectF, c3, c4, 90f);
 
                     cache.SolidPath = solidPath;
                     cache.InsidePath = insidePath;
@@ -11176,7 +11119,7 @@ namespace Krypton.Toolkit
                 }
 
                 // Perform actual drawing using the cache values
-                using AntiAlias aa = new AntiAlias(context.Graphics);
+                using var aa = new AntiAlias(context.Graphics);
                 context.Graphics.DrawPath(cache.SolidPen!, cache.SolidPath!);
                 context.Graphics.DrawPath(cache.InsidePen!, cache.InsidePath!);
             }
@@ -11221,7 +11164,7 @@ namespace Krypton.Toolkit
                     // Dispose of existing values
                     cache.Dispose();
 
-                    GraphicsPath solidPath = new GraphicsPath();
+                    var solidPath = new GraphicsPath();
 
                     // Create the rounded complete border
                     solidPath.AddLine(rect.Left + 2, rect.Top, rect.Right - 3, rect.Top);
@@ -11239,11 +11182,11 @@ namespace Krypton.Toolkit
                 }
 
                 // Perform actual drawing using the cache values
-                Rectangle titleRect = new Rectangle(rect.Left + 1, rect.Bottom - GROUP_FRAME_TITLE_HEIGHT,
+                var titleRect = new Rectangle(rect.Left + 1, rect.Bottom - GROUP_FRAME_TITLE_HEIGHT,
                     rect.Width - 2, GROUP_FRAME_TITLE_HEIGHT - 1);
                 context.Graphics.FillRectangle(cache.TitleBrush!, titleRect);
 
-                using AntiAlias aa = new AntiAlias(context.Graphics);
+                using var aa = new AntiAlias(context.Graphics);
                 context.Graphics.DrawPath(cache.SolidPen!, cache.SolidPath!);
             }
 
@@ -11287,7 +11230,7 @@ namespace Krypton.Toolkit
                     // Dispose of existing values
                     cache.Dispose();
 
-                    RectangleF rectF = new RectangleF(rect.Left - 1, rect.Top - 1, rect.Width + 2, rect.Height + 2);
+                    var rectF = new Rectangle(rect.Left - 1, rect.Top - 1, rect.Width + 2, rect.Height + 2);
                     cache.Brush = new LinearGradientBrush(rectF, c1, c2, 90f)
                     {
                         Blend = _ribbonGroup8Blend
@@ -11342,11 +11285,11 @@ namespace Krypton.Toolkit
                     cache.Dispose();
 
                     var topHeight = (int)(rect.Height * percent);
-                    Rectangle topRect = new Rectangle(rect.Left, rect.Top, rect.Width, topHeight);
-                    Rectangle bottomRect = new Rectangle(rect.Left, topRect.Bottom, rect.Width, rect.Height - topHeight);
-                    RectangleF topRectF = new RectangleF(topRect.Left - 1, topRect.Top - 1, topRect.Width + 2,
+                    var topRect = new Rectangle(rect.Left, rect.Top, rect.Width, topHeight);
+                    var bottomRect = new Rectangle(rect.Left, topRect.Bottom, rect.Width, rect.Height - topHeight);
+                    var topRectF = new RectangleF(topRect.Left - 1, topRect.Top - 1, topRect.Width + 2,
                         topRect.Height + 2);
-                    RectangleF bottomRectF = new RectangleF(bottomRect.Left - 1, bottomRect.Top - 1,
+                    var bottomRectF = new RectangleF(bottomRect.Left - 1, bottomRect.Top - 1,
                         bottomRect.Width + 2, bottomRect.Height + 2);
 
                     cache.TopBrush = new LinearGradientBrush(topRectF, c1, c2, 90f);
@@ -11356,8 +11299,8 @@ namespace Krypton.Toolkit
                 }
 
                 // Perform actual drawing using the cache values
-                context.Graphics.FillRectangle(cache.TopBrush!, cache.TopRect!);
-                context.Graphics.FillRectangle(cache.BottomBrush!, cache.BottomRect!);
+                context.Graphics.FillRectangle(cache.TopBrush!, cache.TopRect);
+                context.Graphics.FillRectangle(cache.BottomBrush!, cache.BottomRect);
             }
 
             return memento;
@@ -11403,9 +11346,9 @@ namespace Krypton.Toolkit
                     // Dispose of existing values
                     cache.Dispose();
 
-                    GraphicsPath borderPath = new GraphicsPath();
-                    GraphicsPath topRight1 = new GraphicsPath();
-                    GraphicsPath bottomLeft1 = new GraphicsPath();
+                    var borderPath = new GraphicsPath();
+                    var topRight1 = new GraphicsPath();
+                    var bottomLeft1 = new GraphicsPath();
 
                     // Find values needed for drawing the main border
                     var left = rect.X + 1;
@@ -11461,7 +11404,7 @@ namespace Krypton.Toolkit
                     cache.WhitenPen = new Pen(c5);
                 }
 
-                using AntiAlias aa = new AntiAlias(context.Graphics);
+                using var aa = new AntiAlias(context.Graphics);
                 // Draw the light borders
                 context.Graphics.DrawPath(cache.LightPen!, cache.TopRight1!);
                 context.Graphics.DrawPath(cache.LightPen!, cache.BottomLeft1!);
@@ -11519,9 +11462,9 @@ namespace Krypton.Toolkit
                     // Dispose of existing values
                     cache.Dispose();
 
-                    GraphicsPath borderPath = new GraphicsPath();
-                    GraphicsPath topRight1 = new GraphicsPath();
-                    GraphicsPath bottomLeft1 = new GraphicsPath();
+                    var borderPath = new GraphicsPath();
+                    var topRight1 = new GraphicsPath();
+                    var bottomLeft1 = new GraphicsPath();
 
                     // Find values needed for drawing the main border
                     var left = rect.X + 1;
@@ -11578,7 +11521,7 @@ namespace Krypton.Toolkit
                     cache.WhitenPen = new Pen(c5);
                 }
 
-                using AntiAlias aa = new AntiAlias(context.Graphics);
+                using var aa = new AntiAlias(context.Graphics);
                 // Draw the light borders
                 context.Graphics.DrawPath(cache.LightPen!, cache.TopRight1!);
                 context.Graphics.DrawPath(cache.LightPen!, cache.BottomLeft1!);
@@ -11853,9 +11796,9 @@ namespace Krypton.Toolkit
                     cache.InnerBrush = new LinearGradientBrush(rect, c1, c2, 90f);
                     cache.DarkPen = new Pen(c3);
 
-                    GraphicsPath darkPath = new GraphicsPath();
-                    GraphicsPath lightPath1 = new GraphicsPath();
-                    GraphicsPath lightPath2 = new GraphicsPath();
+                    var darkPath = new GraphicsPath();
+                    var lightPath1 = new GraphicsPath();
+                    var lightPath2 = new GraphicsPath();
 
                     // Create the dark border
                     darkPath.AddLine(rect.Left, rect.Top + 0.75f, rect.Left + 1, rect.Top);
@@ -11881,13 +11824,13 @@ namespace Krypton.Toolkit
                 }
 
                 // Draw a gradient for the inside of the area
-                context.Graphics.FillRectangle(cache.InnerBrush!, cache.InnerRect!);
+                context.Graphics.FillRectangle(cache.InnerBrush!, cache.InnerRect);
 
                 // Draw the dark/light lines
-                using AntiAlias aa = new AntiAlias(context.Graphics);
+                using var aa = new AntiAlias(context.Graphics);
                 context.Graphics.DrawPath(cache.DarkPen!, cache.DarkPath!);
-                context.Graphics.DrawPath(_light1Pen!, cache.LightPath1!);
-                context.Graphics.DrawPath(_light2Pen!, cache.LightPath2!);
+                context.Graphics.DrawPath(_light1Pen, cache.LightPath1!);
+                context.Graphics.DrawPath(_light2Pen, cache.LightPath2!);
             }
 
             return memento;
@@ -11942,7 +11885,7 @@ namespace Krypton.Toolkit
                 // Draw the outside border
                 context.Graphics.DrawRectangle(cache.DarkPen!, rect.X, rect.Y, rect.Width - 1, rect.Height - 1);
 
-                // Draw ligher top and bottom lines
+                // Draw lighter top and bottom lines
                 context.Graphics.DrawLine(cache.LightPen!, rect.X + 1, rect.Y + 1, rect.Width - 2, rect.Y + 1);
                 context.Graphics.DrawLine(cache.LightPen!, rect.X + 1, rect.Bottom - 2, rect.Width - 2, rect.Bottom - 2);
             }
@@ -11995,10 +11938,10 @@ namespace Krypton.Toolkit
                 // Draw a gradient for the inside of the area
                 context.Graphics.FillRectangle(cache.BackBrush!, rect);
 
-                using AntiAlias aa = new AntiAlias(context.Graphics);
+                using var aa = new AntiAlias(context.Graphics);
                 if (shape == PaletteRibbonShape.Office2010)
                 {
-                    context.Graphics.DrawPolygon(cache.BorderPen!, new Point[]{
+                    context.Graphics.DrawPolygon(cache.BorderPen!, new[]{
                         new Point(rect.Left + 1, rect.Top), new Point(rect.Right - 2, rect.Top),
                         new Point(rect.Right - 1, rect.Top + 1), new Point(rect.Right - 1, rect.Bottom - 2),
                         new Point(rect.Right - 2, rect.Bottom - 1), new Point(rect.Left + 1, rect.Bottom - 1),


### PR DESCRIPTION
  - Better handling of the edge cases
  - Better drawing without the need to "Hack" rectangles.
  - Move "GraphicsHint"'s closer to usage
- Apply code styles to the "Big File"
  - Remove some ReSharper things
  - Spell checking
  - Comment out unused fields
  - Use `var`'s for when they are `new`ed
- Add `TransparencyKey` and draw into the borders only
- Remove remnants of commented out code


![image](https://github.com/user-attachments/assets/adba20e7-0acd-48cc-b71d-49b5ce12c32e)



![image](https://github.com/user-attachments/assets/77072fba-e0af-4102-b8eb-6747d5871cd8)

#1749