### PR TITLE
1787-Office-2k10-2k7-Silver-Dark-Mode-Ribbon-hovered-button-text-is-h…

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2024-11-xx - Build 2411 - November 2024
+* Resolved [#1787](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1787) Office2007 en 2010 Silver Darkmode themes ribbon buttton tracking colors adjusted.
 * Resolved [#1800](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1800) `KryptonDataGridViewComboBoxEditingControl.EditingControlFormattedValue` property is differently implemented.
 * Resolved [#66](https://github.com/Krypton-Suite/Standard-Toolkit/issues/66), Cannot Add Ribbon-Buttons-Container (KryptonRibbonGroupTripple) when using .netcore onwards [Returns error due to abstract class]
 * Resolved [#1757](https://github.com/Krypton-Suite/Standard-Toolkit/issues1757), KForm has a thin magenta border after the fix of #1749

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverDarkMode.cs
@@ -612,25 +612,25 @@ namespace Krypton.Toolkit
         private static readonly Color[] _buttonBorderColors =
         [
             Color.FromArgb(212, 212, 212), // Button, Disabled, Border
-                                                                Color.FromArgb(163, 179, 220), // Button, Tracking, Border 1
-                                                                Color.FromArgb(128, 141, 173), // Button, Tracking, Border 2
-                                                                Color.FromArgb(90, 99, 122), // Button, Pressed, Border 1
-                                                                Color.FromArgb(118, 130, 160), // Button, Pressed, Border 2
-                                                                Color.FromArgb(136, 150, 185), // Button, Checked, Border 1
-                                                                Color.FromArgb(174, 192, 236)  // Button, Checked, Border 2
+            Color.FromArgb(163, 179, 220), // Button, Tracking, Border 1
+            Color.FromArgb(128, 141, 173), // Button, Tracking, Border 2
+            Color.FromArgb(90, 99, 122), // Button, Pressed, Border 1
+            Color.FromArgb(118, 130, 160), // Button, Pressed, Border 2
+            Color.FromArgb(136, 150, 185), // Button, Checked, Border 1
+            Color.FromArgb(174, 192, 236)  // Button, Checked, Border 2
         ];
         private static readonly Color[] _buttonBackColors =
         [
             Color.FromArgb(221, 221, 221), // Button, Disabled, Back 1
-                                                                Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
-                                                                Color.FromArgb(54,64,88), // Button, Tracking, Back 1
-                                                                Color.FromArgb(106,123,164), // Button, Tracking, Back 2
-                                                                Color.FromArgb(95, 107, 137), // Button, Pressed, Back 1
-                                                                Color.FromArgb(54,64,88), // Button, Pressed, Back 2
-                                                                Color.FromArgb(54,64,88), // Button, Checked, Back 1
-                                                                Color.FromArgb(122, 137, 174), // Button, Checked, Back 2
-                                                                Color.FromArgb(119, 134, 172), // Button, Checked Tracking, Back 1
-                                                                Color.FromArgb(135, 148, 182)  // Button, Checked Tracking, Back 2
+            Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
+            Color.FromArgb(142,156,187), // Button, Tracking, Back 1
+            Color.FromArgb(106,123,164), // Button, Tracking, Back 2
+            Color.FromArgb(95, 107, 137), // Button, Pressed, Back 1
+            Color.FromArgb(54,64,88), // Button, Pressed, Back 2
+            Color.FromArgb(54,64,88), // Button, Checked, Back 1
+            Color.FromArgb(122, 137, 174), // Button, Checked, Back 2
+            Color.FromArgb(119, 134, 172), // Button, Checked Tracking, Back 1
+            Color.FromArgb(135, 148, 182)  // Button, Checked Tracking, Back 2
         ];
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverDarkMode.cs
@@ -630,25 +630,25 @@ namespace Krypton.Toolkit
         private static readonly Color[] _buttonBorderColors =
         [
             Color.FromArgb(212, 212, 212), // Button, Disabled, Border
-                                                                Color.FromArgb(163, 179, 220), // Button, Tracking, Border 1
-                                                                Color.FromArgb(128, 141, 173), // Button, Tracking, Border 2
-                                                                Color.FromArgb(90, 99, 122), // Button, Pressed, Border 1
-                                                                Color.FromArgb(118, 130, 160), // Button, Pressed, Border 2
-                                                                Color.FromArgb(136, 150, 185), // Button, Checked, Border 1
-                                                                Color.FromArgb(174, 192, 236)  // Button, Checked, Border 2
+            Color.FromArgb(163, 179, 220), // Button, Tracking, Border 1
+            Color.FromArgb(128, 141, 173), // Button, Tracking, Border 2
+            Color.FromArgb(90, 99, 122), // Button, Pressed, Border 1
+            Color.FromArgb(118, 130, 160), // Button, Pressed, Border 2
+            Color.FromArgb(136, 150, 185), // Button, Checked, Border 1
+            Color.FromArgb(174, 192, 236)  // Button, Checked, Border 2
         ];
         private static readonly Color[] _buttonBackColors =
         [
             Color.FromArgb(221, 221, 221), // Button, Disabled, Back 1
-                                                                Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
-                                                                Color.FromArgb(54,64,88), // Button, Tracking, Back 1
-                                                                Color.FromArgb(106,123,164), // Button, Tracking, Back 2
-                                                                Color.FromArgb(73, 84, 113), // Button, Pressed, Back 1
-                                                                Color.FromArgb(54,64,88), // Button, Pressed, Back 2
-                                                                Color.FromArgb(54,64,88), // Button, Checked, Back 1
-                                                                Color.FromArgb(122, 137, 174), // Button, Checked, Back 2
-                                                                Color.FromArgb(119, 134, 172), // Button, Checked Tracking, Back 1
-                                                                Color.FromArgb(135, 148, 182)  // Button, Checked Tracking, Back 2
+            Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
+            Color.FromArgb(142,156,187), // Button, Tracking, Back 1
+            Color.FromArgb(106,123,164), // Button, Tracking, Back 2
+            Color.FromArgb(73, 84, 113), // Button, Pressed, Back 1
+            Color.FromArgb(54,64,88), // Button, Pressed, Back 2
+            Color.FromArgb(54,64,88), // Button, Checked, Back 1
+            Color.FromArgb(122, 137, 174), // Button, Checked, Back 2
+            Color.FromArgb(119, 134, 172), // Button, Checked Tracking, Back 1
+            Color.FromArgb(135, 148, 182)  // Button, Checked Tracking, Back 2
         ];
 
         #endregion


### PR DESCRIPTION
[Issue 1787-Office-2k10-2k7-Silver-Dark-Mode-Ribbon-hovered-button-text-is-hard-to-read](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1787)
- Tracking colours adjusted.
- And the change log


![compile-results](https://github.com/user-attachments/assets/87bc0a58-9914-43ed-8c0d-edbbf5479988)
