### PR TITLE
1862-V95-visualpanel-throws-null-exception

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2025-02-01 - Build 2502 (Version 90 - Patch 1) - February 2025
+* Resolved [#1862](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1862) `VisualPanel.PaintTransparentBackground()` throws a null reference exception
 * Resolved [#1399](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1399), Hard coded colour setting removed from the `KryptonRibbonTab`.
 * Resolved [#1837](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1837), `KryptonMessageBoxDefaultButton.Button2` doesn't work
 * Resolved [#1807](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1807), ChromeBorderWidth and Padding

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPanel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPanel.cs
@@ -1095,14 +1095,16 @@ namespace Krypton.Toolkit
             if ((parent is not null) && NeedTransparentPaint)
             {
                 // Only grab the required reference once
-                if (_miPTB.Equals(null) /*== null*/)
+                if (_miPTB is null)
                 {
                     // Use reflection so we can call the Windows Forms internal method for painting parent background
-                    _miPTB = typeof(Control).GetMethod(nameof(PaintTransparentBackground),
-                                                       BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.InvokeMethod,
-                                                       null, CallingConventions.HasThis,
-                                                       [typeof(PaintEventArgs), typeof(Rectangle), typeof(Region)],
-                                                       null)!;
+                    _miPTB = typeof(Control).GetMethod(
+                        nameof(PaintTransparentBackground),
+                        BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.InvokeMethod,
+                        null, 
+                        CallingConventions.HasThis,
+                        [typeof(PaintEventArgs), typeof(Rectangle), typeof(Region)],
+                        null)!;
                 }
 
                 _miPTB.Invoke(this, [e!, ClientRectangle, null!]);


### PR DESCRIPTION
[Issue 1862-visualform-throws-null-exception](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1862)
- Normal null check restored
- And the change log

![compile-results](https://github.com/user-attachments/assets/cf5a7354-8bd4-4663-8034-7c08f384110f)
