### PR TITLE
1772-V85-KryptonDataGridComboBox-properties-have-incorrect-defaul…

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-07-xx - Build 2408 (Patch 2) - July 2024
+* Resolved [1772](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1772), `KryptonDataGridViewComboBox` properties, `AutoCompleteMode` and `AutoCompleteSource` have incorrect default values.
 * Resolved [#1755](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1755), Ribbon `GalleryButtonController` timer component causes an exception on mouse movements.
 * Resolved [#1697](https://github.com/Krypton-Suite/Standard-Toolkit/issues1697), `KryptonComboBox` change in DropDownStyle cripples the control while the control is disabled en reenabled again.
 * Resolved [#1548](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1548), KComboBox DropDown arrow is illegible in certain themes

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxCell.cs
@@ -188,7 +188,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// The AutoCompleteMode property replicates the one from the KryptonComboBox control
         /// </summary>
-        [DefaultValue(121)]
+        [DefaultValue(AutoCompleteMode.None)]
         public AutoCompleteMode AutoCompleteMode
         {
             get => _autoCompleteMode;
@@ -206,7 +206,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// The AutoCompleteSource property replicates the one from the KryptonComboBox control
         /// </summary>
-        [DefaultValue(121)]
+        [DefaultValue(AutoCompleteSource.None)]
         public AutoCompleteSource AutoCompleteSource
         {
             get => _autoCompleteSource;

--- a/Source/Krypton Components/TestForm/Form1.Designer.cs
+++ b/Source/Krypton Components/TestForm/Form1.Designer.cs
@@ -533,12 +533,10 @@
             this.ButtonSpecs.Add(this.buttonSpecAny10);
             this.ClientSize = new System.Drawing.Size(600, 635);
             this.Controls.Add(this.kryptonPanel1);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
             this.FormTitleAlign = Krypton.Toolkit.PaletteRelativeAlign.Inherit;
             this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "Form1";
             this.Text = "Form1";
-            this.WindowState = System.Windows.Forms.FormWindowState.Maximized;
             this.Load += new System.EventHandler(this.Form1_Load);
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).EndInit();
             this.kryptonPanel1.ResumeLayout(false);


### PR DESCRIPTION
[1772-V85-KryptonDataGridComboBox-properties-have-incorrect-default-values](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1772)
- Values corrected 
- Update the change log

![compile-results](https://github.com/user-attachments/assets/f321d3d4-7ae0-402f-bfb4-7292450c8dfa)
