### PR TITLE
1842-Setting-KryptonTextBox-Multiline-to-true-shrinks-the-control

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2025-11-xx - Build 2511 - November 2025
+* Resolved [#1842](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1842), `KryptonTextBox` height colapses when the MultiLine property is enabled.
 * Implemented [#1184](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1184), A proper `SplashScreen` item
 * Implemented [#1236](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1236), Backport `StockIconId` feature
 * Support for .NET 10

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,7 +3,7 @@
 =======
 
 ## 2025-11-xx - Build 2511 - November 2025
-* Resolved [#1842](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1842), `KryptonTextBox` height colapses when the MultiLine property is enabled.
+* Resolved [#1842](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1842), `KryptonTextBox` height collapses when the MultiLine property is enabled.
 * Implemented [#1184](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1184), A proper `SplashScreen` item
 * Implemented [#1236](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1236), Backport `StockIconId` feature
 * Support for .NET 10

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
@@ -1840,7 +1840,18 @@ namespace Krypton.Toolkit
             if (!ignoreAnchored || ((Anchor & (AnchorStyles.Bottom | AnchorStyles.Top)) != (AnchorStyles.Bottom | AnchorStyles.Top)))
             {
                 // If auto sizing the control and not in multiline mode then override the height
-                Height = _autoSize && !Multiline ? PreferredHeight : _cachedHeight;
+                //Height = _autoSize && !Multiline ? PreferredHeight : _cachedHeight;
+
+                // #1842 when autosize == true and MultiLine == true and the _cachedHeight == -1 which is the initial value
+                // the box collapses. Only when _cachedHeight > -1 it will be assigned. Otherwise Height is left alone.
+                if (_autoSize && !Multiline)
+                {
+                    Height = PreferredHeight;
+                }
+                else if (_cachedHeight > -1)
+                {
+                    Height = _cachedHeight;
+                }
             }
         }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
@@ -1840,8 +1840,6 @@ namespace Krypton.Toolkit
             if (!ignoreAnchored || ((Anchor & (AnchorStyles.Bottom | AnchorStyles.Top)) != (AnchorStyles.Bottom | AnchorStyles.Top)))
             {
                 // If auto sizing the control and not in multiline mode then override the height
-                //Height = _autoSize && !Multiline ? PreferredHeight : _cachedHeight;
-
                 // #1842 when autosize == true and MultiLine == true and the _cachedHeight == -1 which is the initial value
                 // the box collapses. Only when _cachedHeight > -1 it will be assigned. Otherwise Height is left alone.
                 if (_autoSize && !Multiline)


### PR DESCRIPTION
[Issue 1842-Setting-KryptonTextBox-Multiline-to-true-shrinks-the-control](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1842)
- Fixes the height problem on enabling MultiLine
- And the change log

![compile-results](https://github.com/user-attachments/assets/a42aff07-fe3b-45b1-809b-b4cc792b1498)
