### PR TITLE
1840-remove-dn9-warnings

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Editors/PaletteDrawBordersEditor.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Editors/PaletteDrawBordersEditor.cs
@@ -47,7 +47,7 @@ namespace Krypton.Toolkit
                 if (provider.GetService(typeof(IWindowsFormsEditorService)) is IWindowsFormsEditorService service)
                 {
                     // Create the custom control used to edit value
-                    var selector = new PaletteDrawBordersSelector
+                    PaletteDrawBordersSelector selector = new PaletteDrawBordersSelector
                     {
                         // Populate selector with starting value
                         Value = (PaletteDrawBorders)value

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Other/OverrideComboBoxStyleDropDownStyle.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Other/OverrideComboBoxStyleDropDownStyle.cs
@@ -31,7 +31,7 @@ namespace Krypton.Toolkit
         {
             if (provider?.GetService(typeof(IWindowsFormsEditorService)) is IWindowsFormsEditorService svc)
             {
-                var ctrl = new UserControl();
+                UserControl ctrl = new();
                 ListBox clb = new ListBox { Dock = DockStyle.Fill };
                 
                 if (clb is not null && value is not null)


### PR DESCRIPTION
[Issue 1840-remove-dn9-warnings](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1840)
- Changes to nullability annotations
- https://learn.microsoft.com/en-us/dotnet/core/compatibility/windows-forms/9.0/nullability-changes
- No change log provided.

![compile-results](https://github.com/user-attachments/assets/d7a3e751-1990-4dbc-8e8b-9688c3ae74c3)
