### PR TITLE
1842-V95-Setting-KryptonTextBox-Multiline-to-true-shrinks-the-control

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,7 +3,7 @@
 =======
 
 ## 2025-02-01 - Build 2502 (Version 90 - Patch 1) - February 2025
-* Resolved [#1842](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1842), `KryptonTextBox` height colapses when MultiLine is enabled.
+* Resolved [#1842](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1842), `KryptonTextBox` height collapses when MultiLine is enabled.
 
 =======
 

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -2,6 +2,11 @@
 
 =======
 
+## 2025-02-01 - Build 2502 (Version 90 - Patch 1) - February 2025
+* Resolved [#1842](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1842), `KryptonTextBox` height colapses when MultiLine is enabled.
+
+=======
+
 ## 2024-11-12 - Build 2411 - November 2024
 * Resolved [#1820](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1820), When KryptonDataGridView.AutoGenerate is set Winforms columns are used. See the issue for full text.
 * Resolved [#1787](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1787), Office 2007 & 2010 Silver Darkmode themes ribbon buttton tracking colors adjusted.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
@@ -1840,7 +1840,16 @@ namespace Krypton.Toolkit
             if (!ignoreAnchored || ((Anchor & (AnchorStyles.Bottom | AnchorStyles.Top)) != (AnchorStyles.Bottom | AnchorStyles.Top)))
             {
                 // If auto sizing the control and not in multiline mode then override the height
-                Height = _autoSize && !Multiline ? PreferredHeight : _cachedHeight;
+                // #1842 when autosize == true and MultiLine == true and the _cachedHeight == -1 which is the initial value
+                // the box collapses. Only when _cachedHeight > -1 it will be assigned. Otherwise Height is left alone.
+                if (_autoSize && !Multiline)
+                {
+                    Height = PreferredHeight;
+                }
+                else if (_cachedHeight > -1)
+                {
+                    Height = _cachedHeight;
+                }
             }
         }
 


### PR DESCRIPTION
[Issue 1842-Setting-KryptonTextBox-Multiline-to-true-shrinks-the-control](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1842)
- Fixes the height problem on enabling MultiLine
- And the change log

![compile-results](https://github.com/user-attachments/assets/05273c95-8673-444e-8dca-64eb17ecdbf8)
