### PR TITLE
Correct Testform csproj.

### DIFF
--- a/Source/Krypton Components/TestForm/TestForm.csproj
+++ b/Source/Krypton Components/TestForm/TestForm.csproj
@@ -41,9 +41,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Reference Include="Krypton.Toolkit">
-		  <HintPath>..\Krypton.Toolkit\obj\Debug\net462\Krypton.Toolkit.dll</HintPath>
-		</Reference>
 		<Reference Include="System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="$(TargetFramework.StartsWith('net4'))">
 			<SpecificVersion>True</SpecificVersion>
 			<Version>4.0.0.0</Version>


### PR DESCRIPTION
No ticket since this is only for TestForm
Removes the hintpath reference.