### PR TITLE
1772-KryptonDataGridComboBoxCell-properties-have-incorrect-default-values

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
+* Resolved [#1772](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1772), `KryptonDataGridViewComboBoxCell` properties, `AutoCompleteMode` and `AutoCompleteSource` have incorrect default values.
 * Resolved [#1715](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1715), Not Implemented Exception thrown for `GetRibbonBackColorStyle` `PaletteOffice2010Base.cs`
 * Resolved [#1299](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1299), Ribbon context colours not implemented
 * Resolved [#1749](https://github.com/Krypton-Suite/Standard-Toolkit/issues1749), Rounded Form borders have "Triangles" in corners.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxCell.cs
@@ -187,7 +187,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// The AutoCompleteMode property replicates the one from the KryptonComboBox control
         /// </summary>
-        [DefaultValue(121)]
+        [DefaultValue(AutoCompleteMode.None)]
         public AutoCompleteMode AutoCompleteMode
         {
             get => _autoCompleteMode;
@@ -205,7 +205,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// The AutoCompleteSource property replicates the one from the KryptonComboBox control
         /// </summary>
-        [DefaultValue(121)]
+        [DefaultValue(AutoCompleteSource.None)]
         public AutoCompleteSource AutoCompleteSource
         {
             get => _autoCompleteSource;


### PR DESCRIPTION
[1772-KryptonDataGridComboBoxCell-properties-have-incorrect-default-values](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1772)
- Values corrected 
- Update the change log

![compile-results](https://github.com/user-attachments/assets/a5b05140-7c40-4d0c-bfe1-db53e63142b0)
