### PR TITLE
1840-remove-dn9-warnings

### DIFF
--- a/Source/.editorconfig
+++ b/Source/.editorconfig
@@ -78,7 +78,7 @@ csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimenta
 csharp_style_prefer_switch_expression = true:suggestion
 csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
 csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
-dotnet_diagnostic.WFO1000.severity = suggestion
+dotnet_diagnostic.WFO1000.severity = Warning
 
 
 [*.{cs,vb}]


### PR DESCRIPTION
[Issue 1840-remove-dn9-warnings](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1840)
- Set WFO1000 from suggestion to warning
- No change log provided.

![compile-results](https://github.com/user-attachments/assets/3558fe00-ba63-4066-93f2-df5869d5471d)
