### PR TITLE
1399 ribbon tab text o2k10 colours not correct

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -8,8 +8,12 @@
 
 =======
 
-## 2024-11-12 - Build 2411 - November 2024
+## 2025-01-12 - Build 2501 - January 2025
 * Resolved [#1399](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1399), Hard coded colour setting removed from the `KryptonRibbonTab`.
+
+=======
+
+## 2024-11-12 - Build 2411 - November 2024
 * Resolved [#1787](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1787), Office 2007 & 2010 Silver Darkmode themes ribbon button tracking colors adjusted.
 * Resolved [#1800](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1800), `KryptonDataGridViewComboBoxEditingControl.EditingControlFormattedValue` property is differently implemented.
 * Resolved [#66](https://github.com/Krypton-Suite/Standard-Toolkit/issues/66), Cannot Add Ribbon-Buttons-Container (KryptonRibbonGroupTripple) when using .NETCore onwards [Returns error due to abstract class]

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -9,6 +9,7 @@
 =======
 
 ## 2024-11-12 - Build 2411 - November 2024
+* Resolved [#1399](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1399), Hard coded colour setting removed from the `KryptonRibbonTab`.
 * Resolved [#1787](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1787), Office 2007 & 2010 Silver Darkmode themes ribbon button tracking colors adjusted.
 * Resolved [#1800](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1800), `KryptonDataGridViewComboBoxEditingControl.EditingControlFormattedValue` property is differently implemented.
 * Resolved [#66](https://github.com/Krypton-Suite/Standard-Toolkit/issues/66), Cannot Add Ribbon-Buttons-Container (KryptonRibbonGroupTripple) when using .NETCore onwards [Returns error due to abstract class]

--- a/Source/Krypton Components/Krypton.Ribbon/Palette/PaletteRibbonContextDouble.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Palette/PaletteRibbonContextDouble.cs
@@ -181,22 +181,25 @@ namespace Krypton.Ribbon
         /// <returns>Color value.</returns>
         public Color GetRibbonTextColor(PaletteState state)
         {
-            Color retColor = _inherit.GetRibbonTextColor(state);
+            return _inherit.GetRibbonTextColor(state);
 
-            // If empty then try and recover the context specific color
-            if (retColor == Color.Empty)
-            {
-                retColor = CheckForContextColor();
-            }
-            else if ((state == PaletteState.Normal) && LightBackground)
-            {
-                // With a light background we force the color to be dark in normal state so it stands out
-                return Color.FromArgb(Math.Min(retColor.R, (byte)60),
-                                      Math.Min(retColor.G, (byte)60),
-                                      Math.Min(retColor.B, (byte)60));
-            }
+            // #1399 Disable this override on the theme color arrays and accepting the normal return color
+            // The approach below goes outside of the theme color array and causes problems.
 
-            return retColor;
+            //// If empty then try and recover the context specific color
+            //if (retColor == Color.Empty)
+            //{
+            //    retColor = CheckForContextColor();
+            //}
+            //else if ((state == PaletteState.Normal) && LightBackground)
+            //{
+            //    // With a light background we force the color to be dark in normal state so it stands out
+            //    return Color.FromArgb(Math.Min(retColor.R, (byte)60),
+            //                          Math.Min(retColor.G, (byte)60),
+            //                          Math.Min(retColor.B, (byte)60));
+            //}
+
+            //return retColor;
         }
         #endregion
 


### PR DESCRIPTION
[Issue 1399-ribbon-tab-text-O2k10-colours-not-correct](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1399)
- Disable override on GetRibbonTextColor
- And the change log

![compile-results](https://github.com/user-attachments/assets/9b93a028-d25c-4364-a40c-5f1224eacc1d)
