### PR TITLE
1843-navigator-tab-buttonspec-image-cut-off

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2025-11-xx - Build 2511 - November 2025
+* Resolved [#1843](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1843), `ButtonSpec` position is off due to an incorrect padding when style is set to "List Item".
 * Resolved [#1842](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1842), `KryptonTextBox` height collapses when the MultiLine property is enabled.
 * Implemented [#1184](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1184), A proper `SplashScreen` item
 * Implemented [#1236](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1236), Backport `StockIconId` feature

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Bases/PaletteMicrosoft365Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Bases/PaletteMicrosoft365Base.cs
@@ -39,7 +39,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, 0, 0, 0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkMode.cs
@@ -640,7 +640,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, 0, 0, 0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkModeAlternate.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkModeAlternate.cs
@@ -641,7 +641,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, 0, 0, 0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueDarkMode.cs
@@ -630,7 +630,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, 0, 0, 0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueLightMode.cs
@@ -642,7 +642,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, 0, 0, 0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverDarkMode.cs
@@ -630,7 +630,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, 0, 0, 0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverLightMode.cs
@@ -634,7 +634,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, 0, 0, 0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Bases/PaletteOffice2007Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Bases/PaletteOffice2007Base.cs
@@ -39,7 +39,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, 0, 0, 0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlackDarkMode.cs
@@ -657,7 +657,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, 0, 0, 0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueDarkMode.cs
@@ -502,7 +502,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, 0, 0, 0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueLightMode.cs
@@ -504,7 +504,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, 0, 0, 0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverDarkMode.cs
@@ -477,7 +477,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, 0, 0, 0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverLightMode.cs
@@ -477,7 +477,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, 0, 0, 0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Bases/PaletteOffice2010Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Bases/PaletteOffice2010Base.cs
@@ -38,7 +38,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, 0, 0, 0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlackDarkMode.cs
@@ -849,7 +849,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, 0, 0, 0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueDarkMode.cs
@@ -495,7 +495,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, 0, 0, 0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueLightMode.cs
@@ -507,7 +507,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, 0, 0, 0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverDarkMode.cs
@@ -497,7 +497,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, 0, 0, 0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverLightMode.cs
@@ -501,7 +501,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, 0, 0, 0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Official Themes/PaletteOffice2010Black.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Official Themes/PaletteOffice2010Black.cs
@@ -522,7 +522,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, 0, 0, 0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Bases/PaletteOffice2013Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Bases/PaletteOffice2013Base.cs
@@ -38,7 +38,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, 0, 0, 0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013White.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013White.cs
@@ -489,7 +489,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, 0, 0, 0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/Base/PaletteSparkleBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/Base/PaletteSparkleBase.cs
@@ -38,7 +38,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(3, 0, 3, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, 0, 0, 0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/Extra Themes/PaletteSparkleBlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/Extra Themes/PaletteSparkleBlueDarkMode.cs
@@ -413,7 +413,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(3, 0, 3, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, 0, 0, 0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/PaletteVisualStudioBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/PaletteVisualStudioBase.cs
@@ -37,7 +37,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, 0, 0, 0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2007/PaletteVisualStudio2010With2007Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2007/PaletteVisualStudio2010With2007Base.cs
@@ -34,7 +34,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, 0, 0, 0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2010/PaletteVisualStudio2010With2010Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2010/PaletteVisualStudio2010With2010Base.cs
@@ -34,7 +34,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, 0, 0, 0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2013/PaletteVisualStudio2010With2013Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2013/PaletteVisualStudio2010With2013Base.cs
@@ -34,7 +34,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, 0, 0, 0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/365/PaletteVisualStudio2010With365Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/365/PaletteVisualStudio2010With365Base.cs
@@ -34,7 +34,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, 0, 0, 0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);


### PR DESCRIPTION
[Issue 1843-navigator-tab-buttonspec-image-cut-off](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1843)
- Listim item button paddding changed
- And the  change log

![compile-results](https://github.com/user-attachments/assets/ef9f1db7-ba3d-4894-b810-cde6065dccc3)
