### PR TITLE
1755-V85-Ribbon-moving-the-mouse-over-the-dropdown-arrow-of-a-gallery…

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-07-xx - Build 2408 (Patch 2) - July 2024
+* Resolved [#1755](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1755), Ribbon `GalleryButtonController` timer component causes an exception on mouse movements.
 * Resolved [#1697](https://github.com/Krypton-Suite/Standard-Toolkit/issues1697), `KryptonComboBox` change in DropDownStyle cripples the control while the control is disabled en reenabled again.
 * Resolved [#1548](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1548), KComboBox DropDown arrow is illegible in certain themes
 * Resolved [#1659](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1659), Solves `KryptonMessageBox` selected text issue, usage of diverse line breaks and sizing issues.

--- a/Source/Krypton Components/Krypton.Ribbon/Controller/GalleryButtonController.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controller/GalleryButtonController.cs
@@ -73,7 +73,7 @@ namespace Krypton.Ribbon
                 _pressed = false;
                 _mouseOver = false;
                 UpdateTargetState(new Point(int.MaxValue, int.MaxValue));
-                _repeatTimer.Stop();
+                _repeatTimer?.Stop();
             }
         }
         #endregion
@@ -116,7 +116,7 @@ namespace Krypton.Ribbon
                 if (Target.Enabled)
                 {
                     OnClick(new MouseEventArgs(MouseButtons.Left, 1, pt.X, pt.Y, 0));
-                    _repeatTimer.Start();
+                    _repeatTimer?.Start();
                 }
             }
 
@@ -136,7 +136,7 @@ namespace Krypton.Ribbon
             {
                 _pressed = false;
                 UpdateTargetState(pt);
-                _repeatTimer.Stop();
+                _repeatTimer?.Stop();
             }
         }
 
@@ -153,7 +153,7 @@ namespace Krypton.Ribbon
                 _pressed = false;
                 _mouseOver = false;
                 UpdateTargetState(c);
-                _repeatTimer.Stop();
+                _repeatTimer?.Stop();
             }
         }
 
@@ -243,7 +243,7 @@ namespace Krypton.Ribbon
             if (!Target.Enabled)
             {
                 newState = PaletteState.Disabled;
-                _repeatTimer.Stop();
+                _repeatTimer?.Stop();
             }
             else
             {
@@ -283,7 +283,7 @@ namespace Krypton.Ribbon
             }
             else
             {
-                _repeatTimer.Stop();
+                _repeatTimer?.Stop();
             }
         }
             


### PR DESCRIPTION
[Issue 1755-V85-Ribbon-moving-the-mouse-over-the-dropdown-arrow-of-a-gallery-causes-an-exception](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1755)
- Fixes the issue
- And the change log

![compile-results](https://github.com/user-attachments/assets/52db4467-2850-460e-8462-59aafd7e182f)
