### PR TITLE
1842-V85-Setting-KryptonTextBox-Multiline-to-true-shrinks-the-control

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -2,6 +2,11 @@
 
 =======
 
+# 2025-02-01 - Build 2502 (Patch 5) - Fefruary 2025
+* Resolved [#1842](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1842), `KryptonTextBox` height collapses when MultiLine is enabled.
+
+=======
+
 # 2024-11-14 - Build 2411 (Patch 4) - November 2024
 * Resolved [#1837](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1837), `KryptonMessageBoxDefaultButton.Button2` doesn't work
 * Resolved [#1820](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1820), When KryptonDataGridView.AutoGenerate is set WinForms columns are used. See the issue for full text.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
@@ -1854,7 +1854,16 @@ namespace Krypton.Toolkit
             if (!ignoreAnchored || ((Anchor & (AnchorStyles.Bottom | AnchorStyles.Top)) != (AnchorStyles.Bottom | AnchorStyles.Top)))
             {
                 // If auto sizing the control and not in multiline mode then override the height
-                Height = _autoSize && !Multiline ? PreferredHeight : _cachedHeight;
+                // #1842 when autosize == true and MultiLine == true and the _cachedHeight == -1 which is the initial value
+                // the box collapses. Only when _cachedHeight > -1 it will be assigned. Otherwise Height is left alone.
+                if (_autoSize && !Multiline)
+                {
+                    Height = PreferredHeight;
+                }
+                else if (_cachedHeight > -1)
+                {
+                    Height = _cachedHeight;
+                }
             }
         }
 


### PR DESCRIPTION
[Issue 1842-Setting-KryptonTextBox-Multiline-to-true-shrinks-the-control](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1842)
- Fixes the height problem on enabling MultiLine
- And the change log

![compile-results](https://github.com/user-attachments/assets/ceb778d5-1644-4850-bc30-7ed0b28e2d60)
