### PR TITLE
1241-KryptonDataGridViewComboBoxColumn-Ignores-ValueMember-in-Binding

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -5,6 +5,7 @@
 ## 2025-02-01 - Build 2502 (Version 90 - Patch 1) - February 2025
 * Resolved [#1807](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1807), ChromeBorderWidth and Padding
 * Resolved [#1842](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1842), `KryptonTextBox` height collapses when MultiLine is enabled.
+* Resolved [#1241](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1241), `KryptonDataGridViewComboBoxColumn` ignores `ValueMember` in data binding. 
 
 =======
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxEditingControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxEditingControl.cs
@@ -118,7 +118,26 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Returns the current value of the editing control.
         /// </summary>
-        public virtual object GetEditingControlFormattedValue(DataGridViewDataErrorContexts context) => Text!;
+        public virtual object GetEditingControlFormattedValue(DataGridViewDataErrorContexts context)
+        {
+            if (SelectedIndex > -1)
+            {
+                if (SelectedValue is not null
+                    && ValueMember is not null
+                    && ValueMember.Length > 0)
+                {
+                    return SelectedValue.ToString() ?? string.Empty;
+                }
+
+                if (SelectedItem is not null)
+                {
+                    return SelectedItem.ToString() ?? string.Empty;
+                }
+            }
+
+            // For all other cases, return an empty string
+            return string.Empty;
+        }
 
         /// <summary>
         /// Called by the grid to give the editing control a chance to prepare itself for the editing session.


### PR DESCRIPTION
[Issue 1241-KryptonDataGridViewComboBoxColumn-Ignores-ValueMember-in-Binding](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1241)
- Resolves the returned text when ValueMember is set
- And the change log

![compile-results](https://github.com/user-attachments/assets/4e23eb91-fa94-4543-bb38-94bde5241d8c)
