### PR TITLE
1804-Remove-warning-from-CommonHelper.cs

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/General/CommonHelper.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/CommonHelper.cs
@@ -1447,7 +1447,7 @@ namespace Krypton.Toolkit
         /// <returns>Reference to new instance.</returns>
         public static object CreateInstance(Type itemType, IDesignerHost? host)
         {
-            object retObj;
+            object? retObj;
 
             // Cannot use the designer host to create component unless the type implements IComponent
             if (typeof(IComponent).IsAssignableFrom(itemType) && (host != null))


### PR DESCRIPTION
[1804-Remove-warning-from-CommonHelper.cs](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1804)
Warning removed

![compile-results](https://github.com/user-attachments/assets/965aa2cf-6bf0-4e7f-af57-67a9bfb8c276)
