### PR TITLE
1862-V100-visualpanel-throws-null-exception

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2025-11-xx - Build 2511 - November 2025
+* Resolved [#1862](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1862) `VisualPanel.PaintTransparentBackground()` throws a null reference exception
 * Resolved [#1842](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1842), `KryptonTextBox` height collapses when the MultiLine property is enabled.
 * Implemented [#1184](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1184), A proper `SplashScreen` item
 * Implemented [#1236](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1236), Backport `StockIconId` feature

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPanel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPanel.cs
@@ -1100,14 +1100,16 @@ namespace Krypton.Toolkit
             if ((parent is not null) && NeedTransparentPaint)
             {
                 // Only grab the required reference once
-                if (_miPTB.Equals(null) /*== null*/)
+                if (_miPTB is null)
                 {
                     // Use reflection so we can call the Windows Forms internal method for painting parent background
-                    _miPTB = typeof(Control).GetMethod(nameof(PaintTransparentBackground),
-                                                       BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.InvokeMethod,
-                                                       null, CallingConventions.HasThis,
-                                                       [typeof(PaintEventArgs), typeof(Rectangle), typeof(Region)],
-                                                       null)!;
+                    _miPTB = typeof(Control).GetMethod(
+                        nameof(PaintTransparentBackground),
+                        BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.InvokeMethod,
+                        null,
+                        CallingConventions.HasThis,
+                        [typeof(PaintEventArgs), typeof(Rectangle), typeof(Region)],
+                        null)!;
                 }
 
                 _miPTB.Invoke(this, [e!, ClientRectangle, null!]);


### PR DESCRIPTION
[Issue 1862-visualform-throws-null-exception](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1862)
- Normal null check restored
- And the change log

![compile-results](https://github.com/user-attachments/assets/5236f3f6-1585-4f43-a553-201efdbccc11)
