### PR TITLE
1800-EditingControlFormattedValue-is-differently-implemented

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
+* Resolved [#1800](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1800) `KryptonDataGridViewComboBoxEditingControl.EditingControlFormattedValue` property is differently implemented.
 * Resolved [#66](https://github.com/Krypton-Suite/Standard-Toolkit/issues/66), Cannot Add Ribbon-Buttons-Container (KryptonRibbonGroupTripple) when using .netcore onwards [Returns error due to abstract class]
 * Resolved [#1757](https://github.com/Krypton-Suite/Standard-Toolkit/issues1757), KForm has a thin magenta border after the fix of #1749
 * Implemented [#1765](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1765), Colours for `KryptonRibbon` contexts need sorting out

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxEditingControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxEditingControl.cs
@@ -60,9 +60,16 @@ namespace Krypton.Toolkit
             // will be converted to String.Empty.
 
             get => GetEditingControlFormattedValue(DataGridViewDataErrorContexts.Formatting);
-            set => Text = value is string str && str is not null
-                ? str
-                : string.Empty;
+
+            set
+            {
+                // #1800 correct to the standard of the Winforms counterpart
+                // Text is only set if the cast is correct. null value will also be rejected.
+                if (value is string str)
+                {
+                    Text = str;
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
[1800-EditingControlFormattedValue-is-differently-implemented](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1800)
- Updated
- And the change log.

![compile-results](https://github.com/user-attachments/assets/68d00208-d446-4b27-8119-6a1c19a39944)
