### PR TITLE
- Fix Borders: all over the places...

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,8 @@
 =======
 
 ## 2025-02-01 - Build 2502 (Version 90 - Patch 1) - February 2025
+* Resolved [#1877](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1843), HeaderGroups are 'clipped' after upgrade to 90.24.11.317
+* Resolved [#1783](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1843), KForm borders incorrect
 * Resolved [#1807](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1807), ChromeBorderWidth and Padding
 * Resolved [#1842](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1842), `KryptonTextBox` height collapses when MultiLine is enabled.
 

--- a/Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln.DotSettings
+++ b/Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln.DotSettings
@@ -31,6 +31,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Dockable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Dockspace/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Floatspace/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Giduac/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Horz/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ke/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=keytip/@EntryIndexedValue">True</s:Boolean>

--- a/Source/Krypton Components/Krypton.Navigator/Dragging/DropSolidWindow.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Dragging/DropSolidWindow.cs
@@ -40,8 +40,8 @@ namespace Krypton.Navigator
             MaximizeBox = false;
             MinimizeBox = false;
             ShowInTaskbar = false;
-            BackColor = Color.Magenta;
-            TransparencyKey = Color.Magenta;
+            BackColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+            TransparencyKey = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
             Opacity = _paletteDragDrop.GetDragDropSolidOpacity();
         }
 

--- a/Source/Krypton Components/Krypton.Navigator/Palette/PaletteBarRedirect.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Palette/PaletteBarRedirect.cs
@@ -333,13 +333,15 @@ namespace Krypton.Navigator
         #endregion
 
         #region IPaletteMetric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             // Is this the metric we provide?
             switch (metric)
@@ -371,7 +373,7 @@ namespace Krypton.Navigator
             }
 
             // Pass onto the inheritance
-            return _redirect!.GetMetricInt(state, metric);
+            return _redirect!.GetMetricInt(owningForm, state, metric);
         }
 
         /// <summary>
@@ -387,10 +389,11 @@ namespace Krypton.Navigator
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state, PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -427,7 +430,7 @@ namespace Krypton.Navigator
             }
 
             // Pass onto the inheritance
-            return _redirect!.GetMetricPadding(state, metric);
+            return _redirect!.GetMetricPadding(owningForm, state, metric);
         }
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Navigator/Palette/PaletteNavContent.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Palette/PaletteNavContent.cs
@@ -129,7 +129,7 @@ namespace Krypton.Navigator
             LongText.TextV = GetContentLongTextV(state);
             LongText.MultiLineH = GetContentLongTextMultiLineH(state);
             LongText.MultiLine = GetContentLongTextMultiLine(state);
-            Padding = GetContentPadding(state);
+            Padding = GetBorderContentPadding(null, state);
             AdjacentGap = GetContentAdjacentGap(state);
         }
         #endregion
@@ -666,12 +666,13 @@ namespace Krypton.Navigator
         /// <summary>
         /// Gets the actual padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public Padding GetContentPadding(PaletteState state)
+        public Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteState state)
         {
             // Initialize the padding from inherited values
-            Padding paddingInherit = _inherit!.GetContentPadding(state);
+            Padding paddingInherit = _inherit!.GetBorderContentPadding(owningForm, state);
             Padding paddingThis = Padding;
 
             // Override with specified values

--- a/Source/Krypton Components/Krypton.Navigator/Palette/PaletteNavigatorRedirect.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Palette/PaletteNavigatorRedirect.cs
@@ -43,7 +43,7 @@ namespace Krypton.Navigator
         }
 
         /// <summary>
-        /// Initialize a new instance of the PaletteNavigatorNormabled class.
+        /// Initialize a new instance of the PaletteNavigatorRedirect class.
         /// </summary>
         /// <param name="navigator">Reference to owning navigator.</param>
         /// <param name="redirectNavigator">inheritance redirection for navigator level.</param>
@@ -352,48 +352,43 @@ namespace Krypton.Navigator
         #endregion
 
         #region IPaletteMetric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
-            switch (metric)
+            if (metric == PaletteMetricInt.PageButtonInset 
+                && Metrics.PageButtonSpecInset != -1)
             {
-                case PaletteMetricInt.PageButtonInset:
-                    if (Metrics.PageButtonSpecInset != -1)
-                    {
-                        return Metrics.PageButtonSpecInset;
-                    }
-                    break;
+                return Metrics.PageButtonSpecInset;
             }
 
             // Pass onto the inheritance
-            return base.GetMetricInt(state, metric);
+            return base.GetMetricInt(owningForm, state, metric);
         }
 
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state, PaletteMetricPadding metric)
         {
-            switch (metric)
+            if (metric == PaletteMetricPadding.PageButtonPadding 
+                && !Metrics.PageButtonSpecPadding.Equals(CommonHelper.InheritPadding))
             {
-                case PaletteMetricPadding.PageButtonPadding:
-                    if (!Metrics.PageButtonSpecPadding.Equals(CommonHelper.InheritPadding))
-                    {
-                        return Metrics.PageButtonSpecPadding;
-                    }
-                    break;
+                return Metrics.PageButtonSpecPadding;
             }
 
             // Pass onto the inheritance
-            return base.GetMetricPadding(state, metric);
+            return base.GetMetricPadding(owningForm, state, metric);
         }
         #endregion
 

--- a/Source/Krypton Components/Krypton.Navigator/Palette/PaletteRedirectRibbonTabContent.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Palette/PaletteRedirectRibbonTabContent.cs
@@ -287,7 +287,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentDraw(state) ?? Target!.GetContentDraw(style, state);
+            return inherit?.GetContentDraw(state) 
+                   ?? Target!.GetContentDraw(style, state);
         }
 
         /// <summary>
@@ -300,7 +301,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentDrawFocus(state) ?? Target!.GetContentDrawFocus(style, state);
+            return inherit?.GetContentDrawFocus(state) 
+                   ?? Target!.GetContentDrawFocus(style, state);
         }
 
         /// <summary>
@@ -313,7 +315,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentImageH(state) ?? Target!.GetContentImageH(style, state);
+            return inherit?.GetContentImageH(state) 
+                   ?? Target!.GetContentImageH(style, state);
         }
 
         /// <summary>
@@ -326,7 +329,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentImageV(state) ?? Target!.GetContentImageV(style, state);
+            return inherit?.GetContentImageV(state) 
+                   ?? Target!.GetContentImageV(style, state);
         }
 
         /// <summary>
@@ -339,7 +343,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentImageEffect(state) ?? Target!.GetContentImageEffect(style, state);
+            return inherit?.GetContentImageEffect(state) 
+                   ?? Target!.GetContentImageEffect(style, state);
         }
 
         /// <summary>
@@ -352,7 +357,9 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentShortTextFont(state) ?? Target!.GetContentShortTextFont(style, state) ?? throw new NullReferenceException("The result of GetContentShortTextFont() cannot be null.");
+            return inherit?.GetContentShortTextFont(state) 
+                   ?? Target?.GetContentShortTextFont(style, state) 
+                   ?? throw new NullReferenceException("The result of GetContentShortTextFont() cannot be null.");
         }
 
         /// <summary>
@@ -365,7 +372,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentShortTextHint(state) ?? Target!.GetContentShortTextHint(style, state);
+            return inherit?.GetContentShortTextHint(state) 
+                   ?? Target!.GetContentShortTextHint(style, state);
         }
 
         /// <summary>
@@ -378,7 +386,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentShortTextPrefix(state) ?? Target!.GetContentShortTextPrefix(style, state);
+            return inherit?.GetContentShortTextPrefix(state) 
+                   ?? Target!.GetContentShortTextPrefix(style, state);
         }
 
         /// <summary>
@@ -391,7 +400,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentShortTextMultiLine(state) ?? Target!.GetContentShortTextMultiLine(style, state);
+            return inherit?.GetContentShortTextMultiLine(state) 
+                   ?? Target!.GetContentShortTextMultiLine(style, state);
         }
 
         /// <summary>
@@ -404,7 +414,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentShortTextTrim(state) ?? Target!.GetContentShortTextTrim(style, state);
+            return inherit?.GetContentShortTextTrim(state) 
+                   ?? Target!.GetContentShortTextTrim(style, state);
         }
 
         /// <summary>
@@ -417,7 +428,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentShortTextH(state) ?? Target!.GetContentShortTextH(style, state);
+            return inherit?.GetContentShortTextH(state) 
+                   ?? Target!.GetContentShortTextH(style, state);
         }
 
         /// <summary>
@@ -430,7 +442,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentShortTextV(state) ?? Target!.GetContentShortTextV(style, state);
+            return inherit?.GetContentShortTextV(state) 
+                   ?? Target!.GetContentShortTextV(style, state);
         }
 
         /// <summary>
@@ -443,7 +456,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentShortTextMultiLineH(state) ?? Target!.GetContentShortTextMultiLineH(style, state);
+            return inherit?.GetContentShortTextMultiLineH(state) 
+                   ?? Target!.GetContentShortTextMultiLineH(style, state);
         }
 
         /// <summary>
@@ -456,7 +470,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentShortTextColor1(state) ?? Target!.GetContentShortTextColor1(style, state);
+            return inherit?.GetContentShortTextColor1(state) 
+                   ?? Target!.GetContentShortTextColor1(style, state);
         }
 
         /// <summary>
@@ -469,7 +484,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentShortTextColor2(state) ?? Target!.GetContentShortTextColor2(style, state);
+            return inherit?.GetContentShortTextColor2(state) 
+                   ?? Target!.GetContentShortTextColor2(style, state);
         }
 
         /// <summary>
@@ -482,7 +498,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentShortTextColorStyle(state) ?? Target!.GetContentShortTextColorStyle(style, state);
+            return inherit?.GetContentShortTextColorStyle(state) 
+                   ?? Target!.GetContentShortTextColorStyle(style, state);
         }
 
         /// <summary>
@@ -495,7 +512,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentShortTextColorAlign(state) ?? Target!.GetContentShortTextColorAlign(style, state);
+            return inherit?.GetContentShortTextColorAlign(state) 
+                   ?? Target!.GetContentShortTextColorAlign(style, state);
         }
 
         /// <summary>
@@ -508,7 +526,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentShortTextColorAngle(state) ?? Target!.GetContentShortTextColorAngle(style, state);
+            return inherit?.GetContentShortTextColorAngle(state) 
+                   ?? Target!.GetContentShortTextColorAngle(style, state);
         }
 
         /// <summary>
@@ -521,7 +540,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentShortTextImage(state) ?? Target!.GetContentShortTextImage(style, state);
+            return inherit?.GetContentShortTextImage(state) 
+                   ?? Target!.GetContentShortTextImage(style, state);
         }
 
         /// <summary>
@@ -534,7 +554,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentShortTextImageStyle(state) ?? Target!.GetContentShortTextImageStyle(style, state);
+            return inherit?.GetContentShortTextImageStyle(state) 
+                   ?? Target!.GetContentShortTextImageStyle(style, state);
         }
 
         /// <summary>
@@ -547,7 +568,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentShortTextImageAlign(state) ?? Target!.GetContentShortTextImageAlign(style, state);
+            return inherit?.GetContentShortTextImageAlign(state) 
+                   ?? Target!.GetContentShortTextImageAlign(style, state);
         }
 
         /// <summary>
@@ -560,7 +582,9 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentLongTextFont(state) ?? Target!.GetContentLongTextFont(style, state) ?? throw new NullReferenceException("The result of GetContentLongTextFont() cannot be null.");
+            return inherit?.GetContentLongTextFont(state) 
+                   ?? Target?.GetContentLongTextFont(style, state) 
+                   ?? throw new NullReferenceException("The result of GetContentLongTextFont() cannot be null.");
         }
 
         /// <summary>
@@ -573,7 +597,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentLongTextHint(state) ?? Target!.GetContentLongTextHint(style, state);
+            return inherit?.GetContentLongTextHint(state) 
+                   ?? Target!.GetContentLongTextHint(style, state);
         }
 
         /// <summary>
@@ -586,7 +611,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentLongTextMultiLine(state) ?? Target!.GetContentLongTextMultiLine(style, state);
+            return inherit?.GetContentLongTextMultiLine(state) 
+                   ?? Target!.GetContentLongTextMultiLine(style, state);
         }
 
         /// <summary>
@@ -599,7 +625,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentLongTextTrim(state) ?? Target!.GetContentLongTextTrim(style, state);
+            return inherit?.GetContentLongTextTrim(state) 
+                   ?? Target!.GetContentLongTextTrim(style, state);
         }
 
         /// <summary>
@@ -612,7 +639,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentLongTextPrefix(state) ?? Target!.GetContentLongTextPrefix(style, state);
+            return inherit?.GetContentLongTextPrefix(state) 
+                   ?? Target!.GetContentLongTextPrefix(style, state);
         }
 
         /// <summary>
@@ -625,7 +653,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentLongTextH(state) ?? Target!.GetContentLongTextH(style, state);
+            return inherit?.GetContentLongTextH(state) 
+                   ?? Target!.GetContentLongTextH(style, state);
         }
 
         /// <summary>
@@ -638,7 +667,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentLongTextV(state) ?? Target!.GetContentLongTextV(style, state);
+            return inherit?.GetContentLongTextV(state) 
+                   ?? Target!.GetContentLongTextV(style, state);
         }
 
         /// <summary>
@@ -651,7 +681,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentLongTextMultiLineH(state) ?? Target!.GetContentLongTextMultiLineH(style, state);
+            return inherit?.GetContentLongTextMultiLineH(state) 
+                   ?? Target!.GetContentLongTextMultiLineH(style, state);
         }
 
         /// <summary>
@@ -664,7 +695,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentLongTextColor1(state) ?? Target!.GetContentLongTextColor1(style, state);
+            return inherit?.GetContentLongTextColor1(state) 
+                   ?? Target!.GetContentLongTextColor1(style, state);
         }
 
         /// <summary>
@@ -677,7 +709,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentLongTextColor2(state) ?? Target!.GetContentLongTextColor2(style, state);
+            return inherit?.GetContentLongTextColor2(state) 
+                   ?? Target!.GetContentLongTextColor2(style, state);
         }
 
         /// <summary>
@@ -690,7 +723,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentLongTextColorStyle(state) ?? Target!.GetContentLongTextColorStyle(style, state);
+            return inherit?.GetContentLongTextColorStyle(state) 
+                   ?? Target!.GetContentLongTextColorStyle(style, state);
         }
 
         /// <summary>
@@ -703,7 +737,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentLongTextColorAlign(state) ?? Target!.GetContentLongTextColorAlign(style, state);
+            return inherit?.GetContentLongTextColorAlign(state) 
+                   ?? Target!.GetContentLongTextColorAlign(style, state);
         }
 
         /// <summary>
@@ -716,7 +751,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentLongTextImage(state) ?? Target!.GetContentLongTextImage(style, state);
+            return inherit?.GetContentLongTextImage(state) 
+                   ?? Target!.GetContentLongTextImage(style, state);
         }
 
         /// <summary>
@@ -729,7 +765,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentLongTextImageStyle(state) ?? Target!.GetContentLongTextImageStyle(style, state);
+            return inherit?.GetContentLongTextImageStyle(state) 
+                   ?? Target!.GetContentLongTextImageStyle(style, state);
         }
 
         /// <summary>
@@ -742,20 +779,23 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentLongTextImageAlign(state) ?? Target!.GetContentLongTextImageAlign(style, state);
+            return inherit?.GetContentLongTextImageAlign(state) 
+                   ?? Target!.GetContentLongTextImageAlign(style, state);
         }
 
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style, PaletteState state)
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentPadding(state) ?? Target!.GetContentPadding(style, state);
+            return inherit?.GetBorderContentPadding(owningForm, state) 
+                   ?? Target!.GetBorderContentPadding(owningForm, style, state);
         }
 
         /// <summary>
@@ -768,7 +808,8 @@ namespace Krypton.Navigator
         {
             IPaletteContent? inherit = GetContentInherit(state);
 
-            return inherit?.GetContentAdjacentGap(state) ?? Target!.GetContentAdjacentGap(style, state);
+            return inherit?.GetContentAdjacentGap(state) 
+                   ?? Target!.GetContentAdjacentGap(style, state);
         }
         #endregion
 

--- a/Source/Krypton Components/Krypton.Navigator/Palette/PaletteRibbonTabContentInheritOverride.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Palette/PaletteRibbonTabContentInheritOverride.cs
@@ -1229,24 +1229,25 @@ namespace Krypton.Navigator
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public virtual Padding GetContentPadding(PaletteState state)
+        public virtual Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteState state)
         {
             if (Apply)
             {
-                Padding ret = _primaryContent.GetContentPadding(Override ? OverrideState : state);
+                Padding ret = _primaryContent.GetBorderContentPadding(owningForm, Override ? OverrideState : state);
 
                 if (ret.All == -1)
                 {
-                    ret = _backupContent.GetContentPadding(state);
+                    ret = _backupContent.GetBorderContentPadding(owningForm, state);
                 }
 
                 return ret;
             }
             else
             {
-                return _backupContent.GetContentPadding(state);
+                return _backupContent.GetBorderContentPadding(owningForm, state);
             }
         }
 

--- a/Source/Krypton Components/Krypton.Navigator/Palette/RibbonTabToContent.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Palette/RibbonTabToContent.cs
@@ -347,9 +347,10 @@ namespace Krypton.Navigator
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public Padding GetContentPadding(PaletteState state) => PaletteContent!.GetContentPadding(state);
+        public Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteState state) => PaletteContent!.GetBorderContentPadding(owningForm, state);
 
         /// <summary>
         /// Gets the padding between adjacent content items.

--- a/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderOutlookBase.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderOutlookBase.cs
@@ -2121,8 +2121,8 @@ namespace Krypton.Navigator
                 addRemoveButtons.Items.Add(addRemoveButtonItems);
 
                 // Setup the transparent color for the images
-                moreButtons.ImageTransparentColor = Color.Magenta;
-                fewerButtons.ImageTransparentColor = Color.Magenta;
+                moreButtons.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                fewerButtons.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
 
                 // Decide if the more/fewer buttons should be enabled/disabled
                 moreButtons.Enabled = AreMoreButtons();

--- a/Source/Krypton Components/Krypton.Navigator/View Layout/ViewLayoutBar.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Layout/ViewLayoutBar.cs
@@ -321,7 +321,7 @@ namespace Krypton.Navigator
             {
                 // Default to no space between each child item
                 // If we have a metric provider then get the child gap to use
-                var gap = _paletteMetric?.GetMetricInt(State, _metricGap) ?? context.Renderer.RenderTabBorder.GetTabBorderSpacingGap(TabBorderStyle);
+                var gap = _paletteMetric?.GetMetricInt(null, State, _metricGap) ?? context.Renderer.RenderTabBorder.GetTabBorderSpacingGap(TabBorderStyle);
 
                 // Line spacing gap can never be less than zero
                 var lineGap = (gap < 0 ? 0 : gap);
@@ -852,7 +852,7 @@ namespace Krypton.Navigator
             {
                 // Default to no space between each child item
                 // If we have a metric provider then get the child gap to use
-                var gap = _paletteMetric?.GetMetricInt(State, _metricGap) ?? context.Renderer.RenderTabBorder.GetTabBorderSpacingGap(TabBorderStyle);
+                var gap = _paletteMetric?.GetMetricInt(null, State, _metricGap) ?? context.Renderer.RenderTabBorder.GetTabBorderSpacingGap(TabBorderStyle);
 
                 // Line spacing gap can never be less than zero
                 var lineGap = (gap < 0 ? 0 : gap);

--- a/Source/Krypton Components/Krypton.Ribbon/Controls Visuals/KeyTipControl.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controls Visuals/KeyTipControl.cs
@@ -44,7 +44,7 @@ namespace Krypton.Ribbon
             StartPosition = FormStartPosition.Manual;
             FormBorderStyle = FormBorderStyle.None;
             ShowInTaskbar = false;
-            TransparencyKey = Color.Magenta;
+            TransparencyKey = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
 #pragma warning disable CS0618 // Type or member is obsolete
             UseDropShadow = false;
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/Source/Krypton Components/Krypton.Ribbon/Designers/Designers/KryptonRibbonGroupClusterDesigner.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Designers/Designers/KryptonRibbonGroupClusterDesigner.cs
@@ -511,8 +511,8 @@ namespace Krypton.Ribbon
                                                               _deleteClusterMenu });
 
                     // Ensure add images have correct transparent background
-                    _addButtonMenu.ImageTransparentColor = Color.Magenta;
-                    _addColorButtonMenu.ImageTransparentColor = Color.Magenta;
+                    _addButtonMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                    _addColorButtonMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
                 }
 
                 // Update verbs to work out correct enable states

--- a/Source/Krypton Components/Krypton.Ribbon/Designers/Designers/KryptonRibbonGroupDesigner.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Designers/Designers/KryptonRibbonGroupDesigner.cs
@@ -638,10 +638,10 @@ namespace Krypton.Ribbon
                                                               _clearItemsMenu, new ToolStripSeparator(),
                                                               _deleteGroupMenu });
 
-                    _addTripleMenu.ImageTransparentColor = Color.Magenta;
-                    _addLinesMenu.ImageTransparentColor = Color.Magenta;
-                    _addSeparatorMenu.ImageTransparentColor = Color.Magenta;
-                    _addGalleryMenu.ImageTransparentColor = Color.Magenta;
+                    _addTripleMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                    _addLinesMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                    _addSeparatorMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                    _addGalleryMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
                 }
 
                 // Update verbs to work out correct enable states

--- a/Source/Krypton Components/Krypton.Ribbon/Designers/Designers/KryptonRibbonGroupLinesDesigner.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Designers/Designers/KryptonRibbonGroupLinesDesigner.cs
@@ -1187,22 +1187,22 @@ namespace Krypton.Ribbon
                     });
 
                     // Ensure add images have correct transparent background
-                    _addButtonMenu.ImageTransparentColor = Color.Magenta;
-                    _addColorButtonMenu.ImageTransparentColor = Color.Magenta;
-                    _addCheckBoxMenu.ImageTransparentColor = Color.Magenta;
-                    _addRadioButtonMenu.ImageTransparentColor = Color.Magenta;
-                    _addLabelMenu.ImageTransparentColor = Color.Magenta;
-                    _addCustomControlMenu.ImageTransparentColor = Color.Magenta;
-                    _addClusterMenu.ImageTransparentColor = Color.Magenta;
-                    _addTextBoxMenu.ImageTransparentColor = Color.Magenta;
-                    _addMaskedTextBoxMenu.ImageTransparentColor = Color.Magenta;
-                    _addRichTextBoxMenu.ImageTransparentColor = Color.Magenta;
-                    _addComboBoxMenu.ImageTransparentColor = Color.Magenta;
-                    _addNumericUpDownMenu.ImageTransparentColor = Color.Magenta;
-                    _addDomainUpDownMenu.ImageTransparentColor = Color.Magenta;
-                    _addDateTimePickerMenu.ImageTransparentColor = Color.Magenta;
-                    _addTrackBarMenu.ImageTransparentColor = Color.Magenta;
-                    _addThemeComboBoxMenu.ImageTransparentColor = Color.Magenta;
+                    _addButtonMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                    _addColorButtonMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                    _addCheckBoxMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                    _addRadioButtonMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                    _addLabelMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                    _addCustomControlMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                    _addClusterMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                    _addTextBoxMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                    _addMaskedTextBoxMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                    _addRichTextBoxMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                    _addComboBoxMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                    _addNumericUpDownMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                    _addDomainUpDownMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                    _addDateTimePickerMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                    _addTrackBarMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                    _addThemeComboBoxMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
                 }
 
                 // Update verbs to work out correct enable states

--- a/Source/Krypton Components/Krypton.Ribbon/Designers/Designers/KryptonRibbonGroupTripleDesigner.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Designers/Designers/KryptonRibbonGroupTripleDesigner.cs
@@ -1067,21 +1067,21 @@ namespace Krypton.Ribbon
                     });
 
                     // Ensure add images have correct transparent background
-                    _addButtonMenu.ImageTransparentColor = Color.Magenta;
-                    _addColorButtonMenu.ImageTransparentColor = Color.Magenta;
-                    _addCheckBoxMenu.ImageTransparentColor = Color.Magenta;
-                    _addRadioButtonMenu.ImageTransparentColor = Color.Magenta;
-                    _addLabelMenu.ImageTransparentColor = Color.Magenta;
-                    _addCustomControlMenu.ImageTransparentColor = Color.Magenta;
-                    _addTextBoxMenu.ImageTransparentColor = Color.Magenta;
-                    _addMaskedTextBoxMenu.ImageTransparentColor = Color.Magenta;
-                    _addRichTextBoxMenu.ImageTransparentColor = Color.Magenta;
-                    _addComboBoxMenu.ImageTransparentColor = Color.Magenta;
-                    _addNumericUpDownMenu.ImageTransparentColor = Color.Magenta;
-                    _addDomainUpDownMenu.ImageTransparentColor = Color.Magenta;
-                    _addDateTimePickerMenu.ImageTransparentColor = Color.Magenta;
-                    _addTrackBarMenu.ImageTransparentColor = Color.Magenta;
-                    _addThemeComboBoxMenu.ImageTransparentColor = Color.Magenta;
+                    _addButtonMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                    _addColorButtonMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                    _addCheckBoxMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                    _addRadioButtonMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                    _addLabelMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                    _addCustomControlMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                    _addTextBoxMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                    _addMaskedTextBoxMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                    _addRichTextBoxMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                    _addComboBoxMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                    _addNumericUpDownMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                    _addDomainUpDownMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                    _addDateTimePickerMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                    _addTrackBarMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+                    _addThemeComboBoxMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
                 }
 
                 // Update verbs to work out correct enable states

--- a/Source/Krypton Components/Krypton.Ribbon/Designers/Designers/KryptonRibbonTabDesigner.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Designers/Designers/KryptonRibbonTabDesigner.cs
@@ -488,7 +488,7 @@ namespace Krypton.Ribbon
                                                               _clearGroupsMenu, new ToolStripSeparator(),
                                                               _deleteTabMenu });
 
-                    _addGroupMenu.ImageTransparentColor = Color.Magenta;
+                    _addGroupMenu.ImageTransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
                 }
 
                 // Update verbs to work out correct enable states

--- a/Source/Krypton Components/Krypton.Ribbon/Palette/QATButtonToContent.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Palette/QATButtonToContent.cs
@@ -326,9 +326,10 @@ namespace Krypton.Ribbon
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public Padding GetContentPadding(PaletteState state) => Padding.Empty;
+        public Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteState state) => Padding.Empty;
 
         /// <summary>
         /// Gets the padding between adjacent content items.

--- a/Source/Krypton Components/Krypton.Ribbon/Palette/RibbonRecentDocsTitleToContent.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Palette/RibbonRecentDocsTitleToContent.cs
@@ -85,9 +85,10 @@ namespace Krypton.Ribbon
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteState state) => _titlePadding;
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteState state) => _titlePadding;
 
         /// <summary>
         /// Gets the font for the short text.

--- a/Source/Krypton Components/Krypton.Ribbon/Palette/RibbonToContent.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Palette/RibbonToContent.cs
@@ -328,9 +328,10 @@ namespace Krypton.Ribbon
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public virtual Padding GetContentPadding(PaletteState state) => Padding.Empty;
+        public virtual Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteState state) => Padding.Empty;
 
         /// <summary>
         /// Gets the padding between adjacent content items.

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonDesignCluster.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonDesignCluster.cs
@@ -35,7 +35,7 @@ namespace Krypton.Ribbon
             // Use image list to convert background Magenta to transparent
             _imageList = new ImageList
             {
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _imageList.Images.AddRange([
                 GenericImageResources.KryptonRibbonGroupClusterButton,

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonDesignGroupContainer.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonDesignGroupContainer.cs
@@ -35,7 +35,7 @@ namespace Krypton.Ribbon
             // Use image list to convert background Magenta to transparent
             _imageList = new ImageList
             {
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _imageList.Images.AddRange([
                 GenericImageResources.KryptonRibbonGroupTriple,

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonDesignGroupLines.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonDesignGroupLines.cs
@@ -35,7 +35,7 @@ namespace Krypton.Ribbon
             // Use image list to convert background Magenta to transparent
             _imageList = new ImageList
             {
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _imageList.Images.AddRange([
                 GenericImageResources.KryptonRibbonGroupButton,

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonDesignGroupTriple.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonDesignGroupTriple.cs
@@ -38,7 +38,7 @@ namespace Krypton.Ribbon
             // Use image list to convert background Magenta to transparent
             _imageList = new ImageList
             {
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _imageList.Images.AddRange([
                 GenericImageResources.KryptonRibbonGroupButton,

--- a/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonQATExtraButton.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Draw/ViewDrawRibbonQATExtraButton.cs
@@ -20,7 +20,7 @@ namespace Krypton.Ribbon
     internal class ViewDrawRibbonQATExtraButton : ViewLeaf
     {
         // TODO: Needs to be scaled
-        private static readonly Size _contentSize = new Size(-4, -7);
+        private static readonly Size _contentSize = new Size(-2, -5);
 
         #region Instance Fields
         private readonly Size _viewSize; // = new(13, 22);
@@ -153,31 +153,30 @@ namespace Krypton.Ribbon
             Enabled = _ribbon.Enabled;
 
             IPaletteBack paletteBack = _ribbon.StateCommon.RibbonGroupDialogButton.PaletteBack;
-            IPaletteBorder? paletteBorder = _ribbon.StateCommon.RibbonGroupDialogButton.PaletteBorder;
+            IPaletteBorder paletteBorder = _ribbon.StateCommon.RibbonGroupDialogButton.PaletteBorder;
             IPaletteRibbonGeneral paletteGeneral = _ribbon.StateCommon.RibbonGeneral;
 
             // Do we need to draw the background?
             if (paletteBack.GetBackDraw(State) == InheritBool.True)
             {
                 // Get the border path which the background is clipped to drawing within
-                using GraphicsPath borderPath = context.Renderer.RenderStandardBorder.GetBackPath(context, ClientRectangle, paletteBorder!, VisualOrientation.Top, State);
-                Padding borderPadding = context.Renderer.RenderStandardBorder.GetBorderRawPadding(paletteBorder!, State, VisualOrientation.Top);
+                using GraphicsPath borderPath = context.Renderer.RenderStandardBorder.GetBackPath(context, ClientRectangle, paletteBorder, VisualOrientation.Top, State);
+                Padding borderPadding = context.Renderer.RenderStandardBorder.GetBorderRawPadding(paletteBorder, State, VisualOrientation.Top);
 
                 // Apply the padding depending on the orientation
                 Rectangle enclosingRect = CommonHelper.ApplyPadding(VisualOrientation.Top, ClientRectangle, borderPadding);
 
                 // Render the background inside the border path
-                using var gh = new GraphicsHint(context.Graphics, paletteBorder!.GetBorderGraphicsHint(PaletteState.Normal));
+                using var gh = new GraphicsHint(context.Graphics, paletteBorder.GetBorderGraphicsHint(PaletteState.Normal));
                 _mementoBack = context.Renderer.RenderStandardBack.DrawBack(context, enclosingRect, borderPath,
                     paletteBack, VisualOrientation.Top,
                     State, _mementoBack);
             }
 
             // Do we need to draw the border?
-            if (paletteBorder?.GetBorderDraw(State) == InheritBool.True)
+            if (paletteBorder.GetBorderDraw(State) == InheritBool.True)
             {
-                context.Renderer.RenderStandardBorder.DrawBorder(context, ClientRectangle, paletteBorder, 
-                    VisualOrientation.Top, State);
+                context.Renderer.RenderStandardBorder.DrawBorder(context, ClientRectangle, paletteBorder, VisualOrientation.Top, State);
             }
 
             // Find the content area inside the button rectangle

--- a/Source/Krypton Components/Krypton.Toolkit/AccurateText/AccurateText.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/AccurateText/AccurateText.cs
@@ -105,7 +105,7 @@ namespace Krypton.Toolkit
                     break;
 
                 default:
-    // Should never happen!
+                    // Should never happen!
                     Debug.Assert(false);
                     DebugTools.NotImplemented(align.ToString());
                     break;
@@ -139,7 +139,7 @@ namespace Krypton.Toolkit
                     break;
 
                 default:
-    // Should never happen!
+                    // Should never happen!
                     Debug.Assert(false);
                     DebugTools.NotImplemented(trim.ToString());
                     break;
@@ -161,7 +161,7 @@ namespace Krypton.Toolkit
                     break;
 
                 default:
-    // Should never happen!
+                    // Should never happen!
                     Debug.Assert(false);
                     DebugTools.NotImplemented(prefix.ToString());
                     break;
@@ -193,7 +193,7 @@ namespace Krypton.Toolkit
 
                     return new AccurateTextMemento(text, font, textSize, format, hint, disposeFont);
                 };
-                //);
+            //);
             // Return a memento with drawing details
             return memento.Invoke();
         }
@@ -289,8 +289,7 @@ namespace Krypton.Toolkit
 
                     try
                     {
-
-                                g.DrawString(memento.Text, memento.Font!, brush, rect, memento.Format);
+                        g.DrawString(memento.Text, memento.Font!, brush, rect, memento.Format);
                     }
                     catch
                     {

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/SeparatorController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/SeparatorController.cs
@@ -94,7 +94,7 @@ namespace Krypton.Toolkit
                 MinimizeBox = false;
                 ShowInTaskbar = false;
                 BackColor = Color.Black;
-                TransparencyKey = Color.Magenta;
+                TransparencyKey = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
                 Opacity = 0.5;
             }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -411,7 +411,7 @@ namespace Krypton.Toolkit
                                     // Draw text using font defined by the control
                                     var rectangle = new Rectangle(rect.left, rect.top, rect.right - rect.left,
                                         rect.bottom - rect.top);
-                                    rectangle = CommonHelper.ApplyPadding(VisualOrientation.Top, rectangle, states.Content.GetContentPadding(state));
+                                    rectangle = CommonHelper.ApplyPadding(VisualOrientation.Top, rectangle, states.Content.GetBorderContentPadding(null, state));
                                     // Find correct text color
                                     Color textColor = states.Content.GetContentShortTextColor1(state);
                                     Font? contentShortTextFont = states.Content.GetContentShortTextFont(state);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
@@ -1114,11 +1114,13 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
-        => GetPaletteContent(style, state).GetContentPadding(state);
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
+        => GetPaletteContent(style, state).GetBorderContentPadding(owningForm, state);
 
         /// <summary>
         /// Gets the padding between adjacent content items.
@@ -1131,25 +1133,28 @@ namespace Krypton.Toolkit
         #endregion
 
         #region PaletteBase Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric) => metric switch
+        /// <inheritdoc />
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric) => metric switch
         {
-            PaletteMetricInt.BarButtonEdgeInside or PaletteMetricInt.BarButtonEdgeOutside or PaletteMetricInt.CheckButtonGap or PaletteMetricInt.RibbonTabGap => Navigator.StateCommon.Bar.GetMetricInt(state, metric),
-            PaletteMetricInt.HeaderButtonEdgeInsetPrimary => HeaderStyles.HeaderPrimary.StateCommon.GetMetricInt(state, metric),
-            PaletteMetricInt.HeaderButtonEdgeInsetSecondary => HeaderStyles.HeaderSecondary.StateCommon.GetMetricInt(state, metric),
-            PaletteMetricInt.HeaderButtonEdgeInsetDockInactive => HeaderStyles.HeaderDockInactive.StateCommon.GetMetricInt(state, metric),
-            PaletteMetricInt.HeaderButtonEdgeInsetDockActive => HeaderStyles.HeaderDockActive.StateCommon.GetMetricInt(state, metric),
-            PaletteMetricInt.HeaderButtonEdgeInsetForm => HeaderStyles.HeaderForm.StateCommon.GetMetricInt(state, metric),
-            PaletteMetricInt.HeaderButtonEdgeInsetCustom1 => HeaderStyles.HeaderCustom1.StateCommon.GetMetricInt(state, metric),
-            PaletteMetricInt.HeaderButtonEdgeInsetCustom2 => HeaderStyles.HeaderCustom2.StateCommon.GetMetricInt(state, metric),
-            PaletteMetricInt.HeaderButtonEdgeInsetCustom3 => HeaderStyles.HeaderCustom3.StateCommon.GetMetricInt(state, metric),
+            PaletteMetricInt.BarButtonEdgeInside or PaletteMetricInt.BarButtonEdgeOutside or PaletteMetricInt.CheckButtonGap or PaletteMetricInt.RibbonTabGap => Navigator.StateCommon.Bar.GetMetricInt(owningForm, state, metric),
+            PaletteMetricInt.HeaderButtonEdgeInsetPrimary => HeaderStyles.HeaderPrimary.StateCommon.GetMetricInt(owningForm, state, metric),
+            PaletteMetricInt.HeaderButtonEdgeInsetSecondary => HeaderStyles.HeaderSecondary.StateCommon.GetMetricInt(owningForm, state, metric),
+            PaletteMetricInt.HeaderButtonEdgeInsetDockInactive => HeaderStyles.HeaderDockInactive.StateCommon.GetMetricInt(owningForm, state, metric),
+            PaletteMetricInt.HeaderButtonEdgeInsetDockActive => HeaderStyles.HeaderDockActive.StateCommon.GetMetricInt(owningForm, state, metric),
+            PaletteMetricInt.HeaderButtonEdgeInsetForm => HeaderStyles.HeaderForm.StateCommon.GetMetricInt(owningForm, state, metric),
+            PaletteMetricInt.HeaderButtonEdgeInsetCustom1 => HeaderStyles.HeaderCustom1.StateCommon.GetMetricInt(owningForm, state, metric),
+            PaletteMetricInt.HeaderButtonEdgeInsetCustom2 => HeaderStyles.HeaderCustom2.StateCommon.GetMetricInt(owningForm, state, metric),
+            PaletteMetricInt.HeaderButtonEdgeInsetCustom3 => HeaderStyles.HeaderCustom3.StateCommon.GetMetricInt(owningForm, state, metric),
             // Otherwise use base instance for the value instead
-            _ => _redirector.GetMetricInt(state, metric)
+            _ => _redirector.GetMetricInt(owningForm, state, metric)
         };
 
         /// <summary>
@@ -1172,10 +1177,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -1184,39 +1191,39 @@ namespace Krypton.Toolkit
                 case PaletteMetricPadding.BarPaddingOutside:
                 case PaletteMetricPadding.BarPaddingOnly:
                 case PaletteMetricPadding.BarButtonPadding:
-                    return Navigator.StateCommon.Bar.GetMetricPadding(state, metric);
+                    return Navigator.StateCommon.Bar.GetMetricPadding(owningForm, state, metric);
                 case PaletteMetricPadding.HeaderGroupPaddingPrimary:
                 case PaletteMetricPadding.HeaderGroupPaddingSecondary:
                 case PaletteMetricPadding.HeaderGroupPaddingDockInactive:
                 case PaletteMetricPadding.HeaderGroupPaddingDockActive:
-                    return HeaderGroup.StateCommon.GetMetricPadding(state, metric);
+                    return HeaderGroup.StateCommon.GetMetricPadding(owningForm, state, metric);
                 case PaletteMetricPadding.HeaderButtonPaddingPrimary:
-                    return HeaderStyles.HeaderPrimary.StateCommon.GetMetricPadding(state, metric);
+                    return HeaderStyles.HeaderPrimary.StateCommon.GetMetricPadding(owningForm, state, metric);
                 case PaletteMetricPadding.HeaderButtonPaddingSecondary:
-                    return HeaderStyles.HeaderSecondary.StateCommon.GetMetricPadding(state, metric);
+                    return HeaderStyles.HeaderSecondary.StateCommon.GetMetricPadding(owningForm, state, metric);
                 case PaletteMetricPadding.HeaderButtonPaddingDockInactive:
-                    return HeaderStyles.HeaderDockInactive.StateCommon.GetMetricPadding(state, metric);
+                    return HeaderStyles.HeaderDockInactive.StateCommon.GetMetricPadding(owningForm, state, metric);
                 case PaletteMetricPadding.HeaderButtonPaddingDockActive:
-                    return HeaderStyles.HeaderDockActive.StateCommon.GetMetricPadding(state, metric);
+                    return HeaderStyles.HeaderDockActive.StateCommon.GetMetricPadding(owningForm, state, metric);
                 case PaletteMetricPadding.HeaderButtonPaddingForm:
-                    return HeaderStyles.HeaderForm.StateCommon.GetMetricPadding(state, metric);
+                    return HeaderStyles.HeaderForm.StateCommon.GetMetricPadding(owningForm, state, metric);
                 case PaletteMetricPadding.HeaderButtonPaddingCustom1:
-                    return HeaderStyles.HeaderCustom1.StateCommon.GetMetricPadding(state, metric);
+                    return HeaderStyles.HeaderCustom1.StateCommon.GetMetricPadding(owningForm, state, metric);
                 case PaletteMetricPadding.HeaderButtonPaddingCustom2:
-                    return HeaderStyles.HeaderCustom2.StateCommon.GetMetricPadding(state, metric);
+                    return HeaderStyles.HeaderCustom2.StateCommon.GetMetricPadding(owningForm, state, metric);
                 case PaletteMetricPadding.HeaderButtonPaddingCustom3:
-                    return HeaderStyles.HeaderCustom3.StateCommon.GetMetricPadding(state, metric);
+                    return HeaderStyles.HeaderCustom3.StateCommon.GetMetricPadding(owningForm, state, metric);
                 case PaletteMetricPadding.SeparatorPaddingLowProfile:
                     switch (state)
                     {
                         case PaletteState.Disabled:
-                            return SeparatorStyles.SeparatorLowProfile.StateDisabled.GetMetricPadding(state, metric);
+                            return SeparatorStyles.SeparatorLowProfile.StateDisabled.GetMetricPadding(owningForm, state, metric);
                         case PaletteState.Normal:
-                            return SeparatorStyles.SeparatorLowProfile.StateNormal.GetMetricPadding(state, metric);
+                            return SeparatorStyles.SeparatorLowProfile.StateNormal.GetMetricPadding(owningForm, state, metric);
                         case PaletteState.Tracking:
-                            return SeparatorStyles.SeparatorLowProfile.StateTracking.GetMetricPadding(state, metric);
+                            return SeparatorStyles.SeparatorLowProfile.StateTracking.GetMetricPadding(owningForm, state, metric);
                         case PaletteState.Pressed:
-                            return SeparatorStyles.SeparatorLowProfile.StatePressed.GetMetricPadding(state, metric);
+                            return SeparatorStyles.SeparatorLowProfile.StatePressed.GetMetricPadding(owningForm, state, metric);
                     }
                     break;
                 case PaletteMetricPadding.SeparatorPaddingHighProfile:
@@ -1224,58 +1231,58 @@ namespace Krypton.Toolkit
                     switch (state)
                     {
                         case PaletteState.Disabled:
-                            return SeparatorStyles.SeparatorHighProfile.StateDisabled.GetMetricPadding(state, metric);
+                            return SeparatorStyles.SeparatorHighProfile.StateDisabled.GetMetricPadding(owningForm, state, metric);
                         case PaletteState.Normal:
-                            return SeparatorStyles.SeparatorHighProfile.StateNormal.GetMetricPadding(state, metric);
+                            return SeparatorStyles.SeparatorHighProfile.StateNormal.GetMetricPadding(owningForm, state, metric);
                         case PaletteState.Tracking:
-                            return SeparatorStyles.SeparatorHighProfile.StateTracking.GetMetricPadding(state, metric);
+                            return SeparatorStyles.SeparatorHighProfile.StateTracking.GetMetricPadding(owningForm, state, metric);
                         case PaletteState.Pressed:
-                            return SeparatorStyles.SeparatorHighProfile.StatePressed.GetMetricPadding(state, metric);
+                            return SeparatorStyles.SeparatorHighProfile.StatePressed.GetMetricPadding(owningForm, state, metric);
                     }
                     break;
                 case PaletteMetricPadding.SeparatorPaddingCustom1:
                     switch (state)
                     {
                         case PaletteState.Disabled:
-                            return SeparatorStyles.SeparatorCustom1.StateDisabled.GetMetricPadding(state, metric);
+                            return SeparatorStyles.SeparatorCustom1.StateDisabled.GetMetricPadding(owningForm, state, metric);
                         case PaletteState.Normal:
-                            return SeparatorStyles.SeparatorCustom1.StateNormal.GetMetricPadding(state, metric);
+                            return SeparatorStyles.SeparatorCustom1.StateNormal.GetMetricPadding(owningForm, state, metric);
                         case PaletteState.Tracking:
-                            return SeparatorStyles.SeparatorCustom1.StateTracking.GetMetricPadding(state, metric);
+                            return SeparatorStyles.SeparatorCustom1.StateTracking.GetMetricPadding(owningForm, state, metric);
                         case PaletteState.Pressed:
-                            return SeparatorStyles.SeparatorCustom1.StatePressed.GetMetricPadding(state, metric);
+                            return SeparatorStyles.SeparatorCustom1.StatePressed.GetMetricPadding(owningForm, state, metric);
                     }
                     break;
                 case PaletteMetricPadding.SeparatorPaddingCustom2:
                     switch (state)
                     {
                         case PaletteState.Disabled:
-                            return SeparatorStyles.SeparatorCustom2.StateDisabled.GetMetricPadding(state, metric);
+                            return SeparatorStyles.SeparatorCustom2.StateDisabled.GetMetricPadding(owningForm, state, metric);
                         case PaletteState.Normal:
-                            return SeparatorStyles.SeparatorCustom2.StateNormal.GetMetricPadding(state, metric);
+                            return SeparatorStyles.SeparatorCustom2.StateNormal.GetMetricPadding(owningForm, state, metric);
                         case PaletteState.Tracking:
-                            return SeparatorStyles.SeparatorCustom2.StateTracking.GetMetricPadding(state, metric);
+                            return SeparatorStyles.SeparatorCustom2.StateTracking.GetMetricPadding(owningForm, state, metric);
                         case PaletteState.Pressed:
-                            return SeparatorStyles.SeparatorCustom2.StatePressed.GetMetricPadding(state, metric);
+                            return SeparatorStyles.SeparatorCustom2.StatePressed.GetMetricPadding(owningForm, state, metric);
                     }
                     break;
                 case PaletteMetricPadding.SeparatorPaddingCustom3:
                     switch (state)
                     {
                         case PaletteState.Disabled:
-                            return SeparatorStyles.SeparatorCustom3.StateDisabled.GetMetricPadding(state, metric);
+                            return SeparatorStyles.SeparatorCustom3.StateDisabled.GetMetricPadding(owningForm, state, metric);
                         case PaletteState.Normal:
-                            return SeparatorStyles.SeparatorCustom3.StateNormal.GetMetricPadding(state, metric);
+                            return SeparatorStyles.SeparatorCustom3.StateNormal.GetMetricPadding(owningForm, state, metric);
                         case PaletteState.Tracking:
-                            return SeparatorStyles.SeparatorCustom3.StateTracking.GetMetricPadding(state, metric);
+                            return SeparatorStyles.SeparatorCustom3.StateTracking.GetMetricPadding(owningForm, state, metric);
                         case PaletteState.Pressed:
-                            return SeparatorStyles.SeparatorCustom3.StatePressed.GetMetricPadding(state, metric);
+                            return SeparatorStyles.SeparatorCustom3.StatePressed.GetMetricPadding(owningForm, state, metric);
                     }
                     break;
             }
 
             // Otherwise use base instance for the value instead
-            return _redirector.GetMetricPadding(state, metric);
+            return _redirector.GetMetricPadding(owningForm, state, metric);
         }
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -1943,7 +1943,7 @@ namespace Krypton.Toolkit
                 _columnPadding = StateCommon.HeaderColumn.Content.Padding;
                 if (_columnPadding.Equals(CommonHelper.InheritPadding))
                 {
-                    _columnPadding = StateCommon.HeaderColumn.Content.GetContentPadding(state);
+                    _columnPadding = StateCommon.HeaderColumn.Content.GetBorderContentPadding(null, state);
                 }
 
                 ColumnHeadersDefaultCellStyle.Padding = _columnPadding;
@@ -1954,7 +1954,7 @@ namespace Krypton.Toolkit
                 _rowPadding = StateCommon.HeaderRow.Content.Padding;
                 if (_rowPadding.Equals(CommonHelper.InheritPadding))
                 {
-                    _rowPadding = StateCommon.HeaderRow.Content.GetContentPadding(state);
+                    _rowPadding = StateCommon.HeaderRow.Content.GetBorderContentPadding(null, state);
                 }
 
                 RowHeadersDefaultCellStyle.Padding = _rowPadding;
@@ -1965,7 +1965,7 @@ namespace Krypton.Toolkit
                 _dataCellPadding = StateCommon.DataCell.Content.Padding;
                 if (_dataCellPadding.Equals(CommonHelper.InheritPadding))
                 {
-                    _dataCellPadding = StateCommon.DataCell.Content.GetContentPadding(state);
+                    _dataCellPadding = StateCommon.DataCell.Content.GetBorderContentPadding(null, state);
                 }
 
                 DefaultCellStyle.Padding = _dataCellPadding;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -13,6 +13,8 @@
 // ReSharper disable InconsistentNaming
 
 // ReSharper disable UnusedMember.Global
+using SolidBrush = System.Drawing.SolidBrush;
+
 namespace Krypton.Toolkit
 {
     /// <summary>
@@ -132,7 +134,7 @@ namespace Krypton.Toolkit
             buttonSpecsFixed.AddRange([ButtonSpecMin, ButtonSpecMax, ButtonSpecClose]);
 
             // Create the palette storage
-            StateCommon = new PaletteFormRedirect(Redirector, NeedPaintDelegate);
+            StateCommon = new PaletteFormRedirect(Redirector, NeedPaintDelegate, this);
             StateInactive = new PaletteForm(StateCommon, StateCommon.Header, NeedPaintDelegate);
             StateActive = new PaletteForm(StateCommon, StateCommon.Header, NeedPaintDelegate);
 
@@ -180,7 +182,7 @@ namespace Krypton.Toolkit
                 [PaletteMetricInt.HeaderButtonEdgeInsetForm],
                 [PaletteMetricPadding.HeaderButtonPaddingForm],
                                                        CreateToolStripRenderer,
-                                                       OnButtonManagerNeedPaint!);
+                                                       OnNeedPaint);
 
             // Create the manager for handling tooltips
             ToolTipManager = new ToolTipManager(new ToolTipValues(null)); // use default, as each button "could" have different values ??!!??
@@ -201,7 +203,7 @@ namespace Krypton.Toolkit
 #pragma warning disable CS0618
             _useDropShadow = false;
 #pragma warning restore CS0618
-            TransparencyKey = Color.Magenta; // Bug #1749
+            TransparencyKey = GlobalStaticValues.TRANSPARENCY_KEY_COLOR; // Bug #1749
         }
 
         /// <summary>
@@ -633,7 +635,15 @@ namespace Krypton.Toolkit
         [Category(@"Appearance")]
         [DefaultValue(KryptonFormTitleStyle.Inherit),
          Description(@"Arranges the current window title alignment.")]
-        public KryptonFormTitleStyle TitleStyle { get => _titleStyle; set { _titleStyle = value; UpdateTitleStyle(value); } }
+        public KryptonFormTitleStyle TitleStyle
+        {
+            get => _titleStyle;
+            set
+            {
+                _titleStyle = value;
+                UpdateTitleStyle(value);
+            }
+        }
 
         #endregion
 
@@ -769,7 +779,7 @@ namespace Krypton.Toolkit
         /// Create the redirector instance.
         /// </summary>
         /// <returns>PaletteRedirect derived class.</returns>
-        protected override PaletteRedirect CreateRedirector() => new FormPaletteRedirect(GetResolvedPalette(), this);
+        protected override PaletteRedirect CreateRedirector() => new FormPaletteRedirect(GetResolvedPalette()!, this);
 
         internal class FormPaletteRedirect : PaletteRedirect
         {
@@ -1329,8 +1339,20 @@ namespace Krypton.Toolkit
                         || (GetDefinedIcon() != _cacheIcon)
                         )
                     {
+                        Rectangle realWindowRectangle = RealWindowRectangle;
                         // Ask the view to perform a layout
-                        using (var context = new ViewLayoutContext(ViewManager, this, RealWindowRectangle, Renderer))
+                        if (GetWindowState() == FormWindowState.Maximized)
+                        {
+                            if (MdiParent == null)
+                            {
+                                // Get the size of each window border
+                                var xBorder = PI.GetSystemMetrics(PI.SM_.CXSIZEFRAME) * 2;
+                                // Reduce the Bounds by the padding on all but the top
+                                realWindowRectangle.Width -= xBorder;
+                            }
+                        }
+
+                        using (var context = new ViewLayoutContext(ViewManager, this, realWindowRectangle, Renderer))
                         {
                             ViewManager.Layout(context);
                         }
@@ -1388,9 +1410,22 @@ namespace Krypton.Toolkit
                         UpdateRegionForMaximized();
                     }
                 }
-                else
+                else if (MdiParent != null)
+                {
+                    using var backBrush = new SolidBrush(MdiParent.ActiveMdiChild == MdiParent
+                        ? StateActive.Border.Color1
+                        : StateInactive.Border.Color1);
+                    g.FillRectangle(backBrush, rect); // Bug #????
+                }
+                else if (TransparencyKey == GlobalStaticValues.TRANSPARENCY_KEY_COLOR)
                 {
                     g.FillRectangle(Brushes.Magenta, rect); // Bug #1749
+                }
+                else
+                {
+                    // TODO: Use a cached brush !
+                    using var backBrush = new SolidBrush(TransparencyKey);
+                    g.FillRectangle(backBrush, rect); // Bug #1749
                 }
 
                 // We draw the main form and header background
@@ -1407,11 +1442,14 @@ namespace Krypton.Toolkit
             if (MdiParent == null)
             {
                 // Get the size of each window border
+                var xBorder = PI.GetSystemMetrics(PI.SM_.CXSIZEFRAME) * 2;
+                var yBorder = PI.GetSystemMetrics(PI.SM_.CYSIZEFRAME) * 2;
+
                 Padding padding = RealWindowBorders;
 
                 // Reduce the Bounds by the padding on all but the top
-                var maximizedRect = new Rectangle(padding.Left, padding.Left, Width - padding.Horizontal,
-                    Height - padding.Left - padding.Bottom);
+                var maximizedRect = new Rectangle(xBorder, yBorder, Width - (xBorder * 2),
+                    Height - (yBorder * 2));
 
                 // Use this as the new region
                 SuspendPaint();
@@ -1575,34 +1613,6 @@ namespace Krypton.Toolkit
 
             // Not showing a popup page anymore
             _visualPopupToolTip = null;
-        }
-
-        private void OnButtonManagerNeedPaint(object sender, NeedLayoutEventArgs e)
-        {
-            // Only interested in optimizing specific button spec changes
-            if (sender is ButtonSpecView bsView)
-            {
-                ButtonSpec bs = bsView.ButtonSpec;
-
-                // Only interest in the three form level buttons, as we know 
-                // these never change in size because of a paint request
-                if ((bs == ButtonSpecMin) ||
-                    (bs == ButtonSpecMax) ||
-                    (bs == ButtonSpecClose))
-                {
-                    // Translate the button rectangle into the non client area
-                    Rectangle buttonRect = bsView.ViewButton.ClientRectangle;
-                    Padding borders = RealWindowBorders;
-                    buttonRect.X -= borders.Left;
-                    buttonRect.Y -= borders.Top;
-
-                    // Only invalidate the actual button area itself
-                    OnNeedPaint(sender, new NeedLayoutEventArgs(false, buttonRect));
-                    return;
-                }
-            }
-
-            OnNeedPaint(sender, e);
         }
 
         private void OnStatusDockChanged(object? sender, EventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs
@@ -1559,7 +1559,7 @@ namespace Krypton.Toolkit
             if (!IsDisposed && !Disposing)
             {
                 // Update with latest content padding for placing around the contained text box control
-                Padding contentPadding = GetTripleState().PaletteContent!.GetContentPadding(_drawDockerOuter.State);
+                Padding contentPadding = GetTripleState().PaletteContent!.GetBorderContentPadding(null, _drawDockerOuter.State);
                 _layoutFill.DisplayPadding = contentPadding;
             }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
@@ -1930,7 +1930,7 @@ namespace Krypton.Toolkit
             if (!IsDisposed && !Disposing)
             {
                 // Update with latest content padding for placing around the contained text box control
-                Padding contentPadding = GetTripleState().PaletteContent!.GetContentPadding(_drawDockerOuter.State);
+                Padding contentPadding = GetTripleState().PaletteContent!.GetBorderContentPadding(null, _drawDockerOuter.State);
                 _layoutFill.DisplayPadding = contentPadding;
             }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
@@ -1603,7 +1603,7 @@ namespace Krypton.Toolkit
                 var paletteContent = GetTripleState().PaletteContent;
                 if (paletteContent != null)
                 {
-                    Padding contentPadding = paletteContent.GetContentPadding(_drawDockerOuter.State);
+                    Padding contentPadding = paletteContent.GetBorderContentPadding(null, _drawDockerOuter.State);
                     _layoutFill.DisplayPadding = contentPadding;
                 }
             }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareForm.cs
@@ -417,12 +417,8 @@ namespace Krypton.Toolkit
             MessageButton helpButton = _buttons switch
             {
                 KryptonMessageBoxButtons.OK => _button2,
-                KryptonMessageBoxButtons.OKCancel
-                    or KryptonMessageBoxButtons.YesNo
-                    or KryptonMessageBoxButtons.RetryCancel => _button3,
-                KryptonMessageBoxButtons.AbortRetryIgnore
-                    or KryptonMessageBoxButtons.YesNoCancel
-                    or KryptonMessageBoxButtons.CancelTryContinue => _button4,
+                KryptonMessageBoxButtons.OKCancel or KryptonMessageBoxButtons.YesNo or KryptonMessageBoxButtons.RetryCancel => _button3,
+                KryptonMessageBoxButtons.AbortRetryIgnore or KryptonMessageBoxButtons.YesNoCancel or KryptonMessageBoxButtons.CancelTryContinue => _button4,
                 _ => throw new ArgumentOutOfRangeException()
             };
             if (helpButton != null)
@@ -521,11 +517,11 @@ namespace Krypton.Toolkit
             }
 
             // Calculate the size of the icon area and text area including margins
-            Padding textPadding = krtbMessageText.StateCommon.Content.GetContentPadding(PaletteState.Normal);
+            Padding textPadding = krtbMessageText.StateCommon.Content.GetBorderContentPadding(null, PaletteState.Normal);
             Padding textAreaAllMargin = Padding.Add(textPadding, kpnlContentArea.Margin);
-            Size iconArea = new Size(_messageIcon.Width + _messageIcon.Margin.Left + _messageIcon.Margin.Right,
+            var iconArea = new Size(_messageIcon.Width + _messageIcon.Margin.Left + _messageIcon.Margin.Right,
                 _messageIcon.Height + _messageIcon.Margin.Top + _messageIcon.Margin.Bottom);
-            Size textArea = new Size(textSize.Width + textAreaAllMargin.Left + textAreaAllMargin.Right,
+            var textArea = new Size(textSize.Width + textAreaAllMargin.Left + textAreaAllMargin.Right,
                 textSize.Height + textAreaAllMargin.Top + textAreaAllMargin.Bottom);
             return new Size(textArea.Width + iconArea.Width,
                 Math.Max(iconArea.Height, textArea.Height));

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareFormDep.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareFormDep.cs
@@ -847,12 +847,8 @@ namespace Krypton.Toolkit
             MessageButton helpButton = _buttons switch
             {
                 KryptonMessageBoxButtons.OK => _button2,
-                KryptonMessageBoxButtons.OKCancel
-                    or KryptonMessageBoxButtons.YesNo
-                    or KryptonMessageBoxButtons.RetryCancel => _button3,
-                KryptonMessageBoxButtons.AbortRetryIgnore
-                    or KryptonMessageBoxButtons.YesNoCancel
-                    or KryptonMessageBoxButtons.CancelTryContinue => _button4,
+                KryptonMessageBoxButtons.OKCancel or KryptonMessageBoxButtons.YesNo or KryptonMessageBoxButtons.RetryCancel => _button3,
+                KryptonMessageBoxButtons.AbortRetryIgnore or KryptonMessageBoxButtons.YesNoCancel or KryptonMessageBoxButtons.CancelTryContinue => _button4,
                 _ => throw new EvaluateException("_buttons out of range")
             };
             if (helpButton != null)
@@ -1053,7 +1049,7 @@ namespace Krypton.Toolkit
             switch (contentAreaType)
             {
                 case MessageBoxContentAreaType.Normal:
-                    return krtbMessageText.StateCommon.Content.GetContentPadding(PaletteState.Normal);
+                    return krtbMessageText.StateCommon.Content.GetBorderContentPadding(null, PaletteState.Normal);
                 case MessageBoxContentAreaType.LinkLabel:
                     return klwlblMessageText.Padding;
                 case null:

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContainerControlBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContainerControlBase.cs
@@ -563,7 +563,7 @@ namespace Krypton.Toolkit
         /// <returns>True to allow; otherwise false.</returns>
         protected bool CanProcessMnemonic()
         {
-            Control c = this;
+            Control? c = this;
 
             // Test each control in parent chain
             while (c != null)
@@ -575,7 +575,7 @@ namespace Krypton.Toolkit
                 }
 
                 // Move up one level
-                c = c.Parent!;
+                c = c.Parent;
             }
 
             // Evert control in chain is visible and enabled, so allow mnemonics

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContextMenu.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContextMenu.cs
@@ -431,7 +431,7 @@ namespace Krypton.Toolkit
             };
 
             var layoutDocker = new ViewLayoutDocker();
-            Padding outerPadding = _provider.ProviderRedirector.GetMetricPadding(PaletteState.Normal, PaletteMetricPadding.ContextMenuItemOuter);
+            Padding outerPadding = _provider.ProviderRedirector.GetMetricPadding(null, PaletteState.Normal, PaletteMetricPadding.ContextMenuItemOuter);
             layoutDocker.Add(new ViewLayoutSeparator(outerPadding.Top), ViewDockStyle.Top);
             layoutDocker.Add(new ViewLayoutSeparator(outerPadding.Bottom), ViewDockStyle.Bottom);
             layoutDocker.Add(new ViewLayoutSeparator(outerPadding.Left), ViewDockStyle.Left);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
@@ -756,7 +756,6 @@ namespace Krypton.Toolkit
                 // the 'this.Size' which is out of date when performing a resize of the window.
                 var windowRect = new PI.RECT();
                 PI.GetWindowRect(Handle, ref windowRect);
-
                 // Create rectangle that encloses the entire window
                 return new Rectangle(0, 0,
                                      windowRect.right - windowRect.left,
@@ -1011,9 +1010,7 @@ namespace Krypton.Toolkit
         {
             var processed = false;
 
-            if (!CommonHelper.IsFormMaximized(this)
-                && _themedApp
-                )
+            if (_themedApp)
             {
                 switch (m.Msg)
                 {
@@ -1151,7 +1148,7 @@ namespace Krypton.Toolkit
 
             // Adjust the maximized size and position to fit the work area of the correct monitor
             const int MONITOR_DEFAULT_TO_NEAREST = 0x00000002;
-            var monitor = PI.MonitorFromWindow(m.HWnd, MONITOR_DEFAULT_TO_NEAREST);
+            IntPtr monitor = PI.MonitorFromWindow(m.HWnd, MONITOR_DEFAULT_TO_NEAREST);
 
             if (monitor != IntPtr.Zero)
             {
@@ -1494,7 +1491,7 @@ namespace Krypton.Toolkit
             if (windowBounds is { Width: > 0, Height: > 0 })
             {
                 // Get the device context for this window
-                var hDC = PI.GetWindowDC(Handle);
+                IntPtr hDC = PI.GetWindowDC(Handle);
 
                 // If we managed to get a device context
                 if (hDC != IntPtr.Zero)
@@ -1521,7 +1518,7 @@ namespace Krypton.Toolkit
                             }
 
                             // Create one the correct size and cache for future drawing
-                            var hBitmap = PI.CreateCompatibleBitmap(hDC, windowBounds.Width, windowBounds.Height);
+                            IntPtr hBitmap = PI.CreateCompatibleBitmap(hDC, windowBounds.Width, windowBounds.Height);
 
                             // If we managed to get a compatible bitmap
                             if (hBitmap != IntPtr.Zero)
@@ -1730,7 +1727,7 @@ namespace Krypton.Toolkit
         private void UpdateDpiFactors()
         {
             // Do not use the control dpi, as these values are being used to target the screen
-            var screenDc = PI.GetDC(IntPtr.Zero);
+            IntPtr screenDc = PI.GetDC(IntPtr.Zero);
             if (screenDc != IntPtr.Zero)
             {
                 FactorDpiX = PI.GetDeviceCaps(screenDc, PI.DeviceCap.LOGPIXELSX) / 96f;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxForm.cs
@@ -426,12 +426,8 @@ namespace Krypton.Toolkit
             MessageButton helpButton = _buttons switch
             {
                 KryptonMessageBoxButtons.OK => _button2,
-                KryptonMessageBoxButtons.OKCancel
-                    or KryptonMessageBoxButtons.YesNo
-                    or KryptonMessageBoxButtons.RetryCancel => _button3,
-                KryptonMessageBoxButtons.AbortRetryIgnore
-                    or KryptonMessageBoxButtons.YesNoCancel
-                    or KryptonMessageBoxButtons.CancelTryContinue => _button4,
+                KryptonMessageBoxButtons.OKCancel or KryptonMessageBoxButtons.YesNo or KryptonMessageBoxButtons.RetryCancel => _button3,
+                KryptonMessageBoxButtons.AbortRetryIgnore or KryptonMessageBoxButtons.YesNoCancel or KryptonMessageBoxButtons.CancelTryContinue => _button4,
                 _ => throw new ArgumentOutOfRangeException()
             };
             if (helpButton != null)
@@ -529,7 +525,7 @@ namespace Krypton.Toolkit
             }
 
             // Calculate the size of the icon area and text area including margins
-            Padding textPadding = krtbMessageText.StateCommon.Content.GetContentPadding(PaletteState.Normal);
+            Padding textPadding = krtbMessageText.StateCommon.Content.GetBorderContentPadding(null, PaletteState.Normal);
             Padding textAreaAllMargin = Padding.Add(textPadding, kpnlContentArea.Margin);
 
             Size iconArea = new Size(_messageIcon.Width + _messageIcon.Margin.Left + _messageIcon.Margin.Right,

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxFormDep.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxFormDep.cs
@@ -907,12 +907,8 @@ namespace Krypton.Toolkit
             MessageButton helpButton = _buttons switch
             {
                 KryptonMessageBoxButtons.OK => _button2,
-                KryptonMessageBoxButtons.OKCancel
-                    or KryptonMessageBoxButtons.YesNo
-                    or KryptonMessageBoxButtons.RetryCancel => _button3,
-                KryptonMessageBoxButtons.AbortRetryIgnore
-                    or KryptonMessageBoxButtons.YesNoCancel
-                    or KryptonMessageBoxButtons.CancelTryContinue => _button4,
+                KryptonMessageBoxButtons.OKCancel or KryptonMessageBoxButtons.YesNo or KryptonMessageBoxButtons.RetryCancel => _button3,
+                KryptonMessageBoxButtons.AbortRetryIgnore or KryptonMessageBoxButtons.YesNoCancel or KryptonMessageBoxButtons.CancelTryContinue => _button4,
                 _ => throw new ArgumentOutOfRangeException()
             };
             if (helpButton != null)
@@ -1084,7 +1080,7 @@ namespace Krypton.Toolkit
             switch (contentAreaType)
             {
                 case MessageBoxContentAreaType.Normal:
-                    return krtbMessageText.StateCommon.Content.GetContentPadding(PaletteState.Normal);
+                    return krtbMessageText.StateCommon.Content.GetBorderContentPadding(null, PaletteState.Normal);
                 case MessageBoxContentAreaType.LinkLabel:
                     return klwlblMessageText.Padding;
                 case null:

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPopupTooltip.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPopupTooltip.cs
@@ -235,10 +235,12 @@ namespace Krypton.Toolkit
             base.OnLayout(lEvent);
 
             // Need a render context for accessing the renderer
-            using var context = new RenderContext(this, null, ClientRectangle, Renderer);
+            Rectangle rect = ClientRectangle;
+            rect.Inflate(1, 1); // Make sure bottom and left borders are visible
+            using var context = new RenderContext(this, null, rect, Renderer);
             using var gh = new GraphicsHint(context.Graphics, _palette.Border.GetBorderGraphicsHint(PaletteState.Normal));
             // Grab a path that is the outside edge of the border
-            Rectangle borderRect = ClientRectangle;
+            Rectangle borderRect = rect;
             GraphicsPath borderPath1 = Renderer.RenderStandardBorder.GetOutsideBorderPath(context, borderRect, _palette.Border, VisualOrientation.Top, PaletteState.Normal);
             borderRect.Inflate(-1, -1);
             GraphicsPath borderPath2 = Renderer.RenderStandardBorder.GetOutsideBorderPath(context, borderRect, _palette.Border, VisualOrientation.Top, PaletteState.Normal);

--- a/Source/Krypton Components/Krypton.Toolkit/General/GlobalStaticValues.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/GlobalStaticValues.cs
@@ -48,7 +48,7 @@ namespace Krypton.Toolkit
         public const int CURRENT_SUPPORTED_PALETTE_VERSION = 20;
 
         /// <summary>The default highlight debugging color</summary>
-        public static Color DEFAULT_HIGHLIGHT_DEBUGGING_COLOR = Color.Magenta;
+        public static Color DEFAULT_HIGHLIGHT_DEBUGGING_COLOR = Color.Red;
 
         // Used for version reporting
         internal static string DEFAULT_DOCKING_FILE = @"Krypton.Docking.dll";

--- a/Source/Krypton Components/Krypton.Toolkit/General/PlatformInvoke.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/PlatformInvoke.cs
@@ -30,6 +30,7 @@
 
 // Note: DO NOT REMOVE!!!
 using Microsoft.Win32.SafeHandles;
+using static System.Runtime.InteropServices.Marshal;
 
 
 namespace Krypton.Toolkit
@@ -2982,7 +2983,7 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
 
             public WINDOWINFO(int _ = 0) : this()   // Allows automatic initialization of "cbSize" with "new WINDOWINFO(null/true/false)".
                 =>
-                    cbSize = (uint)Marshal.SizeOf(typeof(WINDOWINFO));
+                    cbSize = (uint)SizeOf(typeof(WINDOWINFO));
         }
         internal static bool GetWindowInfo(IntPtr hwnd, out WINDOWINFO pwi)
         {
@@ -3023,7 +3024,7 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
             if (!noThrow
             && IntPtr.Zero == ret)
             {
-                var error = Marshal.GetLastWin32Error();
+                var error = GetLastWin32Error();
                 if (error != 0)
                 {
                     throw new Win32Exception(error);
@@ -3040,7 +3041,7 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
             if (!noThrow
             && IntPtr.Zero == ret)
             {
-                var error = Marshal.GetLastWin32Error();
+                var error = GetLastWin32Error();
                 if (error != 0)
                 {
                     throw new Win32Exception(error);
@@ -3180,7 +3181,7 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
             if (!PostMessage(hWnd, msg, wParam, lParam))
             {
                 // An error occurred
-                throw new Win32Exception(Marshal.GetLastWin32Error());
+                throw new Win32Exception(GetLastWin32Error());
             }
         }
 
@@ -3248,6 +3249,10 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
         [DllImport(Libraries.User32, CharSet = CharSet.Auto)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
         internal static extern void DisableProcessWindowsGhosting();
+
+        [DllImport(Libraries.User32, CharSet = CharSet.Auto)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        internal static extern void AdjustWindowRect(ref RECT rect, uint dwStyle, bool hasMenu);
 
         [DllImport(Libraries.User32, CharSet = CharSet.Auto)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
@@ -3617,8 +3622,17 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
             // https://msdn.microsoft.com/en-us/library/windows/desktop/aa969515(v=vs.85).aspx
             [DllImport(Libraries.DWMApi)]
             [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-            internal static extern int DwmGetWindowAttribute(IntPtr hwnd, DWMWINDOWATTRIBUTE attr, ref int attrValue,
-                int attrSize);
+            internal static extern int DwmGetWindowAttribute(IntPtr hwnd, DWMWINDOWATTRIBUTE attr, ref int attrValue, int attrSize);
+
+            [DllImport(Libraries.DWMApi)]
+            [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+            internal static extern int DwmGetWindowAttribute(IntPtr hwnd, DWMWINDOWATTRIBUTE attr, out RECT pvAttribute, int attrSize);
+
+            internal static Rectangle DwmGetWindowRect(IntPtr hwnd)
+            {
+                DwmGetWindowAttribute(hwnd, DWMWINDOWATTRIBUTE.ExtendedFrameBounds, out RECT rect, SizeOf(typeof(RECT)));
+                return System.Drawing.Rectangle.FromLTRB(rect.left, rect.top, rect.right, rect.bottom);
+            }
 
             //https://msdn.microsoft.com/en-us/library/windows/desktop/aa969524(v=vs.85).aspx
             [DllImport(Libraries.DWMApi)]
@@ -3801,8 +3815,8 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
                 IntPtr accentPtr = IntPtr.Zero;
                 try
                 {
-                    var accentSize = Marshal.SizeOf(accPolicy);
-                    accentPtr = Marshal.AllocHGlobal(accentSize);
+                    var accentSize = SizeOf(accPolicy);
+                    accentPtr = AllocHGlobal(accentSize);
                     Marshal.StructureToPtr(accPolicy, accentPtr, false);
                     var data = new WindowCompositionAttribData(WindowCompositionAttribute.WCA_ACCENT_POLICY,
                         accentPtr, accentSize);
@@ -3813,7 +3827,7 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
                 {
                     if (accentPtr != IntPtr.Zero)
                     {
-                        Marshal.FreeHGlobal(accentPtr);
+                        FreeHGlobal(accentPtr);
                     }
                 }
             }
@@ -4108,7 +4122,7 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
         internal class CHOOSEFONT
         {
-            public int lStructSize = Marshal.SizeOf(typeof(CHOOSEFONT));
+            public int lStructSize = SizeOf(typeof(CHOOSEFONT));
             public IntPtr hwndOwner;
             public IntPtr hDC;
             public IntPtr lpLogFont;
@@ -4412,7 +4426,7 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
         {
             /// <summary>
             /// </summary>            
-            public int cbSize = Marshal.SizeOf(typeof(MONITORINFO));
+            public int cbSize = SizeOf(typeof(MONITORINFO));
 
             /// <summary>
             /// </summary>            

--- a/Source/Krypton Components/Krypton.Toolkit/Krypton.Toolkit 2022.csproj
+++ b/Source/Krypton Components/Krypton.Toolkit/Krypton.Toolkit 2022.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <Choose>
-        <When Condition="'$(Configuration)' == 'Nightly' Or '$(Configuration)' == 'Canary' Or '$(Configuration)' == 'Debug'">
+        <When Condition="'$(Configuration)' == 'Nightly' or '$(Configuration)' == 'Canary' or '$(Configuration)' == 'Debug'">
             <PropertyGroup>
                 <TargetFrameworks>net462;net47;net471;net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
             </PropertyGroup>

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBorder/PaletteBorder.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteBorder/PaletteBorder.cs
@@ -244,12 +244,11 @@ namespace Krypton.Toolkit
         /// <returns>PaletteDrawBorders value.</returns>
         public PaletteDrawBorders GetBorderDrawBorders(PaletteState state)
         {
-            if (DrawBorders != PaletteDrawBorders.Inherit)
-            {
-                return Draw == InheritBool.False ? PaletteDrawBorders.None : DrawBorders;
-            }
-
-            return _inherit.GetBorderDrawBorders(state);
+            return Draw == InheritBool.False 
+                ? PaletteDrawBorders.None 
+                : DrawBorders != PaletteDrawBorders.Inherit 
+                    ? DrawBorders 
+                    : _inherit.GetBorderDrawBorders(state);
         }
 
         #endregion
@@ -645,7 +644,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Border rounding.</returns>
-        public float GetBorderRounding(PaletteState state) => Rounding != -1f ? Rounding : _inherit.GetBorderRounding(state);
+        public virtual float GetBorderRounding(PaletteState state) => Rounding != -1f ? Rounding : _inherit.GetBorderRounding(state);
         #endregion
 
         #region Image

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContent.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContent.cs
@@ -163,7 +163,7 @@ namespace Krypton.Toolkit
             LongText.Image = GetContentLongTextImage(state);
             LongText.ImageStyle = GetContentLongTextImageStyle(state);
             LongText.ImageAlign = GetContentLongTextImageAlign(state);
-            Padding = GetContentPadding(state);
+            Padding = GetBorderContentPadding(null, state);
             AdjacentGap = GetContentAdjacentGap(state);
         }
         #endregion
@@ -708,12 +708,13 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the actual padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public Padding GetContentPadding(PaletteState state)
+        public Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteState state)
         {
             // Initialize the padding from inherited values
-            Padding paddingInherit = _inherit.GetContentPadding(state);
+            Padding paddingInherit = _inherit.GetBorderContentPadding(owningForm, state);
             Padding paddingThis = Padding;
 
             // Override with specified values

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentInherit.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentInherit.cs
@@ -309,9 +309,10 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public abstract Padding GetContentPadding(PaletteState state);
+        public abstract Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteState state);
 
         /// <summary>
         /// Gets the padding between adjacent content items.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentInheritForced.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentInheritForced.cs
@@ -349,9 +349,10 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteState state) => _inherit.GetContentPadding(state);
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteState state) => _inherit.GetBorderContentPadding(owningForm, state);
 
         /// <summary>
         /// Gets the padding between adjacent content items.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentInheritOverride.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentInheritOverride.cs
@@ -56,14 +56,14 @@ namespace Krypton.Toolkit
             Apply = apply;
             OverrideState = overrideState;
 
-            // By default we do override the state
+            // By default, we do override the state
             Override = true;
         }
         #endregion
 
         #region SetPalettes
         /// <summary>
-        /// Update the the primary and backup palettes.
+        /// Update the primary and backup palettes.
         /// </summary>
         /// <param name="primary">New primary palette.</param>
         /// <param name="backup">New backup palette.</param>
@@ -1058,24 +1058,25 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteState state)
         {
             if (Apply)
             {
-                Padding ret = _primary.GetContentPadding(Override ? OverrideState : state);
+                Padding ret = _primary.GetBorderContentPadding(owningForm, Override ? OverrideState : state);
 
                 if (ret.All == -1)
                 {
-                    ret = _backup.GetContentPadding(state);
+                    ret = _backup.GetBorderContentPadding(owningForm, state);
                 }
 
                 return ret;
             }
             else
             {
-                return _backup.GetContentPadding(state);
+                return _backup.GetBorderContentPadding(owningForm, state);
             }
         }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentInheritRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentInheritRedirect.cs
@@ -372,9 +372,10 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteState state) => _redirect.GetContentPadding(Style, state);
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteState state) => _redirect.GetBorderContentPadding(owningForm, Style, state);
 
         /// <summary>
         /// Gets the padding between adjacent content items.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentJustImage.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentJustImage.cs
@@ -44,7 +44,7 @@ namespace Krypton.Toolkit
             Image.Effect = GetContentImageEffect(state);
             Image.ImageColorMap = GetContentImageColorMap(state);
             Image.ImageColorTo = GetContentImageColorTo(state);
-            Padding = GetContentPadding(state);
+            Padding = GetBorderContentPadding(null, state);
         }
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentJustShortText.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentJustShortText.cs
@@ -72,7 +72,7 @@ namespace Krypton.Toolkit
             ShortText.Image = GetContentShortTextImage(state);
             ShortText.ImageStyle = GetContentShortTextImageStyle(state);
             ShortText.ImageAlign = GetContentShortTextImageAlign(state);
-            Padding = GetContentPadding(state);
+            Padding = GetBorderContentPadding(null, state);
         }
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentJustText.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentJustText.cs
@@ -78,7 +78,7 @@ namespace Krypton.Toolkit
             LongText.Image = GetContentLongTextImage(state);
             LongText.ImageStyle = GetContentLongTextImageStyle(state);
             LongText.ImageAlign = GetContentLongTextImageAlign(state);
-            Padding = GetContentPadding(state);
+            Padding = GetBorderContentPadding(null, state);
             AdjacentGap = GetContentAdjacentGap(state);
         }
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentToPalette.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteContent/PaletteContentToPalette.cs
@@ -356,12 +356,14 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Padding
+
         /// <summary>
         /// Gets the actual padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public Padding GetContentPadding(PaletteState state) => _palette.GetContentPadding(ContentStyle, state);
+        public Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteState state) => _palette.GetBorderContentPadding(owningForm, ContentStyle, state);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDefinitions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDefinitions.cs
@@ -488,9 +488,10 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        Padding GetContentPadding(PaletteState state);
+        Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteState state);
 
         /// <summary>
         /// Gets the padding between adjacent content items.
@@ -516,10 +517,11 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        int GetMetricInt(PaletteState state, PaletteMetricInt metric);
+        int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric);
 
         /// <summary>
         /// Gets a boolean metric value.
@@ -532,10 +534,11 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric);
+        Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state, PaletteMetricPadding metric);
     }
     #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDouble/PaletteDoubleMetric.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDouble/PaletteDoubleMetric.cs
@@ -60,15 +60,17 @@ namespace Krypton.Toolkit
         #endregion
 
         #region IPaletteMetric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public virtual int GetMetricInt(PaletteState state, PaletteMetricInt metric) =>
+        public virtual int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric) =>
             // Always pass onto the inheritance
-            _inherit.GetMetricInt(state, metric);
+            _inherit.GetMetricInt(owningForm, state, metric);
 
         /// <summary>
         /// Gets a boolean metric value.
@@ -83,12 +85,14 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public virtual Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric) =>
+        public virtual Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric) =>
             // Always pass onto the inheritance
-            _inherit.GetMetricPadding(state, metric);
+            _inherit.GetMetricPadding(owningForm, state, metric);
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDouble/PaletteDoubleMetricRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDouble/PaletteDoubleMetricRedirect.cs
@@ -69,15 +69,17 @@ namespace Krypton.Toolkit
         #endregion
 
         #region IPaletteMetric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public virtual int GetMetricInt(PaletteState state, PaletteMetricInt metric) =>
+        public virtual int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric) =>
             // Pass onto the inheritance
-            _redirect.GetMetricInt(state, metric);
+            _redirect.GetMetricInt(owningForm, state, metric);
 
         /// <summary>
         /// Gets a boolean metric value.
@@ -92,12 +94,13 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public virtual Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric) =>
+        public virtual Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state, PaletteMetricPadding metric) =>
             // Pass onto the inheritance
-            _redirect.GetMetricPadding(state, metric);
+            _redirect.GetMetricPadding(owningForm, state, metric);
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDouble/PaletteFormDoubleRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDouble/PaletteFormDoubleRedirect.cs
@@ -14,18 +14,18 @@ namespace Krypton.Toolkit
     public class PaletteFormDoubleRedirect : PaletteDoubleRedirect
     {
         #region Identity
-        /// <summary>
-        /// Initialize a new instance of the PaletteDoubleRedirect class.
-        /// </summary>
-        /// <param name="redirect">inheritance redirection instance.</param>
-        /// <param name="backStyle">Initial background style.</param>
-        /// <param name="borderStyle">Initial border style.</param>
-        public PaletteFormDoubleRedirect(PaletteRedirect redirect,
-                                     PaletteBackStyle backStyle,
-                                     PaletteBorderStyle borderStyle)
-            : this(redirect, backStyle, borderStyle, null)
-        {
-        }
+        ///// <summary>
+        ///// Initialize a new instance of the PaletteDoubleRedirect class.
+        ///// </summary>
+        ///// <param name="redirect">inheritance redirection instance.</param>
+        ///// <param name="backStyle">Initial background style.</param>
+        ///// <param name="borderStyle">Initial border style.</param>
+        //public PaletteFormDoubleRedirect(PaletteRedirect redirect,
+        //                             PaletteBackStyle backStyle,
+        //                             PaletteBorderStyle borderStyle)
+        //    : this(redirect, backStyle, borderStyle, null)
+        //{
+        //}
 
         /// <summary>
         /// Initialize a new instance of the PaletteDoubleRedirect class.
@@ -34,10 +34,12 @@ namespace Krypton.Toolkit
         /// <param name="backStyle">Initial background style.</param>
         /// <param name="borderStyle">Initial border style.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
+        /// <param name="ownerForm"></param>
         public PaletteFormDoubleRedirect(PaletteRedirect redirect,
                                      PaletteBackStyle backStyle,
                                      PaletteBorderStyle borderStyle,
-                                     NeedPaintHandler? needPaint)
+                                     NeedPaintHandler? needPaint,
+                                     VisualForm ownerForm)
         {
             // Store the inherit instances
             var backInherit = new PaletteBackInheritRedirect(redirect, backStyle);
@@ -45,7 +47,7 @@ namespace Krypton.Toolkit
 
             // Create storage that maps onto the inherit instances
             var back = new PaletteBack(backInherit, needPaint);
-            var border = new PaletteFormBorder(borderInherit, needPaint);
+            var border = new PaletteFormBorder(borderInherit, needPaint, ownerForm);
 
             Construct(redirect, back, backInherit, border, borderInherit, needPaint);
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteMetric/PaletteMetricRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteMetric/PaletteMetricRedirect.cs
@@ -57,15 +57,17 @@ namespace Krypton.Toolkit
         #endregion
 
         #region IPaletteMetric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public virtual int GetMetricInt(PaletteState state, PaletteMetricInt metric) =>
+        public virtual int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric) =>
             // Pass onto the inheritance
-            _redirect.GetMetricInt(state, metric);
+            _redirect.GetMetricInt(owningForm, state, metric);
 
         /// <summary>
         /// Gets a boolean metric value.
@@ -80,12 +82,14 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public virtual Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric) =>
+        public virtual Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric) =>
             // Pass onto the inheritance
-            _redirect.GetMetricPadding(state, metric);
+            _redirect.GetMetricPadding(owningForm, state, metric);
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirect.cs
@@ -592,10 +592,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state) => _target!.GetContentPadding(style, state);
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state) => _target!.GetBorderContentPadding(owningForm, style, state);
 
         /// <summary>
         /// Gets the padding between adjacent content items.
@@ -608,13 +610,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric) => _target!.GetMetricInt(state, metric);
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric) => _target!.GetMetricInt(owningForm, state, metric);
 
         /// <summary>
         /// Gets a boolean metric value.
@@ -627,10 +631,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric) => _target!.GetMetricPadding(state, metric);
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric) => _target!.GetMetricPadding(owningForm, state, metric);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectContent.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectContent.cs
@@ -650,14 +650,17 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             IPaletteContent? inherit = GetInherit(state);
 
-            return inherit?.GetContentPadding(state) ?? Target!.GetContentPadding(style, state);
+            return inherit?.GetBorderContentPadding(owningForm, state) 
+                   ?? Target!.GetBorderContentPadding(owningForm, style, state);
         }
 
         /// <summary>
@@ -670,7 +673,8 @@ namespace Krypton.Toolkit
         {
             IPaletteContent? inherit = GetInherit(state);
 
-            return inherit?.GetContentAdjacentGap(state) ?? Target!.GetContentAdjacentGap(style, state);
+            return inherit?.GetContentAdjacentGap(state) 
+                   ?? Target!.GetContentAdjacentGap(style, state);
         }
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectDoubleMetric.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectDoubleMetric.cs
@@ -121,17 +121,20 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             IPaletteMetric? inherit = GetInherit(state);
 
-            return inherit?.GetMetricInt(state, metric) ?? Target!.GetMetricInt(state, metric);
+            return inherit?.GetMetricInt(owningForm, state, metric) 
+                   ?? Target!.GetMetricInt(owningForm, state, metric);
         }
 
         /// <summary>
@@ -144,20 +147,24 @@ namespace Krypton.Toolkit
         {
             IPaletteMetric? inherit = GetInherit(state);
 
-            return inherit?.GetMetricBool(state, metric) ?? Target!.GetMetricBool(state, metric);
+            return inherit?.GetMetricBool(state, metric) 
+                   ?? Target!.GetMetricBool(state, metric);
         }
 
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             IPaletteMetric? inherit = GetInherit(state);
 
-            return inherit?.GetMetricPadding(state, metric) ?? Target!.GetMetricPadding(state, metric);
+            return inherit?.GetMetricPadding(owningForm, state, metric) 
+                   ?? Target!.GetMetricPadding(owningForm, state, metric);
         }
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectGrids.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectGrids.cs
@@ -824,14 +824,17 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             IPaletteContent inherit = GetInheritContent(style, state);
 
-            return inherit?.GetContentPadding(state) ?? Target!.GetContentPadding(style, state);
+            return inherit?.GetBorderContentPadding(owningForm, state) 
+                   ?? Target!.GetBorderContentPadding(owningForm, style, state);
         }
 
         /// <summary>
@@ -844,7 +847,8 @@ namespace Krypton.Toolkit
         {
             IPaletteContent inherit = GetInheritContent(style, state);
 
-            return inherit?.GetContentAdjacentGap(state) ?? Target!.GetContentAdjacentGap(style, state);
+            return inherit?.GetContentAdjacentGap(state) 
+                   ?? Target!.GetContentAdjacentGap(style, state);
         }
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectMetric.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectMetric.cs
@@ -75,17 +75,20 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             IPaletteMetric? inherit = GetInherit(state);
 
-            return inherit?.GetMetricInt(state, metric) ?? Target!.GetMetricInt(state, metric);
+            return inherit?.GetMetricInt(owningForm, state, metric) 
+                   ?? Target!.GetMetricInt(owningForm, state, metric);
         }
 
         /// <summary>
@@ -98,20 +101,24 @@ namespace Krypton.Toolkit
         {
             IPaletteMetric? inherit = GetInherit(state);
 
-            return inherit?.GetMetricBool(state, metric) ?? Target!.GetMetricBool(state, metric);
+            return inherit?.GetMetricBool(state, metric) 
+                   ?? Target!.GetMetricBool(state, metric);
         }
 
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             IPaletteMetric? inherit = GetInherit(state);
 
-            return inherit?.GetMetricPadding(state, metric) ?? Target!.GetMetricPadding(state, metric);
+            return inherit?.GetMetricPadding(owningForm, state, metric) 
+                   ?? Target!.GetMetricPadding(owningForm, state, metric);
         }
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectTriple.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectTriple.cs
@@ -632,7 +632,9 @@ public class PaletteRedirectTriple : PaletteRedirect
     {
         IPaletteTriple? inherit = GetInherit(state);
 
-        return inherit != null ? inherit.PaletteContent!.GetContentImageV(state) : Target!.GetContentImageV(style, state);
+        return inherit != null
+            ? inherit.PaletteContent!.GetContentImageV(state)
+            : Target!.GetContentImageV(style, state);
     }
 
     /// <summary>
@@ -645,7 +647,9 @@ public class PaletteRedirectTriple : PaletteRedirect
     {
         IPaletteTriple? inherit = GetInherit(state);
 
-        return inherit != null ? inherit.PaletteContent!.GetContentImageEffect(state) : Target!.GetContentImageEffect(style, state);
+        return inherit != null
+            ? inherit.PaletteContent!.GetContentImageEffect(state)
+            : Target!.GetContentImageEffect(style, state);
     }
 
     /// <summary>
@@ -658,7 +662,9 @@ public class PaletteRedirectTriple : PaletteRedirect
     {
         IPaletteTriple? inherit = GetInherit(state);
 
-        return inherit != null ? inherit.PaletteContent!.GetContentImageColorMap(state) : Target!.GetContentImageColorMap(style, state);
+        return inherit != null
+            ? inherit.PaletteContent!.GetContentImageColorMap(state)
+            : Target!.GetContentImageColorMap(style, state);
     }
 
     /// <summary>
@@ -671,7 +677,9 @@ public class PaletteRedirectTriple : PaletteRedirect
     {
         IPaletteTriple? inherit = GetInherit(state);
 
-        return inherit != null ? inherit.PaletteContent!.GetContentImageColorTo(state) : Target!.GetContentImageColorTo(style, state);
+        return inherit != null
+            ? inherit.PaletteContent!.GetContentImageColorTo(state)
+            : Target!.GetContentImageColorTo(style, state);
     }
 
     /// <summary>
@@ -684,7 +692,9 @@ public class PaletteRedirectTriple : PaletteRedirect
     {
         IPaletteTriple? inherit = GetInherit(state);
 
-        return inherit != null ? inherit.PaletteContent!.GetContentShortTextFont(state) : Target!.GetContentShortTextFont(style, state);
+        return inherit != null
+            ? inherit.PaletteContent!.GetContentShortTextFont(state)
+            : Target!.GetContentShortTextFont(style, state);
     }
 
     /// <summary>
@@ -697,7 +707,9 @@ public class PaletteRedirectTriple : PaletteRedirect
     {
         IPaletteTriple? inherit = GetInherit(state);
 
-        return inherit != null ? inherit.PaletteContent!.GetContentShortTextHint(state) : Target!.GetContentShortTextHint(style, state);
+        return inherit != null
+            ? inherit.PaletteContent!.GetContentShortTextHint(state) 
+            : Target!.GetContentShortTextHint(style, state);
     }
 
     /// <summary>
@@ -710,7 +722,9 @@ public class PaletteRedirectTriple : PaletteRedirect
     {
         IPaletteTriple? inherit = GetInherit(state);
 
-        return inherit != null ? inherit.PaletteContent!.GetContentShortTextPrefix(state) : Target!.GetContentShortTextPrefix(style, state);
+        return inherit != null
+            ? inherit.PaletteContent!.GetContentShortTextPrefix(state)
+            : Target!.GetContentShortTextPrefix(style, state);
     }
 
     /// <summary>
@@ -738,7 +752,9 @@ public class PaletteRedirectTriple : PaletteRedirect
     {
         IPaletteTriple? inherit = GetInherit(state);
 
-        return inherit != null ? inherit.PaletteContent!.GetContentShortTextTrim(state) : Target!.GetContentShortTextTrim(style, state);
+        return inherit != null
+            ? inherit.PaletteContent!.GetContentShortTextTrim(state)
+            : Target!.GetContentShortTextTrim(style, state);
     }
 
     /// <summary>
@@ -751,7 +767,9 @@ public class PaletteRedirectTriple : PaletteRedirect
     {
         IPaletteTriple? inherit = GetInherit(state);
 
-        return inherit != null ? inherit.PaletteContent!.GetContentShortTextH(state) : Target!.GetContentShortTextH(style, state);
+        return inherit != null
+            ? inherit.PaletteContent!.GetContentShortTextH(state)
+            : Target!.GetContentShortTextH(style, state);
     }
 
     /// <summary>
@@ -764,7 +782,9 @@ public class PaletteRedirectTriple : PaletteRedirect
     {
         IPaletteTriple? inherit = GetInherit(state);
 
-        return inherit != null ? inherit.PaletteContent!.GetContentShortTextV(state) : Target!.GetContentShortTextV(style, state);
+        return inherit != null
+            ? inherit.PaletteContent!.GetContentShortTextV(state)
+            : Target!.GetContentShortTextV(style, state);
     }
 
     /// <summary>
@@ -792,7 +812,9 @@ public class PaletteRedirectTriple : PaletteRedirect
     {
         IPaletteTriple? inherit = GetInherit(state);
 
-        return inherit != null ? inherit.PaletteContent!.GetContentShortTextColor1(state) : Target!.GetContentShortTextColor1(style, state);
+        return inherit != null
+            ? inherit.PaletteContent!.GetContentShortTextColor1(state)
+            : Target!.GetContentShortTextColor1(style, state);
     }
 
     /// <summary>
@@ -805,7 +827,9 @@ public class PaletteRedirectTriple : PaletteRedirect
     {
         IPaletteTriple? inherit = GetInherit(state);
 
-        return inherit != null ? inherit.PaletteContent!.GetContentShortTextColor2(state) : Target!.GetContentShortTextColor2(style, state);
+        return inherit != null
+            ? inherit.PaletteContent!.GetContentShortTextColor2(state)
+            : Target!.GetContentShortTextColor2(style, state);
     }
 
     /// <summary>
@@ -863,7 +887,9 @@ public class PaletteRedirectTriple : PaletteRedirect
     {
         IPaletteTriple? inherit = GetInherit(state);
 
-        return inherit != null ? inherit.PaletteContent!.GetContentShortTextImage(state) : Target!.GetContentShortTextImage(style, state);
+        return inherit != null
+            ? inherit.PaletteContent!.GetContentShortTextImage(state)
+            : Target!.GetContentShortTextImage(style, state);
     }
 
     /// <summary>
@@ -906,7 +932,9 @@ public class PaletteRedirectTriple : PaletteRedirect
     {
         IPaletteTriple? inherit = GetInherit(state);
 
-        return inherit != null ? inherit.PaletteContent!.GetContentLongTextFont(state) : Target!.GetContentLongTextFont(style, state);
+        return inherit != null
+            ? inherit.PaletteContent!.GetContentLongTextFont(state)
+            : Target!.GetContentLongTextFont(style, state);
     }
 
     /// <summary>
@@ -919,7 +947,9 @@ public class PaletteRedirectTriple : PaletteRedirect
     {
         IPaletteTriple? inherit = GetInherit(state);
 
-        return inherit != null ? inherit.PaletteContent!.GetContentLongTextHint(state) : Target!.GetContentLongTextHint(style, state);
+        return inherit != null
+            ? inherit.PaletteContent!.GetContentLongTextHint(state)
+            : Target!.GetContentLongTextHint(style, state);
     }
 
     /// <summary>
@@ -932,7 +962,9 @@ public class PaletteRedirectTriple : PaletteRedirect
     {
         IPaletteTriple? inherit = GetInherit(state);
 
-        return inherit != null ? inherit.PaletteContent!.GetContentLongTextMultiLine(state) : Target!.GetContentLongTextMultiLine(style, state);
+        return inherit != null
+            ? inherit.PaletteContent!.GetContentLongTextMultiLine(state)
+            : Target!.GetContentLongTextMultiLine(style, state);
     }
 
     /// <summary>
@@ -945,7 +977,9 @@ public class PaletteRedirectTriple : PaletteRedirect
     {
         IPaletteTriple? inherit = GetInherit(state);
 
-        return inherit != null ? inherit.PaletteContent!.GetContentLongTextTrim(state) : Target!.GetContentLongTextTrim(style, state);
+        return inherit != null 
+            ? inherit.PaletteContent!.GetContentLongTextTrim(state) 
+            : Target!.GetContentLongTextTrim(style, state);
     }
 
     /// <summary>
@@ -958,7 +992,9 @@ public class PaletteRedirectTriple : PaletteRedirect
     {
         IPaletteTriple? inherit = GetInherit(state);
 
-        return inherit != null ? inherit.PaletteContent!.GetContentLongTextPrefix(state) : Target!.GetContentLongTextPrefix(style, state);
+        return inherit != null
+            ? inherit.PaletteContent!.GetContentLongTextPrefix(state)
+            : Target!.GetContentLongTextPrefix(style, state);
     }
 
     /// <summary>
@@ -971,7 +1007,9 @@ public class PaletteRedirectTriple : PaletteRedirect
     {
         IPaletteTriple? inherit = GetInherit(state);
 
-        return inherit != null ? inherit.PaletteContent!.GetContentLongTextH(state) : Target!.GetContentLongTextH(style, state);
+        return inherit != null
+            ? inherit.PaletteContent!.GetContentLongTextH(state)
+            : Target!.GetContentLongTextH(style, state);
     }
 
     /// <summary>
@@ -984,7 +1022,9 @@ public class PaletteRedirectTriple : PaletteRedirect
     {
         IPaletteTriple? inherit = GetInherit(state);
 
-        return inherit != null ? inherit.PaletteContent!.GetContentLongTextV(state) : Target!.GetContentLongTextV(style, state);
+        return inherit != null
+            ? inherit.PaletteContent!.GetContentLongTextV(state)
+            : Target!.GetContentLongTextV(style, state);
     }
 
     /// <summary>
@@ -1012,7 +1052,9 @@ public class PaletteRedirectTriple : PaletteRedirect
     {
         IPaletteTriple? inherit = GetInherit(state);
 
-        return inherit != null ? inherit.PaletteContent!.GetContentLongTextColor1(state) : Target!.GetContentLongTextColor1(style, state);
+        return inherit != null
+            ? inherit.PaletteContent!.GetContentLongTextColor1(state)
+            : Target!.GetContentLongTextColor1(style, state);
     }
 
     /// <summary>
@@ -1025,7 +1067,9 @@ public class PaletteRedirectTriple : PaletteRedirect
     {
         IPaletteTriple? inherit = GetInherit(state);
 
-        return inherit != null ? inherit.PaletteContent!.GetContentLongTextColor2(state) : Target!.GetContentLongTextColor2(style, state);
+        return inherit != null
+            ? inherit.PaletteContent!.GetContentLongTextColor2(state)
+            : Target!.GetContentLongTextColor2(style, state);
     }
 
     /// <summary>
@@ -1083,7 +1127,9 @@ public class PaletteRedirectTriple : PaletteRedirect
     {
         IPaletteTriple? inherit = GetInherit(state);
 
-        return inherit != null ? inherit.PaletteContent!.GetContentLongTextImage(state) : Target!.GetContentLongTextImage(style, state);
+        return inherit != null
+            ? inherit.PaletteContent!.GetContentLongTextImage(state)
+            : Target!.GetContentLongTextImage(style, state);
     }
 
     /// <summary>
@@ -1119,14 +1165,18 @@ public class PaletteRedirectTriple : PaletteRedirect
     /// <summary>
     /// Gets the padding between the border and content drawing.
     /// </summary>
+    /// <param name="owningForm"></param>
     /// <param name="style">Content style.</param>
     /// <param name="state">Palette value should be applicable to this state.</param>
     /// <returns>Padding value.</returns>
-    public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+    public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+        PaletteState state)
     {
         IPaletteTriple? inherit = GetInherit(state);
 
-        return inherit != null ? inherit.PaletteContent!.GetContentPadding(state) : Target!.GetContentPadding(style, state);
+        return inherit != null
+            ? inherit.PaletteContent!.GetBorderContentPadding(owningForm, state)
+            : Target!.GetBorderContentPadding(owningForm, style, state);
     }
 
     /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectTripleMetric.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectTripleMetric.cs
@@ -88,17 +88,20 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             IPaletteMetric? inherit = GetInherit(state);
 
-            return inherit?.GetMetricInt(state, metric) ?? Target!.GetMetricInt(state, metric);
+            return inherit?.GetMetricInt(owningForm, state, metric) 
+                   ?? Target!.GetMetricInt(owningForm, state, metric);
         }
 
         /// <summary>
@@ -111,20 +114,24 @@ namespace Krypton.Toolkit
         {
             IPaletteMetric? inherit = GetInherit(state);
 
-            return inherit?.GetMetricBool(state, metric) ?? Target!.GetMetricBool(state, metric);
+            return inherit?.GetMetricBool(state, metric) 
+                   ?? Target!.GetMetricBool(state, metric);
         }
 
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             IPaletteMetric? inherit = GetInherit(state);
 
-            return inherit?.GetMetricPadding(state, metric) ?? Target!.GetMetricPadding(state, metric);
+            return inherit?.GetMetricPadding(owningForm, state, metric) 
+                   ?? Target!.GetMetricPadding(owningForm, state, metric);
         }
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTripleMetric.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTripleMetric.cs
@@ -51,15 +51,17 @@ namespace Krypton.Toolkit
         #endregion
 
         #region IPaletteMetric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public virtual int GetMetricInt(PaletteState state, PaletteMetricInt metric) =>
+        public virtual int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric) =>
             // Always pass onto the inheritance
-            _inherit.GetMetricInt(state, metric);
+            _inherit.GetMetricInt(owningForm, state, metric);
 
         /// <summary>
         /// Gets a boolean metric value.
@@ -74,12 +76,14 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public virtual Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric) =>
+        public virtual Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric) =>
             // Always pass onto the inheritance
-            _inherit.GetMetricPadding(state, metric);
+            _inherit.GetMetricPadding(owningForm, state, metric);
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTripleMetricRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTripleMetricRedirect.cs
@@ -64,15 +64,17 @@ namespace Krypton.Toolkit
         #endregion
 
         #region IPaletteMetric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public virtual int GetMetricInt(PaletteState state, PaletteMetricInt metric) =>
+        public virtual int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric) =>
             // Pass onto the inheritance
-            _redirect.GetMetricInt(state, metric);
+            _redirect.GetMetricInt(owningForm, state, metric);
 
         /// <summary>
         /// Gets a boolean metric value.
@@ -87,12 +89,14 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public virtual Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric) =>
+        public virtual Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric) =>
             // Pass onto the inheritance
-            _redirect.GetMetricPadding(state, metric);
+            _redirect.GetMetricPadding(owningForm, state, metric);
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTripleRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteTriple/PaletteTripleRedirect.cs
@@ -361,7 +361,7 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public IPaletteBorder? PaletteBorder => Border;
+        public IPaletteBorder PaletteBorder => Border;
 
         /// <summary>
         /// Gets and sets the border palette style.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Base/PaletteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Base/PaletteBase.cs
@@ -655,10 +655,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public abstract Padding GetContentPadding(PaletteContentStyle style, PaletteState state);
+        public abstract Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state);
 
         /// <summary>
         /// Gets the padding between adjacent content items.
@@ -670,13 +672,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public abstract int GetMetricInt(PaletteState state, PaletteMetricInt metric);
+        public abstract int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric);
 
         /// <summary>
         /// Gets a boolean metric value.
@@ -689,10 +693,11 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public abstract Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric);
+        public abstract Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state, PaletteMetricPadding metric);
 
         #endregion
 
@@ -857,7 +862,7 @@ namespace Krypton.Toolkit
                 case PaletteButtonSpecStyle.WorkspaceRestore:
                 case PaletteButtonSpecStyle.RibbonMinimize:
                 case PaletteButtonSpecStyle.RibbonExpand:
-                    return Color.Magenta;
+                    return GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
                 case PaletteButtonSpecStyle.New:
                 case PaletteButtonSpecStyle.Open:
                 case PaletteButtonSpecStyle.SaveAll:
@@ -1159,7 +1164,7 @@ namespace Krypton.Toolkit
                 case PaletteButtonSpecStyle.WorkspaceRestore:
                 case PaletteButtonSpecStyle.RibbonMinimize:
                 case PaletteButtonSpecStyle.RibbonExpand:
-                    return Color.Magenta;
+                    return GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
                 default:
                     // Should never happen!
                     Debug.Assert(false);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Bases/PaletteMicrosoft365Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Bases/PaletteMicrosoft365Base.cs
@@ -27,7 +27,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
         private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
         private static readonly Padding _contentPaddingCalendar = new Padding(2);
-        private static readonly Padding _contentPaddingHeaderForm = new Padding(10, 6, 3, 0); // 10 is from the RealWindowFrameSize +1
+        //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
         private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
         private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
         private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -39,7 +39,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);
@@ -51,7 +51,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _metricPaddingRibbon = new Padding(0, 1, 1, 1);
         private static readonly Padding _metricPaddingRibbonAppButton = new Padding(3, 0, 3, 0);
         private static readonly Padding _metricPaddingHeader = new Padding(0, 3, 1, 3);
-        private static readonly Padding _metricPaddingHeaderForm = new Padding(0, 3, 0, -3); // Move the Maximised Form buttons down a bit
+        //private static readonly Padding _metricPaddingHeaderForm = new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);//, 3, 0, -3); // Move the Maximised Form buttons down a bit
         private static readonly Padding _metricPaddingInputControl = new Padding(0, 1, 0, 1);
         private static readonly Padding _metricPaddingBarInside = new Padding(3);
         private static readonly Padding _metricPaddingBarTabs = new Padding(0);
@@ -1140,7 +1140,7 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => PaletteDrawBorders.Top,
                 PaletteBorderStyle.ContextMenuItemImageColumn => PaletteDrawBorders.Right,
                 PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ContextMenuInner => PaletteDrawBorders.None,
-                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.TopLeftRight,
+                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.None,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -2903,10 +2903,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             // We do not provide override values
             if (CommonHelper.IsOverrideState(state))
@@ -2914,37 +2916,90 @@ namespace Krypton.Toolkit
                 return CommonHelper.InheritPadding;
             }
 
-            return style switch
+            switch (style)
             {
-                PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 => _contentPaddingGrid,
-                PaletteContentStyle.HeaderForm => _contentPaddingHeaderForm,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _contentPaddingHeader1,
-                PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive => _contentPaddingDock,
-                PaletteContentStyle.HeaderSecondary => _contentPaddingHeader2,
-                PaletteContentStyle.HeaderCalendar => _contentPaddingCalendar,
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 => _contentPaddingLabel,
-                PaletteContentStyle.LabelGroupBoxCaption => _contentPaddingLabel2,
-                PaletteContentStyle.ContextMenuItemTextStandard => _contentPaddingContextMenuItemText,
-                PaletteContentStyle.ContextMenuItemTextAlternate => _contentPaddingContextMenuItemTextAlt,
-                PaletteContentStyle.ContextMenuItemShortcutText => _contentPaddingContextMenuItemShortcutText,
-                PaletteContentStyle.ContextMenuItemImage => _contentPaddingContextMenuImage,
-                PaletteContentStyle.LabelToolTip => _contentPaddingToolTip,
-                PaletteContentStyle.LabelSuperTip => _contentPaddingSuperTip,
-                PaletteContentStyle.LabelKeyTip => _contentPaddingKeyTip,
-                PaletteContentStyle.ContextMenuHeading => _contentPaddingContextMenuHeading,
-                PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => InputControlPadding,
-                PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => _contentPaddingButton12,
-                PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay => _contentPaddingButtonInputControl,
-                PaletteContentStyle.ButtonButtonSpec => _contentPaddingButton3,
-                PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => _contentPaddingButton4,
-                PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => _contentPaddingButtonForm,
-                PaletteContentStyle.ButtonGallery => _contentPaddingButtonGallery,
-                PaletteContentStyle.ButtonListItem => _contentPaddingButtonListItem,
-                PaletteContentStyle.ButtonBreadCrumb => _contentPaddingButton6,
-                PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 => _contentPaddingButton5,
-                PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden => _contentPaddingButton7,
-                _ => throw new ArgumentOutOfRangeException(nameof(style))
-            };
+                case PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet
+                    or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2
+                    or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList
+                    or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1
+                    or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3
+                    or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet
+                    or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2
+                    or PaletteContentStyle.GridDataCellCustom3:
+                    return _contentPaddingGrid;
+                case PaletteContentStyle.HeaderForm:
+                    {
+                        Padding borders = owningForm!.RealWindowBorders;
+                        return new Padding(borders.Left, borders.Bottom / 2, 0, 0);
+                    }
+                case PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1
+                    or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3:
+                    return _contentPaddingHeader1;
+                case PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive:
+                    return _contentPaddingDock;
+                case PaletteContentStyle.HeaderSecondary:
+                    return _contentPaddingHeader2;
+                case PaletteContentStyle.HeaderCalendar:
+                    return _contentPaddingCalendar;
+                case PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl
+                    or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl
+                    or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel
+                    or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel
+                    or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2
+                    or PaletteContentStyle.LabelCustom3:
+                    return _contentPaddingLabel;
+                case PaletteContentStyle.LabelGroupBoxCaption:
+                    return _contentPaddingLabel2;
+                case PaletteContentStyle.ContextMenuItemTextStandard:
+                    return _contentPaddingContextMenuItemText;
+                case PaletteContentStyle.ContextMenuItemTextAlternate:
+                    return _contentPaddingContextMenuItemTextAlt;
+                case PaletteContentStyle.ContextMenuItemShortcutText:
+                    return _contentPaddingContextMenuItemShortcutText;
+                case PaletteContentStyle.ContextMenuItemImage:
+                    return _contentPaddingContextMenuImage;
+                case PaletteContentStyle.LabelToolTip:
+                    return _contentPaddingToolTip;
+                case PaletteContentStyle.LabelSuperTip:
+                    return _contentPaddingSuperTip;
+                case PaletteContentStyle.LabelKeyTip:
+                    return _contentPaddingKeyTip;
+                case PaletteContentStyle.ContextMenuHeading:
+                    return _contentPaddingContextMenuHeading;
+                case PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon
+                    or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2
+                    or PaletteContentStyle.InputControlCustom3:
+                    return InputControlPadding;
+                case PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand
+                    or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile
+                    or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini
+                    or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2
+                    or PaletteContentStyle.ButtonCustom3:
+                    return _contentPaddingButton12;
+                case PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay:
+                    return _contentPaddingButtonInputControl;
+                case PaletteContentStyle.ButtonButtonSpec:
+                    return _contentPaddingButton3;
+                case PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow:
+                    return _contentPaddingButton4;
+                case PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose:
+                    return _contentPaddingButtonForm;
+                case PaletteContentStyle.ButtonGallery:
+                    return _contentPaddingButtonGallery;
+                case PaletteContentStyle.ButtonListItem:
+                    return _contentPaddingButtonListItem;
+                case PaletteContentStyle.ButtonBreadCrumb:
+                    return _contentPaddingButton6;
+                case PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile
+                    or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote
+                    or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2
+                    or PaletteContentStyle.TabCustom3:
+                    return _contentPaddingButton5;
+                case PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden:
+                    return _contentPaddingButton7;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style));
+            }
         }
 
         /// <summary>
@@ -2974,10 +3029,11 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             switch (metric)
             {
@@ -2988,7 +3044,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricInt.CheckButtonGap:
                     return 5;
                 case PaletteMetricInt.HeaderButtonEdgeInsetForm:
-                    return 9; // Needs to be the RealWindowBorderWidth Offset - No idea how to get it at this point
+                    return Math.Max(2, owningForm!.RealWindowBorders.Right);
                 case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                     return 1;
                 case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:
@@ -3042,10 +3098,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -3059,7 +3117,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricPadding.BarPaddingOutside:
                     return _metricPaddingBarOutside;
                 case PaletteMetricPadding.HeaderButtonPaddingForm:
-                    return _metricPaddingHeaderForm;
+                    return new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);
                 case PaletteMetricPadding.RibbonButtonPadding:
                     return _metricPaddingRibbon;
                 case PaletteMetricPadding.RibbonAppButton:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkMode.cs
@@ -391,7 +391,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
 
             _galleryButtonList.Images.AddStrip(GalleryImageResources.Gallery2010);
@@ -628,7 +628,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
         private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
         private static readonly Padding _contentPaddingCalendar = new Padding(2);
-        private static readonly Padding _contentPaddingHeaderForm = new Padding(10, 6, 3, 0); // 10 is from the RealWindowFrameSize +1
+        //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
         private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
         private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
         private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -640,7 +640,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);
@@ -652,7 +652,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _metricPaddingRibbon = new Padding(0, 1, 1, 1);
         private static readonly Padding _metricPaddingRibbonAppButton = new Padding(3, 0, 3, 0);
         private static readonly Padding _metricPaddingHeader = new Padding(0, 3, 1, 3);
-        private static readonly Padding _metricPaddingHeaderForm = new Padding(0, 3, 0, -3); // Move the Maximised Form buttons down a bit
+        //private static readonly Padding _metricPaddingHeaderForm = new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);//, 3, 0, -3); // Move the Maximised Form buttons down a bit
         private static readonly Padding _metricPaddingInputControl = new Padding(0, 1, 0, 1);
         private static readonly Padding _metricPaddingBarInside = new Padding(3);
         private static readonly Padding _metricPaddingBarTabs = new Padding(0);
@@ -908,12 +908,15 @@ namespace Krypton.Toolkit
                 PaletteBackStyle.SeparatorLowProfile or PaletteBackStyle.SeparatorCustom1 or PaletteBackStyle.SeparatorCustom2 or PaletteBackStyle.SeparatorCustom3 => InheritBool.False,
                 PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ButtonCalendarDay or PaletteBackStyle.ButtonNavigatorOverflow or PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose => state switch
                 {
-                    PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => InheritBool.False,
+                    PaletteState.Disabled
+                    or PaletteState.Normal
+                    or PaletteState.NormalDefaultOverride => InheritBool.False,
                     _ => InheritBool.True
                 },
                 PaletteBackStyle.ContextMenuItemImage or PaletteBackStyle.ContextMenuItemHighlight => state switch
                 {
-                    PaletteState.Normal or PaletteState.NormalDefaultOverride => InheritBool.False,
+                    PaletteState.Normal
+                    or PaletteState.NormalDefaultOverride => InheritBool.False,
                     _ => InheritBool.True
                 },
                 PaletteBackStyle.ButtonInputControl => state is PaletteState.Disabled or PaletteState.Normal ? InheritBool.False : InheritBool.True,
@@ -938,8 +941,8 @@ namespace Krypton.Toolkit
             return style switch
             {
                 PaletteBackStyle.TabHighProfile or PaletteBackStyle.TabStandardProfile or PaletteBackStyle.TabLowProfile or PaletteBackStyle.TabOneNote or PaletteBackStyle.TabDock or PaletteBackStyle.TabDockAutoHidden or PaletteBackStyle.TabCustom1 or PaletteBackStyle.TabCustom2 or PaletteBackStyle.TabCustom3 or PaletteBackStyle.PanelClient or PaletteBackStyle.PanelRibbonInactive or PaletteBackStyle.PanelAlternate or PaletteBackStyle.PanelCustom1 or PaletteBackStyle.PanelCustom2 or PaletteBackStyle.PanelCustom3 or PaletteBackStyle.SeparatorHighInternalProfile or PaletteBackStyle.SeparatorHighProfile or PaletteBackStyle.SeparatorLowProfile or PaletteBackStyle.SeparatorCustom1 or PaletteBackStyle.SeparatorCustom2 or PaletteBackStyle.SeparatorCustom3 or PaletteBackStyle.ControlClient or PaletteBackStyle.ControlAlternate or PaletteBackStyle.ControlGroupBox or PaletteBackStyle.ControlToolTip or PaletteBackStyle.ControlRibbon or PaletteBackStyle.ControlRibbonAppMenu or PaletteBackStyle.ControlCustom1 or PaletteBackStyle.ControlCustom2 or PaletteBackStyle.ControlCustom3 or PaletteBackStyle.ContextMenuOuter or PaletteBackStyle.ContextMenuInner or PaletteBackStyle.ContextMenuHeading or PaletteBackStyle.ContextMenuSeparator or PaletteBackStyle.ContextMenuItemSplit or PaletteBackStyle.ContextMenuItemImageColumn or PaletteBackStyle.ContextMenuItemImage or PaletteBackStyle.ContextMenuItemHighlight or PaletteBackStyle.InputControlStandalone or PaletteBackStyle.InputControlRibbon or PaletteBackStyle.InputControlCustom1 or PaletteBackStyle.InputControlCustom2 or PaletteBackStyle.InputControlCustom3 or PaletteBackStyle.FormMain or PaletteBackStyle.FormCustom1 or PaletteBackStyle.FormCustom2 or PaletteBackStyle.FormCustom3 or PaletteBackStyle.HeaderPrimary or PaletteBackStyle.HeaderDockInactive or PaletteBackStyle.HeaderDockActive or PaletteBackStyle.HeaderSecondary or PaletteBackStyle.HeaderForm or PaletteBackStyle.HeaderCalendar or PaletteBackStyle.HeaderCustom1 or PaletteBackStyle.HeaderCustom2 or PaletteBackStyle.HeaderCustom3 or PaletteBackStyle.ButtonStandalone or PaletteBackStyle.ButtonGallery or PaletteBackStyle.ButtonAlternate or PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonCalendarDay or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ButtonCluster or PaletteBackStyle.ButtonNavigatorStack or PaletteBackStyle.ButtonNavigatorOverflow or PaletteBackStyle.ButtonNavigatorMini or PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose or PaletteBackStyle.ButtonCustom1 or PaletteBackStyle.ButtonCustom2 or PaletteBackStyle.ButtonCustom3 or PaletteBackStyle.ButtonInputControl or PaletteBackStyle.GridBackgroundList or PaletteBackStyle.GridBackgroundSheet or PaletteBackStyle.GridBackgroundCustom1
-                    or PaletteBackStyle.GridBackgroundCustom2
-                    or PaletteBackStyle.GridBackgroundCustom3
+ or PaletteBackStyle.GridBackgroundCustom2
+ or PaletteBackStyle.GridBackgroundCustom3
  or PaletteBackStyle.GridHeaderColumnList or PaletteBackStyle.GridHeaderColumnSheet or PaletteBackStyle.GridHeaderColumnCustom1 or PaletteBackStyle.GridHeaderColumnCustom2 or PaletteBackStyle.GridHeaderColumnCustom3 or PaletteBackStyle.GridHeaderRowList or PaletteBackStyle.GridHeaderRowSheet or PaletteBackStyle.GridHeaderRowCustom1 or PaletteBackStyle.GridHeaderRowCustom2 or PaletteBackStyle.GridHeaderRowCustom3 or PaletteBackStyle.GridDataCellList or PaletteBackStyle.GridDataCellSheet or PaletteBackStyle.GridDataCellCustom1 or PaletteBackStyle.GridDataCellCustom2 or PaletteBackStyle.GridDataCellCustom3 => PaletteGraphicsHint.None,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
@@ -1580,7 +1583,11 @@ namespace Krypton.Toolkit
                 PaletteBackStyle.GridDataCellSheet => PaletteColorStyle.ExpertChecked,
                 PaletteBackStyle.TabHighProfile or PaletteBackStyle.TabCustom1 or PaletteBackStyle.TabCustom2 or PaletteBackStyle.TabCustom3 => state switch
                 {
-                    PaletteState.Tracking or PaletteState.Pressed or PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => PaletteColorStyle.GlassFade,
+                    PaletteState.Tracking
+                    or PaletteState.Pressed
+                    or PaletteState.CheckedNormal
+                    or PaletteState.CheckedTracking
+                    or PaletteState.CheckedPressed => PaletteColorStyle.GlassFade,
                     _ => PaletteColorStyle.QuarterPhase
                 },
                 PaletteBackStyle.TabStandardProfile => state switch
@@ -1592,8 +1599,8 @@ namespace Krypton.Toolkit
                 PaletteBackStyle.TabLowProfile => PaletteColorStyle.Solid,
                 PaletteBackStyle.TabOneNote or PaletteBackStyle.TabDock or PaletteBackStyle.TabDockAutoHidden => PaletteColorStyle.Linear,
                 PaletteBackStyle.PanelClient or PaletteBackStyle.PanelRibbonInactive or PaletteBackStyle.PanelAlternate or PaletteBackStyle.PanelCustom1 or PaletteBackStyle.PanelCustom2 or PaletteBackStyle.PanelCustom3 or PaletteBackStyle.SeparatorLowProfile or PaletteBackStyle.SeparatorCustom1 or PaletteBackStyle.SeparatorCustom2 or PaletteBackStyle.SeparatorCustom3 or PaletteBackStyle.ControlClient or PaletteBackStyle.ControlAlternate or PaletteBackStyle.ControlGroupBox or PaletteBackStyle.ControlRibbon or PaletteBackStyle.ContextMenuOuter or PaletteBackStyle.ContextMenuInner or PaletteBackStyle.ControlCustom1 or PaletteBackStyle.ControlCustom2 or PaletteBackStyle.ControlCustom3 or PaletteBackStyle.ContextMenuHeading or PaletteBackStyle.ContextMenuItemImageColumn or PaletteBackStyle.InputControlStandalone or PaletteBackStyle.InputControlRibbon or PaletteBackStyle.InputControlCustom1 or PaletteBackStyle.InputControlCustom2 or PaletteBackStyle.InputControlCustom3 or PaletteBackStyle.GridBackgroundList or PaletteBackStyle.GridBackgroundSheet or PaletteBackStyle.GridBackgroundCustom1
-                    or PaletteBackStyle.GridBackgroundCustom2
-                    or PaletteBackStyle.GridBackgroundCustom3
+ or PaletteBackStyle.GridBackgroundCustom2
+ or PaletteBackStyle.GridBackgroundCustom3
  or PaletteBackStyle.HeaderCalendar or PaletteBackStyle.ButtonCalendarDay => PaletteColorStyle.Solid,
                 PaletteBackStyle.ControlRibbonAppMenu => PaletteColorStyle.Switch90,
                 PaletteBackStyle.ContextMenuSeparator or PaletteBackStyle.ContextMenuItemSplit => state == PaletteState.Tracking ? PaletteColorStyle.GlassTrackingFull : PaletteColorStyle.Solid,
@@ -1604,8 +1611,14 @@ namespace Krypton.Toolkit
                 PaletteBackStyle.HeaderPrimary or PaletteBackStyle.HeaderDockInactive or PaletteBackStyle.HeaderSecondary or PaletteBackStyle.HeaderCustom1 or PaletteBackStyle.HeaderCustom2 or PaletteBackStyle.HeaderCustom3 or PaletteBackStyle.HeaderDockActive => PaletteColorStyle.Rounded,
                 PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose => state switch
                 {
-                    PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal or PaletteState.Tracking or PaletteState.CheckedTracking => PaletteColorStyle.Linear,
-                    PaletteState.Pressed or PaletteState.CheckedPressed => PaletteColorStyle.LinearShadow,
+                    PaletteState.Disabled
+                    or PaletteState.Normal
+                    or PaletteState.NormalDefaultOverride
+                    or PaletteState.CheckedNormal
+                    or PaletteState.Tracking
+                    or PaletteState.CheckedTracking => PaletteColorStyle.Linear,
+                    PaletteState.Pressed
+                    or PaletteState.CheckedPressed => PaletteColorStyle.LinearShadow,
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBackStyle.ButtonAlternate or PaletteBackStyle.ButtonStandalone or PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ButtonCluster or PaletteBackStyle.ButtonGallery or PaletteBackStyle.ButtonCustom1 or PaletteBackStyle.ButtonCustom2 or PaletteBackStyle.ButtonCustom3 or PaletteBackStyle.ButtonInputControl or PaletteBackStyle.ContextMenuItemHighlight => state switch
@@ -1613,7 +1626,8 @@ namespace Krypton.Toolkit
                     PaletteState.Disabled => PaletteColorStyle.Solid,
                     PaletteState.Normal => PaletteColorStyle.Linear,
                     PaletteState.Tracking => PaletteColorStyle.ExpertTracking,
-                    PaletteState.Pressed or PaletteState.CheckedPressed => PaletteColorStyle.ExpertPressed,
+                    PaletteState.Pressed
+                    or PaletteState.CheckedPressed => PaletteColorStyle.ExpertPressed,
                     PaletteState.CheckedNormal => PaletteColorStyle.ExpertChecked,
                     PaletteState.CheckedTracking => PaletteColorStyle.ExpertCheckedTracking,
                     _ => throw DebugTools.NotImplemented(state.ToString())
@@ -1621,8 +1635,11 @@ namespace Krypton.Toolkit
                 PaletteBackStyle.ContextMenuItemImage => PaletteColorStyle.Solid,
                 PaletteBackStyle.ButtonNavigatorStack or PaletteBackStyle.ButtonNavigatorOverflow or PaletteBackStyle.ButtonNavigatorMini => state switch
                 {
-                    PaletteState.Tracking or PaletteState.Pressed => PaletteColorStyle.SolidAllLine,
-                    PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => PaletteColorStyle.ExpertSquareHighlight,
+                    PaletteState.Tracking
+                    or PaletteState.Pressed => PaletteColorStyle.SolidAllLine,
+                    PaletteState.CheckedNormal
+                    or PaletteState.CheckedTracking
+                    or PaletteState.CheckedPressed => PaletteColorStyle.ExpertSquareHighlight,
                     _ => PaletteColorStyle.Solid
                 },
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
@@ -1646,8 +1663,8 @@ namespace Krypton.Toolkit
             return style switch
             {
                 PaletteBackStyle.ControlClient or PaletteBackStyle.ControlAlternate or PaletteBackStyle.ControlGroupBox or PaletteBackStyle.ControlRibbon or PaletteBackStyle.ControlRibbonAppMenu or PaletteBackStyle.ControlCustom1 or PaletteBackStyle.ControlCustom2 or PaletteBackStyle.ControlCustom3 or PaletteBackStyle.InputControlStandalone or PaletteBackStyle.InputControlRibbon or PaletteBackStyle.InputControlCustom1 or PaletteBackStyle.InputControlCustom2 or PaletteBackStyle.InputControlCustom3 or PaletteBackStyle.FormMain or PaletteBackStyle.FormCustom1 or PaletteBackStyle.FormCustom2 or PaletteBackStyle.FormCustom3 or PaletteBackStyle.PanelClient or PaletteBackStyle.PanelRibbonInactive or PaletteBackStyle.PanelAlternate or PaletteBackStyle.PanelCustom1 or PaletteBackStyle.PanelCustom2 or PaletteBackStyle.PanelCustom3 or PaletteBackStyle.GridBackgroundList or PaletteBackStyle.GridBackgroundSheet or PaletteBackStyle.GridBackgroundCustom1
-                    or PaletteBackStyle.GridBackgroundCustom2
-                    or PaletteBackStyle.GridBackgroundCustom3
+ or PaletteBackStyle.GridBackgroundCustom2
+ or PaletteBackStyle.GridBackgroundCustom3
  => PaletteRectangleAlign.Control,
                 PaletteBackStyle.ControlToolTip or PaletteBackStyle.SeparatorLowProfile or PaletteBackStyle.SeparatorHighInternalProfile or PaletteBackStyle.SeparatorHighProfile or PaletteBackStyle.SeparatorCustom1 or PaletteBackStyle.SeparatorCustom2 or PaletteBackStyle.SeparatorCustom3 or PaletteBackStyle.HeaderPrimary or PaletteBackStyle.HeaderDockInactive or PaletteBackStyle.HeaderDockActive or PaletteBackStyle.HeaderCalendar or PaletteBackStyle.HeaderSecondary or PaletteBackStyle.HeaderForm or PaletteBackStyle.HeaderCustom1 or PaletteBackStyle.HeaderCustom2 or PaletteBackStyle.HeaderCustom3 or PaletteBackStyle.TabHighProfile or PaletteBackStyle.TabStandardProfile or PaletteBackStyle.TabLowProfile or PaletteBackStyle.TabOneNote or PaletteBackStyle.TabDock or PaletteBackStyle.TabDockAutoHidden or PaletteBackStyle.TabCustom1 or PaletteBackStyle.TabCustom2 or PaletteBackStyle.TabCustom3 or PaletteBackStyle.ButtonStandalone or PaletteBackStyle.ButtonGallery or PaletteBackStyle.ButtonAlternate or PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ButtonCalendarDay or PaletteBackStyle.ButtonCluster or PaletteBackStyle.ButtonNavigatorStack or PaletteBackStyle.ButtonNavigatorOverflow or PaletteBackStyle.ButtonNavigatorMini or PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose or PaletteBackStyle.ButtonCustom1 or PaletteBackStyle.ButtonCustom2 or PaletteBackStyle.ButtonCustom3 or PaletteBackStyle.ButtonInputControl or PaletteBackStyle.GridHeaderColumnList or PaletteBackStyle.GridHeaderColumnSheet or PaletteBackStyle.GridHeaderColumnCustom1 or PaletteBackStyle.GridHeaderColumnCustom2 or PaletteBackStyle.GridHeaderColumnCustom3 or PaletteBackStyle.GridHeaderRowList or PaletteBackStyle.GridHeaderRowSheet or PaletteBackStyle.GridHeaderRowCustom1 or PaletteBackStyle.GridHeaderRowCustom2 or PaletteBackStyle.GridHeaderRowCustom3 or PaletteBackStyle.GridDataCellList or PaletteBackStyle.GridDataCellSheet or PaletteBackStyle.GridDataCellCustom1 or PaletteBackStyle.GridDataCellCustom2 or PaletteBackStyle.GridDataCellCustom3 or PaletteBackStyle.ContextMenuItemImage or PaletteBackStyle.ContextMenuItemHighlight or PaletteBackStyle.ContextMenuOuter or PaletteBackStyle.ContextMenuInner or PaletteBackStyle.ContextMenuHeading or PaletteBackStyle.ContextMenuSeparator or PaletteBackStyle.ContextMenuItemSplit or PaletteBackStyle.ContextMenuItemImageColumn => PaletteRectangleAlign.Local,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
@@ -1671,8 +1688,8 @@ namespace Krypton.Toolkit
             return style switch
             {
                 PaletteBackStyle.PanelClient or PaletteBackStyle.PanelRibbonInactive or PaletteBackStyle.PanelAlternate or PaletteBackStyle.PanelCustom1 or PaletteBackStyle.PanelCustom2 or PaletteBackStyle.PanelCustom3 or PaletteBackStyle.SeparatorLowProfile or PaletteBackStyle.SeparatorHighInternalProfile or PaletteBackStyle.SeparatorHighProfile or PaletteBackStyle.SeparatorCustom1 or PaletteBackStyle.SeparatorCustom2 or PaletteBackStyle.SeparatorCustom3 or PaletteBackStyle.ControlClient or PaletteBackStyle.ControlAlternate or PaletteBackStyle.ControlGroupBox or PaletteBackStyle.ControlToolTip or PaletteBackStyle.ControlRibbon or PaletteBackStyle.ControlRibbonAppMenu or PaletteBackStyle.ControlCustom1 or PaletteBackStyle.ControlCustom2 or PaletteBackStyle.ControlCustom3 or PaletteBackStyle.ContextMenuOuter or PaletteBackStyle.ContextMenuInner or PaletteBackStyle.ContextMenuHeading or PaletteBackStyle.ContextMenuSeparator or PaletteBackStyle.ContextMenuItemSplit or PaletteBackStyle.ContextMenuItemImageColumn or PaletteBackStyle.InputControlStandalone or PaletteBackStyle.InputControlRibbon or PaletteBackStyle.InputControlCustom1 or PaletteBackStyle.InputControlCustom2 or PaletteBackStyle.InputControlCustom3 or PaletteBackStyle.FormMain or PaletteBackStyle.FormCustom1 or PaletteBackStyle.FormCustom2 or PaletteBackStyle.FormCustom3 or PaletteBackStyle.HeaderPrimary or PaletteBackStyle.HeaderDockInactive or PaletteBackStyle.HeaderDockActive or PaletteBackStyle.HeaderCalendar or PaletteBackStyle.HeaderSecondary or PaletteBackStyle.HeaderForm or PaletteBackStyle.HeaderCustom1 or PaletteBackStyle.HeaderCustom2 or PaletteBackStyle.HeaderCustom3 or PaletteBackStyle.TabHighProfile or PaletteBackStyle.TabStandardProfile or PaletteBackStyle.TabLowProfile or PaletteBackStyle.TabOneNote or PaletteBackStyle.TabDock or PaletteBackStyle.TabDockAutoHidden or PaletteBackStyle.TabCustom1 or PaletteBackStyle.TabCustom2 or PaletteBackStyle.TabCustom3 or PaletteBackStyle.ButtonStandalone or PaletteBackStyle.ButtonGallery or PaletteBackStyle.ButtonAlternate or PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ButtonCalendarDay or PaletteBackStyle.ButtonCluster or PaletteBackStyle.ButtonNavigatorStack or PaletteBackStyle.ButtonNavigatorOverflow or PaletteBackStyle.ButtonNavigatorMini or PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose or PaletteBackStyle.ButtonCustom1 or PaletteBackStyle.ButtonCustom2 or PaletteBackStyle.ButtonCustom3 or PaletteBackStyle.ButtonInputControl or PaletteBackStyle.ContextMenuItemImage or PaletteBackStyle.ContextMenuItemHighlight or PaletteBackStyle.GridBackgroundList or PaletteBackStyle.GridBackgroundSheet or PaletteBackStyle.GridBackgroundCustom1
-                    or PaletteBackStyle.GridBackgroundCustom2
-                    or PaletteBackStyle.GridBackgroundCustom3
+ or PaletteBackStyle.GridBackgroundCustom2
+ or PaletteBackStyle.GridBackgroundCustom3
  or PaletteBackStyle.GridHeaderColumnList or PaletteBackStyle.GridHeaderColumnSheet or PaletteBackStyle.GridHeaderColumnCustom1 or PaletteBackStyle.GridHeaderColumnCustom2 or PaletteBackStyle.GridHeaderColumnCustom3 or PaletteBackStyle.GridHeaderRowList or PaletteBackStyle.GridHeaderRowSheet or PaletteBackStyle.GridHeaderRowCustom1 or PaletteBackStyle.GridHeaderRowCustom2 or PaletteBackStyle.GridHeaderRowCustom3 or PaletteBackStyle.GridDataCellList or PaletteBackStyle.GridDataCellSheet or PaletteBackStyle.GridDataCellCustom1 or PaletteBackStyle.GridDataCellCustom2 or PaletteBackStyle.GridDataCellCustom3 => 90f,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
@@ -1695,8 +1712,8 @@ namespace Krypton.Toolkit
             return style switch
             {
                 PaletteBackStyle.PanelClient or PaletteBackStyle.PanelRibbonInactive or PaletteBackStyle.PanelAlternate or PaletteBackStyle.PanelCustom1 or PaletteBackStyle.PanelCustom2 or PaletteBackStyle.PanelCustom3 or PaletteBackStyle.SeparatorLowProfile or PaletteBackStyle.SeparatorHighInternalProfile or PaletteBackStyle.SeparatorHighProfile or PaletteBackStyle.SeparatorCustom1 or PaletteBackStyle.SeparatorCustom2 or PaletteBackStyle.SeparatorCustom3 or PaletteBackStyle.ControlClient or PaletteBackStyle.ControlAlternate or PaletteBackStyle.ControlGroupBox or PaletteBackStyle.ControlToolTip or PaletteBackStyle.ControlRibbon or PaletteBackStyle.ControlRibbonAppMenu or PaletteBackStyle.ControlCustom1 or PaletteBackStyle.ControlCustom2 or PaletteBackStyle.ControlCustom3 or PaletteBackStyle.ContextMenuOuter or PaletteBackStyle.ContextMenuInner or PaletteBackStyle.ContextMenuHeading or PaletteBackStyle.ContextMenuSeparator or PaletteBackStyle.ContextMenuItemSplit or PaletteBackStyle.ContextMenuItemImageColumn or PaletteBackStyle.InputControlStandalone or PaletteBackStyle.InputControlRibbon or PaletteBackStyle.InputControlCustom1 or PaletteBackStyle.InputControlCustom2 or PaletteBackStyle.InputControlCustom3 or PaletteBackStyle.FormMain or PaletteBackStyle.FormCustom1 or PaletteBackStyle.FormCustom2 or PaletteBackStyle.FormCustom3 or PaletteBackStyle.HeaderPrimary or PaletteBackStyle.HeaderDockInactive or PaletteBackStyle.HeaderDockActive or PaletteBackStyle.HeaderCalendar or PaletteBackStyle.HeaderSecondary or PaletteBackStyle.HeaderForm or PaletteBackStyle.HeaderCustom1 or PaletteBackStyle.HeaderCustom2 or PaletteBackStyle.HeaderCustom3 or PaletteBackStyle.TabHighProfile or PaletteBackStyle.TabStandardProfile or PaletteBackStyle.TabLowProfile or PaletteBackStyle.TabOneNote or PaletteBackStyle.TabDock or PaletteBackStyle.TabDockAutoHidden or PaletteBackStyle.TabCustom1 or PaletteBackStyle.TabCustom2 or PaletteBackStyle.TabCustom3 or PaletteBackStyle.ButtonStandalone or PaletteBackStyle.ButtonGallery or PaletteBackStyle.ButtonAlternate or PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ButtonCalendarDay or PaletteBackStyle.ButtonCluster or PaletteBackStyle.ButtonNavigatorStack or PaletteBackStyle.ButtonNavigatorOverflow or PaletteBackStyle.ButtonNavigatorMini or PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose or PaletteBackStyle.ButtonCustom1 or PaletteBackStyle.ButtonCustom2 or PaletteBackStyle.ButtonCustom3 or PaletteBackStyle.ButtonInputControl or PaletteBackStyle.ContextMenuItemImage or PaletteBackStyle.ContextMenuItemHighlight or PaletteBackStyle.GridBackgroundList or PaletteBackStyle.GridBackgroundSheet or PaletteBackStyle.GridBackgroundCustom1
-                    or PaletteBackStyle.GridBackgroundCustom2
-                    or PaletteBackStyle.GridBackgroundCustom3
+ or PaletteBackStyle.GridBackgroundCustom2
+ or PaletteBackStyle.GridBackgroundCustom3
  or PaletteBackStyle.GridHeaderColumnList or PaletteBackStyle.GridHeaderColumnSheet or PaletteBackStyle.GridHeaderColumnCustom1 or PaletteBackStyle.GridHeaderColumnCustom2 or PaletteBackStyle.GridHeaderColumnCustom3 or PaletteBackStyle.GridHeaderRowList or PaletteBackStyle.GridHeaderRowSheet or PaletteBackStyle.GridHeaderRowCustom1 or PaletteBackStyle.GridHeaderRowCustom2 or PaletteBackStyle.GridHeaderRowCustom3 or PaletteBackStyle.GridDataCellList or PaletteBackStyle.GridDataCellSheet or PaletteBackStyle.GridDataCellCustom1 or PaletteBackStyle.GridDataCellCustom2 or PaletteBackStyle.GridDataCellCustom3 => null,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
@@ -1719,8 +1736,8 @@ namespace Krypton.Toolkit
             return style switch
             {
                 PaletteBackStyle.PanelClient or PaletteBackStyle.PanelRibbonInactive or PaletteBackStyle.PanelAlternate or PaletteBackStyle.PanelCustom1 or PaletteBackStyle.PanelCustom2 or PaletteBackStyle.PanelCustom3 or PaletteBackStyle.SeparatorLowProfile or PaletteBackStyle.SeparatorHighInternalProfile or PaletteBackStyle.SeparatorHighProfile or PaletteBackStyle.SeparatorCustom1 or PaletteBackStyle.SeparatorCustom2 or PaletteBackStyle.SeparatorCustom3 or PaletteBackStyle.ControlClient or PaletteBackStyle.ControlAlternate or PaletteBackStyle.ControlGroupBox or PaletteBackStyle.ControlToolTip or PaletteBackStyle.ControlRibbon or PaletteBackStyle.ControlRibbonAppMenu or PaletteBackStyle.ControlCustom1 or PaletteBackStyle.ControlCustom2 or PaletteBackStyle.ControlCustom3 or PaletteBackStyle.ContextMenuOuter or PaletteBackStyle.ContextMenuInner or PaletteBackStyle.ContextMenuHeading or PaletteBackStyle.ContextMenuSeparator or PaletteBackStyle.ContextMenuItemSplit or PaletteBackStyle.ContextMenuItemImageColumn or PaletteBackStyle.InputControlStandalone or PaletteBackStyle.InputControlRibbon or PaletteBackStyle.InputControlCustom1 or PaletteBackStyle.InputControlCustom2 or PaletteBackStyle.InputControlCustom3 or PaletteBackStyle.FormMain or PaletteBackStyle.FormCustom1 or PaletteBackStyle.FormCustom2 or PaletteBackStyle.FormCustom3 or PaletteBackStyle.HeaderPrimary or PaletteBackStyle.HeaderDockInactive or PaletteBackStyle.HeaderDockActive or PaletteBackStyle.HeaderCalendar or PaletteBackStyle.HeaderSecondary or PaletteBackStyle.HeaderForm or PaletteBackStyle.HeaderCustom1 or PaletteBackStyle.HeaderCustom2 or PaletteBackStyle.HeaderCustom3 or PaletteBackStyle.TabHighProfile or PaletteBackStyle.TabStandardProfile or PaletteBackStyle.TabLowProfile or PaletteBackStyle.TabOneNote or PaletteBackStyle.TabDock or PaletteBackStyle.TabDockAutoHidden or PaletteBackStyle.TabCustom1 or PaletteBackStyle.TabCustom2 or PaletteBackStyle.TabCustom3 or PaletteBackStyle.ButtonStandalone or PaletteBackStyle.ButtonGallery or PaletteBackStyle.ButtonAlternate or PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ButtonCalendarDay or PaletteBackStyle.ButtonCluster or PaletteBackStyle.ButtonNavigatorStack or PaletteBackStyle.ButtonNavigatorOverflow or PaletteBackStyle.ButtonNavigatorMini or PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose or PaletteBackStyle.ButtonCustom1 or PaletteBackStyle.ButtonCustom2 or PaletteBackStyle.ButtonCustom3 or PaletteBackStyle.ButtonInputControl or PaletteBackStyle.ContextMenuItemImage or PaletteBackStyle.ContextMenuItemHighlight or PaletteBackStyle.GridBackgroundList or PaletteBackStyle.GridBackgroundSheet or PaletteBackStyle.GridBackgroundCustom1
-                    or PaletteBackStyle.GridBackgroundCustom2
-                    or PaletteBackStyle.GridBackgroundCustom3
+ or PaletteBackStyle.GridBackgroundCustom2
+ or PaletteBackStyle.GridBackgroundCustom3
  or PaletteBackStyle.GridHeaderColumnList or PaletteBackStyle.GridHeaderColumnSheet or PaletteBackStyle.GridHeaderColumnCustom1 or PaletteBackStyle.GridHeaderColumnCustom2 or PaletteBackStyle.GridHeaderColumnCustom3 or PaletteBackStyle.GridHeaderRowList or PaletteBackStyle.GridHeaderRowSheet or PaletteBackStyle.GridHeaderRowCustom1 or PaletteBackStyle.GridHeaderRowCustom2 or PaletteBackStyle.GridHeaderRowCustom3 or PaletteBackStyle.GridDataCellList or PaletteBackStyle.GridDataCellSheet or PaletteBackStyle.GridDataCellCustom1 or PaletteBackStyle.GridDataCellCustom2 or PaletteBackStyle.GridDataCellCustom3 => PaletteImageStyle.Tile,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
@@ -1743,8 +1760,8 @@ namespace Krypton.Toolkit
             return style switch
             {
                 PaletteBackStyle.PanelClient or PaletteBackStyle.PanelRibbonInactive or PaletteBackStyle.PanelAlternate or PaletteBackStyle.PanelCustom1 or PaletteBackStyle.PanelCustom2 or PaletteBackStyle.PanelCustom3 or PaletteBackStyle.SeparatorLowProfile or PaletteBackStyle.SeparatorHighInternalProfile or PaletteBackStyle.SeparatorHighProfile or PaletteBackStyle.SeparatorCustom1 or PaletteBackStyle.SeparatorCustom2 or PaletteBackStyle.SeparatorCustom3 or PaletteBackStyle.ControlClient or PaletteBackStyle.ControlAlternate or PaletteBackStyle.ControlGroupBox or PaletteBackStyle.ControlToolTip or PaletteBackStyle.ControlRibbon or PaletteBackStyle.ControlRibbonAppMenu or PaletteBackStyle.ControlCustom1 or PaletteBackStyle.ControlCustom2 or PaletteBackStyle.ControlCustom3 or PaletteBackStyle.ContextMenuOuter or PaletteBackStyle.ContextMenuInner or PaletteBackStyle.ContextMenuHeading or PaletteBackStyle.ContextMenuSeparator or PaletteBackStyle.ContextMenuItemSplit or PaletteBackStyle.ContextMenuItemImageColumn or PaletteBackStyle.InputControlStandalone or PaletteBackStyle.InputControlRibbon or PaletteBackStyle.InputControlCustom1 or PaletteBackStyle.InputControlCustom2 or PaletteBackStyle.InputControlCustom3 or PaletteBackStyle.FormMain or PaletteBackStyle.FormCustom1 or PaletteBackStyle.FormCustom2 or PaletteBackStyle.FormCustom3 or PaletteBackStyle.HeaderPrimary or PaletteBackStyle.HeaderDockInactive or PaletteBackStyle.HeaderDockActive or PaletteBackStyle.HeaderCalendar or PaletteBackStyle.HeaderSecondary or PaletteBackStyle.HeaderForm or PaletteBackStyle.HeaderCustom1 or PaletteBackStyle.HeaderCustom2 or PaletteBackStyle.HeaderCustom3 or PaletteBackStyle.TabHighProfile or PaletteBackStyle.TabStandardProfile or PaletteBackStyle.TabLowProfile or PaletteBackStyle.TabOneNote or PaletteBackStyle.TabDock or PaletteBackStyle.TabDockAutoHidden or PaletteBackStyle.TabCustom1 or PaletteBackStyle.TabCustom2 or PaletteBackStyle.TabCustom3 or PaletteBackStyle.ButtonStandalone or PaletteBackStyle.ButtonGallery or PaletteBackStyle.ButtonAlternate or PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ButtonCalendarDay or PaletteBackStyle.ButtonCluster or PaletteBackStyle.ButtonNavigatorStack or PaletteBackStyle.ButtonNavigatorOverflow or PaletteBackStyle.ButtonNavigatorMini or PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose or PaletteBackStyle.ButtonCustom1 or PaletteBackStyle.ButtonCustom2 or PaletteBackStyle.ButtonCustom3 or PaletteBackStyle.ButtonInputControl or PaletteBackStyle.ContextMenuItemImage or PaletteBackStyle.ContextMenuItemHighlight or PaletteBackStyle.GridBackgroundList or PaletteBackStyle.GridBackgroundSheet or PaletteBackStyle.GridBackgroundCustom1
-                    or PaletteBackStyle.GridBackgroundCustom2
-                    or PaletteBackStyle.GridBackgroundCustom3
+ or PaletteBackStyle.GridBackgroundCustom2
+ or PaletteBackStyle.GridBackgroundCustom3
  or PaletteBackStyle.GridHeaderColumnList or PaletteBackStyle.GridHeaderColumnSheet or PaletteBackStyle.GridHeaderColumnCustom1 or PaletteBackStyle.GridHeaderColumnCustom2 or PaletteBackStyle.GridHeaderColumnCustom3 or PaletteBackStyle.GridHeaderRowList or PaletteBackStyle.GridHeaderRowSheet or PaletteBackStyle.GridHeaderRowCustom1 or PaletteBackStyle.GridHeaderRowCustom2 or PaletteBackStyle.GridHeaderRowCustom3 or PaletteBackStyle.GridDataCellList or PaletteBackStyle.GridDataCellSheet or PaletteBackStyle.GridDataCellCustom1 or PaletteBackStyle.GridDataCellCustom2 or PaletteBackStyle.GridDataCellCustom3 => PaletteRectangleAlign.Local,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
@@ -1781,12 +1798,15 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlToolTip or PaletteBorderStyle.ControlRibbon or PaletteBorderStyle.ControlRibbonAppMenu or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.ContextMenuOuter or PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit or PaletteBorderStyle.ContextMenuItemImageColumn or PaletteBorderStyle.InputControlStandalone or PaletteBorderStyle.InputControlRibbon or PaletteBorderStyle.InputControlCustom1 or PaletteBorderStyle.InputControlCustom2 or PaletteBorderStyle.InputControlCustom3 or PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCalendar or PaletteBorderStyle.HeaderForm or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.TabHighProfile or PaletteBorderStyle.TabStandardProfile or PaletteBorderStyle.TabLowProfile or PaletteBorderStyle.TabOneNote or PaletteBorderStyle.TabDock or PaletteBorderStyle.TabDockAutoHidden or PaletteBorderStyle.TabCustom1 or PaletteBorderStyle.TabCustom2 or PaletteBorderStyle.TabCustom3 or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 or PaletteBorderStyle.GridDataCellList or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1 or PaletteBorderStyle.GridDataCellCustom2 or PaletteBorderStyle.GridDataCellCustom3 => InheritBool.True,
                 PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCalendarDay or PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonForm or PaletteBorderStyle.ButtonFormClose or PaletteBorderStyle.ButtonInputControl => state switch
                 {
-                    PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => InheritBool.False,
+                    PaletteState.Disabled
+                    or PaletteState.Normal
+                    or PaletteState.NormalDefaultOverride => InheritBool.False,
                     _ => InheritBool.True
                 },
                 PaletteBorderStyle.ContextMenuItemImage or PaletteBorderStyle.ContextMenuItemHighlight => state switch
                 {
-                    PaletteState.Normal or PaletteState.NormalDefaultOverride => InheritBool.False,
+                    PaletteState.Normal
+                    or PaletteState.NormalDefaultOverride => InheritBool.False,
                     _ => InheritBool.True
                 },
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
@@ -1815,7 +1835,7 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => PaletteDrawBorders.Top,
                 PaletteBorderStyle.ContextMenuItemImageColumn => PaletteDrawBorders.Right,
                 PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ContextMenuInner => PaletteDrawBorders.None,
-                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.TopLeftRight,
+                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.None,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -1868,8 +1888,12 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.TabHighProfile or PaletteBorderStyle.TabStandardProfile or PaletteBorderStyle.TabLowProfile or PaletteBorderStyle.TabOneNote or PaletteBorderStyle.TabCustom1 or PaletteBorderStyle.TabCustom2 or PaletteBorderStyle.TabCustom3 => state switch
                 {
                     PaletteState.Disabled => style == PaletteBorderStyle.TabLowProfile ? GlobalStaticValues.EMPTY_COLOR : _disabledBorder,
-                    PaletteState.Normal or PaletteState.Tracking or PaletteState.Pressed => style == PaletteBorderStyle.TabLowProfile ? GlobalStaticValues.EMPTY_COLOR : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
-                    PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
+                    PaletteState.Normal
+                    or PaletteState.Tracking
+                    or PaletteState.Pressed => style == PaletteBorderStyle.TabLowProfile ? GlobalStaticValues.EMPTY_COLOR : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
+                    PaletteState.CheckedNormal
+                    or PaletteState.CheckedPressed
+                    or PaletteState.CheckedTracking => _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.TabDock => state switch
@@ -1936,12 +1960,18 @@ namespace Krypton.Toolkit
                                                    ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
                                                    : _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
-                    PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
+                    PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile
+                    or PaletteBorderStyle.ButtonBreadCrumb
+                    or PaletteBorderStyle.ButtonListItem
+                    or PaletteBorderStyle.ButtonCommand
+                    or PaletteBorderStyle.ButtonButtonSpec
+                    or PaletteBorderStyle.ContextMenuItemHighlight
                                                             ? GlobalStaticValues.EMPTY_COLOR
                                                             : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                    PaletteState.Pressed
+                    or PaletteState.CheckedPressed => _buttonBorderColors[3],
                     PaletteState.CheckedTracking => _buttonBorderColors[3],
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
@@ -1996,8 +2026,12 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.TabHighProfile or PaletteBorderStyle.TabStandardProfile or PaletteBorderStyle.TabLowProfile or PaletteBorderStyle.TabOneNote or PaletteBorderStyle.TabCustom1 or PaletteBorderStyle.TabCustom2 or PaletteBorderStyle.TabCustom3 => state switch
                 {
                     PaletteState.Disabled => style == PaletteBorderStyle.TabLowProfile ? GlobalStaticValues.EMPTY_COLOR : _disabledBorder,
-                    PaletteState.Normal or PaletteState.Tracking or PaletteState.Pressed => style == PaletteBorderStyle.TabLowProfile ? GlobalStaticValues.EMPTY_COLOR : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
-                    PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
+                    PaletteState.Normal
+                    or PaletteState.Tracking
+                    or PaletteState.Pressed => style == PaletteBorderStyle.TabLowProfile ? GlobalStaticValues.EMPTY_COLOR : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
+                    PaletteState.CheckedNormal
+                    or PaletteState.CheckedPressed
+                    or PaletteState.CheckedTracking => _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.TabDock => state switch
@@ -2067,7 +2101,8 @@ namespace Krypton.Toolkit
                     PaletteState.NormalDefaultOverride => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[6],
                     PaletteState.Tracking => _buttonBorderColors[2],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
+                    PaletteState.Pressed
+                    or PaletteState.CheckedPressed => _buttonBorderColors[4],
                     PaletteState.CheckedTracking => _buttonBorderColors[4],
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
@@ -2128,7 +2163,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ButtonInputControl or PaletteBorderStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Normal => PaletteColorStyle.Solid,
-                    PaletteState.Disabled or PaletteState.NormalDefaultOverride => PaletteColorStyle.Solid,
+                    PaletteState.Disabled
+                    or PaletteState.NormalDefaultOverride => PaletteColorStyle.Solid,
                     _ => PaletteColorStyle.Linear
                 },
                 PaletteBorderStyle.ButtonForm or PaletteBorderStyle.ButtonFormClose => PaletteColorStyle.Solid,
@@ -2487,7 +2523,9 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden => TabFontNormal,
                 PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 => state switch
                 {
-                    PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => TabFontSelected,
+                    PaletteState.CheckedNormal
+                    or PaletteState.CheckedPressed
+                    or PaletteState.CheckedTracking => TabFontSelected,
                     _ => TabFontNormal
                 },
                 PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonGallery or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 or PaletteContentStyle.ButtonInputControl => ButtonFont,
@@ -2736,18 +2774,18 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.LabelToolTip or PaletteContentStyle.LabelSuperTip or PaletteContentStyle.LabelKeyTip => _toolTipText,
                 PaletteContentStyle.ContextMenuHeading => _ribbonColours[(int)SchemeOfficeColors.ContextMenuHeadingText],
                 PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile
-                    or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote
-                    or PaletteContentStyle.TabDock or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2
-                    or PaletteContentStyle.TabCustom3 or PaletteContentStyle.ButtonStandalone
-                    or PaletteContentStyle.ButtonGallery or PaletteContentStyle.ButtonAlternate
-                    or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonCustom1
-                    or PaletteContentStyle.ButtonCustom2
-                    or PaletteContentStyle.ButtonCustom3 => state switch
-                    {
-                        PaletteState.Tracking => _buttonTextTracking,
-                        PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal],
-                        _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked]
-                    },
+ or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote
+ or PaletteContentStyle.TabDock or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2
+ or PaletteContentStyle.TabCustom3 or PaletteContentStyle.ButtonStandalone
+ or PaletteContentStyle.ButtonGallery or PaletteContentStyle.ButtonAlternate
+ or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonCustom1
+ or PaletteContentStyle.ButtonCustom2
+ or PaletteContentStyle.ButtonCustom3 => state switch
+ {
+     PaletteState.Tracking => _buttonTextTracking,
+     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal],
+     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked]
+ },
                 /*state != PaletteState.Normal
                     ? _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked]
                     : _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal],
@@ -2760,20 +2798,23 @@ namespace Krypton.Toolkit
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand
-                    or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb
-                    or PaletteContentStyle.ButtonButtonSpec => state switch
-                    {
-                        PaletteState.Tracking => _buttonTextTracking,
-                        PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                       ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                       : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
-                        PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
-                        _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
-                    },
+ or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb
+ or PaletteContentStyle.ButtonButtonSpec => state switch
+ {
+     PaletteState.Tracking => _buttonTextTracking,
+     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
+                                    ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                    : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
+     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
+ },
                 PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => state switch
                 {
-                    PaletteState.Tracking or PaletteState.CheckedTracking => _ribbonColours[(int)SchemeOfficeColors.TextButtonFormTracking],
-                    PaletteState.Pressed or PaletteState.CheckedPressed or PaletteState.CheckedNormal => _ribbonColours[(int)SchemeOfficeColors.TextButtonFormPressed],
+                    PaletteState.Tracking
+                    or PaletteState.CheckedTracking => _ribbonColours[(int)SchemeOfficeColors.TextButtonFormTracking],
+                    PaletteState.Pressed
+                    or PaletteState.CheckedPressed
+                    or PaletteState.CheckedNormal => _ribbonColours[(int)SchemeOfficeColors.TextButtonFormPressed],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonFormNormal]
                 },
                 PaletteContentStyle.ButtonInputControl => state switch
@@ -2851,13 +2892,17 @@ namespace Krypton.Toolkit
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
                                                    ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
                                                    : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
-                    PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
+                    PaletteState.CheckedNormal
+                    or PaletteState.CheckedTracking
+                    or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
                 PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => state switch
                 {
-                    PaletteState.Tracking or PaletteState.CheckedTracking => _ribbonColours[(int)SchemeOfficeColors.TextButtonFormTracking],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonFormPressed],
+                    PaletteState.Tracking
+                    or PaletteState.CheckedTracking => _ribbonColours[(int)SchemeOfficeColors.TextButtonFormTracking],
+                    PaletteState.Pressed
+                    or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonFormPressed],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonFormNormal]
                 },
                 PaletteContentStyle.ButtonInputControl => state != PaletteState.Disabled
@@ -3018,7 +3063,9 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden => TabFontNormal,
                 PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 => state switch
                 {
-                    PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => TabFontSelected,
+                    PaletteState.CheckedNormal
+                    or PaletteState.CheckedPressed
+                    or PaletteState.CheckedTracking => TabFontSelected,
                     _ => TabFontNormal
                 },
                 PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonGallery or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow or PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 or PaletteContentStyle.ButtonInputControl => ButtonFont,
@@ -3250,7 +3297,9 @@ namespace Krypton.Toolkit
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
                                                    ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
                                                    : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
-                    PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
+                    PaletteState.CheckedNormal
+                    or PaletteState.CheckedTracking
+                    or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
                 PaletteContentStyle.ButtonCalendarDay => state switch
@@ -3260,8 +3309,10 @@ namespace Krypton.Toolkit
                 },
                 PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => state switch
                 {
-                    PaletteState.Tracking or PaletteState.CheckedTracking => _ribbonColours[(int)SchemeOfficeColors.TextButtonFormTracking],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonFormPressed],
+                    PaletteState.Tracking
+                    or PaletteState.CheckedTracking => _ribbonColours[(int)SchemeOfficeColors.TextButtonFormTracking],
+                    PaletteState.Pressed
+                    or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonFormPressed],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonFormNormal]
                 },
                 PaletteContentStyle.ButtonInputControl => state switch
@@ -3333,7 +3384,9 @@ namespace Krypton.Toolkit
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
                                                    ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
                                                    : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
-                    PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
+                    PaletteState.CheckedNormal
+                    or PaletteState.CheckedTracking
+                    or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
                 PaletteContentStyle.ButtonCalendarDay => state switch
@@ -3343,8 +3396,10 @@ namespace Krypton.Toolkit
                 },
                 PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => state switch
                 {
-                    PaletteState.Tracking or PaletteState.CheckedTracking => _ribbonColours[(int)SchemeOfficeColors.TextButtonFormTracking],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonFormPressed],
+                    PaletteState.Tracking
+                    or PaletteState.CheckedTracking => _ribbonColours[(int)SchemeOfficeColors.TextButtonFormTracking],
+                    PaletteState.Pressed
+                    or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonFormPressed],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonFormNormal]
                 },
                 PaletteContentStyle.ButtonInputControl => state != PaletteState.Disabled
@@ -3486,10 +3541,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             // We do not provide override values
             if (CommonHelper.IsOverrideState(state))
@@ -3497,37 +3554,90 @@ namespace Krypton.Toolkit
                 return CommonHelper.InheritPadding;
             }
 
-            return style switch
+            switch (style)
             {
-                PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 => _contentPaddingGrid,
-                PaletteContentStyle.HeaderForm => _contentPaddingHeaderForm,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _contentPaddingHeader1,
-                PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive => _contentPaddingDock,
-                PaletteContentStyle.HeaderSecondary => _contentPaddingHeader2,
-                PaletteContentStyle.HeaderCalendar => _contentPaddingCalendar,
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 => _contentPaddingLabel,
-                PaletteContentStyle.LabelGroupBoxCaption => _contentPaddingLabel2,
-                PaletteContentStyle.ContextMenuItemTextStandard => _contentPaddingContextMenuItemText,
-                PaletteContentStyle.ContextMenuItemTextAlternate => _contentPaddingContextMenuItemTextAlt,
-                PaletteContentStyle.ContextMenuItemShortcutText => _contentPaddingContextMenuItemShortcutText,
-                PaletteContentStyle.ContextMenuItemImage => _contentPaddingContextMenuImage,
-                PaletteContentStyle.LabelToolTip => _contentPaddingToolTip,
-                PaletteContentStyle.LabelSuperTip => _contentPaddingSuperTip,
-                PaletteContentStyle.LabelKeyTip => _contentPaddingKeyTip,
-                PaletteContentStyle.ContextMenuHeading => _contentPaddingContextMenuHeading,
-                PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => InputControlPadding,
-                PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => _contentPaddingButton12,
-                PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay => _contentPaddingButtonInputControl,
-                PaletteContentStyle.ButtonButtonSpec => _contentPaddingButton3,
-                PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => _contentPaddingButton4,
-                PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => _contentPaddingButtonForm,
-                PaletteContentStyle.ButtonGallery => _contentPaddingButtonGallery,
-                PaletteContentStyle.ButtonListItem => _contentPaddingButtonListItem,
-                PaletteContentStyle.ButtonBreadCrumb => _contentPaddingButton6,
-                PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 => _contentPaddingButton5,
-                PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden => _contentPaddingButton7,
-                _ => throw new ArgumentOutOfRangeException(nameof(style))
-            };
+                case PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet
+                    or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2
+                    or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList
+                    or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1
+                    or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3
+                    or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet
+                    or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2
+                    or PaletteContentStyle.GridDataCellCustom3:
+                    return _contentPaddingGrid;
+                case PaletteContentStyle.HeaderForm:
+                    {
+                        Padding borders = owningForm!.RealWindowBorders;
+                        return new Padding(borders.Left, borders.Bottom / 2, 0, 0);
+                    }
+                case PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1
+                    or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3:
+                    return _contentPaddingHeader1;
+                case PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive:
+                    return _contentPaddingDock;
+                case PaletteContentStyle.HeaderSecondary:
+                    return _contentPaddingHeader2;
+                case PaletteContentStyle.HeaderCalendar:
+                    return _contentPaddingCalendar;
+                case PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl
+                    or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl
+                    or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel
+                    or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel
+                    or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2
+                    or PaletteContentStyle.LabelCustom3:
+                    return _contentPaddingLabel;
+                case PaletteContentStyle.LabelGroupBoxCaption:
+                    return _contentPaddingLabel2;
+                case PaletteContentStyle.ContextMenuItemTextStandard:
+                    return _contentPaddingContextMenuItemText;
+                case PaletteContentStyle.ContextMenuItemTextAlternate:
+                    return _contentPaddingContextMenuItemTextAlt;
+                case PaletteContentStyle.ContextMenuItemShortcutText:
+                    return _contentPaddingContextMenuItemShortcutText;
+                case PaletteContentStyle.ContextMenuItemImage:
+                    return _contentPaddingContextMenuImage;
+                case PaletteContentStyle.LabelToolTip:
+                    return _contentPaddingToolTip;
+                case PaletteContentStyle.LabelSuperTip:
+                    return _contentPaddingSuperTip;
+                case PaletteContentStyle.LabelKeyTip:
+                    return _contentPaddingKeyTip;
+                case PaletteContentStyle.ContextMenuHeading:
+                    return _contentPaddingContextMenuHeading;
+                case PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon
+                    or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2
+                    or PaletteContentStyle.InputControlCustom3:
+                    return InputControlPadding;
+                case PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand
+                    or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile
+                    or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini
+                    or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2
+                    or PaletteContentStyle.ButtonCustom3:
+                    return _contentPaddingButton12;
+                case PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay:
+                    return _contentPaddingButtonInputControl;
+                case PaletteContentStyle.ButtonButtonSpec:
+                    return _contentPaddingButton3;
+                case PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow:
+                    return _contentPaddingButton4;
+                case PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose:
+                    return _contentPaddingButtonForm;
+                case PaletteContentStyle.ButtonGallery:
+                    return _contentPaddingButtonGallery;
+                case PaletteContentStyle.ButtonListItem:
+                    return _contentPaddingButtonListItem;
+                case PaletteContentStyle.ButtonBreadCrumb:
+                    return _contentPaddingButton6;
+                case PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile
+                    or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote
+                    or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2
+                    or PaletteContentStyle.TabCustom3:
+                    return _contentPaddingButton5;
+                case PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden:
+                    return _contentPaddingButton7;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style));
+            }
         }
 
         /// <summary>
@@ -3554,13 +3664,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             switch (metric)
             {
@@ -3571,7 +3683,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricInt.CheckButtonGap:
                     return 5;
                 case PaletteMetricInt.HeaderButtonEdgeInsetForm:
-                    return 9; // Needs to be the RealWindowBorderWidth Offset - No idea how to get it at this point
+                    return Math.Max(2, owningForm!.RealWindowBorders.Right);
                 case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                     return 1;
                 case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:
@@ -3625,10 +3737,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -3642,7 +3756,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricPadding.BarPaddingOutside:
                     return _metricPaddingBarOutside;
                 case PaletteMetricPadding.HeaderButtonPaddingForm:
-                    return _metricPaddingHeaderForm;
+                    return new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);
                 case PaletteMetricPadding.RibbonButtonPadding:
                     return _metricPaddingRibbon;
                 case PaletteMetricPadding.RibbonAppButton:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkModeAlternate.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkModeAlternate.cs
@@ -393,7 +393,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
 
             _galleryButtonList.Images.AddStrip(GalleryImageResources.Gallery2010);
@@ -629,7 +629,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
         private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
         private static readonly Padding _contentPaddingCalendar = new Padding(2);
-        private static readonly Padding _contentPaddingHeaderForm = new Padding(10, 6, 3, 0); // 10 is from the RealWindowFrameSize +1
+        //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
         private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
         private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
         private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -641,7 +641,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);
@@ -653,7 +653,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _metricPaddingRibbon = new Padding(0, 1, 1, 1);
         private static readonly Padding _metricPaddingRibbonAppButton = new Padding(3, 0, 3, 0);
         private static readonly Padding _metricPaddingHeader = new Padding(0, 3, 1, 3);
-        private static readonly Padding _metricPaddingHeaderForm = new Padding(0, 3, 0, -3); // Move the Maximised Form buttons down a bit
+        //private static readonly Padding _metricPaddingHeaderForm = new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);//, 3, 0, -3); // Move the Maximised Form buttons down a bit
         private static readonly Padding _metricPaddingInputControl = new Padding(0, 1, 0, 1);
         private static readonly Padding _metricPaddingBarInside = new Padding(3);
         private static readonly Padding _metricPaddingBarTabs = new Padding(0);
@@ -1816,7 +1816,7 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => PaletteDrawBorders.Top,
                 PaletteBorderStyle.ContextMenuItemImageColumn => PaletteDrawBorders.Right,
                 PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ContextMenuInner => PaletteDrawBorders.None,
-                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.TopLeftRight,
+                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.None,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -3469,10 +3469,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             // We do not provide override values
             if (CommonHelper.IsOverrideState(state))
@@ -3480,37 +3482,90 @@ namespace Krypton.Toolkit
                 return CommonHelper.InheritPadding;
             }
 
-            return style switch
+            switch (style)
             {
-                PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 => _contentPaddingGrid,
-                PaletteContentStyle.HeaderForm => _contentPaddingHeaderForm,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _contentPaddingHeader1,
-                PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive => _contentPaddingDock,
-                PaletteContentStyle.HeaderSecondary => _contentPaddingHeader2,
-                PaletteContentStyle.HeaderCalendar => _contentPaddingCalendar,
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 => _contentPaddingLabel,
-                PaletteContentStyle.LabelGroupBoxCaption => _contentPaddingLabel2,
-                PaletteContentStyle.ContextMenuItemTextStandard => _contentPaddingContextMenuItemText,
-                PaletteContentStyle.ContextMenuItemTextAlternate => _contentPaddingContextMenuItemTextAlt,
-                PaletteContentStyle.ContextMenuItemShortcutText => _contentPaddingContextMenuItemShortcutText,
-                PaletteContentStyle.ContextMenuItemImage => _contentPaddingContextMenuImage,
-                PaletteContentStyle.LabelToolTip => _contentPaddingToolTip,
-                PaletteContentStyle.LabelSuperTip => _contentPaddingSuperTip,
-                PaletteContentStyle.LabelKeyTip => _contentPaddingKeyTip,
-                PaletteContentStyle.ContextMenuHeading => _contentPaddingContextMenuHeading,
-                PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => InputControlPadding,
-                PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => _contentPaddingButton12,
-                PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay => _contentPaddingButtonInputControl,
-                PaletteContentStyle.ButtonButtonSpec => _contentPaddingButton3,
-                PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => _contentPaddingButton4,
-                PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => _contentPaddingButtonForm,
-                PaletteContentStyle.ButtonGallery => _contentPaddingButtonGallery,
-                PaletteContentStyle.ButtonListItem => _contentPaddingButtonListItem,
-                PaletteContentStyle.ButtonBreadCrumb => _contentPaddingButton6,
-                PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 => _contentPaddingButton5,
-                PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden => _contentPaddingButton7,
-                _ => throw new ArgumentOutOfRangeException(nameof(style))
-            };
+                case PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet
+                    or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2
+                    or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList
+                    or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1
+                    or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3
+                    or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet
+                    or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2
+                    or PaletteContentStyle.GridDataCellCustom3:
+                    return _contentPaddingGrid;
+                case PaletteContentStyle.HeaderForm:
+                    {
+                        Padding borders = owningForm!.RealWindowBorders;
+                        return new Padding(borders.Left, borders.Bottom / 2, 0, 0);
+                    }
+                case PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1
+                    or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3:
+                    return _contentPaddingHeader1;
+                case PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive:
+                    return _contentPaddingDock;
+                case PaletteContentStyle.HeaderSecondary:
+                    return _contentPaddingHeader2;
+                case PaletteContentStyle.HeaderCalendar:
+                    return _contentPaddingCalendar;
+                case PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl
+                    or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl
+                    or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel
+                    or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel
+                    or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2
+                    or PaletteContentStyle.LabelCustom3:
+                    return _contentPaddingLabel;
+                case PaletteContentStyle.LabelGroupBoxCaption:
+                    return _contentPaddingLabel2;
+                case PaletteContentStyle.ContextMenuItemTextStandard:
+                    return _contentPaddingContextMenuItemText;
+                case PaletteContentStyle.ContextMenuItemTextAlternate:
+                    return _contentPaddingContextMenuItemTextAlt;
+                case PaletteContentStyle.ContextMenuItemShortcutText:
+                    return _contentPaddingContextMenuItemShortcutText;
+                case PaletteContentStyle.ContextMenuItemImage:
+                    return _contentPaddingContextMenuImage;
+                case PaletteContentStyle.LabelToolTip:
+                    return _contentPaddingToolTip;
+                case PaletteContentStyle.LabelSuperTip:
+                    return _contentPaddingSuperTip;
+                case PaletteContentStyle.LabelKeyTip:
+                    return _contentPaddingKeyTip;
+                case PaletteContentStyle.ContextMenuHeading:
+                    return _contentPaddingContextMenuHeading;
+                case PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon
+                    or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2
+                    or PaletteContentStyle.InputControlCustom3:
+                    return InputControlPadding;
+                case PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand
+                    or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile
+                    or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini
+                    or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2
+                    or PaletteContentStyle.ButtonCustom3:
+                    return _contentPaddingButton12;
+                case PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay:
+                    return _contentPaddingButtonInputControl;
+                case PaletteContentStyle.ButtonButtonSpec:
+                    return _contentPaddingButton3;
+                case PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow:
+                    return _contentPaddingButton4;
+                case PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose:
+                    return _contentPaddingButtonForm;
+                case PaletteContentStyle.ButtonGallery:
+                    return _contentPaddingButtonGallery;
+                case PaletteContentStyle.ButtonListItem:
+                    return _contentPaddingButtonListItem;
+                case PaletteContentStyle.ButtonBreadCrumb:
+                    return _contentPaddingButton6;
+                case PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile
+                    or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote
+                    or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2
+                    or PaletteContentStyle.TabCustom3:
+                    return _contentPaddingButton5;
+                case PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden:
+                    return _contentPaddingButton7;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style));
+            }
         }
 
         /// <summary>
@@ -3537,13 +3592,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             switch (metric)
             {
@@ -3554,7 +3611,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricInt.CheckButtonGap:
                     return 5;
                 case PaletteMetricInt.HeaderButtonEdgeInsetForm:
-                    return 9; // Needs to be the RealWindowBorderWidth Offset - No idea how to get it at this point
+                    return Math.Max(2, owningForm!.RealWindowBorders.Right);
                 case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                     return 1;
                 case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:
@@ -3608,10 +3665,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -3625,7 +3684,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricPadding.BarPaddingOutside:
                     return _metricPaddingBarOutside;
                 case PaletteMetricPadding.HeaderButtonPaddingForm:
-                    return _metricPaddingHeaderForm;
+                    return new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);
                 case PaletteMetricPadding.RibbonButtonPadding:
                     return _metricPaddingRibbon;
                 case PaletteMetricPadding.RibbonAppButton:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueDarkMode.cs
@@ -388,7 +388,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.Gallery2010);
             _radioButtonArray =
@@ -618,7 +618,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
         private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
         private static readonly Padding _contentPaddingCalendar = new Padding(2);
-        private static readonly Padding _contentPaddingHeaderForm = new Padding(10, 6, 3, 0); // 10 is from the RealWindowFrameSize +1
+        //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
         private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
         private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
         private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -630,7 +630,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);
@@ -642,7 +642,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _metricPaddingRibbon = new Padding(0, 1, 1, 1);
         private static readonly Padding _metricPaddingRibbonAppButton = new Padding(3, 0, 3, 0);
         private static readonly Padding _metricPaddingHeader = new Padding(0, 3, 1, 3);
-        private static readonly Padding _metricPaddingHeaderForm = new Padding(0, 3, 0, -3); // Move the Maximised Form buttons down a bit
+        //private static readonly Padding _metricPaddingHeaderForm = new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);//, 3, 0, -3); // Move the Maximised Form buttons down a bit
         private static readonly Padding _metricPaddingInputControl = new Padding(0, 1, 0, 1);
         private static readonly Padding _metricPaddingBarInside = new Padding(3);
         private static readonly Padding _metricPaddingBarTabs = new Padding(0);
@@ -1769,7 +1769,7 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => PaletteDrawBorders.Top,
                 PaletteBorderStyle.ContextMenuItemImageColumn => PaletteDrawBorders.Right,
                 PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ContextMenuInner => PaletteDrawBorders.None,
-                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.TopLeftRight,
+                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.None,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -3402,10 +3402,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             // We do not provide override values
             if (CommonHelper.IsOverrideState(state))
@@ -3413,37 +3415,90 @@ namespace Krypton.Toolkit
                 return CommonHelper.InheritPadding;
             }
 
-            return style switch
+            switch (style)
             {
-                PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 => _contentPaddingGrid,
-                PaletteContentStyle.HeaderForm => _contentPaddingHeaderForm,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _contentPaddingHeader1,
-                PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive => _contentPaddingDock,
-                PaletteContentStyle.HeaderSecondary => _contentPaddingHeader2,
-                PaletteContentStyle.HeaderCalendar => _contentPaddingCalendar,
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 => _contentPaddingLabel,
-                PaletteContentStyle.LabelGroupBoxCaption => _contentPaddingLabel2,
-                PaletteContentStyle.ContextMenuItemTextStandard => _contentPaddingContextMenuItemText,
-                PaletteContentStyle.ContextMenuItemTextAlternate => _contentPaddingContextMenuItemTextAlt,
-                PaletteContentStyle.ContextMenuItemShortcutText => _contentPaddingContextMenuItemShortcutText,
-                PaletteContentStyle.ContextMenuItemImage => _contentPaddingContextMenuImage,
-                PaletteContentStyle.LabelToolTip => _contentPaddingToolTip,
-                PaletteContentStyle.LabelSuperTip => _contentPaddingSuperTip,
-                PaletteContentStyle.LabelKeyTip => _contentPaddingKeyTip,
-                PaletteContentStyle.ContextMenuHeading => _contentPaddingContextMenuHeading,
-                PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => InputControlPadding,
-                PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => _contentPaddingButton12,
-                PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay => _contentPaddingButtonInputControl,
-                PaletteContentStyle.ButtonButtonSpec => _contentPaddingButton3,
-                PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => _contentPaddingButton4,
-                PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => _contentPaddingButtonForm,
-                PaletteContentStyle.ButtonGallery => _contentPaddingButtonGallery,
-                PaletteContentStyle.ButtonListItem => _contentPaddingButtonListItem,
-                PaletteContentStyle.ButtonBreadCrumb => _contentPaddingButton6,
-                PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 => _contentPaddingButton5,
-                PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden => _contentPaddingButton7,
-                _ => throw new ArgumentOutOfRangeException(nameof(style))
-            };
+                case PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet
+                    or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2
+                    or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList
+                    or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1
+                    or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3
+                    or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet
+                    or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2
+                    or PaletteContentStyle.GridDataCellCustom3:
+                    return _contentPaddingGrid;
+                case PaletteContentStyle.HeaderForm:
+                    {
+                        Padding borders = owningForm!.RealWindowBorders;
+                        return new Padding(borders.Left, borders.Bottom / 2, 0, 0);
+                    }
+                case PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1
+                    or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3:
+                    return _contentPaddingHeader1;
+                case PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive:
+                    return _contentPaddingDock;
+                case PaletteContentStyle.HeaderSecondary:
+                    return _contentPaddingHeader2;
+                case PaletteContentStyle.HeaderCalendar:
+                    return _contentPaddingCalendar;
+                case PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl
+                    or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl
+                    or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel
+                    or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel
+                    or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2
+                    or PaletteContentStyle.LabelCustom3:
+                    return _contentPaddingLabel;
+                case PaletteContentStyle.LabelGroupBoxCaption:
+                    return _contentPaddingLabel2;
+                case PaletteContentStyle.ContextMenuItemTextStandard:
+                    return _contentPaddingContextMenuItemText;
+                case PaletteContentStyle.ContextMenuItemTextAlternate:
+                    return _contentPaddingContextMenuItemTextAlt;
+                case PaletteContentStyle.ContextMenuItemShortcutText:
+                    return _contentPaddingContextMenuItemShortcutText;
+                case PaletteContentStyle.ContextMenuItemImage:
+                    return _contentPaddingContextMenuImage;
+                case PaletteContentStyle.LabelToolTip:
+                    return _contentPaddingToolTip;
+                case PaletteContentStyle.LabelSuperTip:
+                    return _contentPaddingSuperTip;
+                case PaletteContentStyle.LabelKeyTip:
+                    return _contentPaddingKeyTip;
+                case PaletteContentStyle.ContextMenuHeading:
+                    return _contentPaddingContextMenuHeading;
+                case PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon
+                    or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2
+                    or PaletteContentStyle.InputControlCustom3:
+                    return InputControlPadding;
+                case PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand
+                    or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile
+                    or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini
+                    or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2
+                    or PaletteContentStyle.ButtonCustom3:
+                    return _contentPaddingButton12;
+                case PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay:
+                    return _contentPaddingButtonInputControl;
+                case PaletteContentStyle.ButtonButtonSpec:
+                    return _contentPaddingButton3;
+                case PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow:
+                    return _contentPaddingButton4;
+                case PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose:
+                    return _contentPaddingButtonForm;
+                case PaletteContentStyle.ButtonGallery:
+                    return _contentPaddingButtonGallery;
+                case PaletteContentStyle.ButtonListItem:
+                    return _contentPaddingButtonListItem;
+                case PaletteContentStyle.ButtonBreadCrumb:
+                    return _contentPaddingButton6;
+                case PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile
+                    or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote
+                    or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2
+                    or PaletteContentStyle.TabCustom3:
+                    return _contentPaddingButton5;
+                case PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden:
+                    return _contentPaddingButton7;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style));
+            }
         }
 
         /// <summary>
@@ -3470,13 +3525,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             switch (metric)
             {
@@ -3487,7 +3544,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricInt.CheckButtonGap:
                     return 5;
                 case PaletteMetricInt.HeaderButtonEdgeInsetForm:
-                    return 9; // Needs to be the RealWindowBorderWidth Offset - No idea how to get it at this point
+                    return Math.Max(2, owningForm!.RealWindowBorders.Right);
                 case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                     return 1;
                 case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:
@@ -3541,10 +3598,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -3558,7 +3617,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricPadding.BarPaddingOutside:
                     return _metricPaddingBarOutside;
                 case PaletteMetricPadding.HeaderButtonPaddingForm:
-                    return _metricPaddingHeaderForm;
+                    return new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);
                 case PaletteMetricPadding.RibbonButtonPadding:
                     return _metricPaddingRibbon;
                 case PaletteMetricPadding.RibbonAppButton:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueLightMode.cs
@@ -400,7 +400,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.Gallery2010);
             _radioButtonArray =
@@ -630,7 +630,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
         private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
         private static readonly Padding _contentPaddingCalendar = new Padding(2);
-        private static readonly Padding _contentPaddingHeaderForm = new Padding(10, 6, 3, 0); // 10 is from the RealWindowFrameSize +1
+        //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
         private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
         private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
         private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -642,7 +642,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);
@@ -654,7 +654,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _metricPaddingRibbon = new Padding(0, 1, 1, 1);
         private static readonly Padding _metricPaddingRibbonAppButton = new Padding(3, 0, 3, 0);
         private static readonly Padding _metricPaddingHeader = new Padding(0, 3, 1, 3);
-        private static readonly Padding _metricPaddingHeaderForm = new Padding(0, 3, 0, -3); // Move the Maximised Form buttons down a bit
+        //private static readonly Padding _metricPaddingHeaderForm = new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);//, 3, 0, -3); // Move the Maximised Form buttons down a bit
         private static readonly Padding _metricPaddingInputControl = new Padding(0, 1, 0, 1);
         private static readonly Padding _metricPaddingBarInside = new Padding(3);
         private static readonly Padding _metricPaddingBarTabs = new Padding(0);
@@ -1818,7 +1818,7 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => PaletteDrawBorders.Top,
                 PaletteBorderStyle.ContextMenuItemImageColumn => PaletteDrawBorders.Right,
                 PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ContextMenuInner => PaletteDrawBorders.None,
-                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.TopLeftRight,
+                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.None,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -3449,10 +3449,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             // We do not provide override values
             if (CommonHelper.IsOverrideState(state))
@@ -3460,37 +3462,90 @@ namespace Krypton.Toolkit
                 return CommonHelper.InheritPadding;
             }
 
-            return style switch
+            switch (style)
             {
-                PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 => _contentPaddingGrid,
-                PaletteContentStyle.HeaderForm => _contentPaddingHeaderForm,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _contentPaddingHeader1,
-                PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive => _contentPaddingDock,
-                PaletteContentStyle.HeaderSecondary => _contentPaddingHeader2,
-                PaletteContentStyle.HeaderCalendar => _contentPaddingCalendar,
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 => _contentPaddingLabel,
-                PaletteContentStyle.LabelGroupBoxCaption => _contentPaddingLabel2,
-                PaletteContentStyle.ContextMenuItemTextStandard => _contentPaddingContextMenuItemText,
-                PaletteContentStyle.ContextMenuItemTextAlternate => _contentPaddingContextMenuItemTextAlt,
-                PaletteContentStyle.ContextMenuItemShortcutText => _contentPaddingContextMenuItemShortcutText,
-                PaletteContentStyle.ContextMenuItemImage => _contentPaddingContextMenuImage,
-                PaletteContentStyle.LabelToolTip => _contentPaddingToolTip,
-                PaletteContentStyle.LabelSuperTip => _contentPaddingSuperTip,
-                PaletteContentStyle.LabelKeyTip => _contentPaddingKeyTip,
-                PaletteContentStyle.ContextMenuHeading => _contentPaddingContextMenuHeading,
-                PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => InputControlPadding,
-                PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => _contentPaddingButton12,
-                PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay => _contentPaddingButtonInputControl,
-                PaletteContentStyle.ButtonButtonSpec => _contentPaddingButton3,
-                PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => _contentPaddingButton4,
-                PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => _contentPaddingButtonForm,
-                PaletteContentStyle.ButtonGallery => _contentPaddingButtonGallery,
-                PaletteContentStyle.ButtonListItem => _contentPaddingButtonListItem,
-                PaletteContentStyle.ButtonBreadCrumb => _contentPaddingButton6,
-                PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 => _contentPaddingButton5,
-                PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden => _contentPaddingButton7,
-                _ => throw new ArgumentOutOfRangeException(nameof(style))
-            };
+                case PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet
+                    or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2
+                    or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList
+                    or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1
+                    or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3
+                    or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet
+                    or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2
+                    or PaletteContentStyle.GridDataCellCustom3:
+                    return _contentPaddingGrid;
+                case PaletteContentStyle.HeaderForm:
+                    {
+                        Padding borders = owningForm!.RealWindowBorders;
+                        return new Padding(borders.Left, borders.Bottom / 2, 0, 0);
+                    }
+                case PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1
+                    or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3:
+                    return _contentPaddingHeader1;
+                case PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive:
+                    return _contentPaddingDock;
+                case PaletteContentStyle.HeaderSecondary:
+                    return _contentPaddingHeader2;
+                case PaletteContentStyle.HeaderCalendar:
+                    return _contentPaddingCalendar;
+                case PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl
+                    or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl
+                    or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel
+                    or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel
+                    or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2
+                    or PaletteContentStyle.LabelCustom3:
+                    return _contentPaddingLabel;
+                case PaletteContentStyle.LabelGroupBoxCaption:
+                    return _contentPaddingLabel2;
+                case PaletteContentStyle.ContextMenuItemTextStandard:
+                    return _contentPaddingContextMenuItemText;
+                case PaletteContentStyle.ContextMenuItemTextAlternate:
+                    return _contentPaddingContextMenuItemTextAlt;
+                case PaletteContentStyle.ContextMenuItemShortcutText:
+                    return _contentPaddingContextMenuItemShortcutText;
+                case PaletteContentStyle.ContextMenuItemImage:
+                    return _contentPaddingContextMenuImage;
+                case PaletteContentStyle.LabelToolTip:
+                    return _contentPaddingToolTip;
+                case PaletteContentStyle.LabelSuperTip:
+                    return _contentPaddingSuperTip;
+                case PaletteContentStyle.LabelKeyTip:
+                    return _contentPaddingKeyTip;
+                case PaletteContentStyle.ContextMenuHeading:
+                    return _contentPaddingContextMenuHeading;
+                case PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon
+                    or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2
+                    or PaletteContentStyle.InputControlCustom3:
+                    return InputControlPadding;
+                case PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand
+                    or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile
+                    or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini
+                    or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2
+                    or PaletteContentStyle.ButtonCustom3:
+                    return _contentPaddingButton12;
+                case PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay:
+                    return _contentPaddingButtonInputControl;
+                case PaletteContentStyle.ButtonButtonSpec:
+                    return _contentPaddingButton3;
+                case PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow:
+                    return _contentPaddingButton4;
+                case PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose:
+                    return _contentPaddingButtonForm;
+                case PaletteContentStyle.ButtonGallery:
+                    return _contentPaddingButtonGallery;
+                case PaletteContentStyle.ButtonListItem:
+                    return _contentPaddingButtonListItem;
+                case PaletteContentStyle.ButtonBreadCrumb:
+                    return _contentPaddingButton6;
+                case PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile
+                    or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote
+                    or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2
+                    or PaletteContentStyle.TabCustom3:
+                    return _contentPaddingButton5;
+                case PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden:
+                    return _contentPaddingButton7;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style));
+            }
         }
 
         /// <summary>
@@ -3517,13 +3572,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             switch (metric)
             {
@@ -3534,7 +3591,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricInt.CheckButtonGap:
                     return 5;
                 case PaletteMetricInt.HeaderButtonEdgeInsetForm:
-                    return 9; // Needs to be the RealWindowBorderWidth Offset - No idea how to get it at this point
+                    return Math.Max(2, owningForm!.RealWindowBorders.Right);
                 case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                     return 1;
                 case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:
@@ -3588,10 +3645,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -3605,7 +3664,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricPadding.BarPaddingOutside:
                     return _metricPaddingBarOutside;
                 case PaletteMetricPadding.HeaderButtonPaddingForm:
-                    return _metricPaddingHeaderForm;
+                    return new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);
                 case PaletteMetricPadding.RibbonButtonPadding:
                     return _metricPaddingRibbon;
                 case PaletteMetricPadding.RibbonAppButton:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverDarkMode.cs
@@ -388,7 +388,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.Gallery2010);
             _radioButtonArray =
@@ -618,7 +618,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
         private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
         private static readonly Padding _contentPaddingCalendar = new Padding(2);
-        private static readonly Padding _contentPaddingHeaderForm = new Padding(10, 6, 3, 0); // 10 is from the RealWindowFrameSize +1
+        //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
         private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
         private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
         private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -630,7 +630,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);
@@ -642,7 +642,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _metricPaddingRibbon = new Padding(0, 1, 1, 1);
         private static readonly Padding _metricPaddingRibbonAppButton = new Padding(3, 0, 3, 0);
         private static readonly Padding _metricPaddingHeader = new Padding(0, 3, 1, 3);
-        private static readonly Padding _metricPaddingHeaderForm = new Padding(0, 3, 0, -3); // Move the Maximised Form buttons down a bit
+        //private static readonly Padding _metricPaddingHeaderForm = new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);//, 3, 0, -3); // Move the Maximised Form buttons down a bit
         private static readonly Padding _metricPaddingInputControl = new Padding(0, 1, 0, 1);
         private static readonly Padding _metricPaddingBarInside = new Padding(3);
         private static readonly Padding _metricPaddingBarTabs = new Padding(0);
@@ -1794,7 +1794,7 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => PaletteDrawBorders.Top,
                 PaletteBorderStyle.ContextMenuItemImageColumn => PaletteDrawBorders.Right,
                 PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ContextMenuInner => PaletteDrawBorders.None,
-                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.TopLeftRight,
+                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.None,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -3425,10 +3425,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             // We do not provide override values
             if (CommonHelper.IsOverrideState(state))
@@ -3436,37 +3438,90 @@ namespace Krypton.Toolkit
                 return CommonHelper.InheritPadding;
             }
 
-            return style switch
+            switch (style)
             {
-                PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 => _contentPaddingGrid,
-                PaletteContentStyle.HeaderForm => _contentPaddingHeaderForm,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _contentPaddingHeader1,
-                PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive => _contentPaddingDock,
-                PaletteContentStyle.HeaderSecondary => _contentPaddingHeader2,
-                PaletteContentStyle.HeaderCalendar => _contentPaddingCalendar,
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 => _contentPaddingLabel,
-                PaletteContentStyle.LabelGroupBoxCaption => _contentPaddingLabel2,
-                PaletteContentStyle.ContextMenuItemTextStandard => _contentPaddingContextMenuItemText,
-                PaletteContentStyle.ContextMenuItemTextAlternate => _contentPaddingContextMenuItemTextAlt,
-                PaletteContentStyle.ContextMenuItemShortcutText => _contentPaddingContextMenuItemShortcutText,
-                PaletteContentStyle.ContextMenuItemImage => _contentPaddingContextMenuImage,
-                PaletteContentStyle.LabelToolTip => _contentPaddingToolTip,
-                PaletteContentStyle.LabelSuperTip => _contentPaddingSuperTip,
-                PaletteContentStyle.LabelKeyTip => _contentPaddingKeyTip,
-                PaletteContentStyle.ContextMenuHeading => _contentPaddingContextMenuHeading,
-                PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => InputControlPadding,
-                PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => _contentPaddingButton12,
-                PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay => _contentPaddingButtonInputControl,
-                PaletteContentStyle.ButtonButtonSpec => _contentPaddingButton3,
-                PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => _contentPaddingButton4,
-                PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => _contentPaddingButtonForm,
-                PaletteContentStyle.ButtonGallery => _contentPaddingButtonGallery,
-                PaletteContentStyle.ButtonListItem => _contentPaddingButtonListItem,
-                PaletteContentStyle.ButtonBreadCrumb => _contentPaddingButton6,
-                PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 => _contentPaddingButton5,
-                PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden => _contentPaddingButton7,
-                _ => throw new ArgumentOutOfRangeException(nameof(style))
-            };
+                case PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet
+                    or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2
+                    or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList
+                    or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1
+                    or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3
+                    or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet
+                    or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2
+                    or PaletteContentStyle.GridDataCellCustom3:
+                    return _contentPaddingGrid;
+                case PaletteContentStyle.HeaderForm:
+                    {
+                        Padding borders = owningForm!.RealWindowBorders;
+                        return new Padding(borders.Left, borders.Bottom / 2, 0, 0);
+                    }
+                case PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1
+                    or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3:
+                    return _contentPaddingHeader1;
+                case PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive:
+                    return _contentPaddingDock;
+                case PaletteContentStyle.HeaderSecondary:
+                    return _contentPaddingHeader2;
+                case PaletteContentStyle.HeaderCalendar:
+                    return _contentPaddingCalendar;
+                case PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl
+                    or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl
+                    or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel
+                    or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel
+                    or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2
+                    or PaletteContentStyle.LabelCustom3:
+                    return _contentPaddingLabel;
+                case PaletteContentStyle.LabelGroupBoxCaption:
+                    return _contentPaddingLabel2;
+                case PaletteContentStyle.ContextMenuItemTextStandard:
+                    return _contentPaddingContextMenuItemText;
+                case PaletteContentStyle.ContextMenuItemTextAlternate:
+                    return _contentPaddingContextMenuItemTextAlt;
+                case PaletteContentStyle.ContextMenuItemShortcutText:
+                    return _contentPaddingContextMenuItemShortcutText;
+                case PaletteContentStyle.ContextMenuItemImage:
+                    return _contentPaddingContextMenuImage;
+                case PaletteContentStyle.LabelToolTip:
+                    return _contentPaddingToolTip;
+                case PaletteContentStyle.LabelSuperTip:
+                    return _contentPaddingSuperTip;
+                case PaletteContentStyle.LabelKeyTip:
+                    return _contentPaddingKeyTip;
+                case PaletteContentStyle.ContextMenuHeading:
+                    return _contentPaddingContextMenuHeading;
+                case PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon
+                    or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2
+                    or PaletteContentStyle.InputControlCustom3:
+                    return InputControlPadding;
+                case PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand
+                    or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile
+                    or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini
+                    or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2
+                    or PaletteContentStyle.ButtonCustom3:
+                    return _contentPaddingButton12;
+                case PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay:
+                    return _contentPaddingButtonInputControl;
+                case PaletteContentStyle.ButtonButtonSpec:
+                    return _contentPaddingButton3;
+                case PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow:
+                    return _contentPaddingButton4;
+                case PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose:
+                    return _contentPaddingButtonForm;
+                case PaletteContentStyle.ButtonGallery:
+                    return _contentPaddingButtonGallery;
+                case PaletteContentStyle.ButtonListItem:
+                    return _contentPaddingButtonListItem;
+                case PaletteContentStyle.ButtonBreadCrumb:
+                    return _contentPaddingButton6;
+                case PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile
+                    or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote
+                    or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2
+                    or PaletteContentStyle.TabCustom3:
+                    return _contentPaddingButton5;
+                case PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden:
+                    return _contentPaddingButton7;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style));
+            }
         }
 
         /// <summary>
@@ -3493,13 +3548,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             switch (metric)
             {
@@ -3510,7 +3567,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricInt.CheckButtonGap:
                     return 5;
                 case PaletteMetricInt.HeaderButtonEdgeInsetForm:
-                    return 9; // Needs to be the RealWindowBorderWidth Offset - No idea how to get it at this point
+                    return Math.Max(2, owningForm!.RealWindowBorders.Right);
                 case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                     return 1;
                 case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:
@@ -3564,10 +3621,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -3581,7 +3640,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricPadding.BarPaddingOutside:
                     return _metricPaddingBarOutside;
                 case PaletteMetricPadding.HeaderButtonPaddingForm:
-                    return _metricPaddingHeaderForm;
+                    return new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);
                 case PaletteMetricPadding.RibbonButtonPadding:
                     return _metricPaddingRibbon;
                 case PaletteMetricPadding.RibbonAppButton:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverLightMode.cs
@@ -392,7 +392,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.Gallery2010);
             _radioButtonArray =
@@ -622,7 +622,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
         private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
         private static readonly Padding _contentPaddingCalendar = new Padding(2);
-        private static readonly Padding _contentPaddingHeaderForm = new Padding(10, 6, 3, 0); // 10 is from the RealWindowFrameSize +1
+        //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
         private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
         private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
         private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -634,7 +634,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);
@@ -646,7 +646,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _metricPaddingRibbon = new Padding(0, 1, 1, 1);
         private static readonly Padding _metricPaddingRibbonAppButton = new Padding(3, 0, 3, 0);
         private static readonly Padding _metricPaddingHeader = new Padding(0, 3, 1, 3);
-        private static readonly Padding _metricPaddingHeaderForm = new Padding(0, 3, 0, -3); // Move the Maximised Form buttons down a bit
+        //private static readonly Padding _metricPaddingHeaderForm = new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);//, 3, 0, -3); // Move the Maximised Form buttons down a bit
         private static readonly Padding _metricPaddingInputControl = new Padding(0, 1, 0, 1);
         private static readonly Padding _metricPaddingBarInside = new Padding(3);
         private static readonly Padding _metricPaddingBarTabs = new Padding(0);
@@ -1812,7 +1812,7 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => PaletteDrawBorders.Top,
                 PaletteBorderStyle.ContextMenuItemImageColumn => PaletteDrawBorders.Right,
                 PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ContextMenuInner => PaletteDrawBorders.None,
-                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.TopLeftRight,
+                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.None,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -3443,10 +3443,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             // We do not provide override values
             if (CommonHelper.IsOverrideState(state))
@@ -3454,37 +3456,90 @@ namespace Krypton.Toolkit
                 return CommonHelper.InheritPadding;
             }
 
-            return style switch
+            switch (style)
             {
-                PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 => _contentPaddingGrid,
-                PaletteContentStyle.HeaderForm => _contentPaddingHeaderForm,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _contentPaddingHeader1,
-                PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive => _contentPaddingDock,
-                PaletteContentStyle.HeaderSecondary => _contentPaddingHeader2,
-                PaletteContentStyle.HeaderCalendar => _contentPaddingCalendar,
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 => _contentPaddingLabel,
-                PaletteContentStyle.LabelGroupBoxCaption => _contentPaddingLabel2,
-                PaletteContentStyle.ContextMenuItemTextStandard => _contentPaddingContextMenuItemText,
-                PaletteContentStyle.ContextMenuItemTextAlternate => _contentPaddingContextMenuItemTextAlt,
-                PaletteContentStyle.ContextMenuItemShortcutText => _contentPaddingContextMenuItemShortcutText,
-                PaletteContentStyle.ContextMenuItemImage => _contentPaddingContextMenuImage,
-                PaletteContentStyle.LabelToolTip => _contentPaddingToolTip,
-                PaletteContentStyle.LabelSuperTip => _contentPaddingSuperTip,
-                PaletteContentStyle.LabelKeyTip => _contentPaddingKeyTip,
-                PaletteContentStyle.ContextMenuHeading => _contentPaddingContextMenuHeading,
-                PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => InputControlPadding,
-                PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => _contentPaddingButton12,
-                PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay => _contentPaddingButtonInputControl,
-                PaletteContentStyle.ButtonButtonSpec => _contentPaddingButton3,
-                PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => _contentPaddingButton4,
-                PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => _contentPaddingButtonForm,
-                PaletteContentStyle.ButtonGallery => _contentPaddingButtonGallery,
-                PaletteContentStyle.ButtonListItem => _contentPaddingButtonListItem,
-                PaletteContentStyle.ButtonBreadCrumb => _contentPaddingButton6,
-                PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 => _contentPaddingButton5,
-                PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden => _contentPaddingButton7,
-                _ => throw new ArgumentOutOfRangeException(nameof(style))
-            };
+                case PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet
+                    or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2
+                    or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList
+                    or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1
+                    or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3
+                    or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet
+                    or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2
+                    or PaletteContentStyle.GridDataCellCustom3:
+                    return _contentPaddingGrid;
+                case PaletteContentStyle.HeaderForm:
+                    {
+                        Padding borders = owningForm!.RealWindowBorders;
+                        return new Padding(borders.Left, borders.Bottom / 2, 0, 0);
+                    }
+                case PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1
+                    or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3:
+                    return _contentPaddingHeader1;
+                case PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive:
+                    return _contentPaddingDock;
+                case PaletteContentStyle.HeaderSecondary:
+                    return _contentPaddingHeader2;
+                case PaletteContentStyle.HeaderCalendar:
+                    return _contentPaddingCalendar;
+                case PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl
+                    or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl
+                    or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel
+                    or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel
+                    or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2
+                    or PaletteContentStyle.LabelCustom3:
+                    return _contentPaddingLabel;
+                case PaletteContentStyle.LabelGroupBoxCaption:
+                    return _contentPaddingLabel2;
+                case PaletteContentStyle.ContextMenuItemTextStandard:
+                    return _contentPaddingContextMenuItemText;
+                case PaletteContentStyle.ContextMenuItemTextAlternate:
+                    return _contentPaddingContextMenuItemTextAlt;
+                case PaletteContentStyle.ContextMenuItemShortcutText:
+                    return _contentPaddingContextMenuItemShortcutText;
+                case PaletteContentStyle.ContextMenuItemImage:
+                    return _contentPaddingContextMenuImage;
+                case PaletteContentStyle.LabelToolTip:
+                    return _contentPaddingToolTip;
+                case PaletteContentStyle.LabelSuperTip:
+                    return _contentPaddingSuperTip;
+                case PaletteContentStyle.LabelKeyTip:
+                    return _contentPaddingKeyTip;
+                case PaletteContentStyle.ContextMenuHeading:
+                    return _contentPaddingContextMenuHeading;
+                case PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon
+                    or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2
+                    or PaletteContentStyle.InputControlCustom3:
+                    return InputControlPadding;
+                case PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand
+                    or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile
+                    or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini
+                    or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2
+                    or PaletteContentStyle.ButtonCustom3:
+                    return _contentPaddingButton12;
+                case PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay:
+                    return _contentPaddingButtonInputControl;
+                case PaletteContentStyle.ButtonButtonSpec:
+                    return _contentPaddingButton3;
+                case PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow:
+                    return _contentPaddingButton4;
+                case PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose:
+                    return _contentPaddingButtonForm;
+                case PaletteContentStyle.ButtonGallery:
+                    return _contentPaddingButtonGallery;
+                case PaletteContentStyle.ButtonListItem:
+                    return _contentPaddingButtonListItem;
+                case PaletteContentStyle.ButtonBreadCrumb:
+                    return _contentPaddingButton6;
+                case PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile
+                    or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote
+                    or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2
+                    or PaletteContentStyle.TabCustom3:
+                    return _contentPaddingButton5;
+                case PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden:
+                    return _contentPaddingButton7;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style));
+            }
         }
 
         /// <summary>
@@ -3511,13 +3566,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             switch (metric)
             {
@@ -3528,7 +3585,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricInt.CheckButtonGap:
                     return 5;
                 case PaletteMetricInt.HeaderButtonEdgeInsetForm:
-                    return 9; // Needs to be the RealWindowBorderWidth Offset - No idea how to get it at this point
+                    return Math.Max(2, owningForm!.RealWindowBorders.Right);
                 case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                     return 1;
                 case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:
@@ -3582,10 +3639,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -3599,7 +3658,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricPadding.BarPaddingOutside:
                     return _metricPaddingBarOutside;
                 case PaletteMetricPadding.HeaderButtonPaddingForm:
-                    return _metricPaddingHeaderForm;
+                    return new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);
                 case PaletteMetricPadding.RibbonButtonPadding:
                     return _metricPaddingRibbon;
                 case PaletteMetricPadding.RibbonAppButton:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Non Official Themes/PaletteMicrosoft365Blue.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Non Official Themes/PaletteMicrosoft365Blue.cs
@@ -399,7 +399,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.Gallery2010);
             _radioButtonArray =

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Black.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Black.cs
@@ -403,7 +403,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
 
             _galleryButtonList.Images.AddStrip(GalleryImageResources.Gallery2010);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365DarkGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365DarkGray.cs
@@ -384,7 +384,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.Gallery2010);
             _radioButtonArray =

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Silver.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Silver.cs
@@ -402,7 +402,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.Gallery2010);
             _radioButtonArray =

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365White.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365White.cs
@@ -388,7 +388,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.Gallery2010);
             _radioButtonArray =

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Bases/PaletteOffice2007Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Bases/PaletteOffice2007Base.cs
@@ -26,7 +26,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
         private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
         private static readonly Padding _contentPaddingCalendar = new Padding(2);
-        private static readonly Padding _contentPaddingHeaderForm = new Padding(10, 6, 3, 0); // 10 is from the RealWindowFrameSize +1
+        //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
         private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
         private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
         private static readonly Padding _contentPaddingButtonCalendar = new Padding(-1);
@@ -39,7 +39,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);
@@ -51,7 +51,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _metricPaddingRibbon = new Padding(0, 1, 1, 1);
         private static readonly Padding _metricPaddingRibbonAppButton = new Padding(3, 0, 3, 0);
         private static readonly Padding _metricPaddingHeader = new Padding(0, 3, 1, 3);
-        private static readonly Padding _metricPaddingHeaderForm = new Padding(0, 3, 0, -3); // Move the Maximised Form buttons down a bit
+        //private static readonly Padding _metricPaddingHeaderForm = new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);//, 3, 0, -3); // Move the Maximised Form buttons down a bit
         private static readonly Padding _metricPaddingInputControl = new Padding(0, 1, 0, 1);
         private static readonly Padding _metricPaddingBarInside = new Padding(3);
         private static readonly Padding _metricPaddingBarTabs = new Padding(0);
@@ -282,22 +282,39 @@ namespace Krypton.Toolkit
                 return InheritBool.Inherit;
             }
 
-            return style switch
+            switch (style)
             {
-                PaletteBackStyle.SeparatorLowProfile or PaletteBackStyle.SeparatorCustom1 or PaletteBackStyle.SeparatorCustom2 or PaletteBackStyle.SeparatorCustom3 => InheritBool.False,
-                PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ButtonCalendarDay or PaletteBackStyle.ButtonNavigatorOverflow or PaletteBackStyle.ButtonForm or PaletteBackStyle.ButtonFormClose => state switch
-                {
-                    PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => InheritBool.False,
-                    _ => InheritBool.True
-                },
-                PaletteBackStyle.ContextMenuItemImage or PaletteBackStyle.ContextMenuItemHighlight => state switch
-                {
-                    PaletteState.Normal or PaletteState.NormalDefaultOverride => InheritBool.False,
-                    _ => InheritBool.True
-                },
-                PaletteBackStyle.ButtonInputControl => state is PaletteState.Disabled or PaletteState.Normal ? InheritBool.False : InheritBool.True,
-                _ => InheritBool.True // Default to drawing the background
-            };
+                case PaletteBackStyle.SeparatorLowProfile:
+                case PaletteBackStyle.SeparatorCustom1:
+                case PaletteBackStyle.SeparatorCustom2:
+                case PaletteBackStyle.SeparatorCustom3:
+                    return InheritBool.False;
+                case PaletteBackStyle.ButtonLowProfile:
+                case PaletteBackStyle.ButtonBreadCrumb:
+                case PaletteBackStyle.ButtonListItem:
+                case PaletteBackStyle.ButtonCommand:
+                case PaletteBackStyle.ButtonButtonSpec:
+                case PaletteBackStyle.ButtonCalendarDay:
+                case PaletteBackStyle.ButtonNavigatorOverflow:
+                case PaletteBackStyle.ButtonForm:
+                case PaletteBackStyle.ButtonFormClose:
+                    return state switch
+                    {
+                        PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride =>
+                            InheritBool.False,
+                        _ => InheritBool.True
+                    };
+                case PaletteBackStyle.ContextMenuItemImage or PaletteBackStyle.ContextMenuItemHighlight:
+                    return state switch
+                    {
+                        PaletteState.Normal or PaletteState.NormalDefaultOverride => InheritBool.False,
+                        _ => InheritBool.True
+                    };
+                case PaletteBackStyle.ButtonInputControl:
+                    return state is PaletteState.Disabled or PaletteState.Normal ? InheritBool.False : InheritBool.True;
+                default:
+                    return InheritBool.True; // Default to drawing the background
+            }
         }
 
         /// <summary>
@@ -3403,11 +3420,13 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             // We do not provide override values
             if (CommonHelper.IsOverrideState(state))
@@ -3415,37 +3434,90 @@ namespace Krypton.Toolkit
                 return CommonHelper.InheritPadding;
             }
 
-            return style switch
+            switch (style)
             {
-                PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 => _contentPaddingGrid,
-                PaletteContentStyle.HeaderForm => _contentPaddingHeaderForm,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _contentPaddingHeader1,
-                PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive => _contentPaddingDock,
-                PaletteContentStyle.HeaderSecondary => _contentPaddingHeader2,
-                PaletteContentStyle.HeaderCalendar => _contentPaddingCalendar,
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 => _contentPaddingLabel,
-                PaletteContentStyle.LabelGroupBoxCaption => _contentPaddingLabel2,
-                PaletteContentStyle.ContextMenuItemTextStandard => _contentPaddingContextMenuItemText,
-                PaletteContentStyle.ContextMenuItemTextAlternate => _contentPaddingContextMenuItemTextAlt,
-                PaletteContentStyle.ContextMenuItemShortcutText => _contentPaddingContextMenuItemShortcutText,
-                PaletteContentStyle.ContextMenuItemImage => _contentPaddingContextMenuImage,
-                PaletteContentStyle.LabelToolTip => _contentPaddingToolTip,
-                PaletteContentStyle.LabelSuperTip => _contentPaddingSuperTip,
-                PaletteContentStyle.LabelKeyTip => _contentPaddingKeyTip,
-                PaletteContentStyle.ContextMenuHeading => _contentPaddingContextMenuHeading,
-                PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => InputControlPadding,
-                PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => _contentPaddingButton12,
-                PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay => _contentPaddingButtonInputControl,
-                PaletteContentStyle.ButtonButtonSpec => _contentPaddingButton3,
-                PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => _contentPaddingButton4,
-                PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => _contentPaddingButtonForm,
-                PaletteContentStyle.ButtonGallery => _contentPaddingButtonGallery,
-                PaletteContentStyle.ButtonListItem => _contentPaddingButtonListItem,
-                PaletteContentStyle.ButtonBreadCrumb => _contentPaddingButton6,
-                PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 => _contentPaddingButton5,
-                PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden => _contentPaddingButton7,
-                _ => throw new ArgumentOutOfRangeException(nameof(style))
-            };
+                case PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet
+                    or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2
+                    or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList
+                    or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1
+                    or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3
+                    or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet
+                    or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2
+                    or PaletteContentStyle.GridDataCellCustom3:
+                    return _contentPaddingGrid;
+                case PaletteContentStyle.HeaderForm:
+                    {
+                        Padding borders = owningForm!.RealWindowBorders;
+                        return new Padding(borders.Left, borders.Bottom / 2, 0, 0);
+                    }
+                case PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1
+                    or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3:
+                    return _contentPaddingHeader1;
+                case PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive:
+                    return _contentPaddingDock;
+                case PaletteContentStyle.HeaderSecondary:
+                    return _contentPaddingHeader2;
+                case PaletteContentStyle.HeaderCalendar:
+                    return _contentPaddingCalendar;
+                case PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl
+                    or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl
+                    or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel
+                    or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel
+                    or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2
+                    or PaletteContentStyle.LabelCustom3:
+                    return _contentPaddingLabel;
+                case PaletteContentStyle.LabelGroupBoxCaption:
+                    return _contentPaddingLabel2;
+                case PaletteContentStyle.ContextMenuItemTextStandard:
+                    return _contentPaddingContextMenuItemText;
+                case PaletteContentStyle.ContextMenuItemTextAlternate:
+                    return _contentPaddingContextMenuItemTextAlt;
+                case PaletteContentStyle.ContextMenuItemShortcutText:
+                    return _contentPaddingContextMenuItemShortcutText;
+                case PaletteContentStyle.ContextMenuItemImage:
+                    return _contentPaddingContextMenuImage;
+                case PaletteContentStyle.LabelToolTip:
+                    return _contentPaddingToolTip;
+                case PaletteContentStyle.LabelSuperTip:
+                    return _contentPaddingSuperTip;
+                case PaletteContentStyle.LabelKeyTip:
+                    return _contentPaddingKeyTip;
+                case PaletteContentStyle.ContextMenuHeading:
+                    return _contentPaddingContextMenuHeading;
+                case PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon
+                    or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2
+                    or PaletteContentStyle.InputControlCustom3:
+                    return InputControlPadding;
+                case PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand
+                    or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile
+                    or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini
+                    or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2
+                    or PaletteContentStyle.ButtonCustom3:
+                    return _contentPaddingButton12;
+                case PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay:
+                    return _contentPaddingButtonInputControl;
+                case PaletteContentStyle.ButtonButtonSpec:
+                    return _contentPaddingButton3;
+                case PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow:
+                    return _contentPaddingButton4;
+                case PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose:
+                    return _contentPaddingButtonForm;
+                case PaletteContentStyle.ButtonGallery:
+                    return _contentPaddingButtonGallery;
+                case PaletteContentStyle.ButtonListItem:
+                    return _contentPaddingButtonListItem;
+                case PaletteContentStyle.ButtonBreadCrumb:
+                    return _contentPaddingButton6;
+                case PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile
+                    or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote
+                    or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2
+                    or PaletteContentStyle.TabCustom3:
+                    return _contentPaddingButton5;
+                case PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden:
+                    return _contentPaddingButton7;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style));
+            }
         }
 
         /// <summary>
@@ -3473,13 +3545,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             switch (metric)
             {
@@ -3490,7 +3564,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricInt.CheckButtonGap:
                     return 5;
                 case PaletteMetricInt.HeaderButtonEdgeInsetForm:
-                    return 9; // Needs to be the RealWindowBorderWidth Offset - No idea how to get it at this point
+                    return Math.Max(2, owningForm!.RealWindowBorders.Right);
                 case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                     return 1;
                 case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:
@@ -3544,10 +3618,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -3561,7 +3637,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricPadding.BarPaddingOutside:
                     return _metricPaddingBarOutside;
                 case PaletteMetricPadding.HeaderButtonPaddingForm:
-                    return _metricPaddingHeaderForm;
+                    return new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);
                 case PaletteMetricPadding.RibbonButtonPadding:
                     return _metricPaddingRibbon;
                 case PaletteMetricPadding.RibbonAppButton:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlackDarkMode.cs
@@ -301,7 +301,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.GallerySilverBlack);
             _radioButtonArray =
@@ -644,7 +644,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
         private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
         private static readonly Padding _contentPaddingCalendar = new Padding(2);
-        private static readonly Padding _contentPaddingHeaderForm = new Padding(10, 6, 3, 0); // 10 is from the RealWindowFrameSize +1
+        //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
         private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
         private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
         private static readonly Padding _contentPaddingButtonCalendar = new Padding(-1);
@@ -657,7 +657,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);
@@ -669,7 +669,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _metricPaddingRibbon = new Padding(0, 1, 1, 1);
         private static readonly Padding _metricPaddingRibbonAppButton = new Padding(3, 0, 3, 0);
         private static readonly Padding _metricPaddingHeader = new Padding(0, 3, 1, 3);
-        private static readonly Padding _metricPaddingHeaderForm = new Padding(0, 3, 0, -3); // Move the Maximised Form buttons down a bit
+        //private static readonly Padding _metricPaddingHeaderForm = new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);//, 3, 0, -3); // Move the Maximised Form buttons down a bit
         private static readonly Padding _metricPaddingInputControl = new Padding(0, 1, 0, 1);
         private static readonly Padding _metricPaddingBarInside = new Padding(3);
         private static readonly Padding _metricPaddingBarTabs = new Padding(0);
@@ -4173,11 +4173,13 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             // We do not provide override values
             if (CommonHelper.IsOverrideState(state))
@@ -4185,37 +4187,90 @@ namespace Krypton.Toolkit
                 return CommonHelper.InheritPadding;
             }
 
-            return style switch
+            switch (style)
             {
-                PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 => _contentPaddingGrid,
-                PaletteContentStyle.HeaderForm => _contentPaddingHeaderForm,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _contentPaddingHeader1,
-                PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive => _contentPaddingDock,
-                PaletteContentStyle.HeaderSecondary => _contentPaddingHeader2,
-                PaletteContentStyle.HeaderCalendar => _contentPaddingCalendar,
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 => _contentPaddingLabel,
-                PaletteContentStyle.LabelGroupBoxCaption => _contentPaddingLabel2,
-                PaletteContentStyle.ContextMenuItemTextStandard => _contentPaddingContextMenuItemText,
-                PaletteContentStyle.ContextMenuItemTextAlternate => _contentPaddingContextMenuItemTextAlt,
-                PaletteContentStyle.ContextMenuItemShortcutText => _contentPaddingContextMenuItemShortcutText,
-                PaletteContentStyle.ContextMenuItemImage => _contentPaddingContextMenuImage,
-                PaletteContentStyle.LabelToolTip => _contentPaddingToolTip,
-                PaletteContentStyle.LabelSuperTip => _contentPaddingSuperTip,
-                PaletteContentStyle.LabelKeyTip => _contentPaddingKeyTip,
-                PaletteContentStyle.ContextMenuHeading => _contentPaddingContextMenuHeading,
-                PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => InputControlPadding,
-                PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => _contentPaddingButton12,
-                PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay => _contentPaddingButtonInputControl,
-                PaletteContentStyle.ButtonButtonSpec => _contentPaddingButton3,
-                PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => _contentPaddingButton4,
-                PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => _contentPaddingButtonForm,
-                PaletteContentStyle.ButtonGallery => _contentPaddingButtonGallery,
-                PaletteContentStyle.ButtonListItem => _contentPaddingButtonListItem,
-                PaletteContentStyle.ButtonBreadCrumb => _contentPaddingButton6,
-                PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 => _contentPaddingButton5,
-                PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden => _contentPaddingButton7,
-                _ => throw new ArgumentOutOfRangeException(nameof(style))
-            };
+                case PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet
+                    or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2
+                    or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList
+                    or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1
+                    or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3
+                    or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet
+                    or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2
+                    or PaletteContentStyle.GridDataCellCustom3:
+                    return _contentPaddingGrid;
+                case PaletteContentStyle.HeaderForm:
+                    {
+                        Padding borders = owningForm!.RealWindowBorders;
+                        return new Padding(borders.Left, borders.Bottom / 2, 0, 0);
+                    }
+                case PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1
+                    or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3:
+                    return _contentPaddingHeader1;
+                case PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive:
+                    return _contentPaddingDock;
+                case PaletteContentStyle.HeaderSecondary:
+                    return _contentPaddingHeader2;
+                case PaletteContentStyle.HeaderCalendar:
+                    return _contentPaddingCalendar;
+                case PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl
+                    or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl
+                    or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel
+                    or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel
+                    or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2
+                    or PaletteContentStyle.LabelCustom3:
+                    return _contentPaddingLabel;
+                case PaletteContentStyle.LabelGroupBoxCaption:
+                    return _contentPaddingLabel2;
+                case PaletteContentStyle.ContextMenuItemTextStandard:
+                    return _contentPaddingContextMenuItemText;
+                case PaletteContentStyle.ContextMenuItemTextAlternate:
+                    return _contentPaddingContextMenuItemTextAlt;
+                case PaletteContentStyle.ContextMenuItemShortcutText:
+                    return _contentPaddingContextMenuItemShortcutText;
+                case PaletteContentStyle.ContextMenuItemImage:
+                    return _contentPaddingContextMenuImage;
+                case PaletteContentStyle.LabelToolTip:
+                    return _contentPaddingToolTip;
+                case PaletteContentStyle.LabelSuperTip:
+                    return _contentPaddingSuperTip;
+                case PaletteContentStyle.LabelKeyTip:
+                    return _contentPaddingKeyTip;
+                case PaletteContentStyle.ContextMenuHeading:
+                    return _contentPaddingContextMenuHeading;
+                case PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon
+                    or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2
+                    or PaletteContentStyle.InputControlCustom3:
+                    return InputControlPadding;
+                case PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand
+                    or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile
+                    or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini
+                    or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2
+                    or PaletteContentStyle.ButtonCustom3:
+                    return _contentPaddingButton12;
+                case PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay:
+                    return _contentPaddingButtonInputControl;
+                case PaletteContentStyle.ButtonButtonSpec:
+                    return _contentPaddingButton3;
+                case PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow:
+                    return _contentPaddingButton4;
+                case PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose:
+                    return _contentPaddingButtonForm;
+                case PaletteContentStyle.ButtonGallery:
+                    return _contentPaddingButtonGallery;
+                case PaletteContentStyle.ButtonListItem:
+                    return _contentPaddingButtonListItem;
+                case PaletteContentStyle.ButtonBreadCrumb:
+                    return _contentPaddingButton6;
+                case PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile
+                    or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote
+                    or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2
+                    or PaletteContentStyle.TabCustom3:
+                    return _contentPaddingButton5;
+                case PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden:
+                    return _contentPaddingButton7;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style));
+            }
         }
 
         /// <summary>
@@ -4243,13 +4298,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             switch (metric)
             {
@@ -4260,7 +4317,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricInt.CheckButtonGap:
                     return 5;
                 case PaletteMetricInt.HeaderButtonEdgeInsetForm:
-                    return 9; // Needs to be the RealWindowBorderWidth Offset - No idea how to get it at this point
+                    return Math.Max(2, owningForm!.RealWindowBorders.Right);
                 case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                     return 1;
                 case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:
@@ -4314,10 +4371,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -4331,7 +4390,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricPadding.BarPaddingOutside:
                     return _metricPaddingBarOutside;
                 case PaletteMetricPadding.HeaderButtonPaddingForm:
-                    return _metricPaddingHeaderForm;
+                    return new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);
                 case PaletteMetricPadding.RibbonButtonPadding:
                     return _metricPaddingRibbon;
                 case PaletteMetricPadding.RibbonAppButton:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueDarkMode.cs
@@ -300,7 +300,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.GalleryBlue);
             _radioButtonArray =
@@ -489,7 +489,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
         private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
         private static readonly Padding _contentPaddingCalendar = new Padding(2);
-        private static readonly Padding _contentPaddingHeaderForm = new Padding(10, 6, 3, 0); // 10 is from the RealWindowFrameSize +1
+        //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
         private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
         private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
         private static readonly Padding _contentPaddingButtonCalendar = new Padding(-1);
@@ -502,7 +502,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);
@@ -514,7 +514,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _metricPaddingRibbon = new Padding(0, 1, 1, 1);
         private static readonly Padding _metricPaddingRibbonAppButton = new Padding(3, 0, 3, 0);
         private static readonly Padding _metricPaddingHeader = new Padding(0, 3, 1, 3);
-        private static readonly Padding _metricPaddingHeaderForm = new Padding(0, 3, 0, -3); // Move the Maximised Form buttons down a bit
+        //private static readonly Padding _metricPaddingHeaderForm = new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);//, 3, 0, -3); // Move the Maximised Form buttons down a bit
         private static readonly Padding _metricPaddingInputControl = new Padding(0, 1, 0, 1);
         private static readonly Padding _metricPaddingBarInside = new Padding(3);
         private static readonly Padding _metricPaddingBarTabs = new Padding(0);
@@ -3465,11 +3465,13 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             // We do not provide override values
             if (CommonHelper.IsOverrideState(state))
@@ -3477,37 +3479,90 @@ namespace Krypton.Toolkit
                 return CommonHelper.InheritPadding;
             }
 
-            return style switch
+            switch (style)
             {
-                PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 => _contentPaddingGrid,
-                PaletteContentStyle.HeaderForm => _contentPaddingHeaderForm,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _contentPaddingHeader1,
-                PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive => _contentPaddingDock,
-                PaletteContentStyle.HeaderSecondary => _contentPaddingHeader2,
-                PaletteContentStyle.HeaderCalendar => _contentPaddingCalendar,
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 => _contentPaddingLabel,
-                PaletteContentStyle.LabelGroupBoxCaption => _contentPaddingLabel2,
-                PaletteContentStyle.ContextMenuItemTextStandard => _contentPaddingContextMenuItemText,
-                PaletteContentStyle.ContextMenuItemTextAlternate => _contentPaddingContextMenuItemTextAlt,
-                PaletteContentStyle.ContextMenuItemShortcutText => _contentPaddingContextMenuItemShortcutText,
-                PaletteContentStyle.ContextMenuItemImage => _contentPaddingContextMenuImage,
-                PaletteContentStyle.LabelToolTip => _contentPaddingToolTip,
-                PaletteContentStyle.LabelSuperTip => _contentPaddingSuperTip,
-                PaletteContentStyle.LabelKeyTip => _contentPaddingKeyTip,
-                PaletteContentStyle.ContextMenuHeading => _contentPaddingContextMenuHeading,
-                PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => InputControlPadding,
-                PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => _contentPaddingButton12,
-                PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay => _contentPaddingButtonInputControl,
-                PaletteContentStyle.ButtonButtonSpec => _contentPaddingButton3,
-                PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => _contentPaddingButton4,
-                PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => _contentPaddingButtonForm,
-                PaletteContentStyle.ButtonGallery => _contentPaddingButtonGallery,
-                PaletteContentStyle.ButtonListItem => _contentPaddingButtonListItem,
-                PaletteContentStyle.ButtonBreadCrumb => _contentPaddingButton6,
-                PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 => _contentPaddingButton5,
-                PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden => _contentPaddingButton7,
-                _ => throw new ArgumentOutOfRangeException(nameof(style))
-            };
+                case PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet
+                    or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2
+                    or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList
+                    or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1
+                    or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3
+                    or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet
+                    or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2
+                    or PaletteContentStyle.GridDataCellCustom3:
+                    return _contentPaddingGrid;
+                case PaletteContentStyle.HeaderForm:
+                    {
+                        Padding borders = owningForm!.RealWindowBorders;
+                        return new Padding(borders.Left, borders.Bottom / 2, 0, 0);
+                    }
+                case PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1
+                    or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3:
+                    return _contentPaddingHeader1;
+                case PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive:
+                    return _contentPaddingDock;
+                case PaletteContentStyle.HeaderSecondary:
+                    return _contentPaddingHeader2;
+                case PaletteContentStyle.HeaderCalendar:
+                    return _contentPaddingCalendar;
+                case PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl
+                    or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl
+                    or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel
+                    or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel
+                    or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2
+                    or PaletteContentStyle.LabelCustom3:
+                    return _contentPaddingLabel;
+                case PaletteContentStyle.LabelGroupBoxCaption:
+                    return _contentPaddingLabel2;
+                case PaletteContentStyle.ContextMenuItemTextStandard:
+                    return _contentPaddingContextMenuItemText;
+                case PaletteContentStyle.ContextMenuItemTextAlternate:
+                    return _contentPaddingContextMenuItemTextAlt;
+                case PaletteContentStyle.ContextMenuItemShortcutText:
+                    return _contentPaddingContextMenuItemShortcutText;
+                case PaletteContentStyle.ContextMenuItemImage:
+                    return _contentPaddingContextMenuImage;
+                case PaletteContentStyle.LabelToolTip:
+                    return _contentPaddingToolTip;
+                case PaletteContentStyle.LabelSuperTip:
+                    return _contentPaddingSuperTip;
+                case PaletteContentStyle.LabelKeyTip:
+                    return _contentPaddingKeyTip;
+                case PaletteContentStyle.ContextMenuHeading:
+                    return _contentPaddingContextMenuHeading;
+                case PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon
+                    or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2
+                    or PaletteContentStyle.InputControlCustom3:
+                    return InputControlPadding;
+                case PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand
+                    or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile
+                    or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini
+                    or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2
+                    or PaletteContentStyle.ButtonCustom3:
+                    return _contentPaddingButton12;
+                case PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay:
+                    return _contentPaddingButtonInputControl;
+                case PaletteContentStyle.ButtonButtonSpec:
+                    return _contentPaddingButton3;
+                case PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow:
+                    return _contentPaddingButton4;
+                case PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose:
+                    return _contentPaddingButtonForm;
+                case PaletteContentStyle.ButtonGallery:
+                    return _contentPaddingButtonGallery;
+                case PaletteContentStyle.ButtonListItem:
+                    return _contentPaddingButtonListItem;
+                case PaletteContentStyle.ButtonBreadCrumb:
+                    return _contentPaddingButton6;
+                case PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile
+                    or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote
+                    or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2
+                    or PaletteContentStyle.TabCustom3:
+                    return _contentPaddingButton5;
+                case PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden:
+                    return _contentPaddingButton7;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style));
+            }
         }
 
         /// <summary>
@@ -3535,13 +3590,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             switch (metric)
             {
@@ -3552,7 +3609,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricInt.CheckButtonGap:
                     return 5;
                 case PaletteMetricInt.HeaderButtonEdgeInsetForm:
-                    return 9; // Needs to be the RealWindowBorderWidth Offset - No idea how to get it at this point
+                    return Math.Max(2, owningForm!.RealWindowBorders.Right);
                 case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                     return 1;
                 case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:
@@ -3606,10 +3663,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -3623,7 +3682,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricPadding.BarPaddingOutside:
                     return _metricPaddingBarOutside;
                 case PaletteMetricPadding.HeaderButtonPaddingForm:
-                    return _metricPaddingHeaderForm;
+                    return new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);
                 case PaletteMetricPadding.RibbonButtonPadding:
                     return _metricPaddingRibbon;
                 case PaletteMetricPadding.RibbonAppButton:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueLightMode.cs
@@ -302,7 +302,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.GalleryBlue);
             _radioButtonArray =
@@ -491,7 +491,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
         private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
         private static readonly Padding _contentPaddingCalendar = new Padding(2);
-        private static readonly Padding _contentPaddingHeaderForm = new Padding(10, 6, 3, 0); // 10 is from the RealWindowFrameSize +1
+        //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
         private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
         private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
         private static readonly Padding _contentPaddingButtonCalendar = new Padding(-1);
@@ -504,7 +504,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);
@@ -516,7 +516,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _metricPaddingRibbon = new Padding(0, 1, 1, 1);
         private static readonly Padding _metricPaddingRibbonAppButton = new Padding(3, 0, 3, 0);
         private static readonly Padding _metricPaddingHeader = new Padding(0, 3, 1, 3);
-        private static readonly Padding _metricPaddingHeaderForm = new Padding(0, 3, 0, -3); // Move the Maximised Form buttons down a bit
+        //private static readonly Padding _metricPaddingHeaderForm = new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);//, 3, 0, -3); // Move the Maximised Form buttons down a bit
         private static readonly Padding _metricPaddingInputControl = new Padding(0, 1, 0, 1);
         private static readonly Padding _metricPaddingBarInside = new Padding(3);
         private static readonly Padding _metricPaddingBarTabs = new Padding(0);
@@ -3941,11 +3941,13 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             // We do not provide override values
             if (CommonHelper.IsOverrideState(state))
@@ -3953,37 +3955,90 @@ namespace Krypton.Toolkit
                 return CommonHelper.InheritPadding;
             }
 
-            return style switch
+            switch (style)
             {
-                PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 => _contentPaddingGrid,
-                PaletteContentStyle.HeaderForm => _contentPaddingHeaderForm,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _contentPaddingHeader1,
-                PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive => _contentPaddingDock,
-                PaletteContentStyle.HeaderSecondary => _contentPaddingHeader2,
-                PaletteContentStyle.HeaderCalendar => _contentPaddingCalendar,
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 => _contentPaddingLabel,
-                PaletteContentStyle.LabelGroupBoxCaption => _contentPaddingLabel2,
-                PaletteContentStyle.ContextMenuItemTextStandard => _contentPaddingContextMenuItemText,
-                PaletteContentStyle.ContextMenuItemTextAlternate => _contentPaddingContextMenuItemTextAlt,
-                PaletteContentStyle.ContextMenuItemShortcutText => _contentPaddingContextMenuItemShortcutText,
-                PaletteContentStyle.ContextMenuItemImage => _contentPaddingContextMenuImage,
-                PaletteContentStyle.LabelToolTip => _contentPaddingToolTip,
-                PaletteContentStyle.LabelSuperTip => _contentPaddingSuperTip,
-                PaletteContentStyle.LabelKeyTip => _contentPaddingKeyTip,
-                PaletteContentStyle.ContextMenuHeading => _contentPaddingContextMenuHeading,
-                PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => InputControlPadding,
-                PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => _contentPaddingButton12,
-                PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay => _contentPaddingButtonInputControl,
-                PaletteContentStyle.ButtonButtonSpec => _contentPaddingButton3,
-                PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => _contentPaddingButton4,
-                PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => _contentPaddingButtonForm,
-                PaletteContentStyle.ButtonGallery => _contentPaddingButtonGallery,
-                PaletteContentStyle.ButtonListItem => _contentPaddingButtonListItem,
-                PaletteContentStyle.ButtonBreadCrumb => _contentPaddingButton6,
-                PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 => _contentPaddingButton5,
-                PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden => _contentPaddingButton7,
-                _ => throw new ArgumentOutOfRangeException(nameof(style))
-            };
+                case PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet
+                    or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2
+                    or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList
+                    or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1
+                    or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3
+                    or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet
+                    or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2
+                    or PaletteContentStyle.GridDataCellCustom3:
+                    return _contentPaddingGrid;
+                case PaletteContentStyle.HeaderForm:
+                    {
+                        Padding borders = owningForm!.RealWindowBorders;
+                        return new Padding(borders.Left, borders.Bottom / 2, 0, 0);
+                    }
+                case PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1
+                    or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3:
+                    return _contentPaddingHeader1;
+                case PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive:
+                    return _contentPaddingDock;
+                case PaletteContentStyle.HeaderSecondary:
+                    return _contentPaddingHeader2;
+                case PaletteContentStyle.HeaderCalendar:
+                    return _contentPaddingCalendar;
+                case PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl
+                    or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl
+                    or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel
+                    or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel
+                    or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2
+                    or PaletteContentStyle.LabelCustom3:
+                    return _contentPaddingLabel;
+                case PaletteContentStyle.LabelGroupBoxCaption:
+                    return _contentPaddingLabel2;
+                case PaletteContentStyle.ContextMenuItemTextStandard:
+                    return _contentPaddingContextMenuItemText;
+                case PaletteContentStyle.ContextMenuItemTextAlternate:
+                    return _contentPaddingContextMenuItemTextAlt;
+                case PaletteContentStyle.ContextMenuItemShortcutText:
+                    return _contentPaddingContextMenuItemShortcutText;
+                case PaletteContentStyle.ContextMenuItemImage:
+                    return _contentPaddingContextMenuImage;
+                case PaletteContentStyle.LabelToolTip:
+                    return _contentPaddingToolTip;
+                case PaletteContentStyle.LabelSuperTip:
+                    return _contentPaddingSuperTip;
+                case PaletteContentStyle.LabelKeyTip:
+                    return _contentPaddingKeyTip;
+                case PaletteContentStyle.ContextMenuHeading:
+                    return _contentPaddingContextMenuHeading;
+                case PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon
+                    or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2
+                    or PaletteContentStyle.InputControlCustom3:
+                    return InputControlPadding;
+                case PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand
+                    or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile
+                    or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini
+                    or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2
+                    or PaletteContentStyle.ButtonCustom3:
+                    return _contentPaddingButton12;
+                case PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay:
+                    return _contentPaddingButtonInputControl;
+                case PaletteContentStyle.ButtonButtonSpec:
+                    return _contentPaddingButton3;
+                case PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow:
+                    return _contentPaddingButton4;
+                case PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose:
+                    return _contentPaddingButtonForm;
+                case PaletteContentStyle.ButtonGallery:
+                    return _contentPaddingButtonGallery;
+                case PaletteContentStyle.ButtonListItem:
+                    return _contentPaddingButtonListItem;
+                case PaletteContentStyle.ButtonBreadCrumb:
+                    return _contentPaddingButton6;
+                case PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile
+                    or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote
+                    or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2
+                    or PaletteContentStyle.TabCustom3:
+                    return _contentPaddingButton5;
+                case PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden:
+                    return _contentPaddingButton7;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style));
+            }
         }
 
         /// <summary>
@@ -4011,13 +4066,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             switch (metric)
             {
@@ -4028,7 +4085,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricInt.CheckButtonGap:
                     return 5;
                 case PaletteMetricInt.HeaderButtonEdgeInsetForm:
-                    return 9; // Needs to be the RealWindowBorderWidth Offset - No idea how to get it at this point
+                    return Math.Max(2, owningForm!.RealWindowBorders.Right);
                 case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                     return 1;
                 case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:
@@ -4082,10 +4139,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -4099,7 +4158,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricPadding.BarPaddingOutside:
                     return _metricPaddingBarOutside;
                 case PaletteMetricPadding.HeaderButtonPaddingForm:
-                    return _metricPaddingHeaderForm;
+                    return new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);
                 case PaletteMetricPadding.RibbonButtonPadding:
                     return _metricPaddingRibbon;
                 case PaletteMetricPadding.RibbonAppButton:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverDarkMode.cs
@@ -306,7 +306,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.GallerySilverBlack);
             _radioButtonArray =
@@ -464,7 +464,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
         private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
         private static readonly Padding _contentPaddingCalendar = new Padding(2);
-        private static readonly Padding _contentPaddingHeaderForm = new Padding(10, 6, 3, 0); // 10 is from the RealWindowFrameSize +1
+        //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
         private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
         private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
         private static readonly Padding _contentPaddingButtonCalendar = new Padding(-1);
@@ -477,7 +477,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);
@@ -489,7 +489,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _metricPaddingRibbon = new Padding(0, 1, 1, 1);
         private static readonly Padding _metricPaddingRibbonAppButton = new Padding(3, 0, 3, 0);
         private static readonly Padding _metricPaddingHeader = new Padding(0, 3, 1, 3);
-        private static readonly Padding _metricPaddingHeaderForm = new Padding(0, 3, 0, -3); // Move the Maximised Form buttons down a bit
+        //private static readonly Padding _metricPaddingHeaderForm = new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);//, 3, 0, -3); // Move the Maximised Form buttons down a bit
         private static readonly Padding _metricPaddingInputControl = new Padding(0, 1, 0, 1);
         private static readonly Padding _metricPaddingBarInside = new Padding(3);
         private static readonly Padding _metricPaddingBarTabs = new Padding(0);
@@ -3915,11 +3915,13 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             // We do not provide override values
             if (CommonHelper.IsOverrideState(state))
@@ -3927,37 +3929,90 @@ namespace Krypton.Toolkit
                 return CommonHelper.InheritPadding;
             }
 
-            return style switch
+            switch (style)
             {
-                PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 => _contentPaddingGrid,
-                PaletteContentStyle.HeaderForm => _contentPaddingHeaderForm,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _contentPaddingHeader1,
-                PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive => _contentPaddingDock,
-                PaletteContentStyle.HeaderSecondary => _contentPaddingHeader2,
-                PaletteContentStyle.HeaderCalendar => _contentPaddingCalendar,
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 => _contentPaddingLabel,
-                PaletteContentStyle.LabelGroupBoxCaption => _contentPaddingLabel2,
-                PaletteContentStyle.ContextMenuItemTextStandard => _contentPaddingContextMenuItemText,
-                PaletteContentStyle.ContextMenuItemTextAlternate => _contentPaddingContextMenuItemTextAlt,
-                PaletteContentStyle.ContextMenuItemShortcutText => _contentPaddingContextMenuItemShortcutText,
-                PaletteContentStyle.ContextMenuItemImage => _contentPaddingContextMenuImage,
-                PaletteContentStyle.LabelToolTip => _contentPaddingToolTip,
-                PaletteContentStyle.LabelSuperTip => _contentPaddingSuperTip,
-                PaletteContentStyle.LabelKeyTip => _contentPaddingKeyTip,
-                PaletteContentStyle.ContextMenuHeading => _contentPaddingContextMenuHeading,
-                PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => InputControlPadding,
-                PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => _contentPaddingButton12,
-                PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay => _contentPaddingButtonInputControl,
-                PaletteContentStyle.ButtonButtonSpec => _contentPaddingButton3,
-                PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => _contentPaddingButton4,
-                PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => _contentPaddingButtonForm,
-                PaletteContentStyle.ButtonGallery => _contentPaddingButtonGallery,
-                PaletteContentStyle.ButtonListItem => _contentPaddingButtonListItem,
-                PaletteContentStyle.ButtonBreadCrumb => _contentPaddingButton6,
-                PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 => _contentPaddingButton5,
-                PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden => _contentPaddingButton7,
-                _ => throw new ArgumentOutOfRangeException(nameof(style))
-            };
+                case PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet
+                    or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2
+                    or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList
+                    or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1
+                    or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3
+                    or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet
+                    or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2
+                    or PaletteContentStyle.GridDataCellCustom3:
+                    return _contentPaddingGrid;
+                case PaletteContentStyle.HeaderForm:
+                    {
+                        Padding borders = owningForm!.RealWindowBorders;
+                        return new Padding(borders.Left, borders.Bottom / 2, 0, 0);
+                    }
+                case PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1
+                    or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3:
+                    return _contentPaddingHeader1;
+                case PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive:
+                    return _contentPaddingDock;
+                case PaletteContentStyle.HeaderSecondary:
+                    return _contentPaddingHeader2;
+                case PaletteContentStyle.HeaderCalendar:
+                    return _contentPaddingCalendar;
+                case PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl
+                    or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl
+                    or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel
+                    or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel
+                    or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2
+                    or PaletteContentStyle.LabelCustom3:
+                    return _contentPaddingLabel;
+                case PaletteContentStyle.LabelGroupBoxCaption:
+                    return _contentPaddingLabel2;
+                case PaletteContentStyle.ContextMenuItemTextStandard:
+                    return _contentPaddingContextMenuItemText;
+                case PaletteContentStyle.ContextMenuItemTextAlternate:
+                    return _contentPaddingContextMenuItemTextAlt;
+                case PaletteContentStyle.ContextMenuItemShortcutText:
+                    return _contentPaddingContextMenuItemShortcutText;
+                case PaletteContentStyle.ContextMenuItemImage:
+                    return _contentPaddingContextMenuImage;
+                case PaletteContentStyle.LabelToolTip:
+                    return _contentPaddingToolTip;
+                case PaletteContentStyle.LabelSuperTip:
+                    return _contentPaddingSuperTip;
+                case PaletteContentStyle.LabelKeyTip:
+                    return _contentPaddingKeyTip;
+                case PaletteContentStyle.ContextMenuHeading:
+                    return _contentPaddingContextMenuHeading;
+                case PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon
+                    or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2
+                    or PaletteContentStyle.InputControlCustom3:
+                    return InputControlPadding;
+                case PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand
+                    or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile
+                    or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini
+                    or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2
+                    or PaletteContentStyle.ButtonCustom3:
+                    return _contentPaddingButton12;
+                case PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay:
+                    return _contentPaddingButtonInputControl;
+                case PaletteContentStyle.ButtonButtonSpec:
+                    return _contentPaddingButton3;
+                case PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow:
+                    return _contentPaddingButton4;
+                case PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose:
+                    return _contentPaddingButtonForm;
+                case PaletteContentStyle.ButtonGallery:
+                    return _contentPaddingButtonGallery;
+                case PaletteContentStyle.ButtonListItem:
+                    return _contentPaddingButtonListItem;
+                case PaletteContentStyle.ButtonBreadCrumb:
+                    return _contentPaddingButton6;
+                case PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile
+                    or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote
+                    or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2
+                    or PaletteContentStyle.TabCustom3:
+                    return _contentPaddingButton5;
+                case PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden:
+                    return _contentPaddingButton7;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style));
+            }
         }
 
         /// <summary>
@@ -3985,13 +4040,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             switch (metric)
             {
@@ -4002,7 +4059,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricInt.CheckButtonGap:
                     return 5;
                 case PaletteMetricInt.HeaderButtonEdgeInsetForm:
-                    return 9; // Needs to be the RealWindowBorderWidth Offset - No idea how to get it at this point
+                    return Math.Max(2, owningForm!.RealWindowBorders.Right);
                 case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                     return 1;
                 case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:
@@ -4056,10 +4113,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -4073,7 +4132,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricPadding.BarPaddingOutside:
                     return _metricPaddingBarOutside;
                 case PaletteMetricPadding.HeaderButtonPaddingForm:
-                    return _metricPaddingHeaderForm;
+                    return new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);
                 case PaletteMetricPadding.RibbonButtonPadding:
                     return _metricPaddingRibbon;
                 case PaletteMetricPadding.RibbonAppButton:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverLightMode.cs
@@ -306,7 +306,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.GallerySilverBlack);
             _radioButtonArray =
@@ -464,7 +464,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
         private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
         private static readonly Padding _contentPaddingCalendar = new Padding(2);
-        private static readonly Padding _contentPaddingHeaderForm = new Padding(10, 6, 3, 0); // 10 is from the RealWindowFrameSize +1
+        //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
         private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
         private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
         private static readonly Padding _contentPaddingButtonCalendar = new Padding(-1);
@@ -477,7 +477,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);
@@ -489,7 +489,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _metricPaddingRibbon = new Padding(0, 1, 1, 1);
         private static readonly Padding _metricPaddingRibbonAppButton = new Padding(3, 0, 3, 0);
         private static readonly Padding _metricPaddingHeader = new Padding(0, 3, 1, 3);
-        private static readonly Padding _metricPaddingHeaderForm = new Padding(0, 3, 0, -3); // Move the Maximised Form buttons down a bit
+        //private static readonly Padding _metricPaddingHeaderForm = new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);//, 3, 0, -3); // Move the Maximised Form buttons down a bit
         private static readonly Padding _metricPaddingInputControl = new Padding(0, 1, 0, 1);
         private static readonly Padding _metricPaddingBarInside = new Padding(3);
         private static readonly Padding _metricPaddingBarTabs = new Padding(0);
@@ -3966,11 +3966,13 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             // We do not provide override values
             if (CommonHelper.IsOverrideState(state))
@@ -3978,37 +3980,90 @@ namespace Krypton.Toolkit
                 return CommonHelper.InheritPadding;
             }
 
-            return style switch
+            switch (style)
             {
-                PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 => _contentPaddingGrid,
-                PaletteContentStyle.HeaderForm => _contentPaddingHeaderForm,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _contentPaddingHeader1,
-                PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive => _contentPaddingDock,
-                PaletteContentStyle.HeaderSecondary => _contentPaddingHeader2,
-                PaletteContentStyle.HeaderCalendar => _contentPaddingCalendar,
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 => _contentPaddingLabel,
-                PaletteContentStyle.LabelGroupBoxCaption => _contentPaddingLabel2,
-                PaletteContentStyle.ContextMenuItemTextStandard => _contentPaddingContextMenuItemText,
-                PaletteContentStyle.ContextMenuItemTextAlternate => _contentPaddingContextMenuItemTextAlt,
-                PaletteContentStyle.ContextMenuItemShortcutText => _contentPaddingContextMenuItemShortcutText,
-                PaletteContentStyle.ContextMenuItemImage => _contentPaddingContextMenuImage,
-                PaletteContentStyle.LabelToolTip => _contentPaddingToolTip,
-                PaletteContentStyle.LabelSuperTip => _contentPaddingSuperTip,
-                PaletteContentStyle.LabelKeyTip => _contentPaddingKeyTip,
-                PaletteContentStyle.ContextMenuHeading => _contentPaddingContextMenuHeading,
-                PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => InputControlPadding,
-                PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => _contentPaddingButton12,
-                PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay => _contentPaddingButtonInputControl,
-                PaletteContentStyle.ButtonButtonSpec => _contentPaddingButton3,
-                PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => _contentPaddingButton4,
-                PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => _contentPaddingButtonForm,
-                PaletteContentStyle.ButtonGallery => _contentPaddingButtonGallery,
-                PaletteContentStyle.ButtonListItem => _contentPaddingButtonListItem,
-                PaletteContentStyle.ButtonBreadCrumb => _contentPaddingButton6,
-                PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 => _contentPaddingButton5,
-                PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden => _contentPaddingButton7,
-                _ => throw new ArgumentOutOfRangeException(nameof(style))
-            };
+                case PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet
+                    or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2
+                    or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList
+                    or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1
+                    or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3
+                    or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet
+                    or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2
+                    or PaletteContentStyle.GridDataCellCustom3:
+                    return _contentPaddingGrid;
+                case PaletteContentStyle.HeaderForm:
+                    {
+                        Padding borders = owningForm!.RealWindowBorders;
+                        return new Padding(borders.Left, borders.Bottom / 2, 0, 0);
+                    }
+                case PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1
+                    or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3:
+                    return _contentPaddingHeader1;
+                case PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive:
+                    return _contentPaddingDock;
+                case PaletteContentStyle.HeaderSecondary:
+                    return _contentPaddingHeader2;
+                case PaletteContentStyle.HeaderCalendar:
+                    return _contentPaddingCalendar;
+                case PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl
+                    or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl
+                    or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel
+                    or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel
+                    or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2
+                    or PaletteContentStyle.LabelCustom3:
+                    return _contentPaddingLabel;
+                case PaletteContentStyle.LabelGroupBoxCaption:
+                    return _contentPaddingLabel2;
+                case PaletteContentStyle.ContextMenuItemTextStandard:
+                    return _contentPaddingContextMenuItemText;
+                case PaletteContentStyle.ContextMenuItemTextAlternate:
+                    return _contentPaddingContextMenuItemTextAlt;
+                case PaletteContentStyle.ContextMenuItemShortcutText:
+                    return _contentPaddingContextMenuItemShortcutText;
+                case PaletteContentStyle.ContextMenuItemImage:
+                    return _contentPaddingContextMenuImage;
+                case PaletteContentStyle.LabelToolTip:
+                    return _contentPaddingToolTip;
+                case PaletteContentStyle.LabelSuperTip:
+                    return _contentPaddingSuperTip;
+                case PaletteContentStyle.LabelKeyTip:
+                    return _contentPaddingKeyTip;
+                case PaletteContentStyle.ContextMenuHeading:
+                    return _contentPaddingContextMenuHeading;
+                case PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon
+                    or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2
+                    or PaletteContentStyle.InputControlCustom3:
+                    return InputControlPadding;
+                case PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand
+                    or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile
+                    or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini
+                    or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2
+                    or PaletteContentStyle.ButtonCustom3:
+                    return _contentPaddingButton12;
+                case PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay:
+                    return _contentPaddingButtonInputControl;
+                case PaletteContentStyle.ButtonButtonSpec:
+                    return _contentPaddingButton3;
+                case PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow:
+                    return _contentPaddingButton4;
+                case PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose:
+                    return _contentPaddingButtonForm;
+                case PaletteContentStyle.ButtonGallery:
+                    return _contentPaddingButtonGallery;
+                case PaletteContentStyle.ButtonListItem:
+                    return _contentPaddingButtonListItem;
+                case PaletteContentStyle.ButtonBreadCrumb:
+                    return _contentPaddingButton6;
+                case PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile
+                    or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote
+                    or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2
+                    or PaletteContentStyle.TabCustom3:
+                    return _contentPaddingButton5;
+                case PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden:
+                    return _contentPaddingButton7;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style));
+            }
         }
 
         /// <summary>
@@ -4036,13 +4091,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             switch (metric)
             {
@@ -4053,7 +4110,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricInt.CheckButtonGap:
                     return 5;
                 case PaletteMetricInt.HeaderButtonEdgeInsetForm:
-                    return 9; // Needs to be the RealWindowBorderWidth Offset - No idea how to get it at this point
+                    return Math.Max(2, owningForm!.RealWindowBorders.Right);
                 case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                     return 1;
                 case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:
@@ -4107,10 +4164,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -4124,7 +4183,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricPadding.BarPaddingOutside:
                     return _metricPaddingBarOutside;
                 case PaletteMetricPadding.HeaderButtonPaddingForm:
-                    return _metricPaddingHeaderForm;
+                    return new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);
                 case PaletteMetricPadding.RibbonButtonPadding:
                     return _metricPaddingRibbon;
                 case PaletteMetricPadding.RibbonAppButton:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Non Official Themes/PaletteOffice2007DarkGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Non Official Themes/PaletteOffice2007DarkGray.cs
@@ -306,7 +306,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.GallerySilverBlack);
             _radioButtonArray =

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Non Official Themes/PaletteOffice2007White.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Non Official Themes/PaletteOffice2007White.cs
@@ -313,7 +313,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.GallerySilverBlack);
             _radioButtonArray =

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Official Themes/PaletteOffice2007Black.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Official Themes/PaletteOffice2007Black.cs
@@ -314,7 +314,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.GallerySilverBlack);
             _radioButtonArray =

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Official Themes/PaletteOffice2007Blue.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Official Themes/PaletteOffice2007Blue.cs
@@ -304,7 +304,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.GalleryBlue);
             _radioButtonArray =

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Official Themes/PaletteOffice2007Silver.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Official Themes/PaletteOffice2007Silver.cs
@@ -304,7 +304,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.GallerySilverBlack);
             _radioButtonArray =

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Bases/PaletteOffice2010Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Bases/PaletteOffice2010Base.cs
@@ -26,7 +26,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
         private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
         private static readonly Padding _contentPaddingCalendar = new Padding(2);
-        private static readonly Padding _contentPaddingHeaderForm = new Padding(10, 6, 3, 0); // 10 is from the RealWindowFrameSize +1
+        //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
         private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
         private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
         private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -38,7 +38,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);
@@ -50,7 +50,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _metricPaddingRibbon = new Padding(0, 1, 1, 1);
         private static readonly Padding _metricPaddingRibbonAppButton = new Padding(3, 0, 3, 0);
         private static readonly Padding _metricPaddingHeader = new Padding(0, 3, 1, 3);
-        private static readonly Padding _metricPaddingHeaderForm = new Padding(0, 3, 0, -3); // Move the Maximised Form buttons down a bit
+        //private static readonly Padding _metricPaddingHeaderForm = new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);//, 3, 0, -3); // Move the Maximised Form buttons down a bit
         private static readonly Padding _metricPaddingInputControl = new Padding(0, 1, 0, 1);
         private static readonly Padding _metricPaddingBarInside = new Padding(3);
         private static readonly Padding _metricPaddingBarTabs = new Padding(0);
@@ -170,7 +170,6 @@ namespace Krypton.Toolkit
             Color.FromArgb(206, 213, 225)
         ];
 
-
         private static readonly Color[] _appButtonTrack =
         [
             Color.FromArgb(255, 251, 230),
@@ -179,7 +178,6 @@ namespace Krypton.Toolkit
             Color.FromArgb(254, 247, 129),
             Color.FromArgb(240, 201, 41)
         ];
-
 
         private static readonly Color[] _appButtonPressed =
         [
@@ -201,7 +199,6 @@ namespace Krypton.Toolkit
             Color.FromArgb(194, 164, 77) // Button, Checked, Border 2
         ];
 
-
         private static readonly Color[] _buttonBackColors =
         [
             Color.FromArgb(250, 250, 250), // Button, Disabled, Back 1
@@ -215,7 +212,6 @@ namespace Krypton.Toolkit
             Color.FromArgb(255, 225, 104), // Button, Checked Tracking, Back 1
             Color.FromArgb(255, 249, 196) // Button, Checked Tracking, Back 2
         ];
-
         #endregion
 
         #endregion
@@ -1165,13 +1161,52 @@ namespace Krypton.Toolkit
 
             return style switch
             {
-                PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlToolTip or PaletteBorderStyle.ControlRibbon or PaletteBorderStyle.ControlRibbonAppMenu or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.ContextMenuOuter or PaletteBorderStyle.InputControlStandalone or PaletteBorderStyle.InputControlRibbon or PaletteBorderStyle.InputControlCustom1 or PaletteBorderStyle.InputControlCustom2 or PaletteBorderStyle.InputControlCustom3 or PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderCalendar or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCalendarDay or PaletteBorderStyle.ButtonInputControl or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonForm or PaletteBorderStyle.ButtonFormClose or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemImage or PaletteBorderStyle.ContextMenuItemHighlight or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 or PaletteBorderStyle.GridDataCellList or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1 or PaletteBorderStyle.GridDataCellCustom2 or PaletteBorderStyle.GridDataCellCustom3 => PaletteDrawBorders.All,
-                PaletteBorderStyle.TabHighProfile or PaletteBorderStyle.TabStandardProfile or PaletteBorderStyle.TabLowProfile or PaletteBorderStyle.TabOneNote or PaletteBorderStyle.TabDock or PaletteBorderStyle.TabDockAutoHidden or PaletteBorderStyle.TabCustom1 or PaletteBorderStyle.TabCustom2 or PaletteBorderStyle.TabCustom3 => PaletteDrawBorders.All,
+                PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile
+                    or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1
+                    or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3
+                    or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate
+                    or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlToolTip
+                    or PaletteBorderStyle.ControlRibbon or PaletteBorderStyle.ControlRibbonAppMenu
+                    or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2
+                    or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.ContextMenuOuter
+                    or PaletteBorderStyle.InputControlStandalone or PaletteBorderStyle.InputControlRibbon
+                    or PaletteBorderStyle.InputControlCustom1 or PaletteBorderStyle.InputControlCustom2
+                    or PaletteBorderStyle.InputControlCustom3 or PaletteBorderStyle.FormMain
+                    or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2
+                    or PaletteBorderStyle.FormCustom3 or PaletteBorderStyle.HeaderPrimary
+                    or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive
+                    or PaletteBorderStyle.HeaderCalendar or PaletteBorderStyle.HeaderSecondary
+                    or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2
+                    or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ButtonStandalone
+                    or PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonAlternate
+                    or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb
+                    or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand
+                    or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCalendarDay
+                    or PaletteBorderStyle.ButtonInputControl or PaletteBorderStyle.ButtonCluster
+                    or PaletteBorderStyle.ButtonForm or PaletteBorderStyle.ButtonFormClose
+                    or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2
+                    or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemImage
+                    or PaletteBorderStyle.ContextMenuItemHighlight or PaletteBorderStyle.GridHeaderColumnList
+                    or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1
+                    or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3
+                    or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet
+                    or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2
+                    or PaletteBorderStyle.GridHeaderRowCustom3 or PaletteBorderStyle.GridDataCellList
+                    or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1
+                    or PaletteBorderStyle.GridDataCellCustom2
+                    or PaletteBorderStyle.GridDataCellCustom3 => PaletteDrawBorders.All,
+                PaletteBorderStyle.TabHighProfile or PaletteBorderStyle.TabStandardProfile
+                    or PaletteBorderStyle.TabLowProfile or PaletteBorderStyle.TabOneNote or PaletteBorderStyle.TabDock
+                    or PaletteBorderStyle.TabDockAutoHidden or PaletteBorderStyle.TabCustom1
+                    or PaletteBorderStyle.TabCustom2 or PaletteBorderStyle.TabCustom3 => PaletteDrawBorders.All,
                 PaletteBorderStyle.ContextMenuHeading => PaletteDrawBorders.Bottom,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => PaletteDrawBorders.Top,
                 PaletteBorderStyle.ContextMenuItemImageColumn => PaletteDrawBorders.Right,
-                PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ContextMenuInner => PaletteDrawBorders.None,
-                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.TopLeftRight,
+                PaletteBorderStyle.ButtonNavigatorStack 
+                    or PaletteBorderStyle.ButtonNavigatorOverflow
+                    or PaletteBorderStyle.ButtonNavigatorMini
+                    or PaletteBorderStyle.ContextMenuInner => PaletteDrawBorders.None,
+                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.None,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -1192,7 +1227,48 @@ namespace Krypton.Toolkit
 
             return style switch
             {
-                PaletteBorderStyle.TabHighProfile or PaletteBorderStyle.TabStandardProfile or PaletteBorderStyle.TabLowProfile or PaletteBorderStyle.TabOneNote or PaletteBorderStyle.TabDock or PaletteBorderStyle.TabDockAutoHidden or PaletteBorderStyle.TabCustom1 or PaletteBorderStyle.TabCustom2 or PaletteBorderStyle.TabCustom3 or PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlRibbon or PaletteBorderStyle.ControlRibbonAppMenu or PaletteBorderStyle.ControlToolTip or PaletteBorderStyle.ContextMenuOuter or PaletteBorderStyle.ContextMenuInner or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit or PaletteBorderStyle.ContextMenuItemImageColumn or PaletteBorderStyle.ContextMenuItemImage or PaletteBorderStyle.ContextMenuItemHighlight or PaletteBorderStyle.InputControlStandalone or PaletteBorderStyle.InputControlRibbon or PaletteBorderStyle.InputControlCustom1 or PaletteBorderStyle.InputControlCustom2 or PaletteBorderStyle.InputControlCustom3 or PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderCalendar or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderForm or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCalendarDay or PaletteBorderStyle.ButtonForm or PaletteBorderStyle.ButtonFormClose or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ButtonInputControl or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 or PaletteBorderStyle.GridDataCellList or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1 or PaletteBorderStyle.GridDataCellCustom2 or PaletteBorderStyle.GridDataCellCustom3 => PaletteGraphicsHint.AntiAlias,
+                PaletteBorderStyle.TabHighProfile or PaletteBorderStyle.TabStandardProfile
+                    or PaletteBorderStyle.TabLowProfile or PaletteBorderStyle.TabOneNote or PaletteBorderStyle.TabDock
+                    or PaletteBorderStyle.TabDockAutoHidden or PaletteBorderStyle.TabCustom1
+                    or PaletteBorderStyle.TabCustom2 or PaletteBorderStyle.TabCustom3
+                    or PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile
+                    or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1
+                    or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3
+                    or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate
+                    or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlRibbon
+                    or PaletteBorderStyle.ControlRibbonAppMenu or PaletteBorderStyle.ControlToolTip
+                    or PaletteBorderStyle.ContextMenuOuter or PaletteBorderStyle.ContextMenuInner
+                    or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2
+                    or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.ContextMenuHeading
+                    or PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit
+                    or PaletteBorderStyle.ContextMenuItemImageColumn or PaletteBorderStyle.ContextMenuItemImage
+                    or PaletteBorderStyle.ContextMenuItemHighlight or PaletteBorderStyle.InputControlStandalone
+                    or PaletteBorderStyle.InputControlRibbon or PaletteBorderStyle.InputControlCustom1
+                    or PaletteBorderStyle.InputControlCustom2 or PaletteBorderStyle.InputControlCustom3
+                    or PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2
+                    or PaletteBorderStyle.FormCustom3 or PaletteBorderStyle.HeaderPrimary
+                    or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive
+                    or PaletteBorderStyle.HeaderCalendar or PaletteBorderStyle.HeaderSecondary
+                    or PaletteBorderStyle.HeaderForm or PaletteBorderStyle.HeaderCustom1
+                    or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3
+                    or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonGallery
+                    or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile
+                    or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem
+                    or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec
+                    or PaletteBorderStyle.ButtonCalendarDay or PaletteBorderStyle.ButtonForm
+                    or PaletteBorderStyle.ButtonFormClose or PaletteBorderStyle.ButtonCustom1
+                    or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3
+                    or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonNavigatorStack
+                    or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini
+                    or PaletteBorderStyle.ButtonInputControl or PaletteBorderStyle.GridHeaderColumnList
+                    or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1
+                    or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3
+                    or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet
+                    or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2
+                    or PaletteBorderStyle.GridHeaderRowCustom3 or PaletteBorderStyle.GridDataCellList
+                    or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1
+                    or PaletteBorderStyle.GridDataCellCustom2
+                    or PaletteBorderStyle.GridDataCellCustom3 => PaletteGraphicsHint.AntiAlias,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -1221,11 +1297,20 @@ namespace Krypton.Toolkit
 
             return style switch
             {
-                PaletteBorderStyle.TabHighProfile or PaletteBorderStyle.TabStandardProfile or PaletteBorderStyle.TabLowProfile or PaletteBorderStyle.TabOneNote or PaletteBorderStyle.TabCustom1 or PaletteBorderStyle.TabCustom2 or PaletteBorderStyle.TabCustom3 => state switch
+                PaletteBorderStyle.TabHighProfile or PaletteBorderStyle.TabStandardProfile
+                    or PaletteBorderStyle.TabLowProfile or PaletteBorderStyle.TabOneNote
+                    or PaletteBorderStyle.TabCustom1 or PaletteBorderStyle.TabCustom2
+                    or PaletteBorderStyle.TabCustom3 => state switch
                 {
-                    PaletteState.Disabled => style == PaletteBorderStyle.TabLowProfile ? GlobalStaticValues.EMPTY_COLOR : _disabledBorder,
-                    PaletteState.Normal or PaletteState.Tracking or PaletteState.Pressed => style == PaletteBorderStyle.TabLowProfile ? GlobalStaticValues.EMPTY_COLOR : _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBorder],
-                    PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeOfficeColors.ControlBorder],
+                    PaletteState.Disabled => style == PaletteBorderStyle.TabLowProfile
+                        ? GlobalStaticValues.EMPTY_COLOR
+                        : _disabledBorder,
+                    PaletteState.Normal or PaletteState.Tracking or PaletteState.Pressed =>
+                        style == PaletteBorderStyle.TabLowProfile
+                            ? GlobalStaticValues.EMPTY_COLOR
+                            : _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBorder],
+                    PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking =>
+                        _ribbonColors[(int)SchemeOfficeColors.ControlBorder],
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.TabDock => state switch
@@ -1233,14 +1318,16 @@ namespace Krypton.Toolkit
                     PaletteState.Disabled => _disabledBorder,
                     PaletteState.Normal => _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
-                    PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeOfficeColors.ControlBorder],
+                    PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking =>
+                        _ribbonColors[(int)SchemeOfficeColors.ControlBorder],
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.TabDockAutoHidden => state switch
                 {
                     PaletteState.Disabled => _disabledBorder,
                     PaletteState.Normal or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBorder],
-                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed
+                        or PaletteState.CheckedPressed => _buttonBorderColors[2],
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
@@ -1474,7 +1561,27 @@ namespace Krypton.Toolkit
                     PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => PaletteColorStyle.Solid,
                     _ => PaletteColorStyle.Sigma
                 },
-                PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlToolTip or PaletteBorderStyle.ControlRibbon or PaletteBorderStyle.ControlRibbonAppMenu or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.ContextMenuOuter or PaletteBorderStyle.ContextMenuInner or PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn or PaletteBorderStyle.ContextMenuItemImage or PaletteBorderStyle.InputControlStandalone or PaletteBorderStyle.InputControlRibbon or PaletteBorderStyle.InputControlCustom1 or PaletteBorderStyle.InputControlCustom2 or PaletteBorderStyle.InputControlCustom3 or PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 or PaletteBorderStyle.HeaderForm or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 or PaletteBorderStyle.GridDataCellList or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1 or PaletteBorderStyle.GridDataCellCustom2 or PaletteBorderStyle.GridDataCellCustom3 or PaletteBorderStyle.HeaderCalendar or PaletteBorderStyle.ButtonCalendarDay => PaletteColorStyle.Solid,
+                PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate
+                    or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlToolTip
+                    or PaletteBorderStyle.ControlRibbon or PaletteBorderStyle.ControlRibbonAppMenu
+                    or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2
+                    or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.ContextMenuOuter
+                    or PaletteBorderStyle.ContextMenuInner or PaletteBorderStyle.ContextMenuHeading
+                    or PaletteBorderStyle.ContextMenuItemImageColumn or PaletteBorderStyle.ContextMenuItemImage
+                    or PaletteBorderStyle.InputControlStandalone or PaletteBorderStyle.InputControlRibbon
+                    or PaletteBorderStyle.InputControlCustom1 or PaletteBorderStyle.InputControlCustom2
+                    or PaletteBorderStyle.InputControlCustom3 or PaletteBorderStyle.FormMain
+                    or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2
+                    or PaletteBorderStyle.FormCustom3 or PaletteBorderStyle.HeaderForm
+                    or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet
+                    or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2
+                    or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList
+                    or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1
+                    or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3
+                    or PaletteBorderStyle.GridDataCellList or PaletteBorderStyle.GridDataCellSheet
+                    or PaletteBorderStyle.GridDataCellCustom1 or PaletteBorderStyle.GridDataCellCustom2
+                    or PaletteBorderStyle.GridDataCellCustom3 or PaletteBorderStyle.HeaderCalendar
+                    or PaletteBorderStyle.ButtonCalendarDay => PaletteColorStyle.Solid,
                 PaletteBorderStyle.ContextMenuItemSplit => state == PaletteState.Tracking ? PaletteColorStyle.Sigma : PaletteColorStyle.Solid,
                 PaletteBorderStyle.ContextMenuSeparator => PaletteColorStyle.Dashed,
                 PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ButtonInputControl or PaletteBorderStyle.ContextMenuItemHighlight => state switch
@@ -1504,7 +1611,15 @@ namespace Krypton.Toolkit
 
             return style switch
             {
-                PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlToolTip or PaletteBorderStyle.ControlRibbon or PaletteBorderStyle.ControlRibbonAppMenu or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.InputControlStandalone or PaletteBorderStyle.InputControlRibbon or PaletteBorderStyle.InputControlCustom1 or PaletteBorderStyle.InputControlCustom2 or PaletteBorderStyle.InputControlCustom3 or PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => PaletteRectangleAlign.Control,
+                PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate
+                    or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlToolTip
+                    or PaletteBorderStyle.ControlRibbon or PaletteBorderStyle.ControlRibbonAppMenu
+                    or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2
+                    or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.InputControlStandalone
+                    or PaletteBorderStyle.InputControlRibbon or PaletteBorderStyle.InputControlCustom1
+                    or PaletteBorderStyle.InputControlCustom2 or PaletteBorderStyle.InputControlCustom3
+                    or PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2
+                    or PaletteBorderStyle.FormCustom3 => PaletteRectangleAlign.Control,
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderCalendar or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderForm or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.TabHighProfile or PaletteBorderStyle.TabStandardProfile or PaletteBorderStyle.TabLowProfile or PaletteBorderStyle.TabOneNote or PaletteBorderStyle.TabDock or PaletteBorderStyle.TabDockAutoHidden or PaletteBorderStyle.TabCustom1 or PaletteBorderStyle.TabCustom2 or PaletteBorderStyle.TabCustom3 or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCalendarDay or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ButtonForm or PaletteBorderStyle.ButtonFormClose or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ButtonInputControl or PaletteBorderStyle.ContextMenuItemImage or PaletteBorderStyle.ContextMenuItemHighlight or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 or PaletteBorderStyle.GridDataCellList or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1 or PaletteBorderStyle.GridDataCellCustom2 or PaletteBorderStyle.GridDataCellCustom3 or PaletteBorderStyle.ContextMenuOuter or PaletteBorderStyle.ContextMenuInner or PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn or PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => PaletteRectangleAlign.Local,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
@@ -1526,7 +1641,47 @@ namespace Krypton.Toolkit
 
             return style switch
             {
-                PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlToolTip or PaletteBorderStyle.ControlRibbon or PaletteBorderStyle.ControlRibbonAppMenu or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.ContextMenuOuter or PaletteBorderStyle.ContextMenuInner or PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit or PaletteBorderStyle.ContextMenuItemImageColumn or PaletteBorderStyle.InputControlStandalone or PaletteBorderStyle.InputControlRibbon or PaletteBorderStyle.InputControlCustom1 or PaletteBorderStyle.InputControlCustom2 or PaletteBorderStyle.InputControlCustom3 or PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderCalendar or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderForm or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.TabHighProfile or PaletteBorderStyle.TabStandardProfile or PaletteBorderStyle.TabLowProfile or PaletteBorderStyle.TabOneNote or PaletteBorderStyle.TabDock or PaletteBorderStyle.TabDockAutoHidden or PaletteBorderStyle.TabCustom1 or PaletteBorderStyle.TabCustom2 or PaletteBorderStyle.TabCustom3 or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCalendarDay or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ButtonForm or PaletteBorderStyle.ButtonFormClose or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ButtonInputControl or PaletteBorderStyle.ContextMenuItemImage or PaletteBorderStyle.ContextMenuItemHighlight or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 or PaletteBorderStyle.GridDataCellList or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1 or PaletteBorderStyle.GridDataCellCustom2 or PaletteBorderStyle.GridDataCellCustom3 => 90f,
+                PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile
+                    or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1
+                    or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3
+                    or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate
+                    or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlToolTip
+                    or PaletteBorderStyle.ControlRibbon or PaletteBorderStyle.ControlRibbonAppMenu
+                    or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2
+                    or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.ContextMenuOuter
+                    or PaletteBorderStyle.ContextMenuInner or PaletteBorderStyle.ContextMenuHeading
+                    or PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit
+                    or PaletteBorderStyle.ContextMenuItemImageColumn or PaletteBorderStyle.InputControlStandalone
+                    or PaletteBorderStyle.InputControlRibbon or PaletteBorderStyle.InputControlCustom1
+                    or PaletteBorderStyle.InputControlCustom2 or PaletteBorderStyle.InputControlCustom3
+                    or PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2
+                    or PaletteBorderStyle.FormCustom3 or PaletteBorderStyle.HeaderPrimary
+                    or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive
+                    or PaletteBorderStyle.HeaderCalendar or PaletteBorderStyle.HeaderSecondary
+                    or PaletteBorderStyle.HeaderForm or PaletteBorderStyle.HeaderCustom1
+                    or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3
+                    or PaletteBorderStyle.TabHighProfile or PaletteBorderStyle.TabStandardProfile
+                    or PaletteBorderStyle.TabLowProfile or PaletteBorderStyle.TabOneNote or PaletteBorderStyle.TabDock
+                    or PaletteBorderStyle.TabDockAutoHidden or PaletteBorderStyle.TabCustom1
+                    or PaletteBorderStyle.TabCustom2 or PaletteBorderStyle.TabCustom3
+                    or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonGallery
+                    or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile
+                    or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem
+                    or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec
+                    or PaletteBorderStyle.ButtonCalendarDay or PaletteBorderStyle.ButtonCluster
+                    or PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow
+                    or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ButtonForm
+                    or PaletteBorderStyle.ButtonFormClose or PaletteBorderStyle.ButtonCustom1
+                    or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3
+                    or PaletteBorderStyle.ButtonInputControl or PaletteBorderStyle.ContextMenuItemImage
+                    or PaletteBorderStyle.ContextMenuItemHighlight or PaletteBorderStyle.GridHeaderColumnList
+                    or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1
+                    or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3
+                    or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet
+                    or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2
+                    or PaletteBorderStyle.GridHeaderRowCustom3 or PaletteBorderStyle.GridDataCellList
+                    or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1
+                    or PaletteBorderStyle.GridDataCellCustom2 or PaletteBorderStyle.GridDataCellCustom3 => 90f,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -1548,7 +1703,44 @@ namespace Krypton.Toolkit
             return style switch
             {
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.ContextMenuInner => 0,
-                PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlToolTip or PaletteBorderStyle.ControlRibbon or PaletteBorderStyle.ControlRibbonAppMenu or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.ContextMenuOuter or PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit or PaletteBorderStyle.ContextMenuItemImageColumn or PaletteBorderStyle.ContextMenuItemImage or PaletteBorderStyle.ContextMenuItemHighlight or PaletteBorderStyle.InputControlStandalone or PaletteBorderStyle.InputControlRibbon or PaletteBorderStyle.InputControlCustom1 or PaletteBorderStyle.InputControlCustom2 or PaletteBorderStyle.InputControlCustom3 or PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderCalendar or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderForm or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.TabHighProfile or PaletteBorderStyle.TabStandardProfile or PaletteBorderStyle.TabLowProfile or PaletteBorderStyle.TabOneNote or PaletteBorderStyle.TabDock or PaletteBorderStyle.TabDockAutoHidden or PaletteBorderStyle.TabCustom1 or PaletteBorderStyle.TabCustom2 or PaletteBorderStyle.TabCustom3 or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCalendarDay or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonInputControl or PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ButtonForm or PaletteBorderStyle.ButtonFormClose or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 or PaletteBorderStyle.GridDataCellList or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1 or PaletteBorderStyle.GridDataCellCustom2 or PaletteBorderStyle.GridDataCellCustom3 => 1,
+                PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate
+                    or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlToolTip
+                    or PaletteBorderStyle.ControlRibbon or PaletteBorderStyle.ControlRibbonAppMenu
+                    or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2
+                    or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.ContextMenuOuter
+                    or PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuSeparator
+                    or PaletteBorderStyle.ContextMenuItemSplit or PaletteBorderStyle.ContextMenuItemImageColumn
+                    or PaletteBorderStyle.ContextMenuItemImage or PaletteBorderStyle.ContextMenuItemHighlight
+                    or PaletteBorderStyle.InputControlStandalone or PaletteBorderStyle.InputControlRibbon
+                    or PaletteBorderStyle.InputControlCustom1 or PaletteBorderStyle.InputControlCustom2
+                    or PaletteBorderStyle.InputControlCustom3 or PaletteBorderStyle.FormMain
+                    or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2
+                    or PaletteBorderStyle.FormCustom3 or PaletteBorderStyle.HeaderPrimary
+                    or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive
+                    or PaletteBorderStyle.HeaderCalendar or PaletteBorderStyle.HeaderSecondary
+                    or PaletteBorderStyle.HeaderForm or PaletteBorderStyle.HeaderCustom1
+                    or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3
+                    or PaletteBorderStyle.TabHighProfile or PaletteBorderStyle.TabStandardProfile
+                    or PaletteBorderStyle.TabLowProfile or PaletteBorderStyle.TabOneNote or PaletteBorderStyle.TabDock
+                    or PaletteBorderStyle.TabDockAutoHidden or PaletteBorderStyle.TabCustom1
+                    or PaletteBorderStyle.TabCustom2 or PaletteBorderStyle.TabCustom3
+                    or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonGallery
+                    or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile
+                    or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem
+                    or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec
+                    or PaletteBorderStyle.ButtonCalendarDay or PaletteBorderStyle.ButtonCluster
+                    or PaletteBorderStyle.ButtonInputControl or PaletteBorderStyle.ButtonNavigatorStack
+                    or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini
+                    or PaletteBorderStyle.ButtonForm or PaletteBorderStyle.ButtonFormClose
+                    or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2
+                    or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.GridHeaderColumnList
+                    or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1
+                    or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3
+                    or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet
+                    or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2
+                    or PaletteBorderStyle.GridHeaderRowCustom3 or PaletteBorderStyle.GridDataCellList
+                    or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1
+                    or PaletteBorderStyle.GridDataCellCustom2 or PaletteBorderStyle.GridDataCellCustom3 => 1,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -1594,7 +1786,47 @@ namespace Krypton.Toolkit
 
             return style switch
             {
-                PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlToolTip or PaletteBorderStyle.ControlRibbon or PaletteBorderStyle.ControlRibbonAppMenu or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.ContextMenuOuter or PaletteBorderStyle.ContextMenuInner or PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit or PaletteBorderStyle.ContextMenuItemImageColumn or PaletteBorderStyle.ContextMenuItemImage or PaletteBorderStyle.ContextMenuItemHighlight or PaletteBorderStyle.InputControlStandalone or PaletteBorderStyle.InputControlRibbon or PaletteBorderStyle.InputControlCustom1 or PaletteBorderStyle.InputControlCustom2 or PaletteBorderStyle.InputControlCustom3 or PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderCalendar or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderForm or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.TabHighProfile or PaletteBorderStyle.TabStandardProfile or PaletteBorderStyle.TabLowProfile or PaletteBorderStyle.TabOneNote or PaletteBorderStyle.TabDock or PaletteBorderStyle.TabDockAutoHidden or PaletteBorderStyle.TabCustom1 or PaletteBorderStyle.TabCustom2 or PaletteBorderStyle.TabCustom3 or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCalendarDay or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ButtonForm or PaletteBorderStyle.ButtonFormClose or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ButtonInputControl or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 or PaletteBorderStyle.GridDataCellList or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1 or PaletteBorderStyle.GridDataCellCustom2 or PaletteBorderStyle.GridDataCellCustom3 => null,
+                PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile
+                    or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1
+                    or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3
+                    or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate
+                    or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlToolTip
+                    or PaletteBorderStyle.ControlRibbon or PaletteBorderStyle.ControlRibbonAppMenu
+                    or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2
+                    or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.ContextMenuOuter
+                    or PaletteBorderStyle.ContextMenuInner or PaletteBorderStyle.ContextMenuHeading
+                    or PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit
+                    or PaletteBorderStyle.ContextMenuItemImageColumn or PaletteBorderStyle.ContextMenuItemImage
+                    or PaletteBorderStyle.ContextMenuItemHighlight or PaletteBorderStyle.InputControlStandalone
+                    or PaletteBorderStyle.InputControlRibbon or PaletteBorderStyle.InputControlCustom1
+                    or PaletteBorderStyle.InputControlCustom2 or PaletteBorderStyle.InputControlCustom3
+                    or PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2
+                    or PaletteBorderStyle.FormCustom3 or PaletteBorderStyle.HeaderPrimary
+                    or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive
+                    or PaletteBorderStyle.HeaderCalendar or PaletteBorderStyle.HeaderSecondary
+                    or PaletteBorderStyle.HeaderForm or PaletteBorderStyle.HeaderCustom1
+                    or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3
+                    or PaletteBorderStyle.TabHighProfile or PaletteBorderStyle.TabStandardProfile
+                    or PaletteBorderStyle.TabLowProfile or PaletteBorderStyle.TabOneNote or PaletteBorderStyle.TabDock
+                    or PaletteBorderStyle.TabDockAutoHidden or PaletteBorderStyle.TabCustom1
+                    or PaletteBorderStyle.TabCustom2 or PaletteBorderStyle.TabCustom3
+                    or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonGallery
+                    or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile
+                    or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem
+                    or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec
+                    or PaletteBorderStyle.ButtonCalendarDay or PaletteBorderStyle.ButtonCluster
+                    or PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow
+                    or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ButtonForm
+                    or PaletteBorderStyle.ButtonFormClose or PaletteBorderStyle.ButtonCustom1
+                    or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3
+                    or PaletteBorderStyle.ButtonInputControl or PaletteBorderStyle.GridHeaderColumnList
+                    or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1
+                    or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3
+                    or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet
+                    or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2
+                    or PaletteBorderStyle.GridHeaderRowCustom3 or PaletteBorderStyle.GridDataCellList
+                    or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1
+                    or PaletteBorderStyle.GridDataCellCustom2 or PaletteBorderStyle.GridDataCellCustom3 => null,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -1615,7 +1847,48 @@ namespace Krypton.Toolkit
 
             return style switch
             {
-                PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlToolTip or PaletteBorderStyle.ControlRibbon or PaletteBorderStyle.ControlRibbonAppMenu or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.ContextMenuOuter or PaletteBorderStyle.ContextMenuInner or PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit or PaletteBorderStyle.ContextMenuItemImage or PaletteBorderStyle.ContextMenuItemImageColumn or PaletteBorderStyle.ContextMenuItemHighlight or PaletteBorderStyle.InputControlStandalone or PaletteBorderStyle.InputControlRibbon or PaletteBorderStyle.InputControlCustom1 or PaletteBorderStyle.InputControlCustom2 or PaletteBorderStyle.InputControlCustom3 or PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderCalendar or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderForm or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.TabHighProfile or PaletteBorderStyle.TabStandardProfile or PaletteBorderStyle.TabLowProfile or PaletteBorderStyle.TabOneNote or PaletteBorderStyle.TabDock or PaletteBorderStyle.TabDockAutoHidden or PaletteBorderStyle.TabCustom1 or PaletteBorderStyle.TabCustom2 or PaletteBorderStyle.TabCustom3 or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCalendarDay or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ButtonForm or PaletteBorderStyle.ButtonFormClose or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ButtonInputControl or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 or PaletteBorderStyle.GridDataCellList or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1 or PaletteBorderStyle.GridDataCellCustom2 or PaletteBorderStyle.GridDataCellCustom3 => PaletteImageStyle.Tile,
+                PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile
+                    or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1
+                    or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3
+                    or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate
+                    or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlToolTip
+                    or PaletteBorderStyle.ControlRibbon or PaletteBorderStyle.ControlRibbonAppMenu
+                    or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2
+                    or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.ContextMenuOuter
+                    or PaletteBorderStyle.ContextMenuInner or PaletteBorderStyle.ContextMenuHeading
+                    or PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit
+                    or PaletteBorderStyle.ContextMenuItemImage or PaletteBorderStyle.ContextMenuItemImageColumn
+                    or PaletteBorderStyle.ContextMenuItemHighlight or PaletteBorderStyle.InputControlStandalone
+                    or PaletteBorderStyle.InputControlRibbon or PaletteBorderStyle.InputControlCustom1
+                    or PaletteBorderStyle.InputControlCustom2 or PaletteBorderStyle.InputControlCustom3
+                    or PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2
+                    or PaletteBorderStyle.FormCustom3 or PaletteBorderStyle.HeaderPrimary
+                    or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive
+                    or PaletteBorderStyle.HeaderCalendar or PaletteBorderStyle.HeaderSecondary
+                    or PaletteBorderStyle.HeaderForm or PaletteBorderStyle.HeaderCustom1
+                    or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3
+                    or PaletteBorderStyle.TabHighProfile or PaletteBorderStyle.TabStandardProfile
+                    or PaletteBorderStyle.TabLowProfile or PaletteBorderStyle.TabOneNote or PaletteBorderStyle.TabDock
+                    or PaletteBorderStyle.TabDockAutoHidden or PaletteBorderStyle.TabCustom1
+                    or PaletteBorderStyle.TabCustom2 or PaletteBorderStyle.TabCustom3
+                    or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonGallery
+                    or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile
+                    or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem
+                    or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec
+                    or PaletteBorderStyle.ButtonCalendarDay or PaletteBorderStyle.ButtonCluster
+                    or PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow
+                    or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ButtonForm
+                    or PaletteBorderStyle.ButtonFormClose or PaletteBorderStyle.ButtonCustom1
+                    or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3
+                    or PaletteBorderStyle.ButtonInputControl or PaletteBorderStyle.GridHeaderColumnList
+                    or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1
+                    or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3
+                    or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet
+                    or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2
+                    or PaletteBorderStyle.GridHeaderRowCustom3 or PaletteBorderStyle.GridDataCellList
+                    or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1
+                    or PaletteBorderStyle.GridDataCellCustom2
+                    or PaletteBorderStyle.GridDataCellCustom3 => PaletteImageStyle.Tile,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -1636,7 +1909,48 @@ namespace Krypton.Toolkit
 
             return style switch
             {
-                PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlToolTip or PaletteBorderStyle.ControlRibbon or PaletteBorderStyle.ControlRibbonAppMenu or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.ContextMenuOuter or PaletteBorderStyle.ContextMenuInner or PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit or PaletteBorderStyle.ContextMenuItemImage or PaletteBorderStyle.ContextMenuItemImageColumn or PaletteBorderStyle.ContextMenuItemHighlight or PaletteBorderStyle.InputControlStandalone or PaletteBorderStyle.InputControlRibbon or PaletteBorderStyle.InputControlCustom1 or PaletteBorderStyle.InputControlCustom2 or PaletteBorderStyle.InputControlCustom3 or PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderCalendar or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderForm or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.TabHighProfile or PaletteBorderStyle.TabStandardProfile or PaletteBorderStyle.TabLowProfile or PaletteBorderStyle.TabOneNote or PaletteBorderStyle.TabDock or PaletteBorderStyle.TabDockAutoHidden or PaletteBorderStyle.TabCustom1 or PaletteBorderStyle.TabCustom2 or PaletteBorderStyle.TabCustom3 or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCalendarDay or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ButtonForm or PaletteBorderStyle.ButtonFormClose or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ButtonInputControl or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 or PaletteBorderStyle.GridDataCellList or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1 or PaletteBorderStyle.GridDataCellCustom2 or PaletteBorderStyle.GridDataCellCustom3 => PaletteRectangleAlign.Local,
+                PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile
+                    or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1
+                    or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3
+                    or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate
+                    or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlToolTip
+                    or PaletteBorderStyle.ControlRibbon or PaletteBorderStyle.ControlRibbonAppMenu
+                    or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2
+                    or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.ContextMenuOuter
+                    or PaletteBorderStyle.ContextMenuInner or PaletteBorderStyle.ContextMenuHeading
+                    or PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit
+                    or PaletteBorderStyle.ContextMenuItemImage or PaletteBorderStyle.ContextMenuItemImageColumn
+                    or PaletteBorderStyle.ContextMenuItemHighlight or PaletteBorderStyle.InputControlStandalone
+                    or PaletteBorderStyle.InputControlRibbon or PaletteBorderStyle.InputControlCustom1
+                    or PaletteBorderStyle.InputControlCustom2 or PaletteBorderStyle.InputControlCustom3
+                    or PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2
+                    or PaletteBorderStyle.FormCustom3 or PaletteBorderStyle.HeaderPrimary
+                    or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive
+                    or PaletteBorderStyle.HeaderCalendar or PaletteBorderStyle.HeaderSecondary
+                    or PaletteBorderStyle.HeaderForm or PaletteBorderStyle.HeaderCustom1
+                    or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3
+                    or PaletteBorderStyle.TabHighProfile or PaletteBorderStyle.TabStandardProfile
+                    or PaletteBorderStyle.TabLowProfile or PaletteBorderStyle.TabOneNote or PaletteBorderStyle.TabDock
+                    or PaletteBorderStyle.TabDockAutoHidden or PaletteBorderStyle.TabCustom1
+                    or PaletteBorderStyle.TabCustom2 or PaletteBorderStyle.TabCustom3
+                    or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonGallery
+                    or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile
+                    or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem
+                    or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec
+                    or PaletteBorderStyle.ButtonCalendarDay or PaletteBorderStyle.ButtonCluster
+                    or PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow
+                    or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ButtonForm
+                    or PaletteBorderStyle.ButtonFormClose or PaletteBorderStyle.ButtonCustom1
+                    or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3
+                    or PaletteBorderStyle.ButtonInputControl or PaletteBorderStyle.GridHeaderColumnList
+                    or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1
+                    or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3
+                    or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet
+                    or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2
+                    or PaletteBorderStyle.GridHeaderRowCustom3 or PaletteBorderStyle.GridDataCellList
+                    or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1
+                    or PaletteBorderStyle.GridDataCellCustom2
+                    or PaletteBorderStyle.GridDataCellCustom3 => PaletteRectangleAlign.Local,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -2902,10 +3216,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             // We do not provide override values
             if (CommonHelper.IsOverrideState(state))
@@ -2913,37 +3229,90 @@ namespace Krypton.Toolkit
                 return CommonHelper.InheritPadding;
             }
 
-            return style switch
+            switch (style)
             {
-                PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 => _contentPaddingGrid,
-                PaletteContentStyle.HeaderForm => _contentPaddingHeaderForm,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _contentPaddingHeader1,
-                PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive => _contentPaddingDock,
-                PaletteContentStyle.HeaderSecondary => _contentPaddingHeader2,
-                PaletteContentStyle.HeaderCalendar => _contentPaddingCalendar,
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 => _contentPaddingLabel,
-                PaletteContentStyle.LabelGroupBoxCaption => _contentPaddingLabel2,
-                PaletteContentStyle.ContextMenuItemTextStandard => _contentPaddingContextMenuItemText,
-                PaletteContentStyle.ContextMenuItemTextAlternate => _contentPaddingContextMenuItemTextAlt,
-                PaletteContentStyle.ContextMenuItemShortcutText => _contentPaddingContextMenuItemShortcutText,
-                PaletteContentStyle.ContextMenuItemImage => _contentPaddingContextMenuImage,
-                PaletteContentStyle.LabelToolTip => _contentPaddingToolTip,
-                PaletteContentStyle.LabelSuperTip => _contentPaddingSuperTip,
-                PaletteContentStyle.LabelKeyTip => _contentPaddingKeyTip,
-                PaletteContentStyle.ContextMenuHeading => _contentPaddingContextMenuHeading,
-                PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => InputControlPadding,
-                PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => _contentPaddingButton12,
-                PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay => _contentPaddingButtonInputControl,
-                PaletteContentStyle.ButtonButtonSpec => _contentPaddingButton3,
-                PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => _contentPaddingButton4,
-                PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => _contentPaddingButtonForm,
-                PaletteContentStyle.ButtonGallery => _contentPaddingButtonGallery,
-                PaletteContentStyle.ButtonListItem => _contentPaddingButtonListItem,
-                PaletteContentStyle.ButtonBreadCrumb => _contentPaddingButton6,
-                PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 => _contentPaddingButton5,
-                PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden => _contentPaddingButton7,
-                _ => throw new ArgumentOutOfRangeException(nameof(style))
-            };
+                case PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet
+                    or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2
+                    or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList
+                    or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1
+                    or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3
+                    or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet
+                    or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2
+                    or PaletteContentStyle.GridDataCellCustom3:
+                    return _contentPaddingGrid;
+                case PaletteContentStyle.HeaderForm:
+                    {
+                        Padding borders = owningForm!.RealWindowBorders;
+                        return new Padding(borders.Left, borders.Bottom / 2, 0, 0);
+                    }
+                case PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1
+                    or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3:
+                    return _contentPaddingHeader1;
+                case PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive:
+                    return _contentPaddingDock;
+                case PaletteContentStyle.HeaderSecondary:
+                    return _contentPaddingHeader2;
+                case PaletteContentStyle.HeaderCalendar:
+                    return _contentPaddingCalendar;
+                case PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl
+                    or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl
+                    or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel
+                    or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel
+                    or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2
+                    or PaletteContentStyle.LabelCustom3:
+                    return _contentPaddingLabel;
+                case PaletteContentStyle.LabelGroupBoxCaption:
+                    return _contentPaddingLabel2;
+                case PaletteContentStyle.ContextMenuItemTextStandard:
+                    return _contentPaddingContextMenuItemText;
+                case PaletteContentStyle.ContextMenuItemTextAlternate:
+                    return _contentPaddingContextMenuItemTextAlt;
+                case PaletteContentStyle.ContextMenuItemShortcutText:
+                    return _contentPaddingContextMenuItemShortcutText;
+                case PaletteContentStyle.ContextMenuItemImage:
+                    return _contentPaddingContextMenuImage;
+                case PaletteContentStyle.LabelToolTip:
+                    return _contentPaddingToolTip;
+                case PaletteContentStyle.LabelSuperTip:
+                    return _contentPaddingSuperTip;
+                case PaletteContentStyle.LabelKeyTip:
+                    return _contentPaddingKeyTip;
+                case PaletteContentStyle.ContextMenuHeading:
+                    return _contentPaddingContextMenuHeading;
+                case PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon
+                    or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2
+                    or PaletteContentStyle.InputControlCustom3:
+                    return InputControlPadding;
+                case PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand
+                    or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile
+                    or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini
+                    or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2
+                    or PaletteContentStyle.ButtonCustom3:
+                    return _contentPaddingButton12;
+                case PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay:
+                    return _contentPaddingButtonInputControl;
+                case PaletteContentStyle.ButtonButtonSpec:
+                    return _contentPaddingButton3;
+                case PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow:
+                    return _contentPaddingButton4;
+                case PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose:
+                    return _contentPaddingButtonForm;
+                case PaletteContentStyle.ButtonGallery:
+                    return _contentPaddingButtonGallery;
+                case PaletteContentStyle.ButtonListItem:
+                    return _contentPaddingButtonListItem;
+                case PaletteContentStyle.ButtonBreadCrumb:
+                    return _contentPaddingButton6;
+                case PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile
+                    or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote
+                    or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2
+                    or PaletteContentStyle.TabCustom3:
+                    return _contentPaddingButton5;
+                case PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden:
+                    return _contentPaddingButton7;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style));
+            }
         }
 
         /// <summary>
@@ -2970,13 +3339,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             switch (metric)
             {
@@ -2987,7 +3358,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricInt.CheckButtonGap:
                     return 5;
                 case PaletteMetricInt.HeaderButtonEdgeInsetForm:
-                    return 9; // Needs to be the RealWindowBorderWidth Offset - No idea how to get it at this point
+                    return Math.Max(2, owningForm!.RealWindowBorders.Right);
                 case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                     return 1;
                 case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:
@@ -3041,10 +3412,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -3058,7 +3431,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricPadding.BarPaddingOutside:
                     return _metricPaddingBarOutside;
                 case PaletteMetricPadding.HeaderButtonPaddingForm:
-                    return _metricPaddingHeaderForm;
+                    return new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);
                 case PaletteMetricPadding.RibbonButtonPadding:
                     return _metricPaddingRibbon;
                 case PaletteMetricPadding.RibbonAppButton:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlackDarkMode.cs
@@ -342,7 +342,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.Gallery2010);
             _radioButtonArray =
@@ -837,7 +837,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
         private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
         private static readonly Padding _contentPaddingCalendar = new Padding(2);
-        private static readonly Padding _contentPaddingHeaderForm = new Padding(10, 6, 3, 0); // 10 is from the RealWindowFrameSize +1
+        //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
         private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
         private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
         private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -849,7 +849,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);
@@ -861,7 +861,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _metricPaddingRibbon = new Padding(0, 1, 1, 1);
         private static readonly Padding _metricPaddingRibbonAppButton = new Padding(3, 0, 3, 0);
         private static readonly Padding _metricPaddingHeader = new Padding(0, 3, 1, 3);
-        private static readonly Padding _metricPaddingHeaderForm = new Padding(0, 3, 0, -3); // Move the Maximised Form buttons down a bit
+        //private static readonly Padding _metricPaddingHeaderForm = new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);//, 3, 0, -3); // Move the Maximised Form buttons down a bit
         private static readonly Padding _metricPaddingInputControl = new Padding(0, 1, 0, 1);
         private static readonly Padding _metricPaddingBarInside = new Padding(3);
         private static readonly Padding _metricPaddingBarTabs = new Padding(0);
@@ -2015,7 +2015,7 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => PaletteDrawBorders.Top,
                 PaletteBorderStyle.ContextMenuItemImageColumn => PaletteDrawBorders.Right,
                 PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ContextMenuInner => PaletteDrawBorders.None,
-                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.TopLeftRight,
+                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.None,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -3737,10 +3737,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             // We do not provide override values
             if (CommonHelper.IsOverrideState(state))
@@ -3748,37 +3750,90 @@ namespace Krypton.Toolkit
                 return CommonHelper.InheritPadding;
             }
 
-            return style switch
+            switch (style)
             {
-                PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 => _contentPaddingGrid,
-                PaletteContentStyle.HeaderForm => _contentPaddingHeaderForm,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _contentPaddingHeader1,
-                PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive => _contentPaddingDock,
-                PaletteContentStyle.HeaderSecondary => _contentPaddingHeader2,
-                PaletteContentStyle.HeaderCalendar => _contentPaddingCalendar,
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 => _contentPaddingLabel,
-                PaletteContentStyle.LabelGroupBoxCaption => _contentPaddingLabel2,
-                PaletteContentStyle.ContextMenuItemTextStandard => _contentPaddingContextMenuItemText,
-                PaletteContentStyle.ContextMenuItemTextAlternate => _contentPaddingContextMenuItemTextAlt,
-                PaletteContentStyle.ContextMenuItemShortcutText => _contentPaddingContextMenuItemShortcutText,
-                PaletteContentStyle.ContextMenuItemImage => _contentPaddingContextMenuImage,
-                PaletteContentStyle.LabelToolTip => _contentPaddingToolTip,
-                PaletteContentStyle.LabelSuperTip => _contentPaddingSuperTip,
-                PaletteContentStyle.LabelKeyTip => _contentPaddingKeyTip,
-                PaletteContentStyle.ContextMenuHeading => _contentPaddingContextMenuHeading,
-                PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => InputControlPadding,
-                PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => _contentPaddingButton12,
-                PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay => _contentPaddingButtonInputControl,
-                PaletteContentStyle.ButtonButtonSpec => _contentPaddingButton3,
-                PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => _contentPaddingButton4,
-                PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => _contentPaddingButtonForm,
-                PaletteContentStyle.ButtonGallery => _contentPaddingButtonGallery,
-                PaletteContentStyle.ButtonListItem => _contentPaddingButtonListItem,
-                PaletteContentStyle.ButtonBreadCrumb => _contentPaddingButton6,
-                PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 => _contentPaddingButton5,
-                PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden => _contentPaddingButton7,
-                _ => throw new ArgumentOutOfRangeException(nameof(style))
-            };
+                case PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet
+                    or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2
+                    or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList
+                    or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1
+                    or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3
+                    or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet
+                    or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2
+                    or PaletteContentStyle.GridDataCellCustom3:
+                    return _contentPaddingGrid;
+                case PaletteContentStyle.HeaderForm:
+                    {
+                        Padding borders = owningForm!.RealWindowBorders;
+                        return new Padding(borders.Left, borders.Bottom / 2, 0, 0);
+                    }
+                case PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1
+                    or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3:
+                    return _contentPaddingHeader1;
+                case PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive:
+                    return _contentPaddingDock;
+                case PaletteContentStyle.HeaderSecondary:
+                    return _contentPaddingHeader2;
+                case PaletteContentStyle.HeaderCalendar:
+                    return _contentPaddingCalendar;
+                case PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl
+                    or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl
+                    or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel
+                    or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel
+                    or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2
+                    or PaletteContentStyle.LabelCustom3:
+                    return _contentPaddingLabel;
+                case PaletteContentStyle.LabelGroupBoxCaption:
+                    return _contentPaddingLabel2;
+                case PaletteContentStyle.ContextMenuItemTextStandard:
+                    return _contentPaddingContextMenuItemText;
+                case PaletteContentStyle.ContextMenuItemTextAlternate:
+                    return _contentPaddingContextMenuItemTextAlt;
+                case PaletteContentStyle.ContextMenuItemShortcutText:
+                    return _contentPaddingContextMenuItemShortcutText;
+                case PaletteContentStyle.ContextMenuItemImage:
+                    return _contentPaddingContextMenuImage;
+                case PaletteContentStyle.LabelToolTip:
+                    return _contentPaddingToolTip;
+                case PaletteContentStyle.LabelSuperTip:
+                    return _contentPaddingSuperTip;
+                case PaletteContentStyle.LabelKeyTip:
+                    return _contentPaddingKeyTip;
+                case PaletteContentStyle.ContextMenuHeading:
+                    return _contentPaddingContextMenuHeading;
+                case PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon
+                    or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2
+                    or PaletteContentStyle.InputControlCustom3:
+                    return InputControlPadding;
+                case PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand
+                    or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile
+                    or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini
+                    or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2
+                    or PaletteContentStyle.ButtonCustom3:
+                    return _contentPaddingButton12;
+                case PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay:
+                    return _contentPaddingButtonInputControl;
+                case PaletteContentStyle.ButtonButtonSpec:
+                    return _contentPaddingButton3;
+                case PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow:
+                    return _contentPaddingButton4;
+                case PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose:
+                    return _contentPaddingButtonForm;
+                case PaletteContentStyle.ButtonGallery:
+                    return _contentPaddingButtonGallery;
+                case PaletteContentStyle.ButtonListItem:
+                    return _contentPaddingButtonListItem;
+                case PaletteContentStyle.ButtonBreadCrumb:
+                    return _contentPaddingButton6;
+                case PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile
+                    or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote
+                    or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2
+                    or PaletteContentStyle.TabCustom3:
+                    return _contentPaddingButton5;
+                case PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden:
+                    return _contentPaddingButton7;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style));
+            }
         }
 
         /// <summary>
@@ -3805,13 +3860,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             switch (metric)
             {
@@ -3822,7 +3879,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricInt.CheckButtonGap:
                     return 5;
                 case PaletteMetricInt.HeaderButtonEdgeInsetForm:
-                    return 9; // Needs to be the RealWindowBorderWidth Offset - No idea how to get it at this point
+                    return Math.Max(2, owningForm!.RealWindowBorders.Right);
                 case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                     return 1;
                 case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:
@@ -3876,10 +3933,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -3893,7 +3952,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricPadding.BarPaddingOutside:
                     return _metricPaddingBarOutside;
                 case PaletteMetricPadding.HeaderButtonPaddingForm:
-                    return _metricPaddingHeaderForm;
+                    return new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);
                 case PaletteMetricPadding.RibbonButtonPadding:
                     return _metricPaddingRibbon;
                 case PaletteMetricPadding.RibbonAppButton:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueDarkMode.cs
@@ -338,7 +338,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.Gallery2010);
             _radioButtonArray =
@@ -483,7 +483,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
         private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
         private static readonly Padding _contentPaddingCalendar = new Padding(2);
-        private static readonly Padding _contentPaddingHeaderForm = new Padding(10, 6, 3, 0); // 10 is from the RealWindowFrameSize +1
+        //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
         private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
         private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
         private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -495,7 +495,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);
@@ -507,7 +507,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _metricPaddingRibbon = new Padding(0, 1, 1, 1);
         private static readonly Padding _metricPaddingRibbonAppButton = new Padding(3, 0, 3, 0);
         private static readonly Padding _metricPaddingHeader = new Padding(0, 3, 1, 3);
-        private static readonly Padding _metricPaddingHeaderForm = new Padding(0, 3, 0, -3); // Move the Maximised Form buttons down a bit
+        //private static readonly Padding _metricPaddingHeaderForm = new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);//, 3, 0, -3); // Move the Maximised Form buttons down a bit
         private static readonly Padding _metricPaddingInputControl = new Padding(0, 1, 0, 1);
         private static readonly Padding _metricPaddingBarInside = new Padding(3);
         private static readonly Padding _metricPaddingBarTabs = new Padding(0);
@@ -1659,7 +1659,7 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => PaletteDrawBorders.Top,
                 PaletteBorderStyle.ContextMenuItemImageColumn => PaletteDrawBorders.Right,
                 PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ContextMenuInner => PaletteDrawBorders.None,
-                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.TopLeftRight,
+                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.None,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -3359,10 +3359,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             // We do not provide override values
             if (CommonHelper.IsOverrideState(state))
@@ -3370,37 +3372,90 @@ namespace Krypton.Toolkit
                 return CommonHelper.InheritPadding;
             }
 
-            return style switch
+            switch (style)
             {
-                PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 => _contentPaddingGrid,
-                PaletteContentStyle.HeaderForm => _contentPaddingHeaderForm,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _contentPaddingHeader1,
-                PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive => _contentPaddingDock,
-                PaletteContentStyle.HeaderSecondary => _contentPaddingHeader2,
-                PaletteContentStyle.HeaderCalendar => _contentPaddingCalendar,
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 => _contentPaddingLabel,
-                PaletteContentStyle.LabelGroupBoxCaption => _contentPaddingLabel2,
-                PaletteContentStyle.ContextMenuItemTextStandard => _contentPaddingContextMenuItemText,
-                PaletteContentStyle.ContextMenuItemTextAlternate => _contentPaddingContextMenuItemTextAlt,
-                PaletteContentStyle.ContextMenuItemShortcutText => _contentPaddingContextMenuItemShortcutText,
-                PaletteContentStyle.ContextMenuItemImage => _contentPaddingContextMenuImage,
-                PaletteContentStyle.LabelToolTip => _contentPaddingToolTip,
-                PaletteContentStyle.LabelSuperTip => _contentPaddingSuperTip,
-                PaletteContentStyle.LabelKeyTip => _contentPaddingKeyTip,
-                PaletteContentStyle.ContextMenuHeading => _contentPaddingContextMenuHeading,
-                PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => InputControlPadding,
-                PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => _contentPaddingButton12,
-                PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay => _contentPaddingButtonInputControl,
-                PaletteContentStyle.ButtonButtonSpec => _contentPaddingButton3,
-                PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => _contentPaddingButton4,
-                PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => _contentPaddingButtonForm,
-                PaletteContentStyle.ButtonGallery => _contentPaddingButtonGallery,
-                PaletteContentStyle.ButtonListItem => _contentPaddingButtonListItem,
-                PaletteContentStyle.ButtonBreadCrumb => _contentPaddingButton6,
-                PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 => _contentPaddingButton5,
-                PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden => _contentPaddingButton7,
-                _ => throw new ArgumentOutOfRangeException(nameof(style))
-            };
+                case PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet
+                    or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2
+                    or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList
+                    or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1
+                    or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3
+                    or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet
+                    or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2
+                    or PaletteContentStyle.GridDataCellCustom3:
+                    return _contentPaddingGrid;
+                case PaletteContentStyle.HeaderForm:
+                    {
+                        Padding borders = owningForm!.RealWindowBorders;
+                        return new Padding(borders.Left, borders.Bottom / 2, 0, 0);
+                    }
+                case PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1
+                    or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3:
+                    return _contentPaddingHeader1;
+                case PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive:
+                    return _contentPaddingDock;
+                case PaletteContentStyle.HeaderSecondary:
+                    return _contentPaddingHeader2;
+                case PaletteContentStyle.HeaderCalendar:
+                    return _contentPaddingCalendar;
+                case PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl
+                    or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl
+                    or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel
+                    or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel
+                    or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2
+                    or PaletteContentStyle.LabelCustom3:
+                    return _contentPaddingLabel;
+                case PaletteContentStyle.LabelGroupBoxCaption:
+                    return _contentPaddingLabel2;
+                case PaletteContentStyle.ContextMenuItemTextStandard:
+                    return _contentPaddingContextMenuItemText;
+                case PaletteContentStyle.ContextMenuItemTextAlternate:
+                    return _contentPaddingContextMenuItemTextAlt;
+                case PaletteContentStyle.ContextMenuItemShortcutText:
+                    return _contentPaddingContextMenuItemShortcutText;
+                case PaletteContentStyle.ContextMenuItemImage:
+                    return _contentPaddingContextMenuImage;
+                case PaletteContentStyle.LabelToolTip:
+                    return _contentPaddingToolTip;
+                case PaletteContentStyle.LabelSuperTip:
+                    return _contentPaddingSuperTip;
+                case PaletteContentStyle.LabelKeyTip:
+                    return _contentPaddingKeyTip;
+                case PaletteContentStyle.ContextMenuHeading:
+                    return _contentPaddingContextMenuHeading;
+                case PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon
+                    or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2
+                    or PaletteContentStyle.InputControlCustom3:
+                    return InputControlPadding;
+                case PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand
+                    or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile
+                    or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini
+                    or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2
+                    or PaletteContentStyle.ButtonCustom3:
+                    return _contentPaddingButton12;
+                case PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay:
+                    return _contentPaddingButtonInputControl;
+                case PaletteContentStyle.ButtonButtonSpec:
+                    return _contentPaddingButton3;
+                case PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow:
+                    return _contentPaddingButton4;
+                case PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose:
+                    return _contentPaddingButtonForm;
+                case PaletteContentStyle.ButtonGallery:
+                    return _contentPaddingButtonGallery;
+                case PaletteContentStyle.ButtonListItem:
+                    return _contentPaddingButtonListItem;
+                case PaletteContentStyle.ButtonBreadCrumb:
+                    return _contentPaddingButton6;
+                case PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile
+                    or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote
+                    or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2
+                    or PaletteContentStyle.TabCustom3:
+                    return _contentPaddingButton5;
+                case PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden:
+                    return _contentPaddingButton7;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style));
+            }
         }
 
         /// <summary>
@@ -3427,13 +3482,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             switch (metric)
             {
@@ -3444,7 +3501,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricInt.CheckButtonGap:
                     return 5;
                 case PaletteMetricInt.HeaderButtonEdgeInsetForm:
-                    return 9; // Needs to be the RealWindowBorderWidth Offset - No idea how to get it at this point
+                    return Math.Max(2, owningForm!.RealWindowBorders.Right);
                 case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                     return 1;
                 case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:
@@ -3498,10 +3555,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -3515,7 +3574,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricPadding.BarPaddingOutside:
                     return _metricPaddingBarOutside;
                 case PaletteMetricPadding.HeaderButtonPaddingForm:
-                    return _metricPaddingHeaderForm;
+                    return new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);
                 case PaletteMetricPadding.RibbonButtonPadding:
                     return _metricPaddingRibbon;
                 case PaletteMetricPadding.RibbonAppButton:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueLightMode.cs
@@ -350,7 +350,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.Gallery2010);
             _radioButtonArray =
@@ -495,7 +495,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
         private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
         private static readonly Padding _contentPaddingCalendar = new Padding(2);
-        private static readonly Padding _contentPaddingHeaderForm = new Padding(10, 6, 3, 0); // 10 is from the RealWindowFrameSize +1
+        //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
         private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
         private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
         private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -507,7 +507,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);
@@ -519,7 +519,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _metricPaddingRibbon = new Padding(0, 1, 1, 1);
         private static readonly Padding _metricPaddingRibbonAppButton = new Padding(3, 0, 3, 0);
         private static readonly Padding _metricPaddingHeader = new Padding(0, 3, 1, 3);
-        private static readonly Padding _metricPaddingHeaderForm = new Padding(0, 3, 0, -3); // Move the Maximised Form buttons down a bit
+        //private static readonly Padding _metricPaddingHeaderForm = new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);//, 3, 0, -3); // Move the Maximised Form buttons down a bit
         private static readonly Padding _metricPaddingInputControl = new Padding(0, 1, 0, 1);
         private static readonly Padding _metricPaddingBarInside = new Padding(3);
         private static readonly Padding _metricPaddingBarTabs = new Padding(0);
@@ -1649,7 +1649,7 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => PaletteDrawBorders.Top,
                 PaletteBorderStyle.ContextMenuItemImageColumn => PaletteDrawBorders.Right,
                 PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ContextMenuInner => PaletteDrawBorders.None,
-                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.TopLeftRight,
+                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.None,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -3349,10 +3349,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             // We do not provide override values
             if (CommonHelper.IsOverrideState(state))
@@ -3360,37 +3362,90 @@ namespace Krypton.Toolkit
                 return CommonHelper.InheritPadding;
             }
 
-            return style switch
+            switch (style)
             {
-                PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 => _contentPaddingGrid,
-                PaletteContentStyle.HeaderForm => _contentPaddingHeaderForm,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _contentPaddingHeader1,
-                PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive => _contentPaddingDock,
-                PaletteContentStyle.HeaderSecondary => _contentPaddingHeader2,
-                PaletteContentStyle.HeaderCalendar => _contentPaddingCalendar,
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 => _contentPaddingLabel,
-                PaletteContentStyle.LabelGroupBoxCaption => _contentPaddingLabel2,
-                PaletteContentStyle.ContextMenuItemTextStandard => _contentPaddingContextMenuItemText,
-                PaletteContentStyle.ContextMenuItemTextAlternate => _contentPaddingContextMenuItemTextAlt,
-                PaletteContentStyle.ContextMenuItemShortcutText => _contentPaddingContextMenuItemShortcutText,
-                PaletteContentStyle.ContextMenuItemImage => _contentPaddingContextMenuImage,
-                PaletteContentStyle.LabelToolTip => _contentPaddingToolTip,
-                PaletteContentStyle.LabelSuperTip => _contentPaddingSuperTip,
-                PaletteContentStyle.LabelKeyTip => _contentPaddingKeyTip,
-                PaletteContentStyle.ContextMenuHeading => _contentPaddingContextMenuHeading,
-                PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => InputControlPadding,
-                PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => _contentPaddingButton12,
-                PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay => _contentPaddingButtonInputControl,
-                PaletteContentStyle.ButtonButtonSpec => _contentPaddingButton3,
-                PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => _contentPaddingButton4,
-                PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => _contentPaddingButtonForm,
-                PaletteContentStyle.ButtonGallery => _contentPaddingButtonGallery,
-                PaletteContentStyle.ButtonListItem => _contentPaddingButtonListItem,
-                PaletteContentStyle.ButtonBreadCrumb => _contentPaddingButton6,
-                PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 => _contentPaddingButton5,
-                PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden => _contentPaddingButton7,
-                _ => throw new ArgumentOutOfRangeException(nameof(style))
-            };
+                case PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet
+                    or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2
+                    or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList
+                    or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1
+                    or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3
+                    or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet
+                    or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2
+                    or PaletteContentStyle.GridDataCellCustom3:
+                    return _contentPaddingGrid;
+                case PaletteContentStyle.HeaderForm:
+                    {
+                        Padding borders = owningForm!.RealWindowBorders;
+                        return new Padding(borders.Left, borders.Bottom / 2, 0, 0);
+                    }
+                case PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1
+                    or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3:
+                    return _contentPaddingHeader1;
+                case PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive:
+                    return _contentPaddingDock;
+                case PaletteContentStyle.HeaderSecondary:
+                    return _contentPaddingHeader2;
+                case PaletteContentStyle.HeaderCalendar:
+                    return _contentPaddingCalendar;
+                case PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl
+                    or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl
+                    or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel
+                    or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel
+                    or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2
+                    or PaletteContentStyle.LabelCustom3:
+                    return _contentPaddingLabel;
+                case PaletteContentStyle.LabelGroupBoxCaption:
+                    return _contentPaddingLabel2;
+                case PaletteContentStyle.ContextMenuItemTextStandard:
+                    return _contentPaddingContextMenuItemText;
+                case PaletteContentStyle.ContextMenuItemTextAlternate:
+                    return _contentPaddingContextMenuItemTextAlt;
+                case PaletteContentStyle.ContextMenuItemShortcutText:
+                    return _contentPaddingContextMenuItemShortcutText;
+                case PaletteContentStyle.ContextMenuItemImage:
+                    return _contentPaddingContextMenuImage;
+                case PaletteContentStyle.LabelToolTip:
+                    return _contentPaddingToolTip;
+                case PaletteContentStyle.LabelSuperTip:
+                    return _contentPaddingSuperTip;
+                case PaletteContentStyle.LabelKeyTip:
+                    return _contentPaddingKeyTip;
+                case PaletteContentStyle.ContextMenuHeading:
+                    return _contentPaddingContextMenuHeading;
+                case PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon
+                    or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2
+                    or PaletteContentStyle.InputControlCustom3:
+                    return InputControlPadding;
+                case PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand
+                    or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile
+                    or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini
+                    or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2
+                    or PaletteContentStyle.ButtonCustom3:
+                    return _contentPaddingButton12;
+                case PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay:
+                    return _contentPaddingButtonInputControl;
+                case PaletteContentStyle.ButtonButtonSpec:
+                    return _contentPaddingButton3;
+                case PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow:
+                    return _contentPaddingButton4;
+                case PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose:
+                    return _contentPaddingButtonForm;
+                case PaletteContentStyle.ButtonGallery:
+                    return _contentPaddingButtonGallery;
+                case PaletteContentStyle.ButtonListItem:
+                    return _contentPaddingButtonListItem;
+                case PaletteContentStyle.ButtonBreadCrumb:
+                    return _contentPaddingButton6;
+                case PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile
+                    or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote
+                    or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2
+                    or PaletteContentStyle.TabCustom3:
+                    return _contentPaddingButton5;
+                case PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden:
+                    return _contentPaddingButton7;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style));
+            }
         }
 
         /// <summary>
@@ -3417,13 +3472,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             switch (metric)
             {
@@ -3434,7 +3491,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricInt.CheckButtonGap:
                     return 5;
                 case PaletteMetricInt.HeaderButtonEdgeInsetForm:
-                    return 9; // Needs to be the RealWindowBorderWidth Offset - No idea how to get it at this point
+                    return Math.Max(2, owningForm!.RealWindowBorders.Right);
                 case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                     return 1;
                 case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:
@@ -3488,10 +3545,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -3505,7 +3564,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricPadding.BarPaddingOutside:
                     return _metricPaddingBarOutside;
                 case PaletteMetricPadding.HeaderButtonPaddingForm:
-                    return _metricPaddingHeaderForm;
+                    return new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);
                 case PaletteMetricPadding.RibbonButtonPadding:
                     return _metricPaddingRibbon;
                 case PaletteMetricPadding.RibbonAppButton:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverDarkMode.cs
@@ -340,7 +340,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.Gallery2010);
             _radioButtonArray =
@@ -485,7 +485,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
         private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
         private static readonly Padding _contentPaddingCalendar = new Padding(2);
-        private static readonly Padding _contentPaddingHeaderForm = new Padding(10, 6, 3, 0); // 10 is from the RealWindowFrameSize +1
+        //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
         private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
         private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
         private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -497,7 +497,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);
@@ -509,7 +509,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _metricPaddingRibbon = new Padding(0, 1, 1, 1);
         private static readonly Padding _metricPaddingRibbonAppButton = new Padding(3, 0, 3, 0);
         private static readonly Padding _metricPaddingHeader = new Padding(0, 3, 1, 3);
-        private static readonly Padding _metricPaddingHeaderForm = new Padding(0, 3, 0, -3); // Move the Maximised Form buttons down a bit
+        //private static readonly Padding _metricPaddingHeaderForm = new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);//, 3, 0, -3); // Move the Maximised Form buttons down a bit
         private static readonly Padding _metricPaddingInputControl = new Padding(0, 1, 0, 1);
         private static readonly Padding _metricPaddingBarInside = new Padding(3);
         private static readonly Padding _metricPaddingBarTabs = new Padding(0);
@@ -1641,7 +1641,7 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => PaletteDrawBorders.Top,
                 PaletteBorderStyle.ContextMenuItemImageColumn => PaletteDrawBorders.Right,
                 PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ContextMenuInner => PaletteDrawBorders.None,
-                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.TopLeftRight,
+                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.None,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -3385,10 +3385,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             // We do not provide override values
             if (CommonHelper.IsOverrideState(state))
@@ -3396,37 +3398,90 @@ namespace Krypton.Toolkit
                 return CommonHelper.InheritPadding;
             }
 
-            return style switch
+            switch (style)
             {
-                PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 => _contentPaddingGrid,
-                PaletteContentStyle.HeaderForm => _contentPaddingHeaderForm,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _contentPaddingHeader1,
-                PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive => _contentPaddingDock,
-                PaletteContentStyle.HeaderSecondary => _contentPaddingHeader2,
-                PaletteContentStyle.HeaderCalendar => _contentPaddingCalendar,
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 => _contentPaddingLabel,
-                PaletteContentStyle.LabelGroupBoxCaption => _contentPaddingLabel2,
-                PaletteContentStyle.ContextMenuItemTextStandard => _contentPaddingContextMenuItemText,
-                PaletteContentStyle.ContextMenuItemTextAlternate => _contentPaddingContextMenuItemTextAlt,
-                PaletteContentStyle.ContextMenuItemShortcutText => _contentPaddingContextMenuItemShortcutText,
-                PaletteContentStyle.ContextMenuItemImage => _contentPaddingContextMenuImage,
-                PaletteContentStyle.LabelToolTip => _contentPaddingToolTip,
-                PaletteContentStyle.LabelSuperTip => _contentPaddingSuperTip,
-                PaletteContentStyle.LabelKeyTip => _contentPaddingKeyTip,
-                PaletteContentStyle.ContextMenuHeading => _contentPaddingContextMenuHeading,
-                PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => InputControlPadding,
-                PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => _contentPaddingButton12,
-                PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay => _contentPaddingButtonInputControl,
-                PaletteContentStyle.ButtonButtonSpec => _contentPaddingButton3,
-                PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => _contentPaddingButton4,
-                PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => _contentPaddingButtonForm,
-                PaletteContentStyle.ButtonGallery => _contentPaddingButtonGallery,
-                PaletteContentStyle.ButtonListItem => _contentPaddingButtonListItem,
-                PaletteContentStyle.ButtonBreadCrumb => _contentPaddingButton6,
-                PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 => _contentPaddingButton5,
-                PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden => _contentPaddingButton7,
-                _ => throw new ArgumentOutOfRangeException(nameof(style))
-            };
+                case PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet
+                    or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2
+                    or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList
+                    or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1
+                    or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3
+                    or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet
+                    or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2
+                    or PaletteContentStyle.GridDataCellCustom3:
+                    return _contentPaddingGrid;
+                case PaletteContentStyle.HeaderForm:
+                    {
+                        Padding borders = owningForm!.RealWindowBorders;
+                        return new Padding(borders.Left, borders.Bottom / 2, 0, 0);
+                    }
+                case PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1
+                    or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3:
+                    return _contentPaddingHeader1;
+                case PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive:
+                    return _contentPaddingDock;
+                case PaletteContentStyle.HeaderSecondary:
+                    return _contentPaddingHeader2;
+                case PaletteContentStyle.HeaderCalendar:
+                    return _contentPaddingCalendar;
+                case PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl
+                    or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl
+                    or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel
+                    or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel
+                    or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2
+                    or PaletteContentStyle.LabelCustom3:
+                    return _contentPaddingLabel;
+                case PaletteContentStyle.LabelGroupBoxCaption:
+                    return _contentPaddingLabel2;
+                case PaletteContentStyle.ContextMenuItemTextStandard:
+                    return _contentPaddingContextMenuItemText;
+                case PaletteContentStyle.ContextMenuItemTextAlternate:
+                    return _contentPaddingContextMenuItemTextAlt;
+                case PaletteContentStyle.ContextMenuItemShortcutText:
+                    return _contentPaddingContextMenuItemShortcutText;
+                case PaletteContentStyle.ContextMenuItemImage:
+                    return _contentPaddingContextMenuImage;
+                case PaletteContentStyle.LabelToolTip:
+                    return _contentPaddingToolTip;
+                case PaletteContentStyle.LabelSuperTip:
+                    return _contentPaddingSuperTip;
+                case PaletteContentStyle.LabelKeyTip:
+                    return _contentPaddingKeyTip;
+                case PaletteContentStyle.ContextMenuHeading:
+                    return _contentPaddingContextMenuHeading;
+                case PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon
+                    or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2
+                    or PaletteContentStyle.InputControlCustom3:
+                    return InputControlPadding;
+                case PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand
+                    or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile
+                    or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini
+                    or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2
+                    or PaletteContentStyle.ButtonCustom3:
+                    return _contentPaddingButton12;
+                case PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay:
+                    return _contentPaddingButtonInputControl;
+                case PaletteContentStyle.ButtonButtonSpec:
+                    return _contentPaddingButton3;
+                case PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow:
+                    return _contentPaddingButton4;
+                case PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose:
+                    return _contentPaddingButtonForm;
+                case PaletteContentStyle.ButtonGallery:
+                    return _contentPaddingButtonGallery;
+                case PaletteContentStyle.ButtonListItem:
+                    return _contentPaddingButtonListItem;
+                case PaletteContentStyle.ButtonBreadCrumb:
+                    return _contentPaddingButton6;
+                case PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile
+                    or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote
+                    or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2
+                    or PaletteContentStyle.TabCustom3:
+                    return _contentPaddingButton5;
+                case PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden:
+                    return _contentPaddingButton7;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style));
+            }
         }
 
         /// <summary>
@@ -3453,13 +3508,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             switch (metric)
             {
@@ -3470,7 +3527,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricInt.CheckButtonGap:
                     return 5;
                 case PaletteMetricInt.HeaderButtonEdgeInsetForm:
-                    return 9; // Needs to be the RealWindowBorderWidth Offset - No idea how to get it at this point
+                    return Math.Max(2, owningForm!.RealWindowBorders.Right);
                 case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                     return 1;
                 case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:
@@ -3524,10 +3581,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -3541,7 +3600,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricPadding.BarPaddingOutside:
                     return _metricPaddingBarOutside;
                 case PaletteMetricPadding.HeaderButtonPaddingForm:
-                    return _metricPaddingHeaderForm;
+                    return new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);
                 case PaletteMetricPadding.RibbonButtonPadding:
                     return _metricPaddingRibbon;
                 case PaletteMetricPadding.RibbonAppButton:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverLightMode.cs
@@ -344,7 +344,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.Gallery2010);
             _radioButtonArray =
@@ -489,7 +489,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
         private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
         private static readonly Padding _contentPaddingCalendar = new Padding(2);
-        private static readonly Padding _contentPaddingHeaderForm = new Padding(10, 6, 3, 0); // 10 is from the RealWindowFrameSize +1
+        //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
         private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
         private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
         private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -501,7 +501,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);
@@ -513,7 +513,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _metricPaddingRibbon = new Padding(0, 1, 1, 1);
         private static readonly Padding _metricPaddingRibbonAppButton = new Padding(3, 0, 3, 0);
         private static readonly Padding _metricPaddingHeader = new Padding(0, 3, 1, 3);
-        private static readonly Padding _metricPaddingHeaderForm = new Padding(0, 3, 0, -3); // Move the Maximised Form buttons down a bit
+        //private static readonly Padding _metricPaddingHeaderForm = new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);//, 3, 0, -3); // Move the Maximised Form buttons down a bit
         private static readonly Padding _metricPaddingInputControl = new Padding(0, 1, 0, 1);
         private static readonly Padding _metricPaddingBarInside = new Padding(3);
         private static readonly Padding _metricPaddingBarTabs = new Padding(0);
@@ -1668,7 +1668,7 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => PaletteDrawBorders.Top,
                 PaletteBorderStyle.ContextMenuItemImageColumn => PaletteDrawBorders.Right,
                 PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ContextMenuInner => PaletteDrawBorders.None,
-                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.TopLeftRight,
+                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.None,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -3368,10 +3368,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             // We do not provide override values
             if (CommonHelper.IsOverrideState(state))
@@ -3379,37 +3381,90 @@ namespace Krypton.Toolkit
                 return CommonHelper.InheritPadding;
             }
 
-            return style switch
+            switch (style)
             {
-                PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 => _contentPaddingGrid,
-                PaletteContentStyle.HeaderForm => _contentPaddingHeaderForm,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _contentPaddingHeader1,
-                PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive => _contentPaddingDock,
-                PaletteContentStyle.HeaderSecondary => _contentPaddingHeader2,
-                PaletteContentStyle.HeaderCalendar => _contentPaddingCalendar,
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 => _contentPaddingLabel,
-                PaletteContentStyle.LabelGroupBoxCaption => _contentPaddingLabel2,
-                PaletteContentStyle.ContextMenuItemTextStandard => _contentPaddingContextMenuItemText,
-                PaletteContentStyle.ContextMenuItemTextAlternate => _contentPaddingContextMenuItemTextAlt,
-                PaletteContentStyle.ContextMenuItemShortcutText => _contentPaddingContextMenuItemShortcutText,
-                PaletteContentStyle.ContextMenuItemImage => _contentPaddingContextMenuImage,
-                PaletteContentStyle.LabelToolTip => _contentPaddingToolTip,
-                PaletteContentStyle.LabelSuperTip => _contentPaddingSuperTip,
-                PaletteContentStyle.LabelKeyTip => _contentPaddingKeyTip,
-                PaletteContentStyle.ContextMenuHeading => _contentPaddingContextMenuHeading,
-                PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => InputControlPadding,
-                PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => _contentPaddingButton12,
-                PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay => _contentPaddingButtonInputControl,
-                PaletteContentStyle.ButtonButtonSpec => _contentPaddingButton3,
-                PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => _contentPaddingButton4,
-                PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => _contentPaddingButtonForm,
-                PaletteContentStyle.ButtonGallery => _contentPaddingButtonGallery,
-                PaletteContentStyle.ButtonListItem => _contentPaddingButtonListItem,
-                PaletteContentStyle.ButtonBreadCrumb => _contentPaddingButton6,
-                PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 => _contentPaddingButton5,
-                PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden => _contentPaddingButton7,
-                _ => throw new ArgumentOutOfRangeException(nameof(style))
-            };
+                case PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet
+                    or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2
+                    or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList
+                    or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1
+                    or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3
+                    or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet
+                    or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2
+                    or PaletteContentStyle.GridDataCellCustom3:
+                    return _contentPaddingGrid;
+                case PaletteContentStyle.HeaderForm:
+                    {
+                        Padding borders = owningForm!.RealWindowBorders;
+                        return new Padding(borders.Left, borders.Bottom / 2, 0, 0);
+                    }
+                case PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1
+                    or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3:
+                    return _contentPaddingHeader1;
+                case PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive:
+                    return _contentPaddingDock;
+                case PaletteContentStyle.HeaderSecondary:
+                    return _contentPaddingHeader2;
+                case PaletteContentStyle.HeaderCalendar:
+                    return _contentPaddingCalendar;
+                case PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl
+                    or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl
+                    or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel
+                    or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel
+                    or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2
+                    or PaletteContentStyle.LabelCustom3:
+                    return _contentPaddingLabel;
+                case PaletteContentStyle.LabelGroupBoxCaption:
+                    return _contentPaddingLabel2;
+                case PaletteContentStyle.ContextMenuItemTextStandard:
+                    return _contentPaddingContextMenuItemText;
+                case PaletteContentStyle.ContextMenuItemTextAlternate:
+                    return _contentPaddingContextMenuItemTextAlt;
+                case PaletteContentStyle.ContextMenuItemShortcutText:
+                    return _contentPaddingContextMenuItemShortcutText;
+                case PaletteContentStyle.ContextMenuItemImage:
+                    return _contentPaddingContextMenuImage;
+                case PaletteContentStyle.LabelToolTip:
+                    return _contentPaddingToolTip;
+                case PaletteContentStyle.LabelSuperTip:
+                    return _contentPaddingSuperTip;
+                case PaletteContentStyle.LabelKeyTip:
+                    return _contentPaddingKeyTip;
+                case PaletteContentStyle.ContextMenuHeading:
+                    return _contentPaddingContextMenuHeading;
+                case PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon
+                    or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2
+                    or PaletteContentStyle.InputControlCustom3:
+                    return InputControlPadding;
+                case PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand
+                    or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile
+                    or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini
+                    or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2
+                    or PaletteContentStyle.ButtonCustom3:
+                    return _contentPaddingButton12;
+                case PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay:
+                    return _contentPaddingButtonInputControl;
+                case PaletteContentStyle.ButtonButtonSpec:
+                    return _contentPaddingButton3;
+                case PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow:
+                    return _contentPaddingButton4;
+                case PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose:
+                    return _contentPaddingButtonForm;
+                case PaletteContentStyle.ButtonGallery:
+                    return _contentPaddingButtonGallery;
+                case PaletteContentStyle.ButtonListItem:
+                    return _contentPaddingButtonListItem;
+                case PaletteContentStyle.ButtonBreadCrumb:
+                    return _contentPaddingButton6;
+                case PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile
+                    or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote
+                    or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2
+                    or PaletteContentStyle.TabCustom3:
+                    return _contentPaddingButton5;
+                case PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden:
+                    return _contentPaddingButton7;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style));
+            }
         }
 
         /// <summary>
@@ -3436,13 +3491,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             switch (metric)
             {
@@ -3453,7 +3510,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricInt.CheckButtonGap:
                     return 5;
                 case PaletteMetricInt.HeaderButtonEdgeInsetForm:
-                    return 9; // Needs to be the RealWindowBorderWidth Offset - No idea how to get it at this point
+                    return Math.Max(2, owningForm!.RealWindowBorders.Right);
                 case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                     return 1;
                 case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:
@@ -3507,10 +3564,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -3524,7 +3583,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricPadding.BarPaddingOutside:
                     return _metricPaddingBarOutside;
                 case PaletteMetricPadding.HeaderButtonPaddingForm:
-                    return _metricPaddingHeaderForm;
+                    return new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);
                 case PaletteMetricPadding.RibbonButtonPadding:
                     return _metricPaddingRibbon;
                 case PaletteMetricPadding.RibbonAppButton:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Non Official Themes/PaletteOffice2010DarkGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Non Official Themes/PaletteOffice2010DarkGray.cs
@@ -332,7 +332,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.Gallery2010);
             _radioButtonArray =

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Non Official Themes/PaletteOffice2010White.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Non Official Themes/PaletteOffice2010White.cs
@@ -335,7 +335,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.Gallery2010);
             _radioButtonArray =

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Official Themes/PaletteOffice2010Black.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Official Themes/PaletteOffice2010Black.cs
@@ -363,7 +363,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.Gallery2010);
             _radioButtonArray =
@@ -510,7 +510,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
         private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
         private static readonly Padding _contentPaddingCalendar = new Padding(2);
-        private static readonly Padding _contentPaddingHeaderForm = new Padding(10, 6, 3, 0); // 10 is from the RealWindowFrameSize +1
+        //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
         private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
         private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
         private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -522,7 +522,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);
@@ -534,7 +534,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _metricPaddingRibbon = new Padding(0, 1, 1, 1);
         private static readonly Padding _metricPaddingRibbonAppButton = new Padding(3, 0, 3, 0);
         private static readonly Padding _metricPaddingHeader = new Padding(0, 3, 1, 3);
-        private static readonly Padding _metricPaddingHeaderForm = new Padding(0, 3, 0, -3); // Move the Maximised Form buttons down a bit
+        //private static readonly Padding _metricPaddingHeaderForm = new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);//, 3, 0, -3); // Move the Maximised Form buttons down a bit
         private static readonly Padding _metricPaddingInputControl = new Padding(0, 1, 0, 1);
         private static readonly Padding _metricPaddingBarInside = new Padding(3);
         private static readonly Padding _metricPaddingBarTabs = new Padding(0);
@@ -1655,7 +1655,7 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => PaletteDrawBorders.Top,
                 PaletteBorderStyle.ContextMenuItemImageColumn => PaletteDrawBorders.Right,
                 PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ContextMenuInner => PaletteDrawBorders.None,
-                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.TopLeftRight,
+                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.None,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -3386,10 +3386,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             // We do not provide override values
             if (CommonHelper.IsOverrideState(state))
@@ -3397,37 +3399,90 @@ namespace Krypton.Toolkit
                 return CommonHelper.InheritPadding;
             }
 
-            return style switch
+            switch (style)
             {
-                PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 => _contentPaddingGrid,
-                PaletteContentStyle.HeaderForm => _contentPaddingHeaderForm,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _contentPaddingHeader1,
-                PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive => _contentPaddingDock,
-                PaletteContentStyle.HeaderSecondary => _contentPaddingHeader2,
-                PaletteContentStyle.HeaderCalendar => _contentPaddingCalendar,
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 => _contentPaddingLabel,
-                PaletteContentStyle.LabelGroupBoxCaption => _contentPaddingLabel2,
-                PaletteContentStyle.ContextMenuItemTextStandard => _contentPaddingContextMenuItemText,
-                PaletteContentStyle.ContextMenuItemTextAlternate => _contentPaddingContextMenuItemTextAlt,
-                PaletteContentStyle.ContextMenuItemShortcutText => _contentPaddingContextMenuItemShortcutText,
-                PaletteContentStyle.ContextMenuItemImage => _contentPaddingContextMenuImage,
-                PaletteContentStyle.LabelToolTip => _contentPaddingToolTip,
-                PaletteContentStyle.LabelSuperTip => _contentPaddingSuperTip,
-                PaletteContentStyle.LabelKeyTip => _contentPaddingKeyTip,
-                PaletteContentStyle.ContextMenuHeading => _contentPaddingContextMenuHeading,
-                PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => InputControlPadding,
-                PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => _contentPaddingButton12,
-                PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay => _contentPaddingButtonInputControl,
-                PaletteContentStyle.ButtonButtonSpec => _contentPaddingButton3,
-                PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => _contentPaddingButton4,
-                PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => _contentPaddingButtonForm,
-                PaletteContentStyle.ButtonGallery => _contentPaddingButtonGallery,
-                PaletteContentStyle.ButtonListItem => _contentPaddingButtonListItem,
-                PaletteContentStyle.ButtonBreadCrumb => _contentPaddingButton6,
-                PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 => _contentPaddingButton5,
-                PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden => _contentPaddingButton7,
-                _ => throw new ArgumentOutOfRangeException(nameof(style))
-            };
+                case PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet
+                    or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2
+                    or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList
+                    or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1
+                    or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3
+                    or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet
+                    or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2
+                    or PaletteContentStyle.GridDataCellCustom3:
+                    return _contentPaddingGrid;
+                case PaletteContentStyle.HeaderForm:
+                    {
+                        Padding borders = owningForm!.RealWindowBorders;
+                        return new Padding(borders.Left, borders.Bottom / 2, 0, 0);
+                    }
+                case PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1
+                    or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3:
+                    return _contentPaddingHeader1;
+                case PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive:
+                    return _contentPaddingDock;
+                case PaletteContentStyle.HeaderSecondary:
+                    return _contentPaddingHeader2;
+                case PaletteContentStyle.HeaderCalendar:
+                    return _contentPaddingCalendar;
+                case PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl
+                    or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl
+                    or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel
+                    or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel
+                    or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2
+                    or PaletteContentStyle.LabelCustom3:
+                    return _contentPaddingLabel;
+                case PaletteContentStyle.LabelGroupBoxCaption:
+                    return _contentPaddingLabel2;
+                case PaletteContentStyle.ContextMenuItemTextStandard:
+                    return _contentPaddingContextMenuItemText;
+                case PaletteContentStyle.ContextMenuItemTextAlternate:
+                    return _contentPaddingContextMenuItemTextAlt;
+                case PaletteContentStyle.ContextMenuItemShortcutText:
+                    return _contentPaddingContextMenuItemShortcutText;
+                case PaletteContentStyle.ContextMenuItemImage:
+                    return _contentPaddingContextMenuImage;
+                case PaletteContentStyle.LabelToolTip:
+                    return _contentPaddingToolTip;
+                case PaletteContentStyle.LabelSuperTip:
+                    return _contentPaddingSuperTip;
+                case PaletteContentStyle.LabelKeyTip:
+                    return _contentPaddingKeyTip;
+                case PaletteContentStyle.ContextMenuHeading:
+                    return _contentPaddingContextMenuHeading;
+                case PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon
+                    or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2
+                    or PaletteContentStyle.InputControlCustom3:
+                    return InputControlPadding;
+                case PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand
+                    or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile
+                    or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini
+                    or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2
+                    or PaletteContentStyle.ButtonCustom3:
+                    return _contentPaddingButton12;
+                case PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay:
+                    return _contentPaddingButtonInputControl;
+                case PaletteContentStyle.ButtonButtonSpec:
+                    return _contentPaddingButton3;
+                case PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow:
+                    return _contentPaddingButton4;
+                case PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose:
+                    return _contentPaddingButtonForm;
+                case PaletteContentStyle.ButtonGallery:
+                    return _contentPaddingButtonGallery;
+                case PaletteContentStyle.ButtonListItem:
+                    return _contentPaddingButtonListItem;
+                case PaletteContentStyle.ButtonBreadCrumb:
+                    return _contentPaddingButton6;
+                case PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile
+                    or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote
+                    or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2
+                    or PaletteContentStyle.TabCustom3:
+                    return _contentPaddingButton5;
+                case PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden:
+                    return _contentPaddingButton7;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style));
+            }
         }
 
         /// <summary>
@@ -3454,13 +3509,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             switch (metric)
             {
@@ -3471,7 +3528,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricInt.CheckButtonGap:
                     return 5;
                 case PaletteMetricInt.HeaderButtonEdgeInsetForm:
-                    return 9; // Needs to be the RealWindowBorderWidth Offset - No idea how to get it at this point
+                    return Math.Max(2, owningForm!.RealWindowBorders.Right);
                 case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                     return 1;
                 case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:
@@ -3525,10 +3582,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -3542,7 +3601,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricPadding.BarPaddingOutside:
                     return _metricPaddingBarOutside;
                 case PaletteMetricPadding.HeaderButtonPaddingForm:
-                    return _metricPaddingHeaderForm;
+                    return new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);
                 case PaletteMetricPadding.RibbonButtonPadding:
                     return _metricPaddingRibbon;
                 case PaletteMetricPadding.RibbonAppButton:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Official Themes/PaletteOffice2010Blue.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Official Themes/PaletteOffice2010Blue.cs
@@ -342,7 +342,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.Gallery2010);
             _radioButtonArray =

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Official Themes/PaletteOffice2010Silver.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Official Themes/PaletteOffice2010Silver.cs
@@ -335,7 +335,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.Gallery2010);
             _radioButtonArray =

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Bases/PaletteOffice2013Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Bases/PaletteOffice2013Base.cs
@@ -26,7 +26,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
         private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
         private static readonly Padding _contentPaddingCalendar = new Padding(2);
-        private static readonly Padding _contentPaddingHeaderForm = new Padding(10, 6, 3, 0); // 10 is from the RealWindowFrameSize +1
+        //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
         private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
         private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
         private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -38,7 +38,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);
@@ -50,7 +50,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _metricPaddingRibbon = new Padding(0, 1, 1, 1);
         private static readonly Padding _metricPaddingRibbonAppButton = new Padding(3, 0, 3, 0);
         private static readonly Padding _metricPaddingHeader = new Padding(0, 3, 1, 3);
-        private static readonly Padding _metricPaddingHeaderForm = new Padding(0, 3, 0, -3); // Move the Maximised Form buttons down a bit
+        //private static readonly Padding _metricPaddingHeaderForm = new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);//, 3, 0, -3); // Move the Maximised Form buttons down a bit
         private static readonly Padding _metricPaddingInputControl = new Padding(0, 1, 0, 1);
         private static readonly Padding _metricPaddingBarInside = new Padding(3);
         private static readonly Padding _metricPaddingBarTabs = new Padding(0);
@@ -1191,7 +1191,7 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => PaletteDrawBorders.Top,
                 PaletteBorderStyle.ContextMenuItemImageColumn => PaletteDrawBorders.Right,
                 PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ContextMenuInner => PaletteDrawBorders.None,
-                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.TopLeftRight,
+                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.None,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -2812,10 +2812,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             // We do not provide override values
             if (CommonHelper.IsOverrideState(state))
@@ -2823,37 +2825,90 @@ namespace Krypton.Toolkit
                 return CommonHelper.InheritPadding;
             }
 
-            return style switch
+            switch (style)
             {
-                PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 => _contentPaddingGrid,
-                PaletteContentStyle.HeaderForm => _contentPaddingHeaderForm,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _contentPaddingHeader1,
-                PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive => _contentPaddingDock,
-                PaletteContentStyle.HeaderSecondary => _contentPaddingHeader2,
-                PaletteContentStyle.HeaderCalendar => _contentPaddingCalendar,
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 => _contentPaddingLabel,
-                PaletteContentStyle.LabelGroupBoxCaption => _contentPaddingLabel2,
-                PaletteContentStyle.ContextMenuItemTextStandard => _contentPaddingContextMenuItemText,
-                PaletteContentStyle.ContextMenuItemTextAlternate => _contentPaddingContextMenuItemTextAlt,
-                PaletteContentStyle.ContextMenuItemShortcutText => _contentPaddingContextMenuItemShortcutText,
-                PaletteContentStyle.ContextMenuItemImage => _contentPaddingContextMenuImage,
-                PaletteContentStyle.LabelToolTip => _contentPaddingToolTip,
-                PaletteContentStyle.LabelSuperTip => _contentPaddingSuperTip,
-                PaletteContentStyle.LabelKeyTip => _contentPaddingKeyTip,
-                PaletteContentStyle.ContextMenuHeading => _contentPaddingContextMenuHeading,
-                PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => InputControlPadding,
-                PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => _contentPaddingButton12,
-                PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay => _contentPaddingButtonInputControl,
-                PaletteContentStyle.ButtonButtonSpec => _contentPaddingButton3,
-                PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => _contentPaddingButton4,
-                PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => _contentPaddingButtonForm,
-                PaletteContentStyle.ButtonGallery => _contentPaddingButtonGallery,
-                PaletteContentStyle.ButtonListItem => _contentPaddingButtonListItem,
-                PaletteContentStyle.ButtonBreadCrumb => _contentPaddingButton6,
-                PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 => _contentPaddingButton5,
-                PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden => _contentPaddingButton7,
-                _ => throw new ArgumentOutOfRangeException(nameof(style))
-            };
+                case PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet
+                    or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2
+                    or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList
+                    or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1
+                    or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3
+                    or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet
+                    or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2
+                    or PaletteContentStyle.GridDataCellCustom3:
+                    return _contentPaddingGrid;
+                case PaletteContentStyle.HeaderForm:
+                    {
+                        Padding borders = owningForm!.RealWindowBorders;
+                        return new Padding(borders.Left, borders.Bottom / 2, 0, 0);
+                    }
+                case PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1
+                    or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3:
+                    return _contentPaddingHeader1;
+                case PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive:
+                    return _contentPaddingDock;
+                case PaletteContentStyle.HeaderSecondary:
+                    return _contentPaddingHeader2;
+                case PaletteContentStyle.HeaderCalendar:
+                    return _contentPaddingCalendar;
+                case PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl
+                    or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl
+                    or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel
+                    or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel
+                    or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2
+                    or PaletteContentStyle.LabelCustom3:
+                    return _contentPaddingLabel;
+                case PaletteContentStyle.LabelGroupBoxCaption:
+                    return _contentPaddingLabel2;
+                case PaletteContentStyle.ContextMenuItemTextStandard:
+                    return _contentPaddingContextMenuItemText;
+                case PaletteContentStyle.ContextMenuItemTextAlternate:
+                    return _contentPaddingContextMenuItemTextAlt;
+                case PaletteContentStyle.ContextMenuItemShortcutText:
+                    return _contentPaddingContextMenuItemShortcutText;
+                case PaletteContentStyle.ContextMenuItemImage:
+                    return _contentPaddingContextMenuImage;
+                case PaletteContentStyle.LabelToolTip:
+                    return _contentPaddingToolTip;
+                case PaletteContentStyle.LabelSuperTip:
+                    return _contentPaddingSuperTip;
+                case PaletteContentStyle.LabelKeyTip:
+                    return _contentPaddingKeyTip;
+                case PaletteContentStyle.ContextMenuHeading:
+                    return _contentPaddingContextMenuHeading;
+                case PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon
+                    or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2
+                    or PaletteContentStyle.InputControlCustom3:
+                    return InputControlPadding;
+                case PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand
+                    or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile
+                    or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini
+                    or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2
+                    or PaletteContentStyle.ButtonCustom3:
+                    return _contentPaddingButton12;
+                case PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay:
+                    return _contentPaddingButtonInputControl;
+                case PaletteContentStyle.ButtonButtonSpec:
+                    return _contentPaddingButton3;
+                case PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow:
+                    return _contentPaddingButton4;
+                case PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose:
+                    return _contentPaddingButtonForm;
+                case PaletteContentStyle.ButtonGallery:
+                    return _contentPaddingButtonGallery;
+                case PaletteContentStyle.ButtonListItem:
+                    return _contentPaddingButtonListItem;
+                case PaletteContentStyle.ButtonBreadCrumb:
+                    return _contentPaddingButton6;
+                case PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile
+                    or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote
+                    or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2
+                    or PaletteContentStyle.TabCustom3:
+                    return _contentPaddingButton5;
+                case PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden:
+                    return _contentPaddingButton7;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style));
+            }
         }
 
         /// <summary>
@@ -2880,13 +2935,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             switch (metric)
             {
@@ -2897,7 +2954,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricInt.CheckButtonGap:
                     return 5;
                 case PaletteMetricInt.HeaderButtonEdgeInsetForm:
-                    return 9; // Needs to be the RealWindowBorderWidth Offset - No idea how to get it at this point
+                    return Math.Max(2, owningForm!.RealWindowBorders.Right);
                 case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                     return 1;
                 case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:
@@ -2951,10 +3008,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -2968,7 +3027,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricPadding.BarPaddingOutside:
                     return _metricPaddingBarOutside;
                 case PaletteMetricPadding.HeaderButtonPaddingForm:
-                    return _metricPaddingHeaderForm;
+                    return new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);
                 case PaletteMetricPadding.RibbonButtonPadding:
                     return _metricPaddingRibbon;
                 case PaletteMetricPadding.RibbonAppButton:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013DarkGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013DarkGray.cs
@@ -326,7 +326,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.Gallery2010);
             _radioButtonArray =

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013LightGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013LightGray.cs
@@ -326,7 +326,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.Gallery2010);
             _radioButtonArray =

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013White.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013White.cs
@@ -333,7 +333,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.Gallery2010);
             _radioButtonArray =
@@ -477,7 +477,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
         private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
         private static readonly Padding _contentPaddingCalendar = new Padding(2);
-        private static readonly Padding _contentPaddingHeaderForm = new Padding(10, 6, 3, 0); // 10 is from the RealWindowFrameSize +1
+        //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
         private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
         private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
         private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -489,7 +489,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);
@@ -501,7 +501,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _metricPaddingRibbon = new Padding(0, 1, 1, 1);
         private static readonly Padding _metricPaddingRibbonAppButton = new Padding(3, 0, 3, 0);
         private static readonly Padding _metricPaddingHeader = new Padding(0, 3, 1, 3);
-        private static readonly Padding _metricPaddingHeaderForm = new Padding(0, 3, 0, -3); // Move the Maximised Form buttons down a bit
+        //private static readonly Padding _metricPaddingHeaderForm = new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);//, 3, 0, -3); // Move the Maximised Form buttons down a bit
         private static readonly Padding _metricPaddingInputControl = new Padding(0, 1, 0, 1);
         private static readonly Padding _metricPaddingBarInside = new Padding(3);
         private static readonly Padding _metricPaddingBarTabs = new Padding(0);
@@ -1570,7 +1570,7 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => PaletteDrawBorders.Top,
                 PaletteBorderStyle.ContextMenuItemImageColumn => PaletteDrawBorders.Right,
                 PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ContextMenuInner => PaletteDrawBorders.None,
-                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.TopLeftRight,
+                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.None,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -3191,10 +3191,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             // We do not provide override values
             if (CommonHelper.IsOverrideState(state))
@@ -3202,37 +3204,90 @@ namespace Krypton.Toolkit
                 return CommonHelper.InheritPadding;
             }
 
-            return style switch
+            switch (style)
             {
-                PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 => _contentPaddingGrid,
-                PaletteContentStyle.HeaderForm => _contentPaddingHeaderForm,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _contentPaddingHeader1,
-                PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive => _contentPaddingDock,
-                PaletteContentStyle.HeaderSecondary => _contentPaddingHeader2,
-                PaletteContentStyle.HeaderCalendar => _contentPaddingCalendar,
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 => _contentPaddingLabel,
-                PaletteContentStyle.LabelGroupBoxCaption => _contentPaddingLabel2,
-                PaletteContentStyle.ContextMenuItemTextStandard => _contentPaddingContextMenuItemText,
-                PaletteContentStyle.ContextMenuItemTextAlternate => _contentPaddingContextMenuItemTextAlt,
-                PaletteContentStyle.ContextMenuItemShortcutText => _contentPaddingContextMenuItemShortcutText,
-                PaletteContentStyle.ContextMenuItemImage => _contentPaddingContextMenuImage,
-                PaletteContentStyle.LabelToolTip => _contentPaddingToolTip,
-                PaletteContentStyle.LabelSuperTip => _contentPaddingSuperTip,
-                PaletteContentStyle.LabelKeyTip => _contentPaddingKeyTip,
-                PaletteContentStyle.ContextMenuHeading => _contentPaddingContextMenuHeading,
-                PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => InputControlPadding,
-                PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => _contentPaddingButton12,
-                PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay => _contentPaddingButtonInputControl,
-                PaletteContentStyle.ButtonButtonSpec => _contentPaddingButton3,
-                PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => _contentPaddingButton4,
-                PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => _contentPaddingButtonForm,
-                PaletteContentStyle.ButtonGallery => _contentPaddingButtonGallery,
-                PaletteContentStyle.ButtonListItem => _contentPaddingButtonListItem,
-                PaletteContentStyle.ButtonBreadCrumb => _contentPaddingButton6,
-                PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 => _contentPaddingButton5,
-                PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden => _contentPaddingButton7,
-                _ => throw new ArgumentOutOfRangeException(nameof(style))
-            };
+                case PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet
+                    or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2
+                    or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList
+                    or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1
+                    or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3
+                    or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet
+                    or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2
+                    or PaletteContentStyle.GridDataCellCustom3:
+                    return _contentPaddingGrid;
+                case PaletteContentStyle.HeaderForm:
+                    {
+                        Padding borders = owningForm!.RealWindowBorders;
+                        return new Padding(borders.Left, borders.Bottom / 2, 0, 0);
+                    }
+                case PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1
+                    or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3:
+                    return _contentPaddingHeader1;
+                case PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive:
+                    return _contentPaddingDock;
+                case PaletteContentStyle.HeaderSecondary:
+                    return _contentPaddingHeader2;
+                case PaletteContentStyle.HeaderCalendar:
+                    return _contentPaddingCalendar;
+                case PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl
+                    or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl
+                    or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel
+                    or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel
+                    or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2
+                    or PaletteContentStyle.LabelCustom3:
+                    return _contentPaddingLabel;
+                case PaletteContentStyle.LabelGroupBoxCaption:
+                    return _contentPaddingLabel2;
+                case PaletteContentStyle.ContextMenuItemTextStandard:
+                    return _contentPaddingContextMenuItemText;
+                case PaletteContentStyle.ContextMenuItemTextAlternate:
+                    return _contentPaddingContextMenuItemTextAlt;
+                case PaletteContentStyle.ContextMenuItemShortcutText:
+                    return _contentPaddingContextMenuItemShortcutText;
+                case PaletteContentStyle.ContextMenuItemImage:
+                    return _contentPaddingContextMenuImage;
+                case PaletteContentStyle.LabelToolTip:
+                    return _contentPaddingToolTip;
+                case PaletteContentStyle.LabelSuperTip:
+                    return _contentPaddingSuperTip;
+                case PaletteContentStyle.LabelKeyTip:
+                    return _contentPaddingKeyTip;
+                case PaletteContentStyle.ContextMenuHeading:
+                    return _contentPaddingContextMenuHeading;
+                case PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon
+                    or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2
+                    or PaletteContentStyle.InputControlCustom3:
+                    return InputControlPadding;
+                case PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand
+                    or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile
+                    or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini
+                    or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2
+                    or PaletteContentStyle.ButtonCustom3:
+                    return _contentPaddingButton12;
+                case PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay:
+                    return _contentPaddingButtonInputControl;
+                case PaletteContentStyle.ButtonButtonSpec:
+                    return _contentPaddingButton3;
+                case PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow:
+                    return _contentPaddingButton4;
+                case PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose:
+                    return _contentPaddingButtonForm;
+                case PaletteContentStyle.ButtonGallery:
+                    return _contentPaddingButtonGallery;
+                case PaletteContentStyle.ButtonListItem:
+                    return _contentPaddingButtonListItem;
+                case PaletteContentStyle.ButtonBreadCrumb:
+                    return _contentPaddingButton6;
+                case PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile
+                    or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote
+                    or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2
+                    or PaletteContentStyle.TabCustom3:
+                    return _contentPaddingButton5;
+                case PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden:
+                    return _contentPaddingButton7;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style));
+            }
         }
 
         /// <summary>
@@ -3259,13 +3314,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             switch (metric)
             {
@@ -3276,7 +3333,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricInt.CheckButtonGap:
                     return 5;
                 case PaletteMetricInt.HeaderButtonEdgeInsetForm:
-                    return 9; // Needs to be the RealWindowBorderWidth Offset - No idea how to get it at this point
+                    return Math.Max(2, owningForm!.RealWindowBorders.Right);
                 case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                     return 1;
                 case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:
@@ -3330,10 +3387,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -3347,7 +3406,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricPadding.BarPaddingOutside:
                     return _metricPaddingBarOutside;
                 case PaletteMetricPadding.HeaderButtonPaddingForm:
-                    return _metricPaddingHeaderForm;
+                    return new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);
                 case PaletteMetricPadding.RibbonButtonPadding:
                     return _metricPaddingRibbon;
                 case PaletteMetricPadding.RibbonAppButton:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Professional/PaletteProfessionalOffice2003.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Professional/PaletteProfessionalOffice2003.cs
@@ -320,21 +320,21 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingHeader2 = new Padding(3, 2, 3, 2);
         private static readonly Padding _contentPaddingHeader3 = new Padding(2, 1, 2, 1);
         private static readonly Padding _contentPaddingCalendar = new Padding(2);
-        private static readonly Padding _contentPaddingHeaderForm = new Padding(10, 6, 3, 1); // 10 is from the RealWindowFrameSize +1
+        //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
         private static readonly Padding _contentPaddingLabel = new Padding(3, 2, 3, 2);
         private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
         private static readonly Padding _contentPaddingButtonCalendar = new Padding(0);
         private static readonly Padding _contentPaddingButtonInputControl = new Padding(1);
         private static readonly Padding _contentPaddingButton12 = new Padding(3, 2, 3, 2);
-        private static readonly Padding _contentPaddingButton3 = new Padding(1, 1, 1, 1);
+        private static readonly Padding _contentPaddingButton3 = new Padding(1);
         private static readonly Padding _contentPaddingButton4 = new Padding(4, 3, 4, 3);
         private static readonly Padding _contentPaddingButton5 = new Padding(3, 3, 3, 2);
         private static readonly Padding _contentPaddingButton6 = new Padding(3);
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 3, 1);
-        private static readonly Padding _contentPaddingButtonForm = new Padding(5, 5, 5, 5);
+        private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingToolTip = new Padding(2, 2, 2, 2);
-        private static readonly Padding _contentPaddingSuperTip = new Padding(4, 4, 4, 4);
+        private static readonly Padding _contentPaddingToolTip = new Padding(2);
+        private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(1, -1, 0, -2);
         private static readonly Padding _contentPaddingContextMenuHeading = new Padding(8, 2, 8, 0);
         private static readonly Padding _contentPaddingContextMenuImage = new Padding(1);
@@ -345,7 +345,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _metricPaddingRibbon = new Padding(0, 1, 1, 1);
         private static readonly Padding _metricPaddingRibbonAppButton = new Padding(3, 0, 3, 0);
         private static readonly Padding _metricPaddingHeader = new Padding(0, 3, 1, 3);
-        private static readonly Padding _metricPaddingHeaderForm = new Padding(0, 3, 0, -3); // Move the Maximised Form buttons down a bit
+        //private static readonly Padding _metricPaddingHeaderForm = new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);//, 3, 0, -3); // Move the Maximised Form buttons down a bit
         private static readonly Padding _metricPaddingBarInside = new Padding(3, 3, 3, 3);
         private static readonly Padding _metricPaddingBarTabs = new Padding(0, 0, 0, 0);
         private static readonly Padding _metricPaddingBarOutside = new Padding(0, 0, 0, 3);
@@ -2826,10 +2826,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             // We do not provide override values
             if (CommonHelper.IsOverrideState(state))
@@ -2837,37 +2839,90 @@ namespace Krypton.Toolkit
                 return CommonHelper.InheritPadding;
             }
 
-            return style switch
+            switch (style)
             {
-                PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 => _contentPaddingGrid,
-                PaletteContentStyle.HeaderForm => _contentPaddingHeaderForm,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _contentPaddingHeader1,
-                PaletteContentStyle.HeaderSecondary => _contentPaddingHeader2,
-                PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive => _contentPaddingHeader3,
-                PaletteContentStyle.HeaderCalendar => _contentPaddingCalendar,
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 => _contentPaddingLabel,
-                PaletteContentStyle.LabelGroupBoxCaption => _contentPaddingLabel2,
-                PaletteContentStyle.ContextMenuItemTextStandard => _contentPaddingContextMenuItemText,
-                PaletteContentStyle.ContextMenuItemTextAlternate => _contentPaddingContextMenuItemTextAlt,
-                PaletteContentStyle.ContextMenuItemShortcutText => _contentPaddingContextMenuItemShortcutText,
-                PaletteContentStyle.LabelToolTip => _contentPaddingToolTip,
-                PaletteContentStyle.LabelSuperTip => _contentPaddingSuperTip,
-                PaletteContentStyle.LabelKeyTip => _contentPaddingKeyTip,
-                PaletteContentStyle.ContextMenuHeading => _contentPaddingContextMenuHeading,
-                PaletteContentStyle.ContextMenuItemImage => _contentPaddingContextMenuImage,
-                PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => InputControlPadding,
-                PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => _contentPaddingButton12,
-                PaletteContentStyle.ButtonInputControl => _contentPaddingButtonInputControl,
-                PaletteContentStyle.ButtonCalendarDay => _contentPaddingButtonCalendar,
-                PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonListItem => _contentPaddingButton3,
-                PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => _contentPaddingButton4,
-                PaletteContentStyle.ButtonBreadCrumb => _contentPaddingButton6,
-                PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => _contentPaddingButtonForm,
-                PaletteContentStyle.ButtonGallery => _contentPaddingButtonGallery,
-                PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 => _contentPaddingButton5,
-                PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden => _contentPaddingButton7,
-                _ => throw new ArgumentOutOfRangeException(nameof(style))
-            };
+                case PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet
+                    or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2
+                    or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList
+                    or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1
+                    or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3
+                    or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet
+                    or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2
+                    or PaletteContentStyle.GridDataCellCustom3:
+                    return _contentPaddingGrid;
+                case PaletteContentStyle.HeaderForm:
+                    {
+                        Padding borders = owningForm!.RealWindowBorders;
+                        return new Padding(borders.Left, borders.Bottom / 2, 0, 0);
+                    }
+                case PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1
+                    or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3:
+                    return _contentPaddingHeader1;
+                case PaletteContentStyle.HeaderSecondary:
+                    return _contentPaddingHeader2;
+                case PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive:
+                    return _contentPaddingHeader3;
+                case PaletteContentStyle.HeaderCalendar:
+                    return _contentPaddingCalendar;
+                case PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl
+                    or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl
+                    or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel
+                    or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel
+                    or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2
+                    or PaletteContentStyle.LabelCustom3:
+                    return _contentPaddingLabel;
+                case PaletteContentStyle.LabelGroupBoxCaption:
+                    return _contentPaddingLabel2;
+                case PaletteContentStyle.ContextMenuItemTextStandard:
+                    return _contentPaddingContextMenuItemText;
+                case PaletteContentStyle.ContextMenuItemTextAlternate:
+                    return _contentPaddingContextMenuItemTextAlt;
+                case PaletteContentStyle.ContextMenuItemShortcutText:
+                    return _contentPaddingContextMenuItemShortcutText;
+                case PaletteContentStyle.LabelToolTip:
+                    return _contentPaddingToolTip;
+                case PaletteContentStyle.LabelSuperTip:
+                    return _contentPaddingSuperTip;
+                case PaletteContentStyle.LabelKeyTip:
+                    return _contentPaddingKeyTip;
+                case PaletteContentStyle.ContextMenuHeading:
+                    return _contentPaddingContextMenuHeading;
+                case PaletteContentStyle.ContextMenuItemImage:
+                    return _contentPaddingContextMenuImage;
+                case PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon
+                    or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2
+                    or PaletteContentStyle.InputControlCustom3:
+                    return InputControlPadding;
+                case PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand
+                    or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile
+                    or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini
+                    or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2
+                    or PaletteContentStyle.ButtonCustom3:
+                    return _contentPaddingButton12;
+                case PaletteContentStyle.ButtonInputControl:
+                    return _contentPaddingButtonInputControl;
+                case PaletteContentStyle.ButtonCalendarDay:
+                    return _contentPaddingButtonCalendar;
+                case PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonListItem:
+                    return _contentPaddingButton3;
+                case PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow:
+                    return _contentPaddingButton4;
+                case PaletteContentStyle.ButtonBreadCrumb:
+                    return _contentPaddingButton6;
+                case PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose:
+                    return _contentPaddingButtonForm;
+                case PaletteContentStyle.ButtonGallery:
+                    return _contentPaddingButtonGallery;
+                case PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile
+                    or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote
+                    or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2
+                    or PaletteContentStyle.TabCustom3:
+                    return _contentPaddingButton5;
+                case PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden:
+                    return _contentPaddingButton7;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style));
+            }
         }
 
         /// <summary>
@@ -2894,13 +2949,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             switch (metric)
             {
@@ -2911,7 +2968,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricInt.CheckButtonGap:
                     return 5;
                 case PaletteMetricInt.HeaderButtonEdgeInsetForm:
-                    return 9; // Needs to be the RealWindowBorderWidth Offset - No idea how to get it at this point
+                    return Math.Max(2, owningForm!.RealWindowBorders.Right);
                 case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                     return 1;
                 case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:
@@ -2965,10 +3022,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -2982,7 +3041,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricPadding.BarPaddingOutside:
                     return _metricPaddingBarOutside;
                 case PaletteMetricPadding.HeaderButtonPaddingForm:
-                    return _metricPaddingHeaderForm;
+                    return new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);
                 case PaletteMetricPadding.RibbonButtonPadding:
                     return _metricPaddingRibbon;
                 case PaletteMetricPadding.RibbonAppButton:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Professional/PaletteProfessionalSystem.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Professional/PaletteProfessionalSystem.cs
@@ -26,7 +26,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingHeader2 = new Padding(3, 2, 3, 2);
         private static readonly Padding _contentPaddingHeader3 = new Padding(2, 1, 2, 1);
         private static readonly Padding _contentPaddingCalendar = new Padding(2);
-        private static readonly Padding _contentPaddingHeaderForm = new Padding(10, 6, 3, 1); // 10 is from the RealWindowFrameSize +1
+        //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
         private static readonly Padding _contentPaddingLabel = new Padding(3, 2, 3, 2);
         private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
         private static readonly Padding _contentPaddingButtonCalendar = new Padding(0);
@@ -37,10 +37,10 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton5 = new Padding(3, 3, 3, 2);
         private static readonly Padding _contentPaddingButton6 = new Padding(3);
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 3, 1);
-        private static readonly Padding _contentPaddingButtonForm = new Padding(5, 5, 5, 5);
+        private static readonly Padding _contentPaddingButtonForm = new Padding(5);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingToolTip = new Padding(2, 2, 2, 2);
-        private static readonly Padding _contentPaddingSuperTip = new Padding(4, 4, 4, 4);
+        private static readonly Padding _contentPaddingToolTip = new Padding(2);
+        private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(1, -1, 0, -2);
         private static readonly Padding _contentPaddingContextMenuHeading = new Padding(8, 2, 8, 0);
         private static readonly Padding _contentPaddingContextMenuImage = new Padding(1);
@@ -51,7 +51,8 @@ namespace Krypton.Toolkit
         private static readonly Padding _metricPaddingRibbon = new Padding(0, 1, 1, 1);
         private static readonly Padding _metricPaddingRibbonAppButton = new Padding(3, 0, 3, 0);
         private static readonly Padding _metricPaddingHeader = new Padding(0, 3, 1, 3);
-        private static readonly Padding _metricPaddingHeaderForm = new Padding(0, 3, 0, -3); // Move the Maximised Form buttons down a bit
+
+        //private static readonly Padding _metricPaddingHeaderForm = new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);//, 3, 0, -3); // Move the Maximised Form buttons down a bit
         private static readonly Padding _metricPaddingBarInside = new Padding(3, 3, 3, 3);
         private static readonly Padding _metricPaddingBarTabs = new Padding(0, 0, 0, 0);
         private static readonly Padding _metricPaddingBarOutside = new Padding(0, 0, 0, 3);
@@ -2531,10 +2532,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             // We do not provide override values
             if (CommonHelper.IsOverrideState(state))
@@ -2542,37 +2545,90 @@ namespace Krypton.Toolkit
                 return CommonHelper.InheritPadding;
             }
 
-            return style switch
+            switch (style)
             {
-                PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 => _contentPaddingGrid,
-                PaletteContentStyle.HeaderForm => _contentPaddingHeaderForm,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _contentPaddingHeader1,
-                PaletteContentStyle.HeaderSecondary => _contentPaddingHeader2,
-                PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive => _contentPaddingHeader3,
-                PaletteContentStyle.HeaderCalendar => _contentPaddingCalendar,
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 => _contentPaddingLabel,
-                PaletteContentStyle.LabelGroupBoxCaption => _contentPaddingLabel2,
-                PaletteContentStyle.ContextMenuItemTextStandard => _contentPaddingContextMenuItemText,
-                PaletteContentStyle.ContextMenuItemTextAlternate => _contentPaddingContextMenuItemTextAlt,
-                PaletteContentStyle.ContextMenuItemShortcutText => _contentPaddingContextMenuItemShortcutText,
-                PaletteContentStyle.LabelToolTip => _contentPaddingToolTip,
-                PaletteContentStyle.LabelSuperTip => _contentPaddingSuperTip,
-                PaletteContentStyle.LabelKeyTip => _contentPaddingKeyTip,
-                PaletteContentStyle.ContextMenuHeading => _contentPaddingContextMenuHeading,
-                PaletteContentStyle.ContextMenuItemImage => _contentPaddingContextMenuImage,
-                PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => InputControlPadding,
-                PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => _contentPaddingButton12,
-                PaletteContentStyle.ButtonInputControl => _contentPaddingButtonInputControl,
-                PaletteContentStyle.ButtonCalendarDay => _contentPaddingButtonCalendar,
-                PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonListItem => _contentPaddingButton3,
-                PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => _contentPaddingButton4,
-                PaletteContentStyle.ButtonBreadCrumb => _contentPaddingButton6,
-                PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => _contentPaddingButtonForm,
-                PaletteContentStyle.ButtonGallery => _contentPaddingButtonGallery,
-                PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 => _contentPaddingButton5,
-                PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden => _contentPaddingButton7,
-                _ => throw new ArgumentOutOfRangeException(nameof(style))
-            };
+                case PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet
+                    or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2
+                    or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList
+                    or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1
+                    or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3
+                    or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet
+                    or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2
+                    or PaletteContentStyle.GridDataCellCustom3:
+                    return _contentPaddingGrid;
+                case PaletteContentStyle.HeaderForm:
+                    {
+                        Padding borders = owningForm!.RealWindowBorders;
+                        return new Padding(borders.Left, borders.Bottom / 2, 0, 0);
+                    }
+                case PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1
+                    or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3:
+                    return _contentPaddingHeader1;
+                case PaletteContentStyle.HeaderSecondary:
+                    return _contentPaddingHeader2;
+                case PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive:
+                    return _contentPaddingHeader3;
+                case PaletteContentStyle.HeaderCalendar:
+                    return _contentPaddingCalendar;
+                case PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl
+                    or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl
+                    or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel
+                    or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel
+                    or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2
+                    or PaletteContentStyle.LabelCustom3:
+                    return _contentPaddingLabel;
+                case PaletteContentStyle.LabelGroupBoxCaption:
+                    return _contentPaddingLabel2;
+                case PaletteContentStyle.ContextMenuItemTextStandard:
+                    return _contentPaddingContextMenuItemText;
+                case PaletteContentStyle.ContextMenuItemTextAlternate:
+                    return _contentPaddingContextMenuItemTextAlt;
+                case PaletteContentStyle.ContextMenuItemShortcutText:
+                    return _contentPaddingContextMenuItemShortcutText;
+                case PaletteContentStyle.LabelToolTip:
+                    return _contentPaddingToolTip;
+                case PaletteContentStyle.LabelSuperTip:
+                    return _contentPaddingSuperTip;
+                case PaletteContentStyle.LabelKeyTip:
+                    return _contentPaddingKeyTip;
+                case PaletteContentStyle.ContextMenuHeading:
+                    return _contentPaddingContextMenuHeading;
+                case PaletteContentStyle.ContextMenuItemImage:
+                    return _contentPaddingContextMenuImage;
+                case PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon
+                    or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2
+                    or PaletteContentStyle.InputControlCustom3:
+                    return InputControlPadding;
+                case PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand
+                    or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile
+                    or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini
+                    or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2
+                    or PaletteContentStyle.ButtonCustom3:
+                    return _contentPaddingButton12;
+                case PaletteContentStyle.ButtonInputControl:
+                    return _contentPaddingButtonInputControl;
+                case PaletteContentStyle.ButtonCalendarDay:
+                    return _contentPaddingButtonCalendar;
+                case PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonListItem:
+                    return _contentPaddingButton3;
+                case PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow:
+                    return _contentPaddingButton4;
+                case PaletteContentStyle.ButtonBreadCrumb:
+                    return _contentPaddingButton6;
+                case PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose:
+                    return _contentPaddingButtonForm;
+                case PaletteContentStyle.ButtonGallery:
+                    return _contentPaddingButtonGallery;
+                case PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile
+                    or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote
+                    or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2
+                    or PaletteContentStyle.TabCustom3:
+                    return _contentPaddingButton5;
+                case PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden:
+                    return _contentPaddingButton7;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style));
+            }
         }
 
         /// <summary>
@@ -2599,13 +2655,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             switch (metric)
             {
@@ -2616,7 +2674,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricInt.CheckButtonGap:
                     return 5;
                 case PaletteMetricInt.HeaderButtonEdgeInsetForm:
-                    return 9; // Needs to be the RealWindowBorderWidth Offset - No idea how to get it at this point
+                    return Math.Max(2, owningForm!.RealWindowBorders.Right);
                 case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                     return 1;
                 case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:
@@ -2670,10 +2728,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -2687,7 +2747,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricPadding.BarPaddingOutside:
                     return _metricPaddingBarOutside;
                 case PaletteMetricPadding.HeaderButtonPaddingForm:
-                    return _metricPaddingHeaderForm;
+                    return new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);
                 case PaletteMetricPadding.RibbonButtonPadding:
                     return _metricPaddingRibbon;
                 case PaletteMetricPadding.RibbonAppButton:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/Base/PaletteSparkleBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/Base/PaletteSparkleBase.cs
@@ -26,7 +26,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingHeader2 = new Padding(3, 2, 2, 2);
         private static readonly Padding _contentPaddingHeader3 = new Padding(2, 1, 2, 1);
         private static readonly Padding _contentPaddingCalendar = new Padding(2);
-        private static readonly Padding _contentPaddingHeaderForm = new Padding(10, -3, 3, -3); // 10 is from the RealWindowFrameSize +1 
+        //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
         private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
         private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
         private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -38,7 +38,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(3, 0, 3, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);
@@ -51,7 +51,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _metricPaddingRibbon = new Padding(0, 1, 1, 1);
         private static readonly Padding _metricPaddingRibbonAppButton = new Padding(3, 0, 3, 0);
         private static readonly Padding _metricPaddingHeader = new Padding(0, 3, 1, 3);
-        private static readonly Padding _metricPaddingHeaderForm = new Padding(0, 3, 0, -3); // Move the Maximised Form buttons down a bit
+        //private static readonly Padding _metricPaddingHeaderForm = new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);//, 3, 0, -3); // Move the Maximised Form buttons down a bit
         private static readonly Padding _metricPaddingInputControl = new Padding(0, 1, 0, 1);
         private static readonly Padding _metricPaddingBarInside = new Padding(3);
         private static readonly Padding _metricPaddingBarTabs = new Padding(0);
@@ -2779,10 +2779,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             // We do not provide override values
             if (CommonHelper.IsOverrideState(state))
@@ -2790,37 +2792,90 @@ namespace Krypton.Toolkit
                 return CommonHelper.InheritPadding;
             }
 
-            return style switch
+            switch (style)
             {
-                PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 => _contentPaddingGrid,
-                PaletteContentStyle.HeaderForm => _contentPaddingHeaderForm,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _contentPaddingHeader1,
-                PaletteContentStyle.HeaderSecondary => _contentPaddingHeader2,
-                PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive => _contentPaddingHeader3,
-                PaletteContentStyle.HeaderCalendar => _contentPaddingCalendar,
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 => _contentPaddingLabel,
-                PaletteContentStyle.LabelGroupBoxCaption => _contentPaddingLabel2,
-                PaletteContentStyle.ContextMenuItemTextStandard => _contentPaddingContextMenuItemText,
-                PaletteContentStyle.ContextMenuItemTextAlternate => _contentPaddingContextMenuItemTextAlt,
-                PaletteContentStyle.ContextMenuItemShortcutText => _contentPaddingContextMenuItemShortcutText,
-                PaletteContentStyle.ContextMenuItemImage => _contentPaddingContextMenuImage,
-                PaletteContentStyle.LabelToolTip => _contentPaddingToolTip,
-                PaletteContentStyle.LabelSuperTip => _contentPaddingSuperTip,
-                PaletteContentStyle.LabelKeyTip => _contentPaddingKeyTip,
-                PaletteContentStyle.ContextMenuHeading => _contentPaddingContextMenuHeading,
-                PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => InputControlPadding,
-                PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => _contentPaddingButton12,
-                PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay => _contentPaddingButtonInputControl,
-                PaletteContentStyle.ButtonButtonSpec => _contentPaddingButton3,
-                PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => _contentPaddingButton4,
-                PaletteContentStyle.ButtonBreadCrumb => _contentPaddingButton6,
-                PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => _contentPaddingButtonForm,
-                PaletteContentStyle.ButtonGallery => _contentPaddingButtonGallery,
-                PaletteContentStyle.ButtonListItem => _contentPaddingButtonListItem,
-                PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 => _contentPaddingButton5,
-                PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden => _contentPaddingButton7,
-                _ => throw new ArgumentOutOfRangeException(nameof(style))
-            };
+                case PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet
+                    or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2
+                    or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList
+                    or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1
+                    or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3
+                    or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet
+                    or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2
+                    or PaletteContentStyle.GridDataCellCustom3:
+                    return _contentPaddingGrid;
+                case PaletteContentStyle.HeaderForm:
+                    {
+                        Padding borders = owningForm!.RealWindowBorders;
+                        return new Padding(borders.Left, borders.Bottom / 2, 0, 0);
+                    }
+                case PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1
+                    or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3:
+                    return _contentPaddingHeader1;
+                case PaletteContentStyle.HeaderSecondary:
+                    return _contentPaddingHeader2;
+                case PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive:
+                    return _contentPaddingHeader3;
+                case PaletteContentStyle.HeaderCalendar:
+                    return _contentPaddingCalendar;
+                case PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl
+                    or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl
+                    or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel
+                    or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel
+                    or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2
+                    or PaletteContentStyle.LabelCustom3:
+                    return _contentPaddingLabel;
+                case PaletteContentStyle.LabelGroupBoxCaption:
+                    return _contentPaddingLabel2;
+                case PaletteContentStyle.ContextMenuItemTextStandard:
+                    return _contentPaddingContextMenuItemText;
+                case PaletteContentStyle.ContextMenuItemTextAlternate:
+                    return _contentPaddingContextMenuItemTextAlt;
+                case PaletteContentStyle.ContextMenuItemShortcutText:
+                    return _contentPaddingContextMenuItemShortcutText;
+                case PaletteContentStyle.ContextMenuItemImage:
+                    return _contentPaddingContextMenuImage;
+                case PaletteContentStyle.LabelToolTip:
+                    return _contentPaddingToolTip;
+                case PaletteContentStyle.LabelSuperTip:
+                    return _contentPaddingSuperTip;
+                case PaletteContentStyle.LabelKeyTip:
+                    return _contentPaddingKeyTip;
+                case PaletteContentStyle.ContextMenuHeading:
+                    return _contentPaddingContextMenuHeading;
+                case PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon
+                    or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2
+                    or PaletteContentStyle.InputControlCustom3:
+                    return InputControlPadding;
+                case PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand
+                    or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile
+                    or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini
+                    or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2
+                    or PaletteContentStyle.ButtonCustom3:
+                    return _contentPaddingButton12;
+                case PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay:
+                    return _contentPaddingButtonInputControl;
+                case PaletteContentStyle.ButtonButtonSpec:
+                    return _contentPaddingButton3;
+                case PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow:
+                    return _contentPaddingButton4;
+                case PaletteContentStyle.ButtonBreadCrumb:
+                    return _contentPaddingButton6;
+                case PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose:
+                    return _contentPaddingButtonForm;
+                case PaletteContentStyle.ButtonGallery:
+                    return _contentPaddingButtonGallery;
+                case PaletteContentStyle.ButtonListItem:
+                    return _contentPaddingButtonListItem;
+                case PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile
+                    or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote
+                    or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2
+                    or PaletteContentStyle.TabCustom3:
+                    return _contentPaddingButton5;
+                case PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden:
+                    return _contentPaddingButton7;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style));
+            }
         }
 
         /// <summary>
@@ -2847,13 +2902,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             switch (metric)
             {
@@ -2864,7 +2921,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricInt.CheckButtonGap:
                     return 5;
                 case PaletteMetricInt.HeaderButtonEdgeInsetForm:
-                    return 9; // Needs to be the RealWindowBorderWidth Offset - No idea how to get it at this point
+                    return Math.Max(2, owningForm!.RealWindowBorders.Right);
                 case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                     return 1;
                 case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:
@@ -2917,10 +2974,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -2934,7 +2993,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricPadding.BarPaddingOutside:
                     return _metricPaddingBarOutside;
                 case PaletteMetricPadding.HeaderButtonPaddingForm:
-                    return _metricPaddingHeaderForm;
+                    return new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);
                 case PaletteMetricPadding.RibbonButtonPadding:
                     return _metricPaddingRibbon;
                 case PaletteMetricPadding.RibbonAppButton:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/Extra Themes/PaletteSparkleBlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/Extra Themes/PaletteSparkleBlueDarkMode.cs
@@ -401,7 +401,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingHeader2 = new Padding(3, 2, 2, 2);
         private static readonly Padding _contentPaddingHeader3 = new Padding(2, 1, 2, 1);
         private static readonly Padding _contentPaddingCalendar = new Padding(2);
-        private static readonly Padding _contentPaddingHeaderForm = new Padding(10, -3, 3, -3); // 10 is from the RealWindowFrameSize +1 
+        //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
         private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
         private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
         private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -413,7 +413,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(3, 0, 3, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);
@@ -426,7 +426,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _metricPaddingRibbon = new Padding(0, 1, 1, 1);
         private static readonly Padding _metricPaddingRibbonAppButton = new Padding(3, 0, 3, 0);
         private static readonly Padding _metricPaddingHeader = new Padding(0, 3, 1, 3);
-        private static readonly Padding _metricPaddingHeaderForm = new Padding(0, 3, 0, -3); // Move the Maximised Form buttons down a bit
+        //private static readonly Padding _metricPaddingHeaderForm = new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);//, 3, 0, -3); // Move the Maximised Form buttons down a bit
         private static readonly Padding _metricPaddingInputControl = new Padding(0, 1, 0, 1);
         private static readonly Padding _metricPaddingBarInside = new Padding(3);
         private static readonly Padding _metricPaddingBarTabs = new Padding(0);
@@ -3011,10 +3011,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             // We do not provide override values
             if (CommonHelper.IsOverrideState(state))
@@ -3022,37 +3024,90 @@ namespace Krypton.Toolkit
                 return CommonHelper.InheritPadding;
             }
 
-            return style switch
+            switch (style)
             {
-                PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 => _contentPaddingGrid,
-                PaletteContentStyle.HeaderForm => _contentPaddingHeaderForm,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _contentPaddingHeader1,
-                PaletteContentStyle.HeaderSecondary => _contentPaddingHeader2,
-                PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive => _contentPaddingHeader3,
-                PaletteContentStyle.HeaderCalendar => _contentPaddingCalendar,
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 => _contentPaddingLabel,
-                PaletteContentStyle.LabelGroupBoxCaption => _contentPaddingLabel2,
-                PaletteContentStyle.ContextMenuItemTextStandard => _contentPaddingContextMenuItemText,
-                PaletteContentStyle.ContextMenuItemTextAlternate => _contentPaddingContextMenuItemTextAlt,
-                PaletteContentStyle.ContextMenuItemShortcutText => _contentPaddingContextMenuItemShortcutText,
-                PaletteContentStyle.ContextMenuItemImage => _contentPaddingContextMenuImage,
-                PaletteContentStyle.LabelToolTip => _contentPaddingToolTip,
-                PaletteContentStyle.LabelSuperTip => _contentPaddingSuperTip,
-                PaletteContentStyle.LabelKeyTip => _contentPaddingKeyTip,
-                PaletteContentStyle.ContextMenuHeading => _contentPaddingContextMenuHeading,
-                PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => InputControlPadding,
-                PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => _contentPaddingButton12,
-                PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay => _contentPaddingButtonInputControl,
-                PaletteContentStyle.ButtonButtonSpec => _contentPaddingButton3,
-                PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => _contentPaddingButton4,
-                PaletteContentStyle.ButtonBreadCrumb => _contentPaddingButton6,
-                PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => _contentPaddingButtonForm,
-                PaletteContentStyle.ButtonGallery => _contentPaddingButtonGallery,
-                PaletteContentStyle.ButtonListItem => _contentPaddingButtonListItem,
-                PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 => _contentPaddingButton5,
-                PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden => _contentPaddingButton7,
-                _ => throw new ArgumentOutOfRangeException(nameof(style))
-            };
+                case PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet
+                    or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2
+                    or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList
+                    or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1
+                    or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3
+                    or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet
+                    or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2
+                    or PaletteContentStyle.GridDataCellCustom3:
+                    return _contentPaddingGrid;
+                case PaletteContentStyle.HeaderForm:
+                    {
+                        Padding borders = owningForm!.RealWindowBorders;
+                        return new Padding(borders.Left, borders.Bottom / 2, 0, 0);
+                    }
+                case PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1
+                    or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3:
+                    return _contentPaddingHeader1;
+                case PaletteContentStyle.HeaderSecondary:
+                    return _contentPaddingHeader2;
+                case PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive:
+                    return _contentPaddingHeader3;
+                case PaletteContentStyle.HeaderCalendar:
+                    return _contentPaddingCalendar;
+                case PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl
+                    or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl
+                    or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel
+                    or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel
+                    or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2
+                    or PaletteContentStyle.LabelCustom3:
+                    return _contentPaddingLabel;
+                case PaletteContentStyle.LabelGroupBoxCaption:
+                    return _contentPaddingLabel2;
+                case PaletteContentStyle.ContextMenuItemTextStandard:
+                    return _contentPaddingContextMenuItemText;
+                case PaletteContentStyle.ContextMenuItemTextAlternate:
+                    return _contentPaddingContextMenuItemTextAlt;
+                case PaletteContentStyle.ContextMenuItemShortcutText:
+                    return _contentPaddingContextMenuItemShortcutText;
+                case PaletteContentStyle.ContextMenuItemImage:
+                    return _contentPaddingContextMenuImage;
+                case PaletteContentStyle.LabelToolTip:
+                    return _contentPaddingToolTip;
+                case PaletteContentStyle.LabelSuperTip:
+                    return _contentPaddingSuperTip;
+                case PaletteContentStyle.LabelKeyTip:
+                    return _contentPaddingKeyTip;
+                case PaletteContentStyle.ContextMenuHeading:
+                    return _contentPaddingContextMenuHeading;
+                case PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon
+                    or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2
+                    or PaletteContentStyle.InputControlCustom3:
+                    return InputControlPadding;
+                case PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand
+                    or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile
+                    or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini
+                    or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2
+                    or PaletteContentStyle.ButtonCustom3:
+                    return _contentPaddingButton12;
+                case PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay:
+                    return _contentPaddingButtonInputControl;
+                case PaletteContentStyle.ButtonButtonSpec:
+                    return _contentPaddingButton3;
+                case PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow:
+                    return _contentPaddingButton4;
+                case PaletteContentStyle.ButtonBreadCrumb:
+                    return _contentPaddingButton6;
+                case PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose:
+                    return _contentPaddingButtonForm;
+                case PaletteContentStyle.ButtonGallery:
+                    return _contentPaddingButtonGallery;
+                case PaletteContentStyle.ButtonListItem:
+                    return _contentPaddingButtonListItem;
+                case PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile
+                    or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote
+                    or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2
+                    or PaletteContentStyle.TabCustom3:
+                    return _contentPaddingButton5;
+                case PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden:
+                    return _contentPaddingButton7;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style));
+            }
         }
 
         /// <summary>
@@ -3079,13 +3134,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             switch (metric)
             {
@@ -3096,7 +3153,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricInt.CheckButtonGap:
                     return 5;
                 case PaletteMetricInt.HeaderButtonEdgeInsetForm:
-                    return 9; // Needs to be the RealWindowBorderWidth Offset - No idea how to get it at this point
+                    return Math.Max(2, owningForm!.RealWindowBorders.Right);
                 case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                     return 1;
                 case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:
@@ -3149,10 +3206,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -3166,7 +3225,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricPadding.BarPaddingOutside:
                     return _metricPaddingBarOutside;
                 case PaletteMetricPadding.HeaderButtonPaddingForm:
-                    return _metricPaddingHeaderForm;
+                    return new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);
                 case PaletteMetricPadding.RibbonButtonPadding:
                     return _metricPaddingRibbon;
                 case PaletteMetricPadding.RibbonAppButton:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/PaletteVisualStudioBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/PaletteVisualStudioBase.cs
@@ -25,7 +25,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
         private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
         private static readonly Padding _contentPaddingCalendar = new Padding(2);
-        private static readonly Padding _contentPaddingHeaderForm = new Padding(10, 6, 3, 0); // 10 is from the RealWindowFrameSize +1
+        //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
         private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
         private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
         private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -37,7 +37,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);
@@ -49,7 +49,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _metricPaddingRibbon = new Padding(0, 1, 1, 1);
         private static readonly Padding _metricPaddingRibbonAppButton = new Padding(3, 0, 3, 0);
         private static readonly Padding _metricPaddingHeader = new Padding(0, 3, 1, 3);
-        private static readonly Padding _metricPaddingHeaderForm = new Padding(0, 3, 0, -3); // Move the Maximised Form buttons down a bit
+        //private static readonly Padding _metricPaddingHeaderForm = new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);//, 3, 0, -3); // Move the Maximised Form buttons down a bit
         private static readonly Padding _metricPaddingInputControl = new Padding(0, 1, 0, 1);
         private static readonly Padding _metricPaddingBarInside = new Padding(3);
         private static readonly Padding _metricPaddingBarTabs = new Padding(0);
@@ -351,7 +351,7 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => PaletteDrawBorders.Top,
                 PaletteBorderStyle.ContextMenuItemImageColumn => PaletteDrawBorders.Right,
                 PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ContextMenuInner => PaletteDrawBorders.None,
-                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.TopLeftRight,
+                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.None,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -1984,10 +1984,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             // We do not provide override values
             if (CommonHelper.IsOverrideState(state))
@@ -1995,37 +1997,90 @@ namespace Krypton.Toolkit
                 return CommonHelper.InheritPadding;
             }
 
-            return style switch
+            switch (style)
             {
-                PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 => _contentPaddingGrid,
-                PaletteContentStyle.HeaderForm => _contentPaddingHeaderForm,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _contentPaddingHeader1,
-                PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive => _contentPaddingDock,
-                PaletteContentStyle.HeaderSecondary => _contentPaddingHeader2,
-                PaletteContentStyle.HeaderCalendar => _contentPaddingCalendar,
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 => _contentPaddingLabel,
-                PaletteContentStyle.LabelGroupBoxCaption => _contentPaddingLabel2,
-                PaletteContentStyle.ContextMenuItemTextStandard => _contentPaddingContextMenuItemText,
-                PaletteContentStyle.ContextMenuItemTextAlternate => _contentPaddingContextMenuItemTextAlt,
-                PaletteContentStyle.ContextMenuItemShortcutText => _contentPaddingContextMenuItemShortcutText,
-                PaletteContentStyle.ContextMenuItemImage => _contentPaddingContextMenuImage,
-                PaletteContentStyle.LabelToolTip => _contentPaddingToolTip,
-                PaletteContentStyle.LabelSuperTip => _contentPaddingSuperTip,
-                PaletteContentStyle.LabelKeyTip => _contentPaddingKeyTip,
-                PaletteContentStyle.ContextMenuHeading => _contentPaddingContextMenuHeading,
-                PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => InputControlPadding,
-                PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => _contentPaddingButton12,
-                PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay => _contentPaddingButtonInputControl,
-                PaletteContentStyle.ButtonButtonSpec => _contentPaddingButton3,
-                PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => _contentPaddingButton4,
-                PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => _contentPaddingButtonForm,
-                PaletteContentStyle.ButtonGallery => _contentPaddingButtonGallery,
-                PaletteContentStyle.ButtonListItem => _contentPaddingButtonListItem,
-                PaletteContentStyle.ButtonBreadCrumb => _contentPaddingButton6,
-                PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 => _contentPaddingButton5,
-                PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden => _contentPaddingButton7,
-                _ => throw new ArgumentOutOfRangeException(nameof(style))
-            };
+                case PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet
+                    or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2
+                    or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList
+                    or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1
+                    or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3
+                    or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet
+                    or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2
+                    or PaletteContentStyle.GridDataCellCustom3:
+                    return _contentPaddingGrid;
+                case PaletteContentStyle.HeaderForm:
+                    {
+                        Padding borders = owningForm!.RealWindowBorders;
+                        return new Padding(borders.Left, borders.Bottom / 2, 0, 0);
+                    }
+                case PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1
+                    or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3:
+                    return _contentPaddingHeader1;
+                case PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive:
+                    return _contentPaddingDock;
+                case PaletteContentStyle.HeaderSecondary:
+                    return _contentPaddingHeader2;
+                case PaletteContentStyle.HeaderCalendar:
+                    return _contentPaddingCalendar;
+                case PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl
+                    or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl
+                    or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel
+                    or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel
+                    or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2
+                    or PaletteContentStyle.LabelCustom3:
+                    return _contentPaddingLabel;
+                case PaletteContentStyle.LabelGroupBoxCaption:
+                    return _contentPaddingLabel2;
+                case PaletteContentStyle.ContextMenuItemTextStandard:
+                    return _contentPaddingContextMenuItemText;
+                case PaletteContentStyle.ContextMenuItemTextAlternate:
+                    return _contentPaddingContextMenuItemTextAlt;
+                case PaletteContentStyle.ContextMenuItemShortcutText:
+                    return _contentPaddingContextMenuItemShortcutText;
+                case PaletteContentStyle.ContextMenuItemImage:
+                    return _contentPaddingContextMenuImage;
+                case PaletteContentStyle.LabelToolTip:
+                    return _contentPaddingToolTip;
+                case PaletteContentStyle.LabelSuperTip:
+                    return _contentPaddingSuperTip;
+                case PaletteContentStyle.LabelKeyTip:
+                    return _contentPaddingKeyTip;
+                case PaletteContentStyle.ContextMenuHeading:
+                    return _contentPaddingContextMenuHeading;
+                case PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon
+                    or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2
+                    or PaletteContentStyle.InputControlCustom3:
+                    return InputControlPadding;
+                case PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand
+                    or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile
+                    or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini
+                    or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2
+                    or PaletteContentStyle.ButtonCustom3:
+                    return _contentPaddingButton12;
+                case PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay:
+                    return _contentPaddingButtonInputControl;
+                case PaletteContentStyle.ButtonButtonSpec:
+                    return _contentPaddingButton3;
+                case PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow:
+                    return _contentPaddingButton4;
+                case PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose:
+                    return _contentPaddingButtonForm;
+                case PaletteContentStyle.ButtonGallery:
+                    return _contentPaddingButtonGallery;
+                case PaletteContentStyle.ButtonListItem:
+                    return _contentPaddingButtonListItem;
+                case PaletteContentStyle.ButtonBreadCrumb:
+                    return _contentPaddingButton6;
+                case PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile
+                    or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote
+                    or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2
+                    or PaletteContentStyle.TabCustom3:
+                    return _contentPaddingButton5;
+                case PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden:
+                    return _contentPaddingButton7;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style));
+            }
         }
 
         /// <summary>
@@ -2052,13 +2107,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             switch (metric)
             {
@@ -2069,7 +2126,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricInt.CheckButtonGap:
                     return 5;
                 case PaletteMetricInt.HeaderButtonEdgeInsetForm:
-                    return 9; // Needs to be the RealWindowBorderWidth Offset - No idea how to get it at this point
+                    return Math.Max(2, owningForm!.RealWindowBorders.Right);
                 case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                     return 1;
                 case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:
@@ -2123,10 +2180,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -2140,7 +2199,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricPadding.BarPaddingOutside:
                     return _metricPaddingBarOutside;
                 case PaletteMetricPadding.HeaderButtonPaddingForm:
-                    return _metricPaddingHeaderForm;
+                    return new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);
                 case PaletteMetricPadding.RibbonButtonPadding:
                     return _metricPaddingRibbon;
                 case PaletteMetricPadding.RibbonAppButton:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2007/PaletteVisualStudio2010With2007Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2007/PaletteVisualStudio2010With2007Base.cs
@@ -22,7 +22,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
         private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
         private static readonly Padding _contentPaddingCalendar = new Padding(2);
-        private static readonly Padding _contentPaddingHeaderForm = new Padding(10, 6, 3, 0); // 10 is from the RealWindowFrameSize +1
+        //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
         private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
         private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
         private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -34,7 +34,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);
@@ -46,7 +46,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _metricPaddingRibbon = new Padding(0, 1, 1, 1);
         private static readonly Padding _metricPaddingRibbonAppButton = new Padding(3, 0, 3, 0);
         private static readonly Padding _metricPaddingHeader = new Padding(0, 3, 1, 3);
-        private static readonly Padding _metricPaddingHeaderForm = new Padding(0, 3, 0, -3); // Move the Maximised Form buttons down a bit
+        //private static readonly Padding _metricPaddingHeaderForm = new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);//, 3, 0, -3); // Move the Maximised Form buttons down a bit
         private static readonly Padding _metricPaddingInputControl = new Padding(0, 1, 0, 1);
         private static readonly Padding _metricPaddingBarInside = new Padding(3);
         private static readonly Padding _metricPaddingBarTabs = new Padding(0);
@@ -1140,7 +1140,7 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => PaletteDrawBorders.Top,
                 PaletteBorderStyle.ContextMenuItemImageColumn => PaletteDrawBorders.Right,
                 PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ContextMenuInner => PaletteDrawBorders.None,
-                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.TopLeftRight,
+                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.None,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -2775,10 +2775,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             // We do not provide override values
             if (CommonHelper.IsOverrideState(state))
@@ -2786,37 +2788,90 @@ namespace Krypton.Toolkit
                 return CommonHelper.InheritPadding;
             }
 
-            return style switch
+            switch (style)
             {
-                PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 => _contentPaddingGrid,
-                PaletteContentStyle.HeaderForm => _contentPaddingHeaderForm,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _contentPaddingHeader1,
-                PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive => _contentPaddingDock,
-                PaletteContentStyle.HeaderSecondary => _contentPaddingHeader2,
-                PaletteContentStyle.HeaderCalendar => _contentPaddingCalendar,
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 => _contentPaddingLabel,
-                PaletteContentStyle.LabelGroupBoxCaption => _contentPaddingLabel2,
-                PaletteContentStyle.ContextMenuItemTextStandard => _contentPaddingContextMenuItemText,
-                PaletteContentStyle.ContextMenuItemTextAlternate => _contentPaddingContextMenuItemTextAlt,
-                PaletteContentStyle.ContextMenuItemShortcutText => _contentPaddingContextMenuItemShortcutText,
-                PaletteContentStyle.ContextMenuItemImage => _contentPaddingContextMenuImage,
-                PaletteContentStyle.LabelToolTip => _contentPaddingToolTip,
-                PaletteContentStyle.LabelSuperTip => _contentPaddingSuperTip,
-                PaletteContentStyle.LabelKeyTip => _contentPaddingKeyTip,
-                PaletteContentStyle.ContextMenuHeading => _contentPaddingContextMenuHeading,
-                PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => InputControlPadding,
-                PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => _contentPaddingButton12,
-                PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay => _contentPaddingButtonInputControl,
-                PaletteContentStyle.ButtonButtonSpec => _contentPaddingButton3,
-                PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => _contentPaddingButton4,
-                PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => _contentPaddingButtonForm,
-                PaletteContentStyle.ButtonGallery => _contentPaddingButtonGallery,
-                PaletteContentStyle.ButtonListItem => _contentPaddingButtonListItem,
-                PaletteContentStyle.ButtonBreadCrumb => _contentPaddingButton6,
-                PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 => _contentPaddingButton5,
-                PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden => _contentPaddingButton7,
-                _ => throw new ArgumentOutOfRangeException(nameof(style))
-            };
+                case PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet
+                    or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2
+                    or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList
+                    or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1
+                    or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3
+                    or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet
+                    or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2
+                    or PaletteContentStyle.GridDataCellCustom3:
+                    return _contentPaddingGrid;
+                case PaletteContentStyle.HeaderForm:
+                    {
+                        Padding borders = owningForm!.RealWindowBorders;
+                        return new Padding(borders.Left, borders.Bottom / 2, 0, 0);
+                    }
+                case PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1
+                    or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3:
+                    return _contentPaddingHeader1;
+                case PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive:
+                    return _contentPaddingDock;
+                case PaletteContentStyle.HeaderSecondary:
+                    return _contentPaddingHeader2;
+                case PaletteContentStyle.HeaderCalendar:
+                    return _contentPaddingCalendar;
+                case PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl
+                    or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl
+                    or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel
+                    or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel
+                    or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2
+                    or PaletteContentStyle.LabelCustom3:
+                    return _contentPaddingLabel;
+                case PaletteContentStyle.LabelGroupBoxCaption:
+                    return _contentPaddingLabel2;
+                case PaletteContentStyle.ContextMenuItemTextStandard:
+                    return _contentPaddingContextMenuItemText;
+                case PaletteContentStyle.ContextMenuItemTextAlternate:
+                    return _contentPaddingContextMenuItemTextAlt;
+                case PaletteContentStyle.ContextMenuItemShortcutText:
+                    return _contentPaddingContextMenuItemShortcutText;
+                case PaletteContentStyle.ContextMenuItemImage:
+                    return _contentPaddingContextMenuImage;
+                case PaletteContentStyle.LabelToolTip:
+                    return _contentPaddingToolTip;
+                case PaletteContentStyle.LabelSuperTip:
+                    return _contentPaddingSuperTip;
+                case PaletteContentStyle.LabelKeyTip:
+                    return _contentPaddingKeyTip;
+                case PaletteContentStyle.ContextMenuHeading:
+                    return _contentPaddingContextMenuHeading;
+                case PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon
+                    or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2
+                    or PaletteContentStyle.InputControlCustom3:
+                    return InputControlPadding;
+                case PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand
+                    or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile
+                    or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini
+                    or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2
+                    or PaletteContentStyle.ButtonCustom3:
+                    return _contentPaddingButton12;
+                case PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay:
+                    return _contentPaddingButtonInputControl;
+                case PaletteContentStyle.ButtonButtonSpec:
+                    return _contentPaddingButton3;
+                case PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow:
+                    return _contentPaddingButton4;
+                case PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose:
+                    return _contentPaddingButtonForm;
+                case PaletteContentStyle.ButtonGallery:
+                    return _contentPaddingButtonGallery;
+                case PaletteContentStyle.ButtonListItem:
+                    return _contentPaddingButtonListItem;
+                case PaletteContentStyle.ButtonBreadCrumb:
+                    return _contentPaddingButton6;
+                case PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile
+                    or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote
+                    or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2
+                    or PaletteContentStyle.TabCustom3:
+                    return _contentPaddingButton5;
+                case PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden:
+                    return _contentPaddingButton7;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style));
+            }
         }
 
         /// <summary>
@@ -2843,13 +2898,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             switch (metric)
             {
@@ -2860,7 +2917,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricInt.CheckButtonGap:
                     return 5;
                 case PaletteMetricInt.HeaderButtonEdgeInsetForm:
-                    return 9; // Needs to be the RealWindowBorderWidth Offset - No idea how to get it at this point
+                    return Math.Max(2, owningForm!.RealWindowBorders.Right);
                 case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                     return 1;
                 case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:
@@ -2914,10 +2971,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -2931,7 +2990,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricPadding.BarPaddingOutside:
                     return _metricPaddingBarOutside;
                 case PaletteMetricPadding.HeaderButtonPaddingForm:
-                    return _metricPaddingHeaderForm;
+                    return new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);
                 case PaletteMetricPadding.RibbonButtonPadding:
                     return _metricPaddingRibbon;
                 case PaletteMetricPadding.RibbonAppButton:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2010/PaletteVisualStudio2010With2010Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2010/PaletteVisualStudio2010With2010Base.cs
@@ -22,7 +22,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
         private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
         private static readonly Padding _contentPaddingCalendar = new Padding(2);
-        private static readonly Padding _contentPaddingHeaderForm = new Padding(10, 6, 3, 0); // 10 is from the RealWindowFrameSize +1
+        //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
         private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
         private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
         private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -34,7 +34,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);
@@ -46,7 +46,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _metricPaddingRibbon = new Padding(0, 1, 1, 1);
         private static readonly Padding _metricPaddingRibbonAppButton = new Padding(3, 0, 3, 0);
         private static readonly Padding _metricPaddingHeader = new Padding(0, 3, 1, 3);
-        private static readonly Padding _metricPaddingHeaderForm = new Padding(0, 3, 0, -3); // Move the Maximised Form buttons down a bit
+        //private static readonly Padding _metricPaddingHeaderForm = new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);//, 3, 0, -3); // Move the Maximised Form buttons down a bit
         private static readonly Padding _metricPaddingInputControl = new Padding(0, 1, 0, 1);
         private static readonly Padding _metricPaddingBarInside = new Padding(3);
         private static readonly Padding _metricPaddingBarTabs = new Padding(0);
@@ -1141,7 +1141,7 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => PaletteDrawBorders.Top,
                 PaletteBorderStyle.ContextMenuItemImageColumn => PaletteDrawBorders.Right,
                 PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ContextMenuInner => PaletteDrawBorders.None,
-                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.TopLeftRight,
+                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.None,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -2776,10 +2776,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             // We do not provide override values
             if (CommonHelper.IsOverrideState(state))
@@ -2787,37 +2789,90 @@ namespace Krypton.Toolkit
                 return CommonHelper.InheritPadding;
             }
 
-            return style switch
+            switch (style)
             {
-                PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 => _contentPaddingGrid,
-                PaletteContentStyle.HeaderForm => _contentPaddingHeaderForm,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _contentPaddingHeader1,
-                PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive => _contentPaddingDock,
-                PaletteContentStyle.HeaderSecondary => _contentPaddingHeader2,
-                PaletteContentStyle.HeaderCalendar => _contentPaddingCalendar,
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 => _contentPaddingLabel,
-                PaletteContentStyle.LabelGroupBoxCaption => _contentPaddingLabel2,
-                PaletteContentStyle.ContextMenuItemTextStandard => _contentPaddingContextMenuItemText,
-                PaletteContentStyle.ContextMenuItemTextAlternate => _contentPaddingContextMenuItemTextAlt,
-                PaletteContentStyle.ContextMenuItemShortcutText => _contentPaddingContextMenuItemShortcutText,
-                PaletteContentStyle.ContextMenuItemImage => _contentPaddingContextMenuImage,
-                PaletteContentStyle.LabelToolTip => _contentPaddingToolTip,
-                PaletteContentStyle.LabelSuperTip => _contentPaddingSuperTip,
-                PaletteContentStyle.LabelKeyTip => _contentPaddingKeyTip,
-                PaletteContentStyle.ContextMenuHeading => _contentPaddingContextMenuHeading,
-                PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => InputControlPadding,
-                PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => _contentPaddingButton12,
-                PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay => _contentPaddingButtonInputControl,
-                PaletteContentStyle.ButtonButtonSpec => _contentPaddingButton3,
-                PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => _contentPaddingButton4,
-                PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => _contentPaddingButtonForm,
-                PaletteContentStyle.ButtonGallery => _contentPaddingButtonGallery,
-                PaletteContentStyle.ButtonListItem => _contentPaddingButtonListItem,
-                PaletteContentStyle.ButtonBreadCrumb => _contentPaddingButton6,
-                PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 => _contentPaddingButton5,
-                PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden => _contentPaddingButton7,
-                _ => throw new ArgumentOutOfRangeException(nameof(style))
-            };
+                case PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet
+                    or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2
+                    or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList
+                    or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1
+                    or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3
+                    or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet
+                    or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2
+                    or PaletteContentStyle.GridDataCellCustom3:
+                    return _contentPaddingGrid;
+                case PaletteContentStyle.HeaderForm:
+                {
+                    Padding borders = owningForm!.RealWindowBorders;
+                    return new Padding(borders.Left, borders.Bottom / 2, 0, 0);
+                }
+                case PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1
+                    or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3:
+                    return _contentPaddingHeader1;
+                case PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive:
+                    return _contentPaddingDock;
+                case PaletteContentStyle.HeaderSecondary:
+                    return _contentPaddingHeader2;
+                case PaletteContentStyle.HeaderCalendar:
+                    return _contentPaddingCalendar;
+                case PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl
+                    or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl
+                    or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel
+                    or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel
+                    or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2
+                    or PaletteContentStyle.LabelCustom3:
+                    return _contentPaddingLabel;
+                case PaletteContentStyle.LabelGroupBoxCaption:
+                    return _contentPaddingLabel2;
+                case PaletteContentStyle.ContextMenuItemTextStandard:
+                    return _contentPaddingContextMenuItemText;
+                case PaletteContentStyle.ContextMenuItemTextAlternate:
+                    return _contentPaddingContextMenuItemTextAlt;
+                case PaletteContentStyle.ContextMenuItemShortcutText:
+                    return _contentPaddingContextMenuItemShortcutText;
+                case PaletteContentStyle.ContextMenuItemImage:
+                    return _contentPaddingContextMenuImage;
+                case PaletteContentStyle.LabelToolTip:
+                    return _contentPaddingToolTip;
+                case PaletteContentStyle.LabelSuperTip:
+                    return _contentPaddingSuperTip;
+                case PaletteContentStyle.LabelKeyTip:
+                    return _contentPaddingKeyTip;
+                case PaletteContentStyle.ContextMenuHeading:
+                    return _contentPaddingContextMenuHeading;
+                case PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon
+                    or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2
+                    or PaletteContentStyle.InputControlCustom3:
+                    return InputControlPadding;
+                case PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand
+                    or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile
+                    or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini
+                    or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2
+                    or PaletteContentStyle.ButtonCustom3:
+                    return _contentPaddingButton12;
+                case PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay:
+                    return _contentPaddingButtonInputControl;
+                case PaletteContentStyle.ButtonButtonSpec:
+                    return _contentPaddingButton3;
+                case PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow:
+                    return _contentPaddingButton4;
+                case PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose:
+                    return _contentPaddingButtonForm;
+                case PaletteContentStyle.ButtonGallery:
+                    return _contentPaddingButtonGallery;
+                case PaletteContentStyle.ButtonListItem:
+                    return _contentPaddingButtonListItem;
+                case PaletteContentStyle.ButtonBreadCrumb:
+                    return _contentPaddingButton6;
+                case PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile
+                    or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote
+                    or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2
+                    or PaletteContentStyle.TabCustom3:
+                    return _contentPaddingButton5;
+                case PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden:
+                    return _contentPaddingButton7;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style));
+            }
         }
 
         /// <summary>
@@ -2844,13 +2899,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             switch (metric)
             {
@@ -2861,7 +2918,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricInt.CheckButtonGap:
                     return 5;
                 case PaletteMetricInt.HeaderButtonEdgeInsetForm:
-                    return 9; // Needs to be the RealWindowBorderWidth Offset - No idea how to get it at this point
+                    return Math.Max(2, owningForm!.RealWindowBorders.Right);
                 case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                     return 1;
                 case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:
@@ -2915,10 +2972,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -2932,7 +2991,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricPadding.BarPaddingOutside:
                     return _metricPaddingBarOutside;
                 case PaletteMetricPadding.HeaderButtonPaddingForm:
-                    return _metricPaddingHeaderForm;
+                    return new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);
                 case PaletteMetricPadding.RibbonButtonPadding:
                     return _metricPaddingRibbon;
                 case PaletteMetricPadding.RibbonAppButton:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2013/PaletteVisualStudio2010With2013Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2013/PaletteVisualStudio2010With2013Base.cs
@@ -22,7 +22,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
         private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
         private static readonly Padding _contentPaddingCalendar = new Padding(2);
-        private static readonly Padding _contentPaddingHeaderForm = new Padding(10, 6, 3, 0); // 10 is from the RealWindowFrameSize +1
+        //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
         private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
         private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
         private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -34,7 +34,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);
@@ -46,7 +46,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _metricPaddingRibbon = new Padding(0, 1, 1, 1);
         private static readonly Padding _metricPaddingRibbonAppButton = new Padding(3, 0, 3, 0);
         private static readonly Padding _metricPaddingHeader = new Padding(0, 3, 1, 3);
-        private static readonly Padding _metricPaddingHeaderForm = new Padding(0, 3, 0, -3); // Move the Maximised Form buttons down a bit
+        //private static readonly Padding _metricPaddingHeaderForm = new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);//, 3, 0, -3); // Move the Maximised Form buttons down a bit
         private static readonly Padding _metricPaddingInputControl = new Padding(0, 1, 0, 1);
         private static readonly Padding _metricPaddingBarInside = new Padding(3);
         private static readonly Padding _metricPaddingBarTabs = new Padding(0);
@@ -1138,7 +1138,7 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => PaletteDrawBorders.Top,
                 PaletteBorderStyle.ContextMenuItemImageColumn => PaletteDrawBorders.Right,
                 PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ContextMenuInner => PaletteDrawBorders.None,
-                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.TopLeftRight,
+                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.None,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -2773,10 +2773,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             // We do not provide override values
             if (CommonHelper.IsOverrideState(state))
@@ -2784,37 +2786,90 @@ namespace Krypton.Toolkit
                 return CommonHelper.InheritPadding;
             }
 
-            return style switch
+            switch (style)
             {
-                PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 => _contentPaddingGrid,
-                PaletteContentStyle.HeaderForm => _contentPaddingHeaderForm,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _contentPaddingHeader1,
-                PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive => _contentPaddingDock,
-                PaletteContentStyle.HeaderSecondary => _contentPaddingHeader2,
-                PaletteContentStyle.HeaderCalendar => _contentPaddingCalendar,
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 => _contentPaddingLabel,
-                PaletteContentStyle.LabelGroupBoxCaption => _contentPaddingLabel2,
-                PaletteContentStyle.ContextMenuItemTextStandard => _contentPaddingContextMenuItemText,
-                PaletteContentStyle.ContextMenuItemTextAlternate => _contentPaddingContextMenuItemTextAlt,
-                PaletteContentStyle.ContextMenuItemShortcutText => _contentPaddingContextMenuItemShortcutText,
-                PaletteContentStyle.ContextMenuItemImage => _contentPaddingContextMenuImage,
-                PaletteContentStyle.LabelToolTip => _contentPaddingToolTip,
-                PaletteContentStyle.LabelSuperTip => _contentPaddingSuperTip,
-                PaletteContentStyle.LabelKeyTip => _contentPaddingKeyTip,
-                PaletteContentStyle.ContextMenuHeading => _contentPaddingContextMenuHeading,
-                PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => InputControlPadding,
-                PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => _contentPaddingButton12,
-                PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay => _contentPaddingButtonInputControl,
-                PaletteContentStyle.ButtonButtonSpec => _contentPaddingButton3,
-                PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => _contentPaddingButton4,
-                PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => _contentPaddingButtonForm,
-                PaletteContentStyle.ButtonGallery => _contentPaddingButtonGallery,
-                PaletteContentStyle.ButtonListItem => _contentPaddingButtonListItem,
-                PaletteContentStyle.ButtonBreadCrumb => _contentPaddingButton6,
-                PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 => _contentPaddingButton5,
-                PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden => _contentPaddingButton7,
-                _ => throw new ArgumentOutOfRangeException(nameof(style))
-            };
+                case PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet
+                    or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2
+                    or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList
+                    or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1
+                    or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3
+                    or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet
+                    or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2
+                    or PaletteContentStyle.GridDataCellCustom3:
+                    return _contentPaddingGrid;
+                case PaletteContentStyle.HeaderForm:
+                    {
+                        Padding borders = owningForm!.RealWindowBorders;
+                        return new Padding(borders.Left, borders.Bottom / 2, 0, 0);
+                    }
+                case PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1
+                    or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3:
+                    return _contentPaddingHeader1;
+                case PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive:
+                    return _contentPaddingDock;
+                case PaletteContentStyle.HeaderSecondary:
+                    return _contentPaddingHeader2;
+                case PaletteContentStyle.HeaderCalendar:
+                    return _contentPaddingCalendar;
+                case PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl
+                    or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl
+                    or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel
+                    or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel
+                    or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2
+                    or PaletteContentStyle.LabelCustom3:
+                    return _contentPaddingLabel;
+                case PaletteContentStyle.LabelGroupBoxCaption:
+                    return _contentPaddingLabel2;
+                case PaletteContentStyle.ContextMenuItemTextStandard:
+                    return _contentPaddingContextMenuItemText;
+                case PaletteContentStyle.ContextMenuItemTextAlternate:
+                    return _contentPaddingContextMenuItemTextAlt;
+                case PaletteContentStyle.ContextMenuItemShortcutText:
+                    return _contentPaddingContextMenuItemShortcutText;
+                case PaletteContentStyle.ContextMenuItemImage:
+                    return _contentPaddingContextMenuImage;
+                case PaletteContentStyle.LabelToolTip:
+                    return _contentPaddingToolTip;
+                case PaletteContentStyle.LabelSuperTip:
+                    return _contentPaddingSuperTip;
+                case PaletteContentStyle.LabelKeyTip:
+                    return _contentPaddingKeyTip;
+                case PaletteContentStyle.ContextMenuHeading:
+                    return _contentPaddingContextMenuHeading;
+                case PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon
+                    or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2
+                    or PaletteContentStyle.InputControlCustom3:
+                    return InputControlPadding;
+                case PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand
+                    or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile
+                    or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini
+                    or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2
+                    or PaletteContentStyle.ButtonCustom3:
+                    return _contentPaddingButton12;
+                case PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay:
+                    return _contentPaddingButtonInputControl;
+                case PaletteContentStyle.ButtonButtonSpec:
+                    return _contentPaddingButton3;
+                case PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow:
+                    return _contentPaddingButton4;
+                case PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose:
+                    return _contentPaddingButtonForm;
+                case PaletteContentStyle.ButtonGallery:
+                    return _contentPaddingButtonGallery;
+                case PaletteContentStyle.ButtonListItem:
+                    return _contentPaddingButtonListItem;
+                case PaletteContentStyle.ButtonBreadCrumb:
+                    return _contentPaddingButton6;
+                case PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile
+                    or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote
+                    or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2
+                    or PaletteContentStyle.TabCustom3:
+                    return _contentPaddingButton5;
+                case PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden:
+                    return _contentPaddingButton7;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style));
+            }
         }
 
         /// <summary>
@@ -2841,13 +2896,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             switch (metric)
             {
@@ -2858,7 +2915,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricInt.CheckButtonGap:
                     return 5;
                 case PaletteMetricInt.HeaderButtonEdgeInsetForm:
-                    return 9; // Needs to be the RealWindowBorderWidth Offset - No idea how to get it at this point
+                    return Math.Max(2, owningForm!.RealWindowBorders.Right);
                 case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                     return 1;
                 case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:
@@ -2912,10 +2969,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -2929,7 +2988,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricPadding.BarPaddingOutside:
                     return _metricPaddingBarOutside;
                 case PaletteMetricPadding.HeaderButtonPaddingForm:
-                    return _metricPaddingHeaderForm;
+                    return new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);
                 case PaletteMetricPadding.RibbonButtonPadding:
                     return _metricPaddingRibbon;
                 case PaletteMetricPadding.RibbonAppButton:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/365/PaletteVisualStudio2010With365Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/365/PaletteVisualStudio2010With365Base.cs
@@ -22,7 +22,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
         private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
         private static readonly Padding _contentPaddingCalendar = new Padding(2);
-        private static readonly Padding _contentPaddingHeaderForm = new Padding(10, 6, 3, 0); // 10 is from the RealWindowFrameSize +1
+        //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
         private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
         private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
         private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -34,7 +34,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _contentPaddingButton7 = new Padding(1, 1, 0, 1);
         private static readonly Padding _contentPaddingButtonForm = new Padding(0);
         private static readonly Padding _contentPaddingButtonGallery = new Padding(1, 0, 1, 0);
-        private static readonly Padding _contentPaddingButtonListItem = new Padding(0, -1, 0, -1);
+        private static readonly Padding _contentPaddingButtonListItem = new Padding(0);
         private static readonly Padding _contentPaddingToolTip = new Padding(2);
         private static readonly Padding _contentPaddingSuperTip = new Padding(4);
         private static readonly Padding _contentPaddingKeyTip = new Padding(0, -1, 0, -3);
@@ -46,7 +46,7 @@ namespace Krypton.Toolkit
         private static readonly Padding _metricPaddingRibbon = new Padding(0, 1, 1, 1);
         private static readonly Padding _metricPaddingRibbonAppButton = new Padding(3, 0, 3, 0);
         private static readonly Padding _metricPaddingHeader = new Padding(0, 3, 1, 3);
-        private static readonly Padding _metricPaddingHeaderForm = new Padding(0, 3, 0, -3); // Move the Maximised Form buttons down a bit
+        //private static readonly Padding _metricPaddingHeaderForm = new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);//, 3, 0, -3); // Move the Maximised Form buttons down a bit
         private static readonly Padding _metricPaddingInputControl = new Padding(0, 1, 0, 1);
         private static readonly Padding _metricPaddingBarInside = new Padding(3);
         private static readonly Padding _metricPaddingBarTabs = new Padding(0);
@@ -1140,7 +1140,7 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => PaletteDrawBorders.Top,
                 PaletteBorderStyle.ContextMenuItemImageColumn => PaletteDrawBorders.Right,
                 PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ContextMenuInner => PaletteDrawBorders.None,
-                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.TopLeftRight,
+                PaletteBorderStyle.HeaderForm => PaletteDrawBorders.None,
                 _ => throw new ArgumentOutOfRangeException(nameof(style))
             };
         }
@@ -2775,10 +2775,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             // We do not provide override values
             if (CommonHelper.IsOverrideState(state))
@@ -2786,37 +2788,90 @@ namespace Krypton.Toolkit
                 return CommonHelper.InheritPadding;
             }
 
-            return style switch
+            switch (style)
             {
-                PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2 or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1 or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3 or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2 or PaletteContentStyle.GridDataCellCustom3 => _contentPaddingGrid,
-                PaletteContentStyle.HeaderForm => _contentPaddingHeaderForm,
-                PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1 or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3 => _contentPaddingHeader1,
-                PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive => _contentPaddingDock,
-                PaletteContentStyle.HeaderSecondary => _contentPaddingHeader2,
-                PaletteContentStyle.HeaderCalendar => _contentPaddingCalendar,
-                PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2 or PaletteContentStyle.LabelCustom3 => _contentPaddingLabel,
-                PaletteContentStyle.LabelGroupBoxCaption => _contentPaddingLabel2,
-                PaletteContentStyle.ContextMenuItemTextStandard => _contentPaddingContextMenuItemText,
-                PaletteContentStyle.ContextMenuItemTextAlternate => _contentPaddingContextMenuItemTextAlt,
-                PaletteContentStyle.ContextMenuItemShortcutText => _contentPaddingContextMenuItemShortcutText,
-                PaletteContentStyle.ContextMenuItemImage => _contentPaddingContextMenuImage,
-                PaletteContentStyle.LabelToolTip => _contentPaddingToolTip,
-                PaletteContentStyle.LabelSuperTip => _contentPaddingSuperTip,
-                PaletteContentStyle.LabelKeyTip => _contentPaddingKeyTip,
-                PaletteContentStyle.ContextMenuHeading => _contentPaddingContextMenuHeading,
-                PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2 or PaletteContentStyle.InputControlCustom3 => InputControlPadding,
-                PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2 or PaletteContentStyle.ButtonCustom3 => _contentPaddingButton12,
-                PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay => _contentPaddingButtonInputControl,
-                PaletteContentStyle.ButtonButtonSpec => _contentPaddingButton3,
-                PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow => _contentPaddingButton4,
-                PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose => _contentPaddingButtonForm,
-                PaletteContentStyle.ButtonGallery => _contentPaddingButtonGallery,
-                PaletteContentStyle.ButtonListItem => _contentPaddingButtonListItem,
-                PaletteContentStyle.ButtonBreadCrumb => _contentPaddingButton6,
-                PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2 or PaletteContentStyle.TabCustom3 => _contentPaddingButton5,
-                PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden => _contentPaddingButton7,
-                _ => throw new ArgumentOutOfRangeException(nameof(style))
-            };
+                case PaletteContentStyle.GridHeaderColumnList or PaletteContentStyle.GridHeaderColumnSheet
+                    or PaletteContentStyle.GridHeaderColumnCustom1 or PaletteContentStyle.GridHeaderColumnCustom2
+                    or PaletteContentStyle.GridHeaderColumnCustom3 or PaletteContentStyle.GridHeaderRowList
+                    or PaletteContentStyle.GridHeaderRowSheet or PaletteContentStyle.GridHeaderRowCustom1
+                    or PaletteContentStyle.GridHeaderRowCustom2 or PaletteContentStyle.GridHeaderRowCustom3
+                    or PaletteContentStyle.GridDataCellList or PaletteContentStyle.GridDataCellSheet
+                    or PaletteContentStyle.GridDataCellCustom1 or PaletteContentStyle.GridDataCellCustom2
+                    or PaletteContentStyle.GridDataCellCustom3:
+                    return _contentPaddingGrid;
+                case PaletteContentStyle.HeaderForm:
+                    {
+                        Padding borders = owningForm!.RealWindowBorders;
+                        return new Padding(borders.Left, borders.Bottom / 2, 0, 0);
+                    }
+                case PaletteContentStyle.HeaderPrimary or PaletteContentStyle.HeaderCustom1
+                    or PaletteContentStyle.HeaderCustom2 or PaletteContentStyle.HeaderCustom3:
+                    return _contentPaddingHeader1;
+                case PaletteContentStyle.HeaderDockInactive or PaletteContentStyle.HeaderDockActive:
+                    return _contentPaddingDock;
+                case PaletteContentStyle.HeaderSecondary:
+                    return _contentPaddingHeader2;
+                case PaletteContentStyle.HeaderCalendar:
+                    return _contentPaddingCalendar;
+                case PaletteContentStyle.LabelNormalControl or PaletteContentStyle.LabelBoldControl
+                    or PaletteContentStyle.LabelItalicControl or PaletteContentStyle.LabelTitleControl
+                    or PaletteContentStyle.LabelNormalPanel or PaletteContentStyle.LabelBoldPanel
+                    or PaletteContentStyle.LabelItalicPanel or PaletteContentStyle.LabelTitlePanel
+                    or PaletteContentStyle.LabelCustom1 or PaletteContentStyle.LabelCustom2
+                    or PaletteContentStyle.LabelCustom3:
+                    return _contentPaddingLabel;
+                case PaletteContentStyle.LabelGroupBoxCaption:
+                    return _contentPaddingLabel2;
+                case PaletteContentStyle.ContextMenuItemTextStandard:
+                    return _contentPaddingContextMenuItemText;
+                case PaletteContentStyle.ContextMenuItemTextAlternate:
+                    return _contentPaddingContextMenuItemTextAlt;
+                case PaletteContentStyle.ContextMenuItemShortcutText:
+                    return _contentPaddingContextMenuItemShortcutText;
+                case PaletteContentStyle.ContextMenuItemImage:
+                    return _contentPaddingContextMenuImage;
+                case PaletteContentStyle.LabelToolTip:
+                    return _contentPaddingToolTip;
+                case PaletteContentStyle.LabelSuperTip:
+                    return _contentPaddingSuperTip;
+                case PaletteContentStyle.LabelKeyTip:
+                    return _contentPaddingKeyTip;
+                case PaletteContentStyle.ContextMenuHeading:
+                    return _contentPaddingContextMenuHeading;
+                case PaletteContentStyle.InputControlStandalone or PaletteContentStyle.InputControlRibbon
+                    or PaletteContentStyle.InputControlCustom1 or PaletteContentStyle.InputControlCustom2
+                    or PaletteContentStyle.InputControlCustom3:
+                    return InputControlPadding;
+                case PaletteContentStyle.ButtonStandalone or PaletteContentStyle.ButtonCommand
+                    or PaletteContentStyle.ButtonAlternate or PaletteContentStyle.ButtonLowProfile
+                    or PaletteContentStyle.ButtonCluster or PaletteContentStyle.ButtonNavigatorMini
+                    or PaletteContentStyle.ButtonCustom1 or PaletteContentStyle.ButtonCustom2
+                    or PaletteContentStyle.ButtonCustom3:
+                    return _contentPaddingButton12;
+                case PaletteContentStyle.ButtonInputControl or PaletteContentStyle.ButtonCalendarDay:
+                    return _contentPaddingButtonInputControl;
+                case PaletteContentStyle.ButtonButtonSpec:
+                    return _contentPaddingButton3;
+                case PaletteContentStyle.ButtonNavigatorStack or PaletteContentStyle.ButtonNavigatorOverflow:
+                    return _contentPaddingButton4;
+                case PaletteContentStyle.ButtonForm or PaletteContentStyle.ButtonFormClose:
+                    return _contentPaddingButtonForm;
+                case PaletteContentStyle.ButtonGallery:
+                    return _contentPaddingButtonGallery;
+                case PaletteContentStyle.ButtonListItem:
+                    return _contentPaddingButtonListItem;
+                case PaletteContentStyle.ButtonBreadCrumb:
+                    return _contentPaddingButton6;
+                case PaletteContentStyle.TabHighProfile or PaletteContentStyle.TabStandardProfile
+                    or PaletteContentStyle.TabLowProfile or PaletteContentStyle.TabOneNote
+                    or PaletteContentStyle.TabCustom1 or PaletteContentStyle.TabCustom2
+                    or PaletteContentStyle.TabCustom3:
+                    return _contentPaddingButton5;
+                case PaletteContentStyle.TabDock or PaletteContentStyle.TabDockAutoHidden:
+                    return _contentPaddingButton7;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(style));
+            }
         }
 
         /// <summary>
@@ -2843,13 +2898,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             switch (metric)
             {
@@ -2860,7 +2917,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricInt.CheckButtonGap:
                     return 5;
                 case PaletteMetricInt.HeaderButtonEdgeInsetForm:
-                    return 9; // Needs to be the RealWindowBorderWidth Offset - No idea how to get it at this point
+                    return Math.Max(2, owningForm!.RealWindowBorders.Right);
                 case PaletteMetricInt.HeaderButtonEdgeInsetInputControl:
                     return 1;
                 case PaletteMetricInt.HeaderButtonEdgeInsetPrimary:
@@ -2914,10 +2971,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -2931,7 +2990,7 @@ namespace Krypton.Toolkit
                 case PaletteMetricPadding.BarPaddingOutside:
                     return _metricPaddingBarOutside;
                 case PaletteMetricPadding.HeaderButtonPaddingForm:
-                    return _metricPaddingHeaderForm;
+                    return new Padding(0, owningForm!.RealWindowBorders.Right, 0, 0);
                 case PaletteMetricPadding.RibbonButtonPadding:
                     return _metricPaddingRibbon;
                 case PaletteMetricPadding.RibbonAppButton:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Official Themes/2010/Variations/2007/PaletteVisualStudio2010Office2007Variation.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Official Themes/2010/Variations/2007/PaletteVisualStudio2010Office2007Variation.cs
@@ -320,7 +320,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.Gallery2010);
             _radioButtonArray =

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Official Themes/2010/Variations/2010/PaletteVisualStudio2010Office2010Variation.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Official Themes/2010/Variations/2010/PaletteVisualStudio2010Office2010Variation.cs
@@ -334,7 +334,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.Gallery2010);
             _radioButtonArray =

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Official Themes/2010/Variations/2013/PaletteVisualStudio2010Office2013Variation.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Official Themes/2010/Variations/2013/PaletteVisualStudio2010Office2013Variation.cs
@@ -326,7 +326,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.Gallery2010);
             _radioButtonArray =

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Official Themes/2010/Variations/365/PaletteVisualStudio2010Microsoft365Variation.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Official Themes/2010/Variations/365/PaletteVisualStudio2010Microsoft365Variation.cs
@@ -326,7 +326,7 @@ namespace Krypton.Toolkit
             {
                 ImageSize = new Size(13, 7),
                 ColorDepth = ColorDepth.Depth24Bit,
-                TransparentColor = Color.Magenta
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             };
             _galleryButtonList.Images.AddStrip(GalleryImageResources.Gallery2010);
             _radioButtonArray =

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteHeaderGroupState.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteHeaderGroupState.cs
@@ -73,10 +73,10 @@ namespace Krypton.Toolkit
         /// </summary>
         public void PopulateFromBase()
         {
-            PrimaryHeaderPadding = _redirect!.GetMetricPadding(PaletteState.Normal, PaletteMetricPadding.HeaderGroupPaddingPrimary);
-            SecondaryHeaderPadding = _redirect!.GetMetricPadding(PaletteState.Normal, PaletteMetricPadding.HeaderGroupPaddingSecondary);
-            DockInactiveHeaderPadding = _redirect!.GetMetricPadding(PaletteState.Normal, PaletteMetricPadding.HeaderGroupPaddingDockInactive);
-            DockActiveHeaderPadding = _redirect!.GetMetricPadding(PaletteState.Normal, PaletteMetricPadding.HeaderGroupPaddingDockActive);
+            PrimaryHeaderPadding = _redirect!.GetMetricPadding(null, PaletteState.Normal, PaletteMetricPadding.HeaderGroupPaddingPrimary);
+            SecondaryHeaderPadding = _redirect!.GetMetricPadding(null, PaletteState.Normal, PaletteMetricPadding.HeaderGroupPaddingSecondary);
+            DockInactiveHeaderPadding = _redirect!.GetMetricPadding(null, PaletteState.Normal, PaletteMetricPadding.HeaderGroupPaddingDockInactive);
+            DockActiveHeaderPadding = _redirect!.GetMetricPadding(null, PaletteState.Normal, PaletteMetricPadding.HeaderGroupPaddingDockActive);
             OverlayHeaders = _redirect!.GetMetricBool(PaletteState.Normal, PaletteMetricBool.HeaderGroupOverlay);
         }
         #endregion
@@ -227,15 +227,17 @@ namespace Krypton.Toolkit
         #endregion
 
         #region IPaletteMetric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public virtual int GetMetricInt(PaletteState state, PaletteMetricInt metric) =>
+        public virtual int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric) =>
             // Always pass onto the inheritance
-            _redirect!.GetMetricInt(state, metric);
+            _redirect!.GetMetricInt(owningForm, state, metric);
 
         /// <summary>
         /// Gets a boolean metric value.
@@ -262,10 +264,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public virtual Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public virtual Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -300,7 +304,7 @@ namespace Krypton.Toolkit
             }
 
             // Pass onto the inheritance
-            return _redirect!.GetMetricPadding(state, metric);
+            return _redirect!.GetMetricPadding(owningForm, state, metric);
         }
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteNavigatorStateBar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteNavigatorStateBar.cs
@@ -85,14 +85,14 @@ namespace Krypton.Toolkit
         /// </summary>
         public void PopulateFromBase()
         {
-            BarPaddingInside = _redirect!.GetMetricPadding(PaletteState.Normal, PaletteMetricPadding.BarPaddingInside);
-            BarPaddingOutside = _redirect.GetMetricPadding(PaletteState.Normal, PaletteMetricPadding.BarPaddingOutside);
-            BarPaddingOnly = _redirect.GetMetricPadding(PaletteState.Normal, PaletteMetricPadding.BarPaddingOnly);
-            ButtonPadding = _redirect.GetMetricPadding(PaletteState.Normal, PaletteMetricPadding.BarButtonPadding);
-            ButtonEdgeInside = _redirect.GetMetricInt(PaletteState.Normal, PaletteMetricInt.BarButtonEdgeInside);
-            ButtonEdgeOutside = _redirect.GetMetricInt(PaletteState.Normal, PaletteMetricInt.BarButtonEdgeOutside);
-            CheckButtonGap = _redirect.GetMetricInt(PaletteState.Normal, PaletteMetricInt.CheckButtonGap);
-            RibbonTabGap = _redirect.GetMetricInt(PaletteState.Normal, PaletteMetricInt.RibbonTabGap);
+            BarPaddingInside = _redirect!.GetMetricPadding(null, PaletteState.Normal, PaletteMetricPadding.BarPaddingInside);
+            BarPaddingOutside = _redirect.GetMetricPadding(null, PaletteState.Normal, PaletteMetricPadding.BarPaddingOutside);
+            BarPaddingOnly = _redirect.GetMetricPadding(null, PaletteState.Normal, PaletteMetricPadding.BarPaddingOnly);
+            ButtonPadding = _redirect.GetMetricPadding(null, PaletteState.Normal, PaletteMetricPadding.BarButtonPadding);
+            ButtonEdgeInside = _redirect.GetMetricInt(null, PaletteState.Normal, PaletteMetricInt.BarButtonEdgeInside);
+            ButtonEdgeOutside = _redirect.GetMetricInt(null, PaletteState.Normal, PaletteMetricInt.BarButtonEdgeOutside);
+            CheckButtonGap = _redirect.GetMetricInt(null, PaletteState.Normal, PaletteMetricInt.CheckButtonGap);
+            RibbonTabGap = _redirect.GetMetricInt(null, PaletteState.Normal, PaletteMetricInt.RibbonTabGap);
         }
         #endregion
 
@@ -358,13 +358,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region IPaletteMetric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public virtual int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public virtual int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
             switch (metric)
             {
@@ -399,7 +401,7 @@ namespace Krypton.Toolkit
             }
 
             // Always pass onto the inheritance
-            return _redirect!.GetMetricInt(state, metric);
+            return _redirect!.GetMetricInt(owningForm, state, metric);
         }
 
         /// <summary>
@@ -415,10 +417,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public virtual Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public virtual Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             switch (metric)
             {
@@ -460,7 +464,7 @@ namespace Krypton.Toolkit
             }
 
             // Pass onto the inheritance
-            return _redirect!.GetMetricPadding(state, metric);
+            return _redirect!.GetMetricPadding(owningForm, state, metric);
         }
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/LinkLabelBehaviorInherit.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/LinkLabelBehaviorInherit.cs
@@ -357,9 +357,10 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteState state) => _inherit.GetContentPadding(state);
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteState state) => _inherit.GetBorderContentPadding(owningForm, state);
 
         /// <summary>
         /// Gets the padding between adjacent content items.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteContentInheritNode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteContentInheritNode.cs
@@ -341,9 +341,10 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteState state) => _inherit.GetContentPadding(state);
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteState state) => _inherit.GetBorderContentPadding(owningForm, state);
 
         /// <summary>
         /// Gets the padding between adjacent content items.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteCueHintText.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteCueHintText.cs
@@ -156,7 +156,7 @@ namespace Krypton.Toolkit
             // Draw entire client area in the background color
             g?.FillRectangle(backBrush, layoutRectangle);
 
-            var padding = GetContentPadding(PaletteState.Normal);
+            var padding = GetBorderContentPadding(null, PaletteState.Normal);
             if (!padding.Equals(CommonHelper.InheritPadding))
             {
                 layoutRectangle.X += padding.Left;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteDataGridViewContentCommon.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteDataGridViewContentCommon.cs
@@ -66,7 +66,7 @@ namespace Krypton.Toolkit
             Font = GetContentShortTextFont(state);
             TextH = GetContentShortTextH(state);
             TextV = GetContentShortTextV(state);
-            Padding = GetContentPadding(state);
+            Padding = GetBorderContentPadding(null, state);
         }
         #endregion
 
@@ -201,12 +201,13 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the actual padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteState state)
         {
             // Initialize the padding from inherited values
-            Padding paddingInherit = Inherit.GetContentPadding(state);
+            Padding paddingInherit = Inherit.GetBorderContentPadding(owningForm, state);
             Padding paddingThis = Padding;
 
             // Override with specified values

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteDataGridViewContentInherit.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteDataGridViewContentInherit.cs
@@ -359,9 +359,10 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteState state) => _cellStyle!.Padding;
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteState state) => _cellStyle!.Padding;
 
         /// <summary>
         /// Gets the padding between adjacent content items.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteDataGridViewContentStates.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteDataGridViewContentStates.cs
@@ -764,12 +764,14 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Padding
+
         /// <summary>
         /// Gets the actual padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public virtual Padding GetContentPadding(PaletteState state) => Inherit.GetContentPadding(state);
+        public virtual Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteState state) => Inherit.GetBorderContentPadding(owningForm, state);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteForm.cs
@@ -83,15 +83,17 @@ namespace Krypton.Toolkit
         #endregion
 
         #region IPaletteMetric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public int GetMetricInt(PaletteState state, PaletteMetricInt metric) =>
+        public int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric) =>
             // Pass onto the inheritance
-            _inherit.GetMetricInt(state, metric);
+            _inherit.GetMetricInt(owningForm, state, metric);
 
         /// <summary>
         /// Gets a boolean metric value.
@@ -106,12 +108,13 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric) =>
+        public Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state, PaletteMetricPadding metric) =>
             // Always pass onto the inheritance
-            _inherit.GetMetricPadding(state, metric);
+            _inherit.GetMetricPadding(owningForm, state, metric);
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteFormRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteFormRedirect.cs
@@ -20,19 +20,20 @@ namespace Krypton.Toolkit
     {
         #region Instance Fields
         private readonly PaletteRedirect _redirect;
-        private InheritBool _overlayHeaders;
-
         #endregion
 
         #region Identity
+
         /// <summary>
         /// Initialize a new instance of the PaletteFormRedirect class.
         /// </summary>
         /// <param name="redirect">inheritance redirection instance.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
+        /// <param name="ownerForm"></param>
         public PaletteFormRedirect(PaletteRedirect redirect,
-                                   NeedPaintHandler needPaint)
-            : this(redirect, redirect, needPaint)
+                                   NeedPaintHandler needPaint,
+                                   VisualForm ownerForm)
+            : this(redirect, redirect, needPaint, ownerForm)
         {
         }
 
@@ -42,13 +43,16 @@ namespace Krypton.Toolkit
         /// <param name="redirectForm">inheritance redirection for form group.</param>
         /// <param name="redirectHeader">inheritance redirection for header.</param>
         /// <param name="needPaint">Delegate for notifying paint requests.</param>
+        /// <param name="ownerForm"></param>
         public PaletteFormRedirect([DisallowNull] PaletteRedirect redirectForm,
                                    [DisallowNull] PaletteRedirect redirectHeader,
-                                   NeedPaintHandler needPaint)
+                                   NeedPaintHandler needPaint,
+                                   VisualForm ownerForm)
             : base(redirectForm, 
                    PaletteBackStyle.FormMain,
                    PaletteBorderStyle.FormMain, 
-                   needPaint)
+                   needPaint,
+                   ownerForm)
         {
             Debug.Assert(redirectForm != null);
             Debug.Assert(redirectHeader != null);
@@ -60,7 +64,7 @@ namespace Krypton.Toolkit
             Header = new PaletteHeaderButtonRedirect(redirectHeader!, PaletteBackStyle.HeaderForm, PaletteBorderStyle.HeaderForm, PaletteContentStyle.HeaderForm, needPaint);
 
             // Default other values
-            _overlayHeaders = InheritBool.Inherit;
+            OverlayHeaders = InheritBool.Inherit;
         }
         #endregion
 
@@ -90,6 +94,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region OverlayHeaders
+
         /// <summary>
         /// Gets and sets a value indicating if headers should overlay the border.
         /// </summary>
@@ -99,29 +104,32 @@ namespace Krypton.Toolkit
         [RefreshProperties(RefreshProperties.All)]
         public InheritBool OverlayHeaders
         {
-            get => _overlayHeaders;
+            get;
 
             set
             {
-                if (_overlayHeaders != value)
+                if (field != value)
                 {
-                    _overlayHeaders = value;
+                    field = value;
                     PerformNeedPaint();
                 }
             }
         }
+
         #endregion
 
         #region IPaletteMetric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public int GetMetricInt(PaletteState state, PaletteMetricInt metric) =>
+        public int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric) =>
             // Pass onto the inheritance
-            _redirect.GetMetricInt(state, metric);
+            _redirect.GetMetricInt(owningForm, state, metric);
 
         /// <summary>
         /// Gets a boolean metric value.
@@ -148,12 +156,13 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric) =>
+        public Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state, PaletteMetricPadding metric) =>
             // Always pass onto the inheritance
-            _redirect.GetMetricPadding(state, metric);
+            _redirect.GetMetricPadding(owningForm, state, metric);
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteHeaderButtonRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteHeaderButtonRedirect.cs
@@ -119,35 +119,30 @@ namespace Krypton.Toolkit
         #endregion
 
         #region IPaletteMetric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
-            // Is this the metric we provide?
-            if (metric is PaletteMetricInt.HeaderButtonEdgeInsetPrimary 
-                or PaletteMetricInt.HeaderButtonEdgeInsetSecondary 
-                or PaletteMetricInt.HeaderButtonEdgeInsetDockInactive 
-                or PaletteMetricInt.HeaderButtonEdgeInsetDockActive 
-                or PaletteMetricInt.HeaderButtonEdgeInsetForm 
-                or PaletteMetricInt.HeaderButtonEdgeInsetInputControl
-                or PaletteMetricInt.HeaderButtonEdgeInsetCustom1
-                or PaletteMetricInt.HeaderButtonEdgeInsetCustom2
-                or PaletteMetricInt.HeaderButtonEdgeInsetCustom3
-                )
+            return metric switch
             {
+                // Is this the metric we provide?
                 // If the user has defined an actual value to use
-                if (ButtonEdgeInset != -1)
-                {
-                    return ButtonEdgeInset;
-                }
-            }
+                PaletteMetricInt.HeaderButtonEdgeInsetPrimary or PaletteMetricInt.HeaderButtonEdgeInsetSecondary
+                    or PaletteMetricInt.HeaderButtonEdgeInsetDockInactive
+                    or PaletteMetricInt.HeaderButtonEdgeInsetDockActive or PaletteMetricInt.HeaderButtonEdgeInsetForm
+                    or PaletteMetricInt.HeaderButtonEdgeInsetInputControl
+                    or PaletteMetricInt.HeaderButtonEdgeInsetCustom1 or PaletteMetricInt.HeaderButtonEdgeInsetCustom2
+                    or PaletteMetricInt.HeaderButtonEdgeInsetCustom3 when ButtonEdgeInset != -1 => ButtonEdgeInset,
+                _ => _redirect.GetMetricInt(owningForm, state, metric)
+            };
 
             // Pass onto the inheritance
-            return _redirect.GetMetricInt(state, metric);
         }
 
         /// <summary>
@@ -163,17 +158,19 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             // Is this the metric we provide?
             if (metric is PaletteMetricPadding.HeaderButtonPaddingPrimary
                 or PaletteMetricPadding.HeaderButtonPaddingSecondary
                 or PaletteMetricPadding.HeaderButtonPaddingDockInactive
                 or PaletteMetricPadding.HeaderButtonPaddingDockActive 
-                or PaletteMetricPadding.HeaderButtonPaddingForm
+                //or PaletteMetricPadding.HeaderButtonPaddingForm
                 or PaletteMetricPadding.HeaderButtonPaddingInputControl
                 or PaletteMetricPadding.HeaderButtonPaddingCustom1
                 or PaletteMetricPadding.HeaderButtonPaddingCustom2
@@ -188,7 +185,7 @@ namespace Krypton.Toolkit
             }
 
             // Pass onto the inheritance
-            return _redirect.GetMetricPadding(state, metric);
+            return _redirect.GetMetricPadding(owningForm, state, metric);
         }
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteHeaderGroup.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteHeaderGroup.cs
@@ -103,15 +103,17 @@ namespace Krypton.Toolkit
         #endregion
 
         #region IPaletteMetric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public int GetMetricInt(PaletteState state, PaletteMetricInt metric) =>
+        public int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric) =>
             // Pass onto the inheritance
-            _inherit.GetMetricInt(state, metric);
+            _inherit.GetMetricInt(owningForm, state, metric);
 
         /// <summary>
         /// Gets a boolean metric value.
@@ -126,12 +128,13 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric) =>
+        public Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state, PaletteMetricPadding metric) =>
             // Always pass onto the inheritance
-            _inherit.GetMetricPadding(state, metric);
+            _inherit.GetMetricPadding(owningForm, state, metric);
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteHeaderGroupRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteHeaderGroupRedirect.cs
@@ -129,15 +129,17 @@ namespace Krypton.Toolkit
         #endregion
 
         #region IPaletteMetric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public int GetMetricInt(PaletteState state, PaletteMetricInt metric) =>
+        public int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric) =>
             // Pass onto the inheritance
-            _redirect!.GetMetricInt(state, metric);
+            _redirect!.GetMetricInt(owningForm, state, metric);
 
         /// <summary>
         /// Gets a boolean metric value.
@@ -161,12 +163,13 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric) =>
+        public Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state, PaletteMetricPadding metric) =>
             // Always pass onto the inheritance
-            _redirect!.GetMetricPadding(state, metric);
+            _redirect!.GetMetricPadding(owningForm, state, metric);
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteHeaderPaddingRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteHeaderPaddingRedirect.cs
@@ -88,13 +88,16 @@ namespace Krypton.Toolkit
         #endregion
 
         #region IPaletteMetric
+
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             // Is this the metric we provide?
             if (metric is PaletteMetricPadding.HeaderGroupPaddingPrimary or PaletteMetricPadding.HeaderGroupPaddingSecondary or PaletteMetricPadding.HeaderGroupPaddingDockInactive or PaletteMetricPadding.HeaderGroupPaddingDockActive)
@@ -107,7 +110,7 @@ namespace Krypton.Toolkit
             }
 
             // Let base class perform its own testing
-            return base.GetMetricPadding(state, metric);
+            return base.GetMetricPadding(owningForm, state, metric);
         }
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteHeaderRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteHeaderRedirect.cs
@@ -135,27 +135,30 @@ namespace Krypton.Toolkit
         #endregion
 
         #region IPaletteMetric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric)
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric)
         {
-            // Is this the metric we provide?
-            if (metric is PaletteMetricInt.HeaderButtonEdgeInsetPrimary or PaletteMetricInt.HeaderButtonEdgeInsetSecondary or PaletteMetricInt.HeaderButtonEdgeInsetDockInactive or PaletteMetricInt.HeaderButtonEdgeInsetDockActive or PaletteMetricInt.HeaderButtonEdgeInsetForm or PaletteMetricInt.HeaderButtonEdgeInsetInputControl or PaletteMetricInt.HeaderButtonEdgeInsetCustom1 or PaletteMetricInt.HeaderButtonEdgeInsetCustom2 or PaletteMetricInt.HeaderButtonEdgeInsetCustom3
-                )
+            return metric switch
             {
+                // Is this the metric we provide?
                 // If the user has defined an actual value to use
-                if (ButtonEdgeInset != -1)
-                {
-                    return ButtonEdgeInset;
-                }
-            }
+                PaletteMetricInt.HeaderButtonEdgeInsetPrimary or PaletteMetricInt.HeaderButtonEdgeInsetSecondary
+                    or PaletteMetricInt.HeaderButtonEdgeInsetDockInactive
+                    or PaletteMetricInt.HeaderButtonEdgeInsetDockActive or PaletteMetricInt.HeaderButtonEdgeInsetForm
+                    or PaletteMetricInt.HeaderButtonEdgeInsetInputControl
+                    or PaletteMetricInt.HeaderButtonEdgeInsetCustom1 or PaletteMetricInt.HeaderButtonEdgeInsetCustom2
+                    or PaletteMetricInt.HeaderButtonEdgeInsetCustom3 when ButtonEdgeInset != -1 => ButtonEdgeInset,
+                _ => _redirect.GetMetricInt(owningForm, state, metric)
+            };
 
             // Pass onto the inheritance
-            return _redirect.GetMetricInt(state, metric);
         }
 
         /// <summary>
@@ -171,24 +174,30 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
-            // Is this the metric we provide?
-            if (metric is PaletteMetricPadding.HeaderButtonPaddingPrimary or PaletteMetricPadding.HeaderButtonPaddingSecondary or PaletteMetricPadding.HeaderButtonPaddingDockInactive or PaletteMetricPadding.HeaderButtonPaddingDockActive or PaletteMetricPadding.HeaderButtonPaddingForm or PaletteMetricPadding.HeaderButtonPaddingInputControl or PaletteMetricPadding.HeaderButtonPaddingCustom1 or PaletteMetricPadding.HeaderButtonPaddingCustom2 or PaletteMetricPadding.HeaderButtonPaddingCustom3
-                )
+            return metric switch
             {
+                // Is this the metric we provide?
                 // If the user has defined an actual value to use
-                if (!ButtonPadding.Equals(CommonHelper.InheritPadding))
-                {
-                    return ButtonPadding;
-                }
-            }
-
-            // Pass onto the inheritance
-            return _redirect.GetMetricPadding(state, metric);
+                PaletteMetricPadding.HeaderButtonPaddingPrimary 
+                    or PaletteMetricPadding.HeaderButtonPaddingSecondary
+                    or PaletteMetricPadding.HeaderButtonPaddingDockInactive
+                    or PaletteMetricPadding.HeaderButtonPaddingDockActive
+                    or PaletteMetricPadding.HeaderButtonPaddingForm
+                    or PaletteMetricPadding.HeaderButtonPaddingInputControl
+                    or PaletteMetricPadding.HeaderButtonPaddingCustom1
+                    or PaletteMetricPadding.HeaderButtonPaddingCustom2
+                    or PaletteMetricPadding.HeaderButtonPaddingCustom3 when !ButtonPadding.Equals(CommonHelper
+                        .InheritPadding) => ButtonPadding,
+                // Pass onto the inheritance
+                _ => _redirect.GetMetricPadding(owningForm, state, metric)
+            };
         }
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteInputControlContentStates.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteInputControlContentStates.cs
@@ -82,7 +82,7 @@ namespace Krypton.Toolkit
             // Get the values and set into storage
             Font = GetContentShortTextFont(state);
             Color1 = GetContentShortTextColor1(state);
-            Padding = GetContentPadding(state);
+            Padding = GetBorderContentPadding(null, state);
         }
         #endregion
 
@@ -491,9 +491,13 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets the actual padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public virtual Padding GetContentPadding(PaletteState state) => !_padding.Equals(CommonHelper.InheritPadding) ? _padding : Inherit.GetContentPadding(state);
+        public virtual Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteState state) => 
+            !_padding.Equals(CommonHelper.InheritPadding)
+                ? _padding
+                : Inherit.GetBorderContentPadding(owningForm, state);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteInputControlTripleRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteInputControlTripleRedirect.cs
@@ -262,13 +262,15 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Metric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public int GetMetricInt(PaletteState state, PaletteMetricInt metric) => _metricRedirect.GetMetricInt(state, metric);
+        public int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric) => _metricRedirect.GetMetricInt(owningForm, state, metric);
 
         /// <summary>
         /// Gets a boolean metric value.
@@ -281,10 +283,11 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric) => _metricRedirect.GetMetricPadding(state, metric);
+        public Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state, PaletteMetricPadding metric) => _metricRedirect.GetMetricPadding(owningForm, state, metric);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectCommon.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectCommon.cs
@@ -53,7 +53,9 @@ namespace Krypton.Toolkit
         public override InheritBool GetBackDraw(PaletteBackStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteBack.GetBackDraw(state) : base.GetBackDraw(style, state);
+            return inherit != null
+                ? inherit.PaletteBack.GetBackDraw(state)
+                : base.GetBackDraw(style, state);
         }
 
         /// <summary>
@@ -65,7 +67,9 @@ namespace Krypton.Toolkit
         public override PaletteGraphicsHint GetBackGraphicsHint(PaletteBackStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteBack.GetBackGraphicsHint(state) : base.GetBackGraphicsHint(style, state);
+            return inherit != null
+                ? inherit.PaletteBack.GetBackGraphicsHint(state)
+                : base.GetBackGraphicsHint(style, state);
         }
 
         /// <summary>
@@ -77,7 +81,9 @@ namespace Krypton.Toolkit
         public override Color GetBackColor1(PaletteBackStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteBack.GetBackColor1(state) : base.GetBackColor1(style, state);
+            return inherit != null
+                ? inherit.PaletteBack.GetBackColor1(state)
+                : base.GetBackColor1(style, state);
         }
 
         /// <summary>
@@ -89,7 +95,9 @@ namespace Krypton.Toolkit
         public override Color GetBackColor2(PaletteBackStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteBack.GetBackColor2(state) : base.GetBackColor2(style, state);
+            return inherit != null
+                ? inherit.PaletteBack.GetBackColor2(state)
+                : base.GetBackColor2(style, state);
         }
 
         /// <summary>
@@ -101,7 +109,9 @@ namespace Krypton.Toolkit
         public override PaletteColorStyle GetBackColorStyle(PaletteBackStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteBack.GetBackColorStyle(state) : base.GetBackColorStyle(style, state);
+            return inherit != null
+                ? inherit.PaletteBack.GetBackColorStyle(state)
+                : base.GetBackColorStyle(style, state);
         }
 
         /// <summary>
@@ -113,7 +123,9 @@ namespace Krypton.Toolkit
         public override PaletteRectangleAlign GetBackColorAlign(PaletteBackStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteBack.GetBackColorAlign(state) : base.GetBackColorAlign(style, state);
+            return inherit != null
+                ? inherit.PaletteBack.GetBackColorAlign(state)
+                : base.GetBackColorAlign(style, state);
         }
 
         /// <summary>
@@ -125,7 +137,9 @@ namespace Krypton.Toolkit
         public override float GetBackColorAngle(PaletteBackStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteBack.GetBackColorAngle(state) : base.GetBackColorAngle(style, state);
+            return inherit != null
+                ? inherit.PaletteBack.GetBackColorAngle(state)
+                : base.GetBackColorAngle(style, state);
         }
 
         /// <summary>
@@ -137,7 +151,9 @@ namespace Krypton.Toolkit
         public override Image? GetBackImage(PaletteBackStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteBack.GetBackImage(state) : base.GetBackImage(style, state);
+            return inherit != null
+                ? inherit.PaletteBack.GetBackImage(state)
+                : base.GetBackImage(style, state);
         }
 
         /// <summary>
@@ -149,7 +165,9 @@ namespace Krypton.Toolkit
         public override PaletteImageStyle GetBackImageStyle(PaletteBackStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteBack.GetBackImageStyle(state) : base.GetBackImageStyle(style, state);
+            return inherit != null
+                ? inherit.PaletteBack.GetBackImageStyle(state)
+                : base.GetBackImageStyle(style, state);
         }
 
         /// <summary>
@@ -161,7 +179,9 @@ namespace Krypton.Toolkit
         public override PaletteRectangleAlign GetBackImageAlign(PaletteBackStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteBack.GetBackImageAlign(state) : base.GetBackImageAlign(style, state);
+            return inherit != null
+                ? inherit.PaletteBack.GetBackImageAlign(state)
+                : base.GetBackImageAlign(style, state);
         }
         #endregion
 
@@ -175,7 +195,9 @@ namespace Krypton.Toolkit
         public override InheritBool GetBorderDraw(PaletteBorderStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteBorder!.GetBorderDraw(state) : base.GetBorderDraw(style, state);
+            return inherit != null
+                ? inherit.PaletteBorder!.GetBorderDraw(state)
+                : base.GetBorderDraw(style, state);
         }
 
         /// <summary>
@@ -187,7 +209,9 @@ namespace Krypton.Toolkit
         public override PaletteDrawBorders GetBorderDrawBorders(PaletteBorderStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteBorder!.GetBorderDrawBorders(state) : base.GetBorderDrawBorders(style, state);
+            return inherit != null
+                ? inherit.PaletteBorder!.GetBorderDrawBorders(state)
+                : base.GetBorderDrawBorders(style, state);
         }
 
         /// <summary>
@@ -199,7 +223,9 @@ namespace Krypton.Toolkit
         public override PaletteGraphicsHint GetBorderGraphicsHint(PaletteBorderStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteBorder!.GetBorderGraphicsHint(state) : base.GetBorderGraphicsHint(style, state);
+            return inherit != null
+                ? inherit.PaletteBorder!.GetBorderGraphicsHint(state)
+                : base.GetBorderGraphicsHint(style, state);
         }
 
         /// <summary>
@@ -211,7 +237,9 @@ namespace Krypton.Toolkit
         public override Color GetBorderColor1(PaletteBorderStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteBorder!.GetBorderColor1(state) : base.GetBorderColor1(style, state);
+            return inherit != null
+                ? inherit.PaletteBorder!.GetBorderColor1(state)
+                : base.GetBorderColor1(style, state);
         }
 
         /// <summary>
@@ -223,7 +251,9 @@ namespace Krypton.Toolkit
         public override Color GetBorderColor2(PaletteBorderStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteBorder!.GetBorderColor2(state) : base.GetBorderColor2(style, state);
+            return inherit != null
+                ? inherit.PaletteBorder!.GetBorderColor2(state)
+                : base.GetBorderColor2(style, state);
         }
 
         /// <summary>
@@ -235,7 +265,9 @@ namespace Krypton.Toolkit
         public override PaletteColorStyle GetBorderColorStyle(PaletteBorderStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteBorder!.GetBorderColorStyle(state) : base.GetBorderColorStyle(style, state);
+            return inherit != null
+                ? inherit.PaletteBorder!.GetBorderColorStyle(state)
+                : base.GetBorderColorStyle(style, state);
         }
 
         /// <summary>
@@ -247,7 +279,9 @@ namespace Krypton.Toolkit
         public override PaletteRectangleAlign GetBorderColorAlign(PaletteBorderStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteBorder!.GetBorderColorAlign(state) : base.GetBorderColorAlign(style, state);
+            return inherit != null
+                ? inherit.PaletteBorder!.GetBorderColorAlign(state)
+                : base.GetBorderColorAlign(style, state);
         }
 
         /// <summary>
@@ -259,7 +293,9 @@ namespace Krypton.Toolkit
         public override float GetBorderColorAngle(PaletteBorderStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteBorder!.GetBorderColorAngle(state) : base.GetBorderColorAngle(style, state);
+            return inherit != null
+                ? inherit.PaletteBorder!.GetBorderColorAngle(state)
+                : base.GetBorderColorAngle(style, state);
         }
 
         /// <summary>
@@ -271,7 +307,9 @@ namespace Krypton.Toolkit
         public override int GetBorderWidth(PaletteBorderStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteBorder!.GetBorderWidth(state) : base.GetBorderWidth(style, state);
+            return inherit != null
+                ? inherit.PaletteBorder!.GetBorderWidth(state)
+                : base.GetBorderWidth(style, state);
         }
 
         /// <summary>
@@ -283,7 +321,9 @@ namespace Krypton.Toolkit
         public override float GetBorderRounding(PaletteBorderStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteBorder!.GetBorderRounding(state) : base.GetBorderRounding(style, state);
+            return inherit != null
+                ? inherit.PaletteBorder!.GetBorderRounding(state)
+                : base.GetBorderRounding(style, state);
         }
 
         /// <summary>
@@ -295,7 +335,9 @@ namespace Krypton.Toolkit
         public override Image? GetBorderImage(PaletteBorderStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteBorder!.GetBorderImage(state) : base.GetBorderImage(style, state);
+            return inherit != null
+                ? inherit.PaletteBorder!.GetBorderImage(state)
+                : base.GetBorderImage(style, state);
         }
 
         /// <summary>
@@ -307,7 +349,9 @@ namespace Krypton.Toolkit
         public override PaletteImageStyle GetBorderImageStyle(PaletteBorderStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteBorder!.GetBorderImageStyle(state) : base.GetBorderImageStyle(style, state);
+            return inherit != null
+                ? inherit.PaletteBorder!.GetBorderImageStyle(state)
+                : base.GetBorderImageStyle(style, state);
         }
 
         /// <summary>
@@ -319,7 +363,9 @@ namespace Krypton.Toolkit
         public override PaletteRectangleAlign GetBorderImageAlign(PaletteBorderStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteBorder!.GetBorderImageAlign(state) : base.GetBorderImageAlign(style, state);
+            return inherit != null
+                ? inherit.PaletteBorder!.GetBorderImageAlign(state)
+                : base.GetBorderImageAlign(style, state);
         }
         #endregion
 
@@ -333,7 +379,9 @@ namespace Krypton.Toolkit
         public override InheritBool GetContentDraw(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteContent!.GetContentDraw(state) : base.GetContentDraw(style, state);
+            return inherit != null
+                ? inherit.PaletteContent!.GetContentDraw(state)
+                : base.GetContentDraw(style, state);
         }
 
         /// <summary>
@@ -345,7 +393,9 @@ namespace Krypton.Toolkit
         public override InheritBool GetContentDrawFocus(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteContent!.GetContentDrawFocus(state) : base.GetContentDrawFocus(style, state);
+            return inherit != null
+                ? inherit.PaletteContent!.GetContentDrawFocus(state)
+                : base.GetContentDrawFocus(style, state);
         }
 
         /// <summary>
@@ -357,7 +407,9 @@ namespace Krypton.Toolkit
         public override PaletteRelativeAlign GetContentImageH(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteContent!.GetContentImageH(state) : base.GetContentImageH(style, state);
+            return inherit != null
+                ? inherit.PaletteContent!.GetContentImageH(state)
+                : base.GetContentImageH(style, state);
         }
 
         /// <summary>
@@ -369,7 +421,9 @@ namespace Krypton.Toolkit
         public override PaletteRelativeAlign GetContentImageV(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteContent!.GetContentImageV(state) : base.GetContentImageV(style, state);
+            return inherit != null
+                ? inherit.PaletteContent!.GetContentImageV(state)
+                : base.GetContentImageV(style, state);
         }
 
         /// <summary>
@@ -381,7 +435,9 @@ namespace Krypton.Toolkit
         public override PaletteImageEffect GetContentImageEffect(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteContent!.GetContentImageEffect(state) : base.GetContentImageEffect(style, state);
+            return inherit != null
+                ? inherit.PaletteContent!.GetContentImageEffect(state)
+                : base.GetContentImageEffect(style, state);
         }
 
         /// <summary>
@@ -393,7 +449,9 @@ namespace Krypton.Toolkit
         public override Font? GetContentShortTextFont(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteContent!.GetContentShortTextFont(state) : base.GetContentShortTextFont(style, state);
+            return inherit != null
+                ? inherit.PaletteContent!.GetContentShortTextFont(state)
+                : base.GetContentShortTextFont(style, state);
         }
 
         /// <summary>
@@ -405,7 +463,9 @@ namespace Krypton.Toolkit
         public override PaletteTextHint GetContentShortTextHint(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteContent!.GetContentShortTextHint(state) : base.GetContentShortTextHint(style, state);
+            return inherit != null
+                ? inherit.PaletteContent!.GetContentShortTextHint(state)
+                : base.GetContentShortTextHint(style, state);
         }
 
         /// <summary>
@@ -417,7 +477,9 @@ namespace Krypton.Toolkit
         public override PaletteTextHotkeyPrefix GetContentShortTextPrefix(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteContent!.GetContentShortTextPrefix(state) : base.GetContentShortTextPrefix(style, state);
+            return inherit != null
+                ? inherit.PaletteContent!.GetContentShortTextPrefix(state)
+                : base.GetContentShortTextPrefix(style, state);
         }
 
         /// <summary>
@@ -429,7 +491,9 @@ namespace Krypton.Toolkit
         public override InheritBool GetContentShortTextMultiLine(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteContent!.GetContentShortTextMultiLine(state) : base.GetContentShortTextMultiLine(style, state);
+            return inherit != null
+                ? inherit.PaletteContent!.GetContentShortTextMultiLine(state)
+                : base.GetContentShortTextMultiLine(style, state);
         }
 
         /// <summary>
@@ -441,7 +505,9 @@ namespace Krypton.Toolkit
         public override PaletteTextTrim GetContentShortTextTrim(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteContent!.GetContentShortTextTrim(state) : base.GetContentShortTextTrim(style, state);
+            return inherit != null
+                ? inherit.PaletteContent!.GetContentShortTextTrim(state)
+                : base.GetContentShortTextTrim(style, state);
         }
 
         /// <summary>
@@ -453,7 +519,9 @@ namespace Krypton.Toolkit
         public override PaletteRelativeAlign GetContentShortTextH(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteContent!.GetContentShortTextH(state) : base.GetContentShortTextH(style, state);
+            return inherit != null
+                ? inherit.PaletteContent!.GetContentShortTextH(state)
+                : base.GetContentShortTextH(style, state);
         }
 
         /// <summary>
@@ -465,7 +533,9 @@ namespace Krypton.Toolkit
         public override PaletteRelativeAlign GetContentShortTextV(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteContent!.GetContentShortTextV(state) : base.GetContentShortTextV(style, state);
+            return inherit != null
+                ? inherit.PaletteContent!.GetContentShortTextV(state)
+                : base.GetContentShortTextV(style, state);
         }
 
         /// <summary>
@@ -491,7 +561,9 @@ namespace Krypton.Toolkit
         public override Color GetContentShortTextColor1(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteContent!.GetContentShortTextColor1(state) : base.GetContentShortTextColor1(style, state);
+            return inherit != null
+                ? inherit.PaletteContent!.GetContentShortTextColor1(state)
+                : base.GetContentShortTextColor1(style, state);
         }
 
         /// <summary>
@@ -503,7 +575,9 @@ namespace Krypton.Toolkit
         public override Color GetContentShortTextColor2(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteContent!.GetContentShortTextColor2(state) : base.GetContentShortTextColor2(style, state);
+            return inherit != null
+                ? inherit.PaletteContent!.GetContentShortTextColor2(state)
+                : base.GetContentShortTextColor2(style, state);
         }
 
         /// <summary>
@@ -557,7 +631,9 @@ namespace Krypton.Toolkit
         public override Image? GetContentShortTextImage(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteContent!.GetContentShortTextImage(state) : base.GetContentShortTextImage(style, state);
+            return inherit != null
+                ? inherit.PaletteContent!.GetContentShortTextImage(state)
+                : base.GetContentShortTextImage(style, state);
         }
 
         /// <summary>
@@ -597,7 +673,9 @@ namespace Krypton.Toolkit
         public override Font? GetContentLongTextFont(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteContent!.GetContentLongTextFont(state) : base.GetContentLongTextFont(style, state);
+            return inherit != null
+                ? inherit.PaletteContent!.GetContentLongTextFont(state)
+                : base.GetContentLongTextFont(style, state);
         }
 
         /// <summary>
@@ -609,7 +687,9 @@ namespace Krypton.Toolkit
         public override PaletteTextHint GetContentLongTextHint(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteContent!.GetContentLongTextHint(state) : base.GetContentLongTextHint(style, state);
+            return inherit != null
+                ? inherit.PaletteContent!.GetContentLongTextHint(state)
+                : base.GetContentLongTextHint(style, state);
         }
 
         /// <summary>
@@ -621,7 +701,9 @@ namespace Krypton.Toolkit
         public override InheritBool GetContentLongTextMultiLine(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteContent!.GetContentLongTextMultiLine(state) : base.GetContentLongTextMultiLine(style, state);
+            return inherit != null
+                ? inherit.PaletteContent!.GetContentLongTextMultiLine(state)
+                : base.GetContentLongTextMultiLine(style, state);
         }
 
         /// <summary>
@@ -633,7 +715,9 @@ namespace Krypton.Toolkit
         public override PaletteTextTrim GetContentLongTextTrim(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteContent!.GetContentLongTextTrim(state) : base.GetContentLongTextTrim(style, state);
+            return inherit != null
+                ? inherit.PaletteContent!.GetContentLongTextTrim(state)
+                : base.GetContentLongTextTrim(style, state);
         }
 
         /// <summary>
@@ -645,7 +729,9 @@ namespace Krypton.Toolkit
         public override PaletteTextHotkeyPrefix GetContentLongTextPrefix(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteContent!.GetContentLongTextPrefix(state) : base.GetContentLongTextPrefix(style, state);
+            return inherit != null
+                ? inherit.PaletteContent!.GetContentLongTextPrefix(state)
+                : base.GetContentLongTextPrefix(style, state);
         }
 
         /// <summary>
@@ -657,7 +743,9 @@ namespace Krypton.Toolkit
         public override PaletteRelativeAlign GetContentLongTextH(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteContent!.GetContentLongTextH(state) : base.GetContentLongTextH(style, state);
+            return inherit != null
+                ? inherit.PaletteContent!.GetContentLongTextH(state)
+                : base.GetContentLongTextH(style, state);
         }
 
         /// <summary>
@@ -669,7 +757,9 @@ namespace Krypton.Toolkit
         public override PaletteRelativeAlign GetContentLongTextV(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteContent!.GetContentLongTextV(state) : base.GetContentLongTextV(style, state);
+            return inherit != null
+                ? inherit.PaletteContent!.GetContentLongTextV(state)
+                : base.GetContentLongTextV(style, state);
         }
 
         /// <summary>
@@ -681,7 +771,9 @@ namespace Krypton.Toolkit
         public override PaletteRelativeAlign GetContentLongTextMultiLineH(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteContent!.GetContentLongTextMultiLineH(state) : base.GetContentLongTextMultiLineH(style, state);
+            return inherit != null
+                ? inherit.PaletteContent!.GetContentLongTextMultiLineH(state)
+                : base.GetContentLongTextMultiLineH(style, state);
         }
 
         /// <summary>
@@ -693,7 +785,9 @@ namespace Krypton.Toolkit
         public override Color GetContentLongTextColor1(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteContent!.GetContentLongTextColor1(state) : base.GetContentLongTextColor1(style, state);
+            return inherit != null
+                ? inherit.PaletteContent!.GetContentLongTextColor1(state)
+                : base.GetContentLongTextColor1(style, state);
         }
 
         /// <summary>
@@ -705,7 +799,9 @@ namespace Krypton.Toolkit
         public override Color GetContentLongTextColor2(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteContent!.GetContentLongTextColor2(state) : base.GetContentLongTextColor2(style, state);
+            return inherit != null
+                ? inherit.PaletteContent!.GetContentLongTextColor2(state)
+                : base.GetContentLongTextColor2(style, state);
         }
 
         /// <summary>
@@ -717,7 +813,9 @@ namespace Krypton.Toolkit
         public override PaletteColorStyle GetContentLongTextColorStyle(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteContent!.GetContentLongTextColorStyle(state) : base.GetContentLongTextColorStyle(style, state);
+            return inherit != null
+                ? inherit.PaletteContent!.GetContentLongTextColorStyle(state)
+                : base.GetContentLongTextColorStyle(style, state);
         }
 
         /// <summary>
@@ -729,7 +827,9 @@ namespace Krypton.Toolkit
         public override PaletteRectangleAlign GetContentLongTextColorAlign(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteContent!.GetContentLongTextColorAlign(state) : base.GetContentLongTextColorAlign(style, state);
+            return inherit != null
+                ? inherit.PaletteContent!.GetContentLongTextColorAlign(state)
+                : base.GetContentLongTextColorAlign(style, state);
         }
 
         /// <summary>
@@ -741,7 +841,9 @@ namespace Krypton.Toolkit
         public override float GetContentLongTextColorAngle(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteContent!.GetContentLongTextColorAngle(state) : base.GetContentLongTextColorAngle(style, state);
+            return inherit != null
+                ? inherit.PaletteContent!.GetContentLongTextColorAngle(state)
+                : base.GetContentLongTextColorAngle(style, state);
         }
 
         /// <summary>
@@ -753,7 +855,9 @@ namespace Krypton.Toolkit
         public override Image? GetContentLongTextImage(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteContent!.GetContentLongTextImage(state) : base.GetContentLongTextImage(style, state);
+            return inherit != null
+                ? inherit.PaletteContent!.GetContentLongTextImage(state)
+                : base.GetContentLongTextImage(style, state);
         }
 
         /// <summary>
@@ -765,7 +869,9 @@ namespace Krypton.Toolkit
         public override PaletteImageStyle GetContentLongTextImageStyle(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteContent!.GetContentLongTextImageStyle(state) : base.GetContentLongTextImageStyle(style, state);
+            return inherit != null
+                ? inherit.PaletteContent!.GetContentLongTextImageStyle(state)
+                : base.GetContentLongTextImageStyle(style, state);
         }
 
         /// <summary>
@@ -777,19 +883,25 @@ namespace Krypton.Toolkit
         public override PaletteRectangleAlign GetContentLongTextImageAlign(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteContent!.GetContentLongTextImageAlign(state) : base.GetContentLongTextImageAlign(style, state);
+            return inherit != null
+                ? inherit.PaletteContent!.GetContentLongTextImageAlign(state)
+                : base.GetContentLongTextImageAlign(style, state);
         }
 
         /// <summary>
         /// Gets the padding between the border and content drawing.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="style">Content style.</param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetContentPadding(PaletteContentStyle style, PaletteState state)
+        public override Padding GetBorderContentPadding(KryptonForm? owningForm, PaletteContentStyle style,
+            PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteContent!.GetContentPadding(state) : base.GetContentPadding(style, state);
+            return inherit != null
+                ? inherit.PaletteContent!.GetBorderContentPadding(owningForm, state)
+                : base.GetBorderContentPadding(owningForm, style, state);
         }
 
         /// <summary>
@@ -801,7 +913,9 @@ namespace Krypton.Toolkit
         public override int GetContentAdjacentGap(PaletteContentStyle style, PaletteState state)
         {
             IPaletteTriple? inherit = GetInherit(state);
-            return inherit != null ? inherit.PaletteContent!.GetContentAdjacentGap(state) : base.GetContentAdjacentGap(style, state);
+            return inherit != null
+                ? inherit.PaletteContent!.GetContentAdjacentGap(state)
+                : base.GetContentAdjacentGap(style, state);
         }
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteSeparatorPadding.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteSeparatorPadding.cs
@@ -67,7 +67,7 @@ namespace Krypton.Toolkit
         public void PopulateFromBase(PaletteState state, PaletteMetricPadding metric)
         {
             base.PopulateFromBase(state);
-            Padding = _inherit!.GetMetricPadding(state, metric);
+            Padding = _inherit!.GetMetricPadding(null, state, metric);
         }
         #endregion
 
@@ -113,15 +113,17 @@ namespace Krypton.Toolkit
         #endregion
 
         #region IPaletteMetric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public int GetMetricInt(PaletteState state, PaletteMetricInt metric) =>
+        public int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric) =>
             // Pass onto the inheritance
-            _inherit!.GetMetricInt(state, metric);
+            _inherit!.GetMetricInt(owningForm, state, metric);
 
         /// <summary>
         /// Gets a boolean metric value.
@@ -136,10 +138,11 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state, PaletteMetricPadding metric)
         {
             // Is this the metric we provide?
             if (metric is PaletteMetricPadding.SeparatorPaddingLowProfile or PaletteMetricPadding.SeparatorPaddingHighProfile or PaletteMetricPadding.SeparatorPaddingHighInternalProfile or PaletteMetricPadding.SeparatorPaddingCustom1 or PaletteMetricPadding.SeparatorPaddingCustom2 or PaletteMetricPadding.SeparatorPaddingCustom3
@@ -148,11 +151,11 @@ namespace Krypton.Toolkit
                 // If the user has defined an actual value to use
                 return !Padding.Equals(CommonHelper.InheritPadding)
                     ? Padding
-                    : _inherit!.GetMetricPadding(state, metric);
+                    : _inherit!.GetMetricPadding(owningForm, state, metric);
             }
 
             // Pass onto the inheritance
-            return _inherit!.GetMetricPadding(state, metric);
+            return _inherit!.GetMetricPadding(owningForm, state, metric);
         }
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteSeparatorPaddingRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteSeparatorPaddingRedirect.cs
@@ -88,15 +88,17 @@ namespace Krypton.Toolkit
         #endregion
 
         #region IPaletteMetric
+
         /// <summary>
         /// Gets an integer metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Integer value.</returns>
-        public override int GetMetricInt(PaletteState state, PaletteMetricInt metric) =>
+        public override int GetMetricInt(KryptonForm? owningForm, PaletteState state, PaletteMetricInt metric) =>
             // Pass onto the inheritance
-            _redirect!.GetMetricInt(state, metric);
+            _redirect!.GetMetricInt(owningForm, state, metric);
 
         /// <summary>
         /// Gets a boolean metric value.
@@ -111,23 +113,30 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a padding metric value.
         /// </summary>
+        /// <param name="owningForm"></param>
         /// <param name="state">Palette value should be applicable to this state.</param>
         /// <param name="metric">Requested metric.</param>
         /// <returns>Padding value.</returns>
-        public override Padding GetMetricPadding(PaletteState state, PaletteMetricPadding metric)
+        public override Padding GetMetricPadding(KryptonForm? owningForm, PaletteState state,
+            PaletteMetricPadding metric)
         {
             // Is this the metric we provide?
-            if (metric is PaletteMetricPadding.SeparatorPaddingLowProfile or PaletteMetricPadding.SeparatorPaddingHighProfile or PaletteMetricPadding.SeparatorPaddingHighInternalProfile or PaletteMetricPadding.SeparatorPaddingCustom1 or PaletteMetricPadding.SeparatorPaddingCustom2 or PaletteMetricPadding.SeparatorPaddingCustom3
+            if (metric is PaletteMetricPadding.SeparatorPaddingLowProfile 
+                or PaletteMetricPadding.SeparatorPaddingHighProfile 
+                or PaletteMetricPadding.SeparatorPaddingHighInternalProfile
+                or PaletteMetricPadding.SeparatorPaddingCustom1
+                or PaletteMetricPadding.SeparatorPaddingCustom2
+                or PaletteMetricPadding.SeparatorPaddingCustom3
                 )
             {
                 // If the user has defined an actual value to use
                 return !Padding.Equals(CommonHelper.InheritPadding)
                     ? Padding
-                    : _redirect!.GetMetricPadding(state, metric);
+                    : _redirect!.GetMetricPadding(owningForm, state, metric);
             }
 
             // Pass onto the inheritance
-            return _redirect!.GetMetricPadding(state, metric);
+            return _redirect!.GetMetricPadding(owningForm, state, metric);
         }
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderBase.cs
@@ -128,7 +128,7 @@ namespace Krypton.Toolkit
         /// Gets a renderer for drawing the toolstrips.
         /// </summary>
         /// <param name="colorPalette">Color palette to use when rendering toolstrip.</param>
-        public abstract ToolStripRenderer RenderToolStrip(PaletteBase colorPalette);
+        public abstract ToolStripRenderer RenderToolStrip([DisallowNull] PaletteBase? colorPalette);
         #endregion
 
         #region RenderStandardBorder

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderDefinitions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderDefinitions.cs
@@ -72,7 +72,7 @@ namespace Krypton.Toolkit
         /// Gets a renderer for drawing the toolstrips.
         /// </summary>
         /// <param name="colorPalette">Color palette to use when rendering toolstrip.</param>
-        ToolStripRenderer RenderToolStrip(PaletteBase colorPalette);
+        ToolStripRenderer RenderToolStrip([DisallowNull] PaletteBase? colorPalette);
     }
     #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderExpertHelpers.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderExpertHelpers.cs
@@ -209,8 +209,8 @@ namespace Krypton.Toolkit
             }
 
             cache.First = DrawBackExpert(rect,
-                CommonHelper.MergeColors(backColor1, 0.5f, Color.White, 0.5f),
-                CommonHelper.MergeColors(backColor2, 0.5f, Color.White, 0.5f),
+                backColor1,//CommonHelper.MergeColors(backColor1, 0.5f, Color.White, 0.5f),
+                backColor2,//CommonHelper.MergeColors(backColor2, 0.5f, Color.White, 0.5f),
                 orientation, context.Graphics, memento, true, false);
 
             cache.Second = DrawBackExpert(rect, backColor1, backColor2, orientation, context.Graphics, memento, false, false);

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderMicrosoft365.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderMicrosoft365.cs
@@ -61,7 +61,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="colourPalette">The colour palette.</param>
         /// <returns></returns>
-        public override ToolStripRenderer RenderToolStrip([DisallowNull] PaletteBase colourPalette)
+        public override ToolStripRenderer RenderToolStrip([DisallowNull] PaletteBase? colourPalette)
         {
             Debug.Assert(colourPalette != null);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderOffice2007.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderOffice2007.cs
@@ -93,7 +93,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="colorPalette">Color palette to use when rendering toolstrip.</param>
         /// <exception cref="ArgumentNullException"></exception>
-        public override ToolStripRenderer RenderToolStrip([DisallowNull] PaletteBase colorPalette)
+        public override ToolStripRenderer RenderToolStrip([DisallowNull] PaletteBase? colorPalette)
         {
             Debug.Assert(colorPalette != null);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderOffice2010.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderOffice2010.cs
@@ -93,7 +93,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="colorPalette">Color palette to use when rendering toolstrip.</param>
         /// <exception cref="ArgumentNullException"></exception>
-        public override ToolStripRenderer RenderToolStrip([DisallowNull] PaletteBase colorPalette)
+        public override ToolStripRenderer RenderToolStrip([DisallowNull] PaletteBase? colorPalette)
         {
             Debug.Assert(colorPalette != null);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderOffice2013.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderOffice2013.cs
@@ -79,7 +79,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="colorPalette">Color palette to use when rendering toolstrip.</param>
         /// <exception cref="ArgumentNullException"></exception>
-        public override ToolStripRenderer RenderToolStrip([DisallowNull] PaletteBase colorPalette)
+        public override ToolStripRenderer RenderToolStrip([DisallowNull] PaletteBase? colorPalette)
         {
             Debug.Assert(colorPalette != null);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderSparkle.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderSparkle.cs
@@ -289,7 +289,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="colorPalette">Color palette to use when rendering toolstrip.</param>
         /// <exception cref="ArgumentNullException"></exception>
-        public override ToolStripRenderer RenderToolStrip([DisallowNull] PaletteBase colorPalette)
+        public override ToolStripRenderer RenderToolStrip([DisallowNull] PaletteBase? colorPalette)
         {
             Debug.Assert(colorPalette != null);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
@@ -8,6 +8,8 @@
  */
 #endregion
 
+using ArgumentNullException = System.ArgumentNullException;
+
 namespace Krypton.Toolkit
 {
     /// <summary>
@@ -347,21 +349,21 @@ namespace Krypton.Toolkit
 
             _gridSortOrder = new ImageList
             {
-                TransparentColor = Color.Magenta,
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR,
                 ImageSize = new Size(17, 11)
             };
             _gridSortOrder.Images.AddStrip(GridImageResources.GridSortOrder);
 
             _gridRowIndicators = new ImageList
             {
-                TransparentColor = Color.Magenta,
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR,
                 ImageSize = new Size(19, 13)
             };
             _gridRowIndicators.Images.AddStrip(GridImageResources.GridRowIndicators);
 
             _gridErrorIcon = new ImageList
             {
-                TransparentColor = Color.Magenta,
+                TransparentColor = GlobalStaticValues.TRANSPARENCY_KEY_COLOR,
                 ImageSize = new Size(18, 17)
             };
             _gridErrorIcon.Images.AddStrip(GenericImageResources.GridErrorIcon);
@@ -373,7 +375,7 @@ namespace Krypton.Toolkit
         /// Gets a renderer for drawing the toolstrips.
         /// </summary>
         /// <param name="colorPalette">Color palette to use when rendering toolstrip.</param>
-        public override ToolStripRenderer RenderToolStrip([DisallowNull] PaletteBase colorPalette)
+        public override ToolStripRenderer RenderToolStrip([DisallowNull] PaletteBase? colorPalette)
         {
             Debug.Assert(colorPalette != null);
 
@@ -677,8 +679,10 @@ namespace Krypton.Toolkit
             Debug.Assert(!context.Control!.IsDisposed);
 
             // Use helper to create a border path in middle of the pen
-            return CreateBorderBackPath(false,
-                                        true,
+            var isForm = context.Control as KryptonForm;
+            var forBorder = isForm != null && isForm.MdiParent == null;
+            return CreateBorderBackPath(forBorder,
+                                  !forBorder,
                                         rect,
                                         CommonHelper.OrientateDrawBorders(palette.GetBorderDrawBorders(state), orientation),
                                         palette.GetBorderWidth(state),
@@ -1089,7 +1093,7 @@ namespace Krypton.Toolkit
             var allocatedHeight = AllocatedTotalHeight(allocation);
 
             // Grab the padding for the content
-            Padding borderPadding = palette.GetContentPadding(state);
+            Padding borderPadding = palette.GetBorderContentPadding(context.Control as KryptonForm, state);
 
             // For the form level buttons we have to calculate the correct padding based on caption area
             PaletteContentStyle contentStyle = palette.GetContentStyle();
@@ -1164,7 +1168,14 @@ namespace Krypton.Toolkit
             Rectangle cacheDisplayRect = availableRect;
 
             // Grab the padding for the content
-            Padding borderPadding = palette.GetContentPadding(state);
+            KryptonForm? ownerForm = context.Control as KryptonForm;
+            if (ownerForm == null
+                && context.Control?.GetType().ToString() == "Krypton.Ribbon.KryptonRibbon")
+            {
+                ownerForm = context.TopControl as KryptonForm;
+            }
+
+            Padding borderPadding = palette.GetBorderContentPadding(ownerForm, state);
 
             // Is the content intended for a vertical drawing orientation?
             var vertical = orientation is VisualOrientation.Left or VisualOrientation.Right;
@@ -1209,7 +1220,7 @@ namespace Krypton.Toolkit
             var spacingGap = palette.GetContentAdjacentGap(state);
 
             // Drawing vertical means we can ignore right to left, otherwise get value from control
-            RightToLeft rtl = vertical ? RightToLeft.No : context.Control.RightToLeft;
+            RightToLeft rtl = vertical ? RightToLeft.No : context.Control!.RightToLeft;
 
             // Allocate space for each required content in turn
             AllocateImageSpace(memento, palette, values, state, availableRect, rtl, ref allocation);
@@ -3808,46 +3819,47 @@ namespace Krypton.Toolkit
                                                          int variant)
         {
             var borderPath = new GraphicsPath();
-
-            // A zero size rectangle cannot be drawn, so return a null path
+            if (borderRounding < 0.1f
+                && CommonHelper.HasABorder(borders)
+                )
+            {   // Deal with issues arrising within https://github.com/Krypton-Suite/Standard-Toolkit/issues/1871
+                borderRounding = 0.1f;
+            }
+            
             if (rect is { Width: > 0, Height: > 0 })
             {
                 // Only use a rounding that will fit inside the rect
                 var rounding = Math.Min(borderRounding, Math.Min(rect.Width / 2f, rect.Height / 2f) - borderWidth);
 
-                // Shrink the rect by half the width of the pen, because the pen will 
-                // draw half the distance overlapping each side of the centre anyway.
-                // Unless not drawing into the middle in which case give the outside.
-                var halfBorderWidth = middle ? borderWidth / 2f : 0f;
 
-                RectangleF rectF = rect;
-                if (forBorder)  // #1757
+                if (middle)
                 {
-                    // Remove the transparency 1/2 pixel around borders
-                    rectF.Inflate(0.5f, 0.5f);
-                }
+                    // Shrink the rect by half the width of the pen, because the pen will 
+                    // draw half the distance overlapping each side of the centre anyway.
+                    // Unless not drawing into the middle in which case give the outside.
+                    int halfBorderWidthTL = (int)((borderWidth + .5f) / 2f);
+                    // Only adjust the edges that are being drawn
+                    if (CommonHelper.HasTopBorder(borders))
+                    {
+                        rect.Y += halfBorderWidthTL;
+                        rect.Height -= halfBorderWidthTL;
+                    }
 
-                // Only adjust the edges that are being drawn
-                if (CommonHelper.HasTopBorder(borders))
-                {
-                    rectF.Y += halfBorderWidth;
-                    rectF.Height -= halfBorderWidth;
-                }
+                    if (CommonHelper.HasLeftBorder(borders))
+                    {
+                        rect.X += halfBorderWidthTL;
+                        rect.Width -= halfBorderWidthTL;
+                    }
 
-                if (CommonHelper.HasLeftBorder(borders))
-                {
-                    rectF.X += halfBorderWidth;
-                    rectF.Width -= halfBorderWidth;
-                }
+                    if (CommonHelper.HasBottomBorder(borders))
+                    {
+                        rect.Height -= halfBorderWidthTL;
+                    }
 
-                if (CommonHelper.HasBottomBorder(borders))
-                {
-                    rectF.Height -= halfBorderWidth;
-                }
-
-                if (CommonHelper.HasRightBorder(borders))
-                {
-                    rectF.Width -= halfBorderWidth;
+                    if (CommonHelper.HasRightBorder(borders))
+                    {
+                        rect.Width -= halfBorderWidthTL;
+                    }
                 }
 
                 // Find the width/height of the arc box
@@ -3857,7 +3869,7 @@ namespace Krypton.Toolkit
                 // If drawing all the four borders use a single routine
                 if (CommonHelper.HasAllBorders(borders))
                 {
-                    CreateAllBorderBackPath(middle, borderPath, rectF, borderWidth, rounding, forBorder, arcLength, arcLength1);
+                    CreateAllBorderBackPath(middle, borderPath, rect, borderWidth, rounding, forBorder, arcLength, arcLength1);
                 }
                 else
                 {
@@ -3872,26 +3884,25 @@ namespace Krypton.Toolkit
                             // because this is going to be used as a region we need to close the path as well.
                             if (rounding > 0)
                             {
-                                CreateBorderBackPathOnlyClosed(middle, borders, borderPath, rectF, arcLength, variant);
+                                CreateBorderBackPathOnlyClosed(middle, borders, borderPath, rect, arcLength, variant);
                             }
                             else
                             {
-                                // Without rounding, we just provide the entire area
-                                borderPath.AddRectangle(rectF);
+                                // Without rounding we just provide the entire area
+                                borderPath.AddRectangle(rect);
                             }
                         }
                         else
                         {
                             // We are calculating the middle of the border as the brush will then draw the entire
                             // border from the middle outwards.
-
                             if (rounding > 0)
                             {
-                                CreateBorderBackPathOnly(middle, borders, borderPath, rectF, arcLength, variant);
+                                CreateBorderBackPathOnly(middle, borders, borderPath, rect, arcLength, variant);
                             }
                             else
                             {
-                                CreateBorderBackPathOnly(borders, borderPath, rectF, variant);
+                                CreateBorderBackPathOnly(borders, borderPath, rect, variant);
                             }
                         }
                     }
@@ -3901,12 +3912,12 @@ namespace Krypton.Toolkit
                         // If there is rounding we need to calculate a path that honors the rounding at corners
                         if (rounding > 0)
                         {
-                            CreateBorderBackPathComplete(middle, borders, borderPath, rectF, arcLength);
+                            CreateBorderBackPathComplete(middle, borders, borderPath, rect, arcLength);
                         }
                         else
                         {
                             // Without rounding the complete path is always just the entire area
-                            borderPath.AddRectangle(rectF);
+                            borderPath.AddRectangle(rect);
                         }
                     }
                 }
@@ -3969,6 +3980,7 @@ namespace Krypton.Toolkit
             switch (borders)
             {
                 case PaletteDrawBorders.None:
+                    borderPath.AddRectangle(rectF);
                     break;
                 case PaletteDrawBorders.Top:
                     borderPath.AddLine(rectF.Left - 1, rectF.Top, rectF.Right + 1, rectF.Top);
@@ -4050,9 +4062,10 @@ namespace Krypton.Toolkit
                                                      float arcLength,
                                                      int variant)
         {
-            //// Reduce the width and height by 1 pixel for drawing into rectangle
-            //rect.Width--;
-            //rect.Height--;
+            // Reduce the width and height by 1 pixel for drawing into rectangle
+            // Fixes the issue as displayed here: https://github.com/Krypton-Suite/Standard-Toolkit/issues/1871#issuecomment-2503893001
+            rectF.Width--;
+            rectF.Height--;
 
             // If trying to get the outside edge then perform some offsetting so that
             // when converted to a region it draws nicely inside the path outline
@@ -4467,8 +4480,10 @@ namespace Krypton.Toolkit
                     AddSlantBothPath(borderPath, orientation, rect, forBorder);
                     break;
                 case TabBorderStyle.OneNote:
+                {
                     // Is the current tab selected?
-                    var selected = state is PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking;
+                    var selected = state is PaletteState.CheckedNormal or PaletteState.CheckedPressed
+                        or PaletteState.CheckedTracking;
 
                     // The right padding depends on the selected state
                     var rp = selected ? SPACING_TAB_ONE_NOTE_RPS : SPACING_TAB_ONE_NOTE_RPI;
@@ -4487,7 +4502,7 @@ namespace Krypton.Toolkit
                     {
                         AddOneNotePath(borderPath, orientation, rect, forBorder, rp);
                     }
-
+                }
                     break;
                 case TabBorderStyle.SmoothEqual:
                 case TabBorderStyle.SmoothOutsize:
@@ -4637,6 +4652,7 @@ namespace Krypton.Toolkit
                     borderPath.AddLine(rect.Left, rect.Top, rect.Right, rect.Top);
                     borderPath.AddLine(rect.Right, rect.Top, rect.Right, rect.Bottom);
                     break;
+
                 case VisualOrientation.Bottom:
                     if (!forBorder)
                     {
@@ -4657,6 +4673,7 @@ namespace Krypton.Toolkit
                     borderPath.AddLine(rect.Left, rect.Bottom, rect.Left, rect.Top);
                     borderPath.AddLine(rect.Left, rect.Top, rect.Right, rect.Top);
                     break;
+
                 case VisualOrientation.Right:
                     if (!forBorder)
                     {
@@ -4692,6 +4709,7 @@ namespace Krypton.Toolkit
                     borderPath.AddLine(rect.Right - x, rect.Top, rect.Right, rect.Top + x);
                     borderPath.AddLine(rect.Right, rect.Top + x, rect.Right, rect.Bottom);
                     break;
+
                 case VisualOrientation.Bottom:
                     if (!forBorder)
                     {
@@ -4716,6 +4734,7 @@ namespace Krypton.Toolkit
                     borderPath.AddLine(rect.Left, rect.Top + x, rect.Left + x, rect.Top);
                     borderPath.AddLine(rect.Left + x, rect.Top, rect.Right, rect.Top);
                     break;
+
                 case VisualOrientation.Right:
                     if (!forBorder)
                     {
@@ -4753,6 +4772,7 @@ namespace Krypton.Toolkit
                     borderPath.AddLine(rect.Left + xW, rect.Top, rect.Right, rect.Top);
                     borderPath.AddLine(rect.Right, rect.Top, rect.Right, rect.Bottom);
                     break;
+
                 case VisualOrientation.Bottom:
                     if (!forBorder)
                     {
@@ -4763,6 +4783,7 @@ namespace Krypton.Toolkit
                     borderPath.AddLine(rect.Left + xW, rect.Bottom, rect.Right, rect.Bottom);
                     borderPath.AddLine(rect.Right, rect.Bottom, rect.Right, rect.Top);
                     break;
+
                 case VisualOrientation.Left:
                     if (!forBorder)
                     {
@@ -4808,6 +4829,7 @@ namespace Krypton.Toolkit
                     borderPath.AddLine(rect.Left, rect.Top, rect.Right - xW, rect.Top);
                     borderPath.AddLine(rect.Right - xW, rect.Top, rect.Right, rect.Bottom);
                     break;
+
                 case VisualOrientation.Bottom:
                     if (!forBorder)
                     {
@@ -4818,6 +4840,7 @@ namespace Krypton.Toolkit
                     borderPath.AddLine(rect.Left, rect.Bottom, rect.Right - xW, rect.Bottom);
                     borderPath.AddLine(rect.Right - xW, rect.Bottom, rect.Right, rect.Top);
                     break;
+
                 case VisualOrientation.Left:
                     if (!forBorder)
                     {
@@ -4863,6 +4886,7 @@ namespace Krypton.Toolkit
                     borderPath.AddLine(rect.Left + xW, rect.Top, rect.Right - xW, rect.Top);
                     borderPath.AddLine(rect.Right - xW, rect.Top, rect.Right, rect.Bottom);
                     break;
+
                 case VisualOrientation.Bottom:
                     if (!forBorder)
                     {
@@ -4873,6 +4897,7 @@ namespace Krypton.Toolkit
                     borderPath.AddLine(rect.Left + xW, rect.Bottom, rect.Right - xW, rect.Bottom);
                     borderPath.AddLine(rect.Right - xW, rect.Bottom, rect.Right, rect.Top);
                     break;
+
                 case VisualOrientation.Left:
                     if (!forBorder)
                     {
@@ -4883,6 +4908,7 @@ namespace Krypton.Toolkit
                     borderPath.AddLine(rect.Left, rect.Bottom - xH, rect.Left, rect.Top + xH);
                     borderPath.AddLine(rect.Left, rect.Top + xH, rect.Right, rect.Top - 1);
                     break;
+
                 case VisualOrientation.Right:
                     if (!forBorder)
                     {
@@ -5023,6 +5049,7 @@ namespace Krypton.Toolkit
                             new Point(rect.Right, rect.Bottom)}, tension);
                     }
                     break;
+
                 case VisualOrientation.Bottom:
                     // If there is not enough room for the rounded style then use the rounded
                     if (rect.Width < 14)
@@ -5047,6 +5074,7 @@ namespace Krypton.Toolkit
                             new Point(rect.Right - indentW, rect.Bottom - 5), new Point(rect.Right, rect.Top)}, tension);
                     }
                     break;
+
                 case VisualOrientation.Left:
                     // If there is not enough room for the rounded style then use the rounded
                     if (rect.Height < 14)
@@ -5071,6 +5099,7 @@ namespace Krypton.Toolkit
                             new Point(rect.Right, rect.Top)}, tension);
                     }
                     break;
+
                 case VisualOrientation.Right:
                     // If there is not enough room for the rounded style then use the rounded
                     if (rect.Height < 14)

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderVisualStudio.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderVisualStudio.cs
@@ -57,7 +57,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="colourPalette">The colour palette.</param>
         /// <returns></returns>
-        public override ToolStripRenderer RenderToolStrip([DisallowNull] PaletteBase colourPalette)
+        public override ToolStripRenderer RenderToolStrip([DisallowNull] PaletteBase? colourPalette)
         {
             Debug.Assert(colourPalette != null);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderVisualStudio2010With2007.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderVisualStudio2010With2007.cs
@@ -92,7 +92,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="colorPalette">Color palette to use when rendering toolstrip.</param>
         /// <exception cref="ArgumentNullException"></exception>
-        public override ToolStripRenderer RenderToolStrip([DisallowNull] PaletteBase colorPalette)
+        public override ToolStripRenderer RenderToolStrip([DisallowNull] PaletteBase? colorPalette)
         {
             Debug.Assert(colorPalette != null);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderVisualStudio2010With2010.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderVisualStudio2010With2010.cs
@@ -94,7 +94,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="colorPalette">Color palette to use when rendering toolstrip.</param>
         /// <exception cref="ArgumentNullException"></exception>
-        public override ToolStripRenderer RenderToolStrip([DisallowNull] PaletteBase colorPalette)
+        public override ToolStripRenderer RenderToolStrip([DisallowNull] PaletteBase? colorPalette)
         {
             Debug.Assert(colorPalette != null);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderVisualStudio2010With2013.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderVisualStudio2010With2013.cs
@@ -76,7 +76,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="colorPalette">Color palette to use when rendering toolstrip.</param>
         /// <exception cref="ArgumentNullException"></exception>
-        public override ToolStripRenderer RenderToolStrip([DisallowNull] PaletteBase colorPalette)
+        public override ToolStripRenderer RenderToolStrip([DisallowNull] PaletteBase? colorPalette)
         {
             Debug.Assert(colorPalette != null);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderVisualStudio2010WithMicrosoft365.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderVisualStudio2010WithMicrosoft365.cs
@@ -58,7 +58,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="colourPalette">The colour palette.</param>
         /// <returns></returns>
-        public override ToolStripRenderer RenderToolStrip([DisallowNull] PaletteBase colourPalette)
+        public override ToolStripRenderer RenderToolStrip([DisallowNull] PaletteBase? colourPalette)
         {
             Debug.Assert(colourPalette != null);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Utilities/PaletteImageScaler.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Utilities/PaletteImageScaler.cs
@@ -160,7 +160,7 @@ namespace Krypton.Toolkit
                 return img;
             }
             using var tmpBmp = new Bitmap(img);
-            tmpBmp.MakeTransparent(Color.Magenta);
+            tmpBmp.MakeTransparent(GlobalStaticValues.TRANSPARENCY_KEY_COLOR);
             return CommonHelper.ScaleImageForSizedDisplay(tmpBmp, img.Width * scaleFactor.Width, img.Height * scaleFactor.Height);
         }
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Values/ButtonValues.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Values/ButtonValues.cs
@@ -227,12 +227,9 @@ namespace Krypton.Toolkit
             }
         }
 
+        private void ResetExtraText() => ExtraText = _defaultExtraText;
         private bool ShouldSerializeExtraText() => ExtraText != _defaultExtraText;
 
-        /// <summary>
-        /// Resets the Description property to its default value.
-        /// </summary>
-        public void ResetExtraText() => ExtraText = _defaultExtraText;
         #endregion
 
         #region UseAsADialogButton
@@ -369,7 +366,8 @@ namespace Krypton.Toolkit
                 }
             }
         }
-
+        private void ResetDropDownArrowColor() => _dropDownArrowColor = GlobalStaticValues.EMPTY_COLOR;
+        private bool ShouldSerializeDropDownArrowColor() => _dropDownArrowColor != GlobalStaticValues.EMPTY_COLOR;
         #endregion
 
         #region CreateImageStates

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawCanvas.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawCanvas.cs
@@ -397,7 +397,7 @@ namespace Krypton.Toolkit
             if (_paletteMetric != null)
             {
                 // Apply padding needed outside the border of the canvas
-                preferredSize = CommonHelper.ApplyPadding(Orientation, preferredSize, _paletteMetric.GetMetricPadding(State, _metricPadding));
+                preferredSize = CommonHelper.ApplyPadding(Orientation, preferredSize, _paletteMetric.GetMetricPadding(context.Control as KryptonForm, State, _metricPadding));
             }
 
             return preferredSize;
@@ -430,7 +430,7 @@ namespace Krypton.Toolkit
             if (_paletteMetric != null)
             {
                 // Get the padding to be applied before the canvas drawing
-                Padding outerPadding = _paletteMetric.GetMetricPadding(State, _metricPadding);
+                Padding outerPadding = _paletteMetric.GetMetricPadding(context.Control as KryptonForm, State, _metricPadding);
 
                 // Apply the padding to the client rectangle
                 ClientRectangle = CommonHelper.ApplyPadding(Orientation, ClientRectangle, outerPadding);

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawContent.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawContent.cs
@@ -410,7 +410,5 @@ namespace Krypton.Toolkit
             return (bool)_pi!.GetValue(c, null)!;
         }
         #endregion
-
-    
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawDocker.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawDocker.cs
@@ -352,7 +352,7 @@ namespace Krypton.Toolkit
                 if (_paletteMetric != null && _metricPadding != PaletteMetricPadding.None)
                 {
                     // Apply padding needed outside the border of the canvas
-                    var padding = _paletteMetric.GetMetricPadding(State, _metricPadding);
+                    var padding = _paletteMetric.GetMetricPadding(context.Control as KryptonForm, State, _metricPadding);
                     preferredSize = CommonHelper.ApplyPadding(Orientation, preferredSize, padding);
                     displayRect = CommonHelper.ApplyPadding(Orientation, displayRect, padding);
                 }
@@ -421,7 +421,7 @@ namespace Krypton.Toolkit
                 if (_paletteMetric != null && _metricPadding != PaletteMetricPadding.None)
                 {
                     // Apply padding needed outside the border of the canvas
-                    var padding = _paletteMetric.GetMetricPadding(State, _metricPadding);
+                    var padding = _paletteMetric.GetMetricPadding(context.Control as KryptonForm, State, _metricPadding);
                     preferredSize = CommonHelper.ApplyPadding(Orientation, preferredSize, padding);
                     displayRect = CommonHelper.ApplyPadding(Orientation, displayRect, padding);
                 }
@@ -561,7 +561,7 @@ namespace Krypton.Toolkit
                 if (_paletteMetric != null && _metricPadding != PaletteMetricPadding.None)
                 {
                     // Get the padding to be applied before the canvas drawing
-                    var outerPadding = _paletteMetric.GetMetricPadding(State, _metricPadding);
+                    var outerPadding = _paletteMetric.GetMetricPadding(context.Control as KryptonForm, State, _metricPadding);
                     ClientRectangle = CommonHelper.ApplyPadding(Orientation, ClientRectangle, outerPadding);
                 }
             }
@@ -570,7 +570,7 @@ namespace Krypton.Toolkit
             var fillerRect = ClientRectangle;
             context.DisplayRectangle = fillerRect;
 
-            // By default all the children need to draw all their borders
+            // By default, all the children need to draw all their borders
             var leftEdges = PaletteDrawBorders.All;
             var rightEdges = PaletteDrawBorders.All;
             var topEdges = PaletteDrawBorders.All;
@@ -717,6 +717,7 @@ namespace Krypton.Toolkit
                         rightEdges &= PaletteDrawBorders.BottomLeftRight;
                         topEdges &= PaletteDrawBorders.BottomLeftRight;
                         break;
+
                     case ViewDockStyle.Bottom:
                         if (childCanvas != null)
                         {
@@ -728,6 +729,7 @@ namespace Krypton.Toolkit
                         rightEdges &= PaletteDrawBorders.TopLeftRight;
                         bottomEdges &= PaletteDrawBorders.TopLeftRight;
                         break;
+
                     case ViewDockStyle.Left:
                         if (childCanvas != null)
                         {
@@ -739,6 +741,7 @@ namespace Krypton.Toolkit
                         bottomEdges &= PaletteDrawBorders.TopBottomRight;
                         leftEdges &= PaletteDrawBorders.TopBottomRight;
                         break;
+
                     case ViewDockStyle.Right:
                         if (childCanvas != null)
                         {

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuItem.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuItem.cs
@@ -81,7 +81,7 @@ namespace Krypton.Toolkit
                 if (_imageColumn)
                 {
                     itemColumnImage = _empty16x16;
-                    itemImageTransparent = Color.Magenta;
+                    itemImageTransparent = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
                 }
 
                 switch (ResolveCheckState)
@@ -144,7 +144,14 @@ namespace Krypton.Toolkit
 
             // SubMenu Indicator
             HasSubMenu = KryptonContextMenuItem.Items.Count > 0;
-            _subMenuContent = new ViewDrawMenuItemContent(menuItemState.ItemImage.Content, new FixedContentValue(null, null, !HasSubMenu ? _empty16x16 : provider.ProviderImages.GetContextMenuSubMenuImage(), KryptonContextMenuItem.Items.Count == 0 ? Color.Magenta : GlobalStaticValues.EMPTY_COLOR), 3);
+            _subMenuContent = new ViewDrawMenuItemContent(menuItemState.ItemImage.Content, new FixedContentValue(null, null, 
+                !HasSubMenu 
+                    ? _empty16x16 
+                    : provider.ProviderImages.GetContextMenuSubMenuImage(), 
+                KryptonContextMenuItem.Items.Count == 0 
+                    ? GlobalStaticValues.TRANSPARENCY_KEY_COLOR 
+                    : GlobalStaticValues.EMPTY_COLOR),
+                3);
             docker.Add(new ViewLayoutCenter(_subMenuContent), ViewDockStyle.Right);
             _subMenuContent.Enabled = ItemEnabled;
 
@@ -517,7 +524,7 @@ namespace Krypton.Toolkit
                     if (_imageColumn)
                     {
                         itemColumnImage = _empty16x16;
-                        itemImageTransparent = Color.Magenta;
+                        itemImageTransparent = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
                     }
 
                     switch (ResolveCheckState)

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawPanel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawPanel.cs
@@ -151,6 +151,13 @@ namespace Krypton.Toolkit
             }
 
             // We take on all the available display area
+            if (context.Control is KryptonForm)
+            {
+                Rectangle contextDisplayRectangle = context.DisplayRectangle;
+                contextDisplayRectangle.Width -= 10;
+                context.DisplayRectangle = contextDisplayRectangle;
+            }
+
             ClientRectangle = context.DisplayRectangle;
 
             // Let child elements layout

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawSeparator.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawSeparator.cs
@@ -210,7 +210,7 @@ namespace Krypton.Toolkit
 
             // Apply padding needed outside the border of the separator
             var rect = CommonHelper.ApplyPadding(Orientation, ClientRectangle,
-                                                       _metric!.GetMetricPadding(ElementState, MetricPadding));
+                                                       _metric!.GetMetricPadding(context.Control as KryptonForm, ElementState, MetricPadding));
 
             // Ask the renderer to perform drawing of the separator glyph
             context.Renderer.RenderGlyph.DrawSeparator(context, rect, _palette!.PaletteBack, _palette.PaletteBorder!,

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawSplitCanvas.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawSplitCanvas.cs
@@ -413,7 +413,7 @@ namespace Krypton.Toolkit
             if (PaletteMetric != null && _metricPadding != PaletteMetricPadding.None)
             {
                 // Apply padding needed outside the border of the canvas
-                preferredSize = CommonHelper.ApplyPadding(Orientation, preferredSize, PaletteMetric.GetMetricPadding(State, _metricPadding));
+                preferredSize = CommonHelper.ApplyPadding(Orientation, preferredSize, PaletteMetric.GetMetricPadding(context.Control as KryptonForm, State, _metricPadding));
             }
 
             return preferredSize;
@@ -446,7 +446,7 @@ namespace Krypton.Toolkit
             if (PaletteMetric != null && _metricPadding != PaletteMetricPadding.None)
             {
                 // Get the padding to be applied before the canvas drawing
-                Padding outerPadding = PaletteMetric.GetMetricPadding(State, _metricPadding);
+                Padding outerPadding = PaletteMetric.GetMetricPadding(context.Control as KryptonForm, State, _metricPadding);
 
                 // Apply the padding to the client rectangle
                 ClientRectangle = CommonHelper.ApplyPadding(Orientation, ClientRectangle, outerPadding);

--- a/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutCenter.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutCenter.cs
@@ -133,7 +133,7 @@ namespace Krypton.Toolkit
             if ((_paletteMetric != null) && (MetricPadding != PaletteMetricPadding.None))
             {
                 // Get the required padding for the border
-                Padding borderPadding = _paletteMetric.GetMetricPadding(ElementState, MetricPadding);
+                Padding borderPadding = _paletteMetric.GetMetricPadding(context.Control as KryptonForm, ElementState, MetricPadding);
 
                 // Applying the padding will depend on the orientation
                 switch(Orientation)
@@ -195,7 +195,7 @@ namespace Krypton.Toolkit
             if ((_paletteMetric != null) && (MetricPadding != PaletteMetricPadding.None))
             {
                 // Get the required padding for the border
-                Padding borderPadding = _paletteMetric.GetMetricPadding(ElementState, MetricPadding);
+                Padding borderPadding = _paletteMetric.GetMetricPadding(context.Control as KryptonForm, ElementState, MetricPadding);
 
                 // Applying the padding will depend on the orientation
                 ClientRectangle = Orientation switch

--- a/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutMenuItemsPile.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutMenuItemsPile.cs
@@ -66,7 +66,7 @@ namespace Krypton.Toolkit
             };
 
             // Grab the padding for around the item stack
-            Padding itemsPadding = _paletteItemHighlight!.GetMetricPadding(PaletteState.Normal, PaletteMetricPadding.ContextMenuItemsCollection);
+            Padding itemsPadding = _paletteItemHighlight!.GetMetricPadding(null, PaletteState.Normal, PaletteMetricPadding.ContextMenuItemsCollection);
             stackDocker.Add(new ViewLayoutSeparator(itemsPadding.Left), ViewDockStyle.Left);
             stackDocker.Add(new ViewLayoutSeparator(itemsPadding.Right), ViewDockStyle.Right);
             stackDocker.Add(new ViewLayoutSeparator(itemsPadding.Top), ViewDockStyle.Top);
@@ -225,7 +225,7 @@ namespace Krypton.Toolkit
                 imageColumnWidth += borderPadding.Left * 3;
 
                 // Add double the metric padding that occurs outside the item highlight
-                Padding itemMetricPadding = _paletteItemHighlight!.GetMetricPadding(PaletteState.Normal, PaletteMetricPadding.ContextMenuItemHighlight);
+                Padding itemMetricPadding = _paletteItemHighlight!.GetMetricPadding(null, PaletteState.Normal, PaletteMetricPadding.ContextMenuItemHighlight);
                 imageColumnWidth += itemMetricPadding.Left * 2;
 
                 _imageColumn.ColumnWidth = imageColumnWidth;

--- a/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutMenuSepGap.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutMenuSepGap.cs
@@ -60,8 +60,8 @@ namespace Krypton.Toolkit
 
             // Grab the padding used for the text/extra content of a menu item
             Padding paddingText = _standardStyle
-                ? _stateCommon.ItemTextStandard.GetContentPadding(PaletteState.Normal)
-                : _stateCommon.ItemTextAlternate.GetContentPadding(PaletteState.Normal);
+                ? _stateCommon.ItemTextStandard.GetBorderContentPadding(context.Control as KryptonForm, PaletteState.Normal)
+                : _stateCommon.ItemTextAlternate.GetBorderContentPadding(context.Control as KryptonForm, PaletteState.Normal);
 
             // Get padding needed for the left edge of the item highlight
             Padding paddingHighlight = context.Renderer.RenderStandardBorder.GetBorderDisplayPadding(_stateCommon.ItemHighlight?.Border!, PaletteState.Normal, VisualOrientation.Top);

--- a/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutMetricSpacer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutMetricSpacer.cs
@@ -78,7 +78,7 @@ namespace Krypton.Toolkit
             Debug.Assert(context != null);
 
             // Get the sizing metric
-            var length = _paletteMetric.GetMetricInt(ElementState, _metricInt);
+            var length = _paletteMetric.GetMetricInt(OwningControl as KryptonForm, ElementState, _metricInt);
 
             // Use the same size for vertical and horizontal
             return new Size(length, length);
@@ -93,7 +93,7 @@ namespace Krypton.Toolkit
             Debug.Assert(context != null);
 
             // Get the sizing metric
-            var length = _paletteMetric.GetMetricInt(ElementState, _metricInt);
+            var length = _paletteMetric.GetMetricInt(OwningControl as KryptonForm, ElementState, _metricInt);
 
             // Always use the metric and ignore given space
             ClientRectangle = new Rectangle(context!.DisplayRectangle.Location, new Size(length, length));

--- a/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutViewport.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Layout/ViewLayoutViewport.cs
@@ -440,7 +440,7 @@ namespace Krypton.Toolkit
             // Reduce available display rect by the required border sizing
             if (_paletteMetrics != null)
             {
-                context.DisplayRectangle = CommonHelper.ApplyPadding(Orientation, originalRect, _paletteMetrics.GetMetricPadding(State, _metricPadding));
+                context.DisplayRectangle = CommonHelper.ApplyPadding(Orientation, originalRect, _paletteMetrics.GetMetricPadding(context.Control as KryptonForm, State, _metricPadding));
             }
 
             // Cache the maximum extent of all the children
@@ -456,7 +456,7 @@ namespace Krypton.Toolkit
             context.DisplayRectangle = originalRect;
 
             // Apply padding needed outside the border of the canvas
-            return CommonHelper.ApplyPadding(Orientation, _extent, _paletteMetrics.GetMetricPadding(State, _metricPadding));
+            return CommonHelper.ApplyPadding(Orientation, _extent, _paletteMetrics.GetMetricPadding(context.Control as KryptonForm, State, _metricPadding));
         }
 
         /// <summary>
@@ -487,7 +487,7 @@ namespace Krypton.Toolkit
             if (_paletteMetrics != null)
             {
                 // Get the padding to be applied
-                Padding outerPadding = _paletteMetrics.GetMetricPadding(State, _metricPadding);
+                Padding outerPadding = _paletteMetrics.GetMetricPadding(context.Control as KryptonForm, State, _metricPadding);
 
                 // Reduce space for children by the padding area
                 positionRectangle = ApplyPadding(positionRectangle, outerPadding);
@@ -595,7 +595,7 @@ namespace Krypton.Toolkit
             if (_paletteMetrics != null)
             {
                 // Get the padding to be applied
-                Padding outerPadding = _paletteMetrics.GetMetricPadding(State, _metricPadding);
+                Padding outerPadding = _paletteMetrics.GetMetricPadding(context.Control as KryptonForm, State, _metricPadding);
 
                 // Reduce the clipping area by the padding
                 clipRectangle = ApplyPadding(clipRectangle, outerPadding);
@@ -854,7 +854,7 @@ namespace Krypton.Toolkit
             // We might not be provided with metrics, so only use if reference provided
             if (_paletteMetrics != null)
             {
-                overs = _paletteMetrics.GetMetricInt(State, _metricOvers) + _scrollOvers;
+                overs = _paletteMetrics.GetMetricInt(OwningControl as KryptonForm, State, _metricOvers) + _scrollOvers;
             }
 
             // Move the required rectangle more than exactly into view in order to make it
@@ -876,7 +876,7 @@ namespace Krypton.Toolkit
                 // Is part of the required rectangle not currently visible
                 if (!ClientRectangle.Contains(rect))
                 {
-                    // Correct the alignmnet to take right to left into account
+                    // Correct the alignment to take right to left into account
                     RelativePositionAlign alignment = AlignmentRTL;
 
                     // Center alignment needs changing to near or far for scrolling
@@ -885,7 +885,7 @@ namespace Krypton.Toolkit
                         alignment = RelativePositionAlign.Near;
                     }
 
-                    // How to scroll into view depends on the alignmnent of items
+                    // How to scroll into view depends on the alignment of items
                     switch (alignment)
                     {
                         case RelativePositionAlign.Near:
@@ -945,11 +945,11 @@ namespace Krypton.Toolkit
 
         private void OnAnimationTick(object? sender, EventArgs e)
         {
-            // Limit check the animation offset, incase the limits have changed
+            // Limit check the animation offset, in case the limits have changed
             _animationOffset.X = Math.Min(Math.Max(_animationOffset.X, _limit.X), 0);
             _animationOffset.Y = Math.Min(Math.Max(_animationOffset.Y, _limit.Y), 0);
 
-            // Find distance half way to the destination
+            // Find distance half-way to the destination
             var distanceX = (_animationOffset.X - _offset.X) / 2;
             var distanceY = (_animationOffset.Y - _offset.Y) / 2;
 


### PR DESCRIPTION
- Attempt to make `GetWindowBorders` the single source of truth.
- Make use of `GlobalStaticValues.TRANSPARENCY_KEY_COLOR`
- Pass `KryptonForm? owningForm` into appropriate functions to determine actual borders in use
- Make sure `MdiParent` is taken care of in `KryptonForm` reuse
- Fix some of the overflow when a form is maximised
- Make sure changes to Layout still allow Tooltips to work.
- Fix Usages of borders when they are Not to be drawn
- Update themes to return the usage of the actual borders rather the hardcoded values
- Fix Designer "Misuse" from the `DropDownArrowColor`

#1871
#1783

No warnings ??

![image](https://github.com/user-attachments/assets/ded65398-41cf-4f4f-89ee-4a19bd341ea0)
