### PR TITLE
1800-V85-EditingControlFormattedValue-is-differently-implemented

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2024-10-14 - Build 2410 (Patch 3) - October 2024
+* Resolved [#1800](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1800) `KryptonDataGridViewComboBoxEditingControl.EditingControlFormattedValue` property is differently implemented.
 * Implement [#1792](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1792), Enable 'SourceLink' for NuGet packages
 * Resolved [#66](https://github.com/Krypton-Suite/Standard-Toolkit/issues/66), Cannot Add Ribbon-Buttons-Container (KryptonRibbonGroupTripple) when using .netcore onwards [Returns error due to abstract class]
 * Resolved [#297](https://github.com/Krypton-Suite/Standard-Toolkit/issues/297), Office 2k7 colour usages are wrong

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxEditingControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxEditingControl.cs
@@ -54,7 +54,16 @@ namespace Krypton.Toolkit
         public virtual object? EditingControlFormattedValue
         {
             get => GetEditingControlFormattedValue(DataGridViewDataErrorContexts.Formatting);
-            set => Text = (string)value;
+
+            set
+            {
+                // #1800 correct to the standard of the Winforms counterpart
+                // Text is only set if the cast is correct. null value will also be rejected.
+                if (value is string str)
+                {
+                    Text = str;
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
[1800-EditingControlFormattedValue-is-differently-implemented](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1800)
- Updated
- And the change log.

![compile-results](https://github.com/user-attachments/assets/3d3b6727-e060-46f8-b6e8-4d8aa6f6038c)
