### PR TITLE
1840-V95-DN9-changes-to-nullability-annotations

### DIFF
--- a/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonAutoHiddenProxyPage.cs
+++ b/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonAutoHiddenProxyPage.cs
@@ -60,6 +60,7 @@ namespace Krypton.Docking
         /// Gets and sets the page text.
         /// </summary>
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override string Text
         {
             // Check for null when initialising
@@ -81,6 +82,7 @@ namespace Krypton.Docking
         /// Gets and sets the title text for the page.
         /// </summary>
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override string TextTitle
         {
             get => Page.TextTitle;
@@ -92,6 +94,7 @@ namespace Krypton.Docking
         /// Gets and sets the description text for the page.
         /// </summary>
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override string TextDescription
         {
             get => Page.TextDescription;
@@ -102,6 +105,7 @@ namespace Krypton.Docking
         /// <summary>
         /// Gets and sets the small image for the page.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Bitmap? ImageSmall
         {
             get => Page.ImageSmall;
@@ -112,6 +116,7 @@ namespace Krypton.Docking
         /// <summary>
         /// Gets and sets the medium image for the page.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Bitmap? ImageMedium
         {
             get => Page.ImageMedium;
@@ -122,6 +127,7 @@ namespace Krypton.Docking
         /// <summary>
         /// Gets and sets the large image for the page.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Bitmap? ImageLarge
         {
             get => Page.ImageLarge;
@@ -132,6 +138,7 @@ namespace Krypton.Docking
         /// <summary>
         /// Gets and sets the page tooltip image.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Bitmap? ToolTipImage
         {
             get => Page.ToolTipImage;
@@ -142,6 +149,7 @@ namespace Krypton.Docking
         /// <summary>
         /// Gets and sets the tooltip image transparent color.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color ToolTipImageTransparentColor
         {
             get => Page.ToolTipImageTransparentColor;
@@ -152,6 +160,7 @@ namespace Krypton.Docking
         /// <summary>
         /// Gets and sets the page tooltip title text.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override string ToolTipTitle
         {
             get => Page.ToolTipTitle;
@@ -162,6 +171,7 @@ namespace Krypton.Docking
         /// <summary>
         /// Gets and sets the page tooltip body text.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override string ToolTipBody
         {
             get => Page.ToolTipBody;
@@ -172,6 +182,7 @@ namespace Krypton.Docking
         /// <summary>
         /// Gets and sets the tooltip label style.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override LabelStyle ToolTipStyle
         {
             get => Page.ToolTipStyle;
@@ -182,6 +193,7 @@ namespace Krypton.Docking
         /// <summary>
         /// Gets and sets the KryptonContextMenu to show when right-clicked.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override KryptonContextMenu? KryptonContextMenu
         {
             get => Page.KryptonContextMenu;
@@ -193,6 +205,7 @@ namespace Krypton.Docking
         /// Gets and sets the unique name of the page.
         /// </summary>
         [DisallowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override string UniqueName
         {
             get => Page.UniqueName;
@@ -217,6 +230,7 @@ namespace Krypton.Docking
         /// <summary>
         /// Gets and sets the set of page flags.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override int Flags
         {
             get => Page.Flags;
@@ -248,6 +262,7 @@ namespace Krypton.Docking
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override bool LastVisibleSet
         {
             get => Page.LastVisibleSet;

--- a/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonAutoHiddenSlidePanel.cs
+++ b/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonAutoHiddenSlidePanel.cs
@@ -241,11 +241,13 @@ namespace Krypton.Docking
         /// <summary>
         /// Gets access to the KryptonPage associated with the slide panel.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public KryptonPage? Page { get; private set; }
 
         /// <summary>
         /// Gets and sets the drag page notify interface associated with the embedded dockspace.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public IDragPageNotify? DragPageNotify
         {
             get => _dockspaceSlide.DragPageNotify;

--- a/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonFloatingWindow.cs
+++ b/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonFloatingWindow.cs
@@ -203,6 +203,7 @@ namespace Krypton.Docking
         /// <summary>
         /// Gets and sets the floating messages interface.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal IFloatingMessages? FloatingMessages { get; set; }
 
         #endregion

--- a/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonSpace.cs
+++ b/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonSpace.cs
@@ -224,6 +224,7 @@ namespace Krypton.Docking
         /// Gets the button spec type for the pin button.
         /// </summary>
         [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public bool AutoHiddenHost { get; set; }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonStorePage.cs
+++ b/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonStorePage.cs
@@ -40,6 +40,7 @@ namespace Krypton.Docking
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public override bool LastVisibleSet
         {
             get => false;

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingControl.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingControl.cs
@@ -100,11 +100,13 @@ namespace Krypton.Docking
         /// <summary>
         /// Gets the control this element is managing.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public Control Control { get; private set; }
 
         /// <summary>
         /// Gets and sets the minimum size for the inner area of the control that docking should not overlap.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public Size InnerMinimum
         {
             get => _innerMinimum;

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingFloating.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingFloating.cs
@@ -87,6 +87,7 @@ namespace Krypton.Docking
         /// <summary>
         /// 
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public bool UseMinimiseBox { get; set; }
         #endregion
 

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingFloatingWindow.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingFloatingWindow.cs
@@ -70,6 +70,7 @@ namespace Krypton.Docking
         /// <summary>
         /// Gets and sets access to the parent docking element.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override IDockingElement? Parent
         {
             set

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingNavigator.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingNavigator.cs
@@ -68,6 +68,7 @@ namespace Krypton.Docking
         /// <summary>
         /// Gets and sets access to the parent docking element.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override IDockingElement? Parent
         {
             set

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingSpace.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingSpace.cs
@@ -219,6 +219,7 @@ namespace Krypton.Docking
         /// <summary>
         /// Gets and sets access to the parent docking element.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override IDockingElement? Parent
         {
             set

--- a/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingWorkspace.cs
+++ b/Source/Krypton Components/Krypton.Docking/Elements Impl/KryptonDockingWorkspace.cs
@@ -63,6 +63,7 @@ namespace Krypton.Docking
         /// <summary>
         /// Gets and sets access to the parent docking element.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override IDockingElement? Parent
         {
             set

--- a/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavFixed.cs
+++ b/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavFixed.cs
@@ -75,6 +75,7 @@ namespace Krypton.Navigator
         [Description(@"Defines header location for the button.")]
         [RefreshProperties(RefreshProperties.All)]
         //[DefaultValue(typeof(HeaderLocation), "PrimaryHeader")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public HeaderLocation HeaderLocation
         {
             get => _location;

--- a/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavigator.cs
+++ b/Source/Krypton Components/Krypton.Navigator/ButtonSpecs/ButtonSpecNavigator.cs
@@ -31,6 +31,7 @@ namespace Krypton.Navigator
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public new PaletteButtonSpecStyle Type
         {
             get => ProtectedType;
@@ -47,6 +48,7 @@ namespace Krypton.Navigator
         [Description(@"Defines a restricted type for a navigator button spec.")]
         [RefreshProperties(RefreshProperties.All)]
         //[DefaultValue(typeof(PaletteNavButtonSpecStyle), "Generic")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteNavButtonSpecStyle TypeRestricted
         {
             get => PaletteTypeToNavigator(ProtectedType);

--- a/Source/Krypton Components/Krypton.Navigator/Controls Navigator/KryptonNavigator.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Controls Navigator/KryptonNavigator.cs
@@ -328,6 +328,7 @@ namespace Krypton.Navigator
         /// </summary>
         [Browsable(false)]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public new string Name
         {
             get => base.Name;
@@ -517,6 +518,7 @@ namespace Krypton.Navigator
         /// <summary>
         /// 
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public KryptonForm? Owner
         {
             get => _owner;
@@ -526,6 +528,7 @@ namespace Krypton.Navigator
         /// <summary>
         /// 
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public bool ControlKryptonFormFeatures
         {
             get => _controlKryptonFormFeatures;
@@ -698,6 +701,7 @@ namespace Krypton.Navigator
         [Category(@"Visuals")]
         [Description(@"Display mode of the control instance.")]
         //[DefaultValue(typeof(NavigatorMode), "Bar - Tab - Group")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public NavigatorMode NavigatorMode
         {
             get => _mode;
@@ -739,6 +743,7 @@ namespace Krypton.Navigator
         [Category(@"Visuals")]
         [Description(@"Page back style.")]
         //[DefaultValue(typeof(PaletteBackStyle), "ControlClient")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public PaletteBackStyle PageBackStyle
         {
             get => _pageBackStyle;
@@ -1037,6 +1042,7 @@ namespace Krypton.Navigator
         /// Gets the child panel used for displaying actual pages.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public KryptonGroupPanel? ChildPanel { get; private set; }
 
         /// <summary>
@@ -1828,6 +1834,7 @@ namespace Krypton.Navigator
         #endregion
 
         #region Internal
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal ViewBuilderBase? ViewBuilder { get; private set; }
 
         internal ButtonSpecCollectionBase? FixedSpecs => Button.FixedSpecs;
@@ -1836,6 +1843,7 @@ namespace Krypton.Navigator
 
         internal void InternalForceViewLayout() => ForceViewLayout();
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal ToolTipManager? HoverManager { get; private set; }
 
         internal bool InternalDesignMode => DesignMode;
@@ -2014,6 +2022,7 @@ namespace Krypton.Navigator
             }
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal bool IsChildPanelBorrowed { get; private set; }
 
         internal void BorrowChildPanel()

--- a/Source/Krypton Components/Krypton.Navigator/Dragging/DropSolidWindow.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Dragging/DropSolidWindow.cs
@@ -69,6 +69,7 @@ namespace Krypton.Navigator
         /// <summary>
         /// Gets and sets the new solid rectangle area.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public Rectangle SolidRect
         {
             get => _solidRect;

--- a/Source/Krypton Components/Krypton.Navigator/Page/KryptonPage.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Page/KryptonPage.cs
@@ -731,6 +731,7 @@ namespace Krypton.Navigator
         [Category(@"Appearance")]
         [Description(@"The unique name of the page.")]
         [DisallowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public virtual string UniqueName
         {
             [DebuggerStepThrough]
@@ -759,6 +760,7 @@ namespace Krypton.Navigator
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         [Category(@"Appearance")]
         [Description(@"When used within a KryptonDockingSpace,\nGive a hint on the Minimum Initial size needed")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public virtual Size AutoHiddenSlideSize
         {
             get => _autoHiddenSlideSize;
@@ -1228,6 +1230,7 @@ namespace Krypton.Navigator
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public virtual bool LastVisibleSet
         {
             get => _setVisible;

--- a/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecExpandRibbon.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecExpandRibbon.cs
@@ -53,6 +53,7 @@ namespace Krypton.Ribbon
         /// <summary>
         /// Gets and sets the actual type of the button.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public PaletteButtonSpecStyle ButtonSpecType
         {
             get => ProtectedType;

--- a/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecMdiChildFixed.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecMdiChildFixed.cs
@@ -44,6 +44,7 @@ namespace Krypton.Ribbon
         /// <summary>
         /// Gets access to the owning krypton form.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public Form? MdiChild { get; set; }
 
         #endregion
@@ -52,6 +53,7 @@ namespace Krypton.Ribbon
         /// <summary>
         /// Gets and sets the actual type of the button.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public PaletteButtonSpecStyle ButtonSpecType
         {
             get => ProtectedType;

--- a/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecMinimizeRibbon.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/ButtonSpec/ButtonSpecMinimizeRibbon.cs
@@ -52,6 +52,7 @@ namespace Krypton.Ribbon
         /// <summary>
         /// Gets and sets the actual type of the button.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public PaletteButtonSpecStyle ButtonSpecType
         {
             get => ProtectedType;

--- a/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonGallery.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonGallery.cs
@@ -318,6 +318,7 @@ namespace Krypton.Ribbon
         /// </summary>
         [Category(@"Visuals")]
         [Description(@"Collection of images for display and selection.")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public ImageList? ImageList
         {
             get => _imageList;
@@ -689,6 +690,7 @@ namespace Krypton.Ribbon
         #endregion
 
         #region Internal
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         internal int TrackingIndex
         {
             get => _trackingIndex;
@@ -738,12 +740,14 @@ namespace Krypton.Ribbon
             // element that thinks it has the focus is informed it does not
             OnMouseLeave(EventArgs.Empty);
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         internal Size InternalPreferredItemSize
         {
             get => _preferredItemSize;
             set => _preferredItemSize = value;
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)] 
         internal KryptonRibbon? Ribbon { get; set; }
 
         internal void OnDropButton() => ShownGalleryDropDown(RectangleToScreen(ClientRectangle),

--- a/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonRibbon.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonRibbon.cs
@@ -574,6 +574,7 @@ namespace Krypton.Ribbon
         /// </summary>
         [Category(@"Values")]
         [Description(@"Currently selected ribbon tab.")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public KryptonRibbonTab? SelectedTab
         {
             get => _selectedTab;
@@ -950,6 +951,7 @@ namespace Krypton.Ribbon
         /// Internal design time method.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool InDesignHelperMode
         {
             get => InDesignMode && _designHelpers;
@@ -971,6 +973,7 @@ namespace Krypton.Ribbon
         /// Gets a value indicating if currently in keyboard mode.
         /// </summary>
         [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public bool KeyboardMode { get; private set; }
 
         #endregion
@@ -1704,6 +1707,7 @@ namespace Krypton.Ribbon
         #endregion
 
         #region Internal
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal bool IgnoreDoubleClickClose { get; set; }
 
         internal void OnDesignTimeAddTab() => DesignTimeAddTab?.Invoke(this, EventArgs.Empty);
@@ -1712,16 +1716,22 @@ namespace Krypton.Ribbon
 
         internal ViewRibbonManager? ViewRibbonManager => ViewManager as ViewRibbonManager;
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal ViewDrawRibbonPanel MainPanel { get; private set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal ViewLayoutRibbonTabsArea? TabsArea { get; private set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal ViewLayoutRibbonGroupsArea GroupsArea { get; private set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal ViewDrawRibbonCaptionArea? CaptionArea { get; private set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal CalculatedValues CalculatedValues { get; private set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         internal PaletteBackStyle BackStyle
         {
             get => _backStyle;
@@ -1733,6 +1743,7 @@ namespace Krypton.Ribbon
             }
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         internal PaletteBackStyle BackInactiveStyle
         {
             get => _backInactiveStyle;
@@ -1785,6 +1796,7 @@ namespace Krypton.Ribbon
             }
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         internal ButtonStyle ScrollerStyle
         {
             get => _scrollerStyle;
@@ -1800,6 +1812,7 @@ namespace Krypton.Ribbon
             }
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         internal ButtonStyle GroupButtonStyle
         {
             get => _groupButtonStyle;
@@ -1815,6 +1828,7 @@ namespace Krypton.Ribbon
             }
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         internal ButtonStyle GroupClusterButtonStyle
         {
             get => _groupClusterButtonStyle;
@@ -1830,6 +1844,7 @@ namespace Krypton.Ribbon
             }
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         internal ButtonStyle GroupCollapsedButtonStyle
         {
             get => _groupCollapsedButtonStyle;
@@ -1845,6 +1860,7 @@ namespace Krypton.Ribbon
             }
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         internal ButtonStyle GroupDialogButtonStyle
         {
             get => _groupDialogButtonStyle;
@@ -1911,6 +1927,7 @@ namespace Krypton.Ribbon
             return c as KryptonForm;
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         internal ButtonStyle QATButtonStyle
         {
             get => _qatButtonStyle;
@@ -2209,6 +2226,7 @@ namespace Krypton.Ribbon
 
         internal bool InKeyboardMode => KeyboardMode;
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal bool InKeyTipsMode { get; private set; }
 
         internal void KillKeyboardMode()
@@ -2292,6 +2310,7 @@ namespace Krypton.Ribbon
 
         internal void UpdateQAT() => CaptionArea?.UpdateQAT();
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         internal KeyTipMode KeyTipMode
         {
             get => _keyTipMode;
@@ -2422,6 +2441,7 @@ namespace Krypton.Ribbon
 
         internal Rectangle KeyTipToScreen(ViewBase? view) => view!.OwningControl!.RectangleToScreen(view.ClientRectangle);
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         internal ViewBase? FocusView
         {
             get => _focusView;
@@ -2442,8 +2462,10 @@ namespace Krypton.Ribbon
             }
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal bool LostFocusLosesKeyboard { get; set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal bool IgnoreRestoreFocus { get; set; }
 
         internal PaletteRibbonShape RibbonShape => StateCommon.RibbonGeneral.GetRibbonShape();

--- a/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonRibbonGroup.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonRibbonGroup.cs
@@ -495,8 +495,10 @@ namespace Krypton.Ribbon
         #endregion
 
         #region Internal
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal bool IsCollapsed { get; set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal bool ShowingAsPopup { get; set; }
 
         internal void OnDesignTimeAddTriple() => DesignTimeAddTriple?.Invoke(this, EventArgs.Empty);

--- a/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonRibbonQATButton.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonRibbonQATButton.cs
@@ -255,6 +255,7 @@ namespace Krypton.Ribbon
         [Description(@"Color to draw as transparent in the ToolTipImage.")]
         [KryptonDefaultColor]
         [Localizable(true)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)] 
         public Color ToolTipImageTransparentColor { get; set; }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Ribbon/Controls Visuals/VisualPopupAppMenu.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controls Visuals/VisualPopupAppMenu.cs
@@ -299,6 +299,7 @@ namespace Krypton.Ribbon
         /// <summary>
         /// Gets and sets the horizontal setting used to position the menu.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public KryptonContextMenuPositionH ShowHorz
         {
             get => _provider.ProviderShowHorz;
@@ -308,6 +309,7 @@ namespace Krypton.Ribbon
         /// <summary>
         /// Gets and sets the vertical setting used to position the menu.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public KryptonContextMenuPositionV ShowVert
         {
             get => _provider.ProviderShowVert;

--- a/Source/Krypton Components/Krypton.Ribbon/Controls Visuals/VisualPopupGroup.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controls Visuals/VisualPopupGroup.cs
@@ -124,6 +124,7 @@ namespace Krypton.Ribbon
         /// <summary>
         /// Gets and sets a flag indicating if previous ribbon focus should be restored on dispose.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public bool RestorePreviousFocus { get; set; }
 
         #endregion

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupClusterColorButton.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupClusterColorButton.cs
@@ -624,6 +624,7 @@ namespace Krypton.Ribbon
         [Category(@"Appearance")]
         [Description(@"Collection of recent colors.")]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public Color[] RecentColors
         {
             get => _recentColors.ToArray();

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupColorButton.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupColorButton.cs
@@ -696,6 +696,7 @@ namespace Krypton.Ribbon
         [Category(@"Appearance")]
         [Description(@"Collection of recent colors.")]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public Color[] RecentColors
         {
             get => _recentColors.ToArray();

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupComboBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupComboBox.cs
@@ -413,6 +413,7 @@ namespace Krypton.Ribbon
         [Category(@"Appearance")]
         [Description(@"Text associated with the control.")]
         [Editor(typeof(MultilineStringEditor), typeof(UITypeEditor))]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public virtual string Text
         {
             get => ComboBox.Text;
@@ -531,6 +532,7 @@ namespace Krypton.Ribbon
         [Category(@"Behavior")]
         [Description(@"The height, in pixels, of items in an owner-draw KryptomComboBox.")]
         [Localizable(true)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public int ItemHeight
         {
             get => ComboBox.ItemHeight;
@@ -1041,10 +1043,13 @@ namespace Krypton.Ribbon
         #endregion
 
         #region Internal
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)] 
         internal Control? LastParentControl { get; set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)] 
         internal KryptonComboBox? LastComboBox { get; set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)] 
         internal NeedPaintHandler? ViewPaintDelegate { get; set; }
 
         internal void OnDesignTimeContextMenu(MouseEventArgs e) => DesignTimeContextMenu?.Invoke(this, e);

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupCustomControl.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupCustomControl.cs
@@ -315,10 +315,13 @@ namespace Krypton.Ribbon
         #endregion
 
         #region Internal
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal Control LastParentControl { get; set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal Control? LastCustomControl { get; set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal NeedPaintHandler? ViewPaintDelegate { get; set; }
 
         internal void OnDesignTimeContextMenu(MouseEventArgs e) => DesignTimeContextMenu?.Invoke(this, e);

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupDateTimePicker.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupDateTimePicker.cs
@@ -932,10 +932,13 @@ namespace Krypton.Ribbon
         #endregion
 
         #region Internal
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal Control LastParentControl { get; set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal KryptonDateTimePicker? LastDateTimePicker { get; set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal NeedPaintHandler? ViewPaintDelegate { get; set; }
 
         internal void OnDesignTimeContextMenu(MouseEventArgs e) => DesignTimeContextMenu?.Invoke(this, e);

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupDomainUpDown.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupDomainUpDown.cs
@@ -222,6 +222,7 @@ namespace Krypton.Ribbon
         [Category(@"Appearance")]
         [Description(@"Text associated with the control.")]
         [Editor(typeof(MultilineStringEditor), typeof(UITypeEditor))]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public string Text
         {
             get => DomainUpDown!.Text;
@@ -633,10 +634,13 @@ namespace Krypton.Ribbon
         #endregion
 
         #region Internal
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal Control LastParentControl { get; set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal KryptonDomainUpDown? LastDomainUpDown { get; set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal NeedPaintHandler? ViewPaintDelegate { get; set; }
 
         internal void OnDesignTimeContextMenu(MouseEventArgs e) => DesignTimeContextMenu?.Invoke(this, e);

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupGallery.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupGallery.cs
@@ -188,6 +188,7 @@ namespace Krypton.Ribbon
         /// </summary>
         [Category(@"Visuals")]
         [Description(@"Collection of images for display and selection.")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public ImageList? ImageList
         {
             get => Gallery.ImageList;
@@ -653,14 +654,18 @@ namespace Krypton.Ribbon
         #endregion
 
         #region Internal
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)] 
         internal Control? LastParentControl { get; set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)] 
         internal KryptonGallery? LastGallery { get; set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)] 
         internal NeedPaintHandler? ViewPaintDelegate { get; set; }
 
         internal void OnDesignTimeContextMenu(MouseEventArgs e) => DesignTimeContextMenu?.Invoke(this, e);
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)] 
         internal int InternalItemCount { get; set; }
 
         internal override bool ProcessCmdKey(ref Message msg, Keys keyData) => false;

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupItem.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupItem.cs
@@ -209,6 +209,7 @@ namespace Krypton.Ribbon
         /// </summary>
         [Browsable(false)]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public BindingContext BindingContext
         {
             get => _bindingContext ??= [];

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupLabel.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupLabel.cs
@@ -399,6 +399,7 @@ namespace Krypton.Ribbon
         #endregion
 
         #region Internal
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal NeedPaintHandler? ViewPaintDelegate { get; set; }
 
         internal void OnDesignTimeContextMenu(MouseEventArgs e) => DesignTimeContextMenu?.Invoke(this, e);

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupMaskedTextBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupMaskedTextBox.cs
@@ -419,6 +419,7 @@ namespace Krypton.Ribbon
         [Category(@"Appearance")]
         [Editor(@"System.Windows.Forms.Design.MaskedTextBoxTextEditor", typeof(UITypeEditor))]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public string? Text
         {
             get => MaskedTextBox.Text;
@@ -954,10 +955,13 @@ namespace Krypton.Ribbon
         #endregion
 
         #region Internal
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         internal Control LastParentControl { get; set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal KryptonMaskedTextBox? LastMaskedTextBox { get; set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal NeedPaintHandler? ViewPaintDelegate { get; set; }
 
         internal void OnDesignTimeContextMenu(MouseEventArgs e) => DesignTimeContextMenu?.Invoke(this, e);

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupNumericUpDown.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupNumericUpDown.cs
@@ -1,4 +1,5 @@
-﻿#region BSD License
+﻿
+#region BSD License
 /*
  * 
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -638,10 +639,13 @@ namespace Krypton.Ribbon
         #endregion
 
         #region Internal
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal Control? LastParentControl { get; set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal KryptonNumericUpDown? LastNumericUpDown { get; set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal NeedPaintHandler? ViewPaintDelegate { get; set; }
 
         internal void OnDesignTimeContextMenu(MouseEventArgs e) => DesignTimeContextMenu?.Invoke(this, e);

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupRichTextBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupRichTextBox.cs
@@ -392,6 +392,7 @@ namespace Krypton.Ribbon
         [Category(@"Appearance")]
         [Description(@"Text associated with the control.")]
         [Editor(typeof(MultilineStringEditor), typeof(UITypeEditor))]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public string Text
         {
             get => RichTextBox!.Text;
@@ -1313,10 +1314,13 @@ namespace Krypton.Ribbon
         #endregion
 
         #region Internal
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal Control LastParentControl { get; set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal KryptonRichTextBox? LastRichTextBox { get; set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal NeedPaintHandler? ViewPaintDelegate { get; set; }
 
         internal void OnDesignTimeContextMenu(MouseEventArgs e) => DesignTimeContextMenu?.Invoke(this, e);

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupTextBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupTextBox.cs
@@ -358,6 +358,7 @@ namespace Krypton.Ribbon
         [Category(@"Appearance")]
         [Description(@"Text associated with the control.")]
         [Editor(typeof(MultilineStringEditor), typeof(UITypeEditor))]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public string Text
         {
             get => TextBox!.Text;
@@ -960,10 +961,13 @@ namespace Krypton.Ribbon
         #endregion
 
         #region Internal
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal Control LastParentControl { get; set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal KryptonTextBox? LastTextBox { get; set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal NeedPaintHandler? ViewPaintDelegate { get; set; }
 
         internal void OnDesignTimeContextMenu(MouseEventArgs e) => DesignTimeContextMenu?.Invoke(this, e);

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupTrackBar.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupTrackBar.cs
@@ -550,10 +550,13 @@ namespace Krypton.Ribbon
         #endregion
 
         #region Internal
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal Control? LastParentControl { get; set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal KryptonTrackBar? LastTrackBar { get; set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal NeedPaintHandler? ViewPaintDelegate { get; set; }
 
         internal void OnDesignTimeContextMenu(MouseEventArgs e) => DesignTimeContextMenu?.Invoke(this, e);

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpec.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpec.cs
@@ -414,6 +414,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Category(@"Data")]
         [Description(@"The unique name of the ButtonSpec.")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)] 
         public string? UniqueName { get; set; }
         private void ResetUniqueName() => UniqueName = CommonHelper.UniqueString;
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecCalendar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecCalendar.cs
@@ -41,18 +41,20 @@ namespace Krypton.Toolkit
 
             // Fix the type
             ProtectedType = fixedStyle;
-        }      
+        }
         #endregion
 
         #region Public
         /// <summary>
         /// Gets and sets the visible state.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)] 
         public bool Visible { get; set; }
 
         /// <summary>
         /// Gets and sets the enabled state.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)] 
         public bool Enabled { get; set; }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecFormFixed.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecFormFixed.cs
@@ -57,6 +57,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the actual type of the button.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual PaletteButtonSpecStyle ButtonSpecType
         {
             get => ProtectedType;

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecRemapByContentView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecRemapByContentView.cs
@@ -34,6 +34,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the foreground to use for color map redirection.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public ViewDrawContent? Foreground { get; set; }
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuColorColumns.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuColorColumns.cs
@@ -372,6 +372,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Internal
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal Color[][] Colors { get; private set; }
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuImageSelect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuImageSelect.cs
@@ -332,6 +332,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Internal
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         internal int TrackingIndex
         {
             get => _trackingIndex;

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuItemBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuItemBase.cs
@@ -145,6 +145,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual string Text
         {
             get => _text;

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuMonthCalendar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuMonthCalendar.cs
@@ -1143,6 +1143,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public int MonthlyBoldedDatesMask { get; private set; }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controller/SeparatorController.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controller/SeparatorController.cs
@@ -122,6 +122,7 @@ namespace Krypton.Toolkit
             /// <summary>
             /// Gets and sets the new solid rectangle area.
             /// </summary>
+            [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
             public Rectangle SolidRect
             {
                 get => _solidRect;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonBorderEdge.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonBorderEdge.cs
@@ -70,6 +70,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color BackColor
         {
             get => base.BackColor;
@@ -83,6 +84,7 @@ namespace Krypton.Toolkit
         [Bindable(false)]
         [AmbientValue(null)]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Font Font
         {
             get => base.Font;
@@ -94,6 +96,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color ForeColor
         {
             get => base.ForeColor;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonButton.cs
@@ -454,6 +454,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public new ImeMode ImeMode
         {
             get => base.ImeMode;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckedListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckedListBox.cs
@@ -475,11 +475,13 @@ namespace Krypton.Toolkit
             /// <summary>
             /// Gets the item index the mouse is over.
             /// </summary>
+            [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
             public int MouseIndex { get; private set; }
 
             /// <summary>
             /// Gets and sets if the mouse is currently over the combo box.
             /// </summary>
+            [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
             public bool MouseOver
             {
                 get => _mouseOver;
@@ -508,6 +510,7 @@ namespace Krypton.Toolkit
             /// <summary>
             /// Gets and sets the drawing mode of the checked list box.
             /// </summary>
+            [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
             public override DrawMode DrawMode
             {
                 get => DrawMode.OwnerDrawVariable;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonColorButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonColorButton.cs
@@ -797,6 +797,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public new ImeMode ImeMode
         {
             get => base.ImeMode;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonColorDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonColorDialog.cs
@@ -92,6 +92,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Changes the title of the common Colour Dialog
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public string Title
         {
             get => _commonDialogHandler.Title;
@@ -101,6 +102,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Changes the default Icon to Developer set
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public Icon Icon
         {
             get => _commonDialogHandler.Icon;
@@ -111,6 +113,7 @@ namespace Krypton.Toolkit
         /// Changes the default Icon to Developer set
         /// </summary>
         [DefaultValue(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public bool ShowIcon
         {
             get => _commonDialogHandler.ShowIcon;
@@ -148,6 +151,7 @@ namespace Krypton.Toolkit
         /// <returns>The color selected by the user. If a color is not selected, the default value is black.</returns>
         [Category("Data")]
         [Description("The color selected in the dialog box")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public new Color Color
         {
             get => !_showAlphaSlider ? base.Color : Color.FromArgb(_alphaSlider.Value, base.Color);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -149,11 +149,13 @@ namespace Krypton.Toolkit
             /// <summary>
             /// Gets and sets if the combo box is currently dropped.
             /// </summary>
+            [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
             public bool Dropped { get; set; }
 
             /// <summary>
             /// Gets and sets if the mouse is currently over the combo box.
             /// </summary>
+            [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
             public bool MouseOver
             {
                 get => _mouseOver;
@@ -1297,6 +1299,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets if the control is in the tab chain.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public new bool TabStop
         {
             get => _comboBox.TabStop;
@@ -1353,6 +1356,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color BackColor
         {
             get => base.BackColor;
@@ -1365,6 +1369,7 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [Bindable(false)]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Font Font
         {
             get => base.Font;
@@ -1377,6 +1382,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color ForeColor
         {
             get => base.ForeColor;
@@ -1400,6 +1406,7 @@ namespace Krypton.Toolkit
         /// Gets and sets the text associated with the control.
         /// </summary>
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public override string Text
         {
             get => _comboBox.Text;
@@ -1468,6 +1475,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the associated context menu strip.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public override ContextMenuStrip? ContextMenuStrip
         {
             get => base.ContextMenuStrip;
@@ -1672,6 +1680,7 @@ namespace Krypton.Toolkit
         [Description(@"The width, in pixels, of the drop-down box in a KryptonComboBox.")]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Browsable(true)]
+        [DefaultValue(200)]
         public int DropDownWidth
         {
             get => _comboBox.DropDownWidth;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCommand.cs
@@ -336,6 +336,7 @@ namespace Krypton.Toolkit
         [Category(@"Appearance")]
         [Description(@"Command image transparent color.")]
         [KryptonDefaultColor]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public Color ImageTransparentColor
         {
             get => _imageTransparentColor;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCommandLinkButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCommandLinkButton.cs
@@ -469,6 +469,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public new ImeMode ImeMode
         {
             get => base.ImeMode;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonContextMenu.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonContextMenu.cs
@@ -452,8 +452,10 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Internal
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal ToolStripDropDownCloseReason CloseReason { get; set; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal VisualContextMenu? VisualContextMenu { get; private set; }
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
@@ -2947,6 +2947,7 @@ namespace Krypton.Toolkit
         /// <inheritdoc />
         [Browsable(false)]
         [DisallowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public new string ThemeName
         {
             get => _basePalette!.ThemeName;
@@ -2955,6 +2956,7 @@ namespace Krypton.Toolkit
 
         /// <inheritdoc />
         [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public new BasePaletteType BasePaletteType
         {
             get => _basePalette!.BasePaletteType;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -344,6 +344,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Indicates if tool tips are Displayed when the mouse hovers over the cell.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)] 
         public new bool ShowCellToolTips { get; set; }
 
         #endregion
@@ -1670,6 +1671,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Internal
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         internal PaletteRedirect Redirector {
             [DebuggerStepThrough]
             get;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxColumn.cs
@@ -240,6 +240,7 @@ namespace Krypton.Toolkit
         [Description(@"The width, in pixels, of the drop-down box in a KryptonComboBox.")]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Browsable(true)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public int DropDownWidth
         {
             get =>
@@ -468,6 +469,7 @@ namespace Krypton.Toolkit
         [Description(@"Indicates the Datasource for the items in this control.")]
         [TypeConverter(@"System.Windows.Forms.Design.DataSourceConverter")]
         [Editor(@"System.Windows.Forms.Design.DataSourceListEditor", typeof(UITypeEditor))]
+        [DefaultValue(null)]
         public object? DataSource
         {
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxEditingControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxEditingControl.cs
@@ -42,6 +42,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Property which caches the grid that uses this editing control
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual DataGridView? EditingControlDataGridView
         {
             get => _dataGridView;
@@ -53,6 +54,7 @@ namespace Krypton.Toolkit
         /// <para>Allows null as input, but null will saved as an empty string.</para>
         /// </summary>
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual object EditingControlFormattedValue 
         {
             // [AllowNull] removes warning CS8767, but allows for null input, which is undesired.
@@ -75,11 +77,13 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Property which represents the row in which the editing control resides
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public virtual int EditingControlRowIndex { get; set; }
 
         /// <summary>
         /// Property which indicates whether the value of the editing control has changed or not
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual bool EditingControlValueChanged
         {
             get => _valueChanged;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewCustomEditingControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewCustomEditingControl.cs
@@ -42,6 +42,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Property which caches the grid that uses this editing control
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual DataGridView? EditingControlDataGridView
         {
             get => _dataGridView;
@@ -53,6 +54,7 @@ namespace Krypton.Toolkit
         /// <para>Allows null as input, but null will saved as an empty string.</para>
         /// </summary>
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual object EditingControlFormattedValue 
         {
             // [AllowNull] removes warning CS8767, but allows for null input, which is undesired.
@@ -68,6 +70,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Property which represents the row in which the editing control resides
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual int EditingControlRowIndex
         {
             get => _rowIndex;
@@ -77,6 +80,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Property which indicates whether the value of the editing control has changed or not
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual bool EditingControlValueChanged
         {
             get => _valueChanged;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDateTimePickerEditingControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDateTimePickerEditingControl.cs
@@ -46,6 +46,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Property which caches the grid that uses this editing control
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual DataGridView? EditingControlDataGridView
         {
             get => _dataGridView;
@@ -56,6 +57,7 @@ namespace Krypton.Toolkit
         /// Property which represents the current formatted value of the editing control
         /// </summary>
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual object EditingControlFormattedValue
         {
             // [AllowNull] removes warning CS8767 and allows to write null
@@ -88,11 +90,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Property which represents the row in which the editing control resides
         /// </summary>
-        public virtual int EditingControlRowIndex { get; set; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] public virtual int EditingControlRowIndex { get; set; }
 
         /// <summary>
         /// Property which indicates whether the value of the editing control has changed or not
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual bool EditingControlValueChanged
         {
             get => _valueChanged;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownEditingControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownEditingControl.cs
@@ -42,6 +42,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Property which caches the grid that uses this editing control
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual DataGridView? EditingControlDataGridView
         {
             get => _dataGridView;
@@ -53,6 +54,7 @@ namespace Krypton.Toolkit
         /// <para>Allows null as input, but null will saved as an empty string.</para>
         /// </summary>
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual object EditingControlFormattedValue 
         {
             // [AllowNull] removes warning CS8767, but allows for null input, which is undesired.
@@ -68,11 +70,13 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Property which represents the row in which the editing control resides
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public virtual int EditingControlRowIndex { get; set; }
 
         /// <summary>
         /// Property which indicates whether the value of the editing control has changed or not
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual bool EditingControlValueChanged
         {
             get => _valueChanged;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewMaskedTextBoxEditingControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewMaskedTextBoxEditingControl.cs
@@ -42,6 +42,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Property which caches the grid that uses this editing control
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual DataGridView? EditingControlDataGridView
         {
             get => _dataGridView;
@@ -53,6 +54,7 @@ namespace Krypton.Toolkit
         /// <para>Allows null as input, but null will saved as an empty string.</para>
         /// </summary>
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual object EditingControlFormattedValue 
         {
             // [AllowNull] removes warning CS8767, but allows for null input, which is undesired.
@@ -68,11 +70,13 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Property which represents the row in which the editing control resides
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public virtual int EditingControlRowIndex { get; set; }
 
         /// <summary>
         /// Property which indicates whether the value of the editing control has changed or not
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual bool EditingControlValueChanged
         {
             get => _valueChanged;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewNumericUpDownEditingControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewNumericUpDownEditingControl.cs
@@ -42,6 +42,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Property which caches the grid that uses this editing control
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual DataGridView? EditingControlDataGridView
         {
             get => _dataGridView;
@@ -53,6 +54,7 @@ namespace Krypton.Toolkit
         /// <para>Allows null as input, but null will saved as an empty string.</para>
         /// </summary>
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual object EditingControlFormattedValue 
         {
             // [AllowNull] removes warning CS8767, but allows for null input, which is undesired.
@@ -68,11 +70,13 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Property which represents the row in which the editing control resides
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public virtual int EditingControlRowIndex { get; set; }
 
         /// <summary>
         /// Property which indicates whether the value of the editing control has changed or not
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual bool EditingControlValueChanged
         {
             get => _valueChanged;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxColumn.cs
@@ -149,6 +149,7 @@ namespace Krypton.Toolkit
         [Category(@"Appearance")]
         [Description(@"DataGridView Column DefaultCell Style\r\nIf you set wrap mode, then this will ensure the DataRows are set to display the wrapped text!")]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public override DataGridViewCellStyle DefaultCellStyle
         {
             // base.DefaultCellStyle will take a null value and handle it.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxEditingControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxEditingControl.cs
@@ -42,6 +42,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Property which caches the grid that uses this editing control
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual DataGridView? EditingControlDataGridView
         {
             get => _dataGridView;
@@ -53,6 +54,7 @@ namespace Krypton.Toolkit
         /// <para>Allows null as input, but null will saved as an empty string.</para>
         /// </summary>
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual object EditingControlFormattedValue 
         {
             // [AllowNull] removes warning CS8767, but allows for null input, which is undesired.
@@ -68,11 +70,13 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Property which represents the row in which the editing control resides
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public virtual int EditingControlRowIndex { get; set; }
 
         /// <summary>
         /// Property which indicates whether the value of the editing control has changed or not
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual bool EditingControlValueChanged
         {
             get => _valueChanged;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDateTimePicker.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDateTimePicker.cs
@@ -332,6 +332,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color BackColor
         {
             get => base.BackColor;
@@ -345,6 +346,7 @@ namespace Krypton.Toolkit
         [Bindable(false)]
         [AmbientValue(null)]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Font Font
         {
             get => base.Font;
@@ -356,6 +358,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color ForeColor
         {
             get => base.ForeColor;
@@ -1323,13 +1326,14 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool IsMouseOver { get; private set; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] public bool IsMouseOver { get; private set; }
 
         /// <summary>
         /// Gets a value indicating if the drop-down calendar is showing.
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public bool IsDropped { get; }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
@@ -67,6 +67,7 @@ namespace Krypton.Toolkit
             /// <summary>
             /// Gets and sets if the mouse is currently over the combo box.
             /// </summary>
+            [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
             public bool MouseOver
             {
                 get => _mouseOver;
@@ -174,6 +175,7 @@ namespace Krypton.Toolkit
             /// <summary>
             /// Gets or sets a value indicating whether a value has been entered by the user.
             /// </summary>
+            [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
             protected internal bool InternalUserEdit
             {
                 get => UserEdit;
@@ -891,6 +893,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets if the control is in the tab chain.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public new bool TabStop
         {
             get => DomainUpDown.TabStop;
@@ -926,6 +929,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color BackColor
         {
             get => base.BackColor;
@@ -939,6 +943,7 @@ namespace Krypton.Toolkit
         [Bindable(false)]
         [AmbientValue(null)]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Font Font
         {
             get => base.Font;
@@ -950,6 +955,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color ForeColor
         {
             get => base.ForeColor;
@@ -979,6 +985,7 @@ namespace Krypton.Toolkit
         /// Gets or sets the text for the control.
         /// </summary>
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public override string Text
         {
             get => DomainUpDown.Text;
@@ -988,6 +995,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the associated context menu strip.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public override ContextMenuStrip? ContextMenuStrip
         {
             get => base.ContextMenuStrip;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDropButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDropButton.cs
@@ -509,6 +509,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public new ImeMode ImeMode
         {
             get => base.ImeMode;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonFontDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonFontDialog.cs
@@ -26,6 +26,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Changes the title of the common Font Dialog
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public string Title
         {
             get => _commonDialogHandler.Title;
@@ -35,7 +36,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Changes the default Icon to Developer set
         /// </summary>
-        //[Browsable(false), EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public Icon Icon
         {
             get => _commonDialogHandler.Icon;
@@ -46,6 +47,7 @@ namespace Krypton.Toolkit
         /// Changes the default Icon to Developer set
         /// </summary>
         [DefaultValue(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public bool ShowIcon
         {
             get => _commonDialogHandler.ShowIcon;
@@ -65,6 +67,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Display the Legacy Extended colours choice
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public bool DisplayExtendedColorsButton
         {
             get => _displayExtendedColorsButton;
@@ -81,6 +84,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Place an informative area at the bottom of the form stating if this will also be used on printers
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public bool DisplayIsPrinterFontDescription
         {
             get

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -425,6 +425,7 @@ namespace Krypton.Toolkit
         /// </value>
         [Category(@"Appearance")]
         [Description(@"Is the user currently an administrator.")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool IsInAdministratorMode
         {
             get => _isInAdministratorMode;
@@ -676,6 +677,7 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [DisallowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public Rectangle CustomCaptionArea { get; set; } = Rectangle.Empty;
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonGroup.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonGroup.cs
@@ -81,6 +81,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public new string Name
         {
             get => base.Name;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonGroupBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonGroupBox.cs
@@ -138,6 +138,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public new string Name
         {
             get => base.Name;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonHeaderGroup.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonHeaderGroup.cs
@@ -237,6 +237,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public new string Name
         {
             get => base.Name;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonHelpCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonHelpCommand.cs
@@ -48,14 +48,33 @@ namespace Krypton.Toolkit
          /// </summary>
          [AllowNull, Category(@"Appearance"), Description(@"State specific images for the help button."), DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
          public ButtonImageStates? ImageStates { get => _imageStates ?? new(); set { _imageStates = value; UpdateImageStates(KryptonManager.InternalGlobalPaletteMode); } }*/
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? ActiveImage 
+        {
+            get => _activeImage;
+            private set => _activeImage = value;
+        }
 
-        public Image? ActiveImage { get => _activeImage; private set => _activeImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? DisabledImage 
+        {
+            get => _disabledImage;
+            private set => _disabledImage = value;
+        }
 
-        public Image? DisabledImage { get => _disabledImage; private set => _disabledImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? NormalImage 
+        {
+            get => _normalImage;
+            private set => _normalImage = value;
+        }
 
-        public Image? NormalImage { get => _normalImage; private set => _normalImage = value; }
-
-        public Image? PressedImage { get => _pressedImage; private set => _pressedImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? PressedImage 
+        {
+            get => _pressedImage;
+            private set => _pressedImage = value;
+        }
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonInputBoxManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonInputBoxManager.cs
@@ -24,7 +24,12 @@ namespace Krypton.Toolkit
 
         #region Properties
 
-        public KryptonInputBoxData InputBoxData { get => _inputBoxData; set => _inputBoxData = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public KryptonInputBoxData InputBoxData 
+        {
+            get => _inputBoxData; 
+            set => _inputBoxData = value;
+        }
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarCopyCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarCopyCommand.cs
@@ -46,21 +46,39 @@ namespace Krypton.Toolkit
 			set { _copyButtonSpec = value; UpdateImage(KryptonManager.CurrentGlobalPaletteMode); }
 		}
 
-		/// <summary>Gets the active image.</summary>
-		/// <value>The active image.</value>
-		public Image? ActiveImage { get => _activeImage; private set => _activeImage = value; }
+        /// <summary>Gets the active image.</summary>
+        /// <value>The active image.</value>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? ActiveImage 
+        {
+            get => _activeImage;
+            private set => _activeImage = value;
+        }
 
-		/// <summary>Gets the disabled image.</summary>
-		/// <value>The disabled image.</value>
-		public Image? DisabledImage { get => _disabledImage; private set => _disabledImage = value; }
+        /// <summary>Gets the disabled image.</summary>
+        /// <value>The disabled image.</value>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)] 
+        public Image? DisabledImage 
+        { 
+            get => _disabledImage; 
+            private set => _disabledImage = value; }
 
-		/// <summary>Gets the normal image.</summary>
-		/// <value>The normal image.</value>
-		public Image? NormalImage { get => _normalImage; private set => _normalImage = value; }
+        /// <summary>Gets the normal image.</summary>
+        /// <value>The normal image.</value>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)] 
+        public Image? NormalImage 
+        { 
+            get => _normalImage; 
+            private set => _normalImage = value; }
 
-		/// <summary>Gets the pressed image.</summary>
-		/// <value>The pressed image.</value>
-		public Image? PressedImage { get => _pressedImage; private set => _pressedImage = value; }
+        /// <summary>Gets the pressed image.</summary>
+        /// <value>The pressed image.</value>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)] 
+        public Image? PressedImage 
+        { 
+            get => _pressedImage; 
+            private set => _pressedImage = value; 
+        }
 
 		#endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarCutCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarCutCommand.cs
@@ -47,19 +47,38 @@ namespace Krypton.Toolkit
 
         /// <summary>Gets the active image.</summary>
         /// <value>The active image.</value>
-        public Image? ActiveImage { get => _activeImage; private set => _activeImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)] 
+        public Image? ActiveImage 
+        { 
+            get => _activeImage; 
+            private set => _activeImage = value; 
+        }
 
         /// <summary>Gets the disabled image.</summary>
         /// <value>The disabled image.</value>
-        public Image? DisabledImage { get => _disabledImage; private set => _disabledImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? DisabledImage 
+        {
+            get => _disabledImage;
+            private set => _disabledImage = value;
+        }
 
         /// <summary>Gets the normal image.</summary>
         /// <value>The normal image.</value>
-        public Image? NormalImage { get => _normalImage; private set => _normalImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)] 
+        public Image? NormalImage 
+        { 
+            get => _normalImage; 
+            private set => _normalImage = value; 
+        }
 
         /// <summary>Gets the pressed image.</summary>
         /// <value>The pressed image.</value>
-        public Image? PressedImage { get => _pressedImage; private set => _pressedImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? PressedImage 
+        {
+            get => _pressedImage; private set => _pressedImage = value;
+        }
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarNewCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarNewCommand.cs
@@ -47,19 +47,39 @@ namespace Krypton.Toolkit
 
         /// <summary>Gets the active image.</summary>
         /// <value>The active image.</value>
-        public Image? ActiveImage { get => _activeImage; private set => _activeImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? ActiveImage 
+        {
+            get => _activeImage;
+            private set => _activeImage = value;
+        }
 
         /// <summary>Gets the disabled image.</summary>
         /// <value>The disabled image.</value>
-        public Image? DisabledImage { get => _disabledImage; private set => _disabledImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? DisabledImage 
+        {
+            get => _disabledImage;
+            private set => _disabledImage = value;
+        }
 
         /// <summary>Gets the normal image.</summary>
         /// <value>The normal image.</value>
-        public Image? NormalImage { get => _normalImage; private set => _normalImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? NormalImage 
+        {
+            get => _normalImage;
+            private set => _normalImage = value;
+        }
 
         /// <summary>Gets the pressed image.</summary>
         /// <value>The pressed image.</value>
-        public Image? PressedImage { get => _pressedImage; private set => _pressedImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? PressedImage 
+        {
+            get => _pressedImage;
+            private set => _pressedImage = value;
+        }
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarOpenCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarOpenCommand.cs
@@ -47,19 +47,39 @@ namespace Krypton.Toolkit
 
         /// <summary>Gets the active image.</summary>
         /// <value>The active image.</value>
-        public Image? ActiveImage { get => _activeImage; private set => _activeImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? ActiveImage 
+        {
+            get => _activeImage;
+            private set => _activeImage = value;
+        }
 
         /// <summary>Gets the disabled image.</summary>
         /// <value>The disabled image.</value>
-        public Image? DisabledImage { get => _disabledImage; private set => _disabledImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? DisabledImage 
+        {
+            get => _disabledImage;
+            private set => _disabledImage = value;
+        }
 
         /// <summary>Gets the normal image.</summary>
         /// <value>The normal image.</value>
-        public Image? NormalImage { get => _normalImage; private set => _normalImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? NormalImage 
+        {
+            get => _normalImage;
+            private set => _normalImage = value;
+        }
 
         /// <summary>Gets the pressed image.</summary>
         /// <value>The pressed image.</value>
-        public Image? PressedImage { get => _pressedImage; private set => _pressedImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? PressedImage 
+        {
+            get => _pressedImage;
+            private set => _pressedImage = value;
+        }
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarPageSetupCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarPageSetupCommand.cs
@@ -47,19 +47,39 @@ namespace Krypton.Toolkit
 
         /// <summary>Gets the active image.</summary>
         /// <value>The active image.</value>
-        public Image? ActiveImage { get => _activeImage; private set => _activeImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? ActiveImage 
+        {
+            get => _activeImage;
+            private set => _activeImage = value;
+        }
 
         /// <summary>Gets the disabled image.</summary>
         /// <value>The disabled image.</value>
-        public Image? DisabledImage { get => _disabledImage; private set => _disabledImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? DisabledImage 
+        {
+            get => _disabledImage;
+            private set => _disabledImage = value;
+        }
 
         /// <summary>Gets the normal image.</summary>
         /// <value>The normal image.</value>
-        public Image? NormalImage { get => _normalImage; private set => _normalImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? NormalImage 
+        {
+            get => _normalImage;
+            private set => _normalImage = value;
+        }
 
         /// <summary>Gets the pressed image.</summary>
         /// <value>The pressed image.</value>
-        public Image? PressedImage { get => _pressedImage; private set => _pressedImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? PressedImage 
+        {
+            get => _pressedImage;
+            private set => _pressedImage = value;
+        }
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarPasteCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarPasteCommand.cs
@@ -47,19 +47,39 @@ namespace Krypton.Toolkit
 
         /// <summary>Gets the active image.</summary>
         /// <value>The active image.</value>
-        public Image? ActiveImage { get => _activeImage; private set => _activeImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? ActiveImage 
+        {
+            get => _activeImage;
+            private set => _activeImage = value;
+        }
 
         /// <summary>Gets the disabled image.</summary>
         /// <value>The disabled image.</value>
-        public Image? DisabledImage { get => _disabledImage; private set => _disabledImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? DisabledImage 
+        {
+            get => _disabledImage;
+            private set => _disabledImage = value;
+        }
 
         /// <summary>Gets the normal image.</summary>
         /// <value>The normal image.</value>
-        public Image? NormalImage { get => _normalImage; private set => _normalImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? NormalImage 
+        {
+            get => _normalImage;
+            private set => _normalImage = value;
+        }
 
         /// <summary>Gets the pressed image.</summary>
         /// <value>The pressed image.</value>
-        public Image? PressedImage { get => _pressedImage; private set => _pressedImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? PressedImage 
+        {
+            get => _pressedImage;
+            private set => _pressedImage = value;
+        }
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarPrintCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarPrintCommand.cs
@@ -39,7 +39,16 @@ namespace Krypton.Toolkit
 
         /// <summary>Gets the button spec style.</summary>
         /// <value>The button spec style.</value>
-        public PaletteButtonSpecStyle ButtonSpecStyle { get => _style; private set { _style = value; UpdateButtonSpec(); } }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public PaletteButtonSpecStyle ButtonSpecStyle 
+        {
+            get => _style;
+            private set
+            {
+                _style = value;
+                UpdateButtonSpec();
+            }
+        }
 
         /// <summary>Gets or sets the print button.</summary>
         /// <value>The print button.</value>
@@ -48,24 +57,49 @@ namespace Krypton.Toolkit
         public ButtonSpecAny? ToolBarPrintButton
         {
             get => _printButtonSpec ?? new ButtonSpecAny();
-            set { _printButtonSpec = value; UpdateImage(KryptonManager.CurrentGlobalPaletteMode); UpdateButtonSpec(); }
+            set
+            {
+                _printButtonSpec = value;
+                UpdateImage(KryptonManager.CurrentGlobalPaletteMode);
+                UpdateButtonSpec();
+            }
         }
 
         /// <summary>Gets the active image.</summary>
         /// <value>The active image.</value>
-        public Image? ActiveImage { get => _activeImage; private set => _activeImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? ActiveImage 
+        {
+            get => _activeImage;
+            private set => _activeImage = value;
+        }
 
         /// <summary>Gets the disabled image.</summary>
         /// <value>The disabled image.</value>
-        public Image? DisabledImage { get => _disabledImage; private set => _disabledImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? DisabledImage 
+        {
+            get => _disabledImage;
+            private set => _disabledImage = value;
+        }
 
         /// <summary>Gets the normal image.</summary>
         /// <value>The normal image.</value>
-        public Image? NormalImage { get => _normalImage; private set => _normalImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? NormalImage 
+        {
+            get => _normalImage;
+            private set => _normalImage = value;
+        }
 
         /// <summary>Gets the pressed image.</summary>
         /// <value>The pressed image.</value>
-        public Image? PressedImage { get => _pressedImage; private set => _pressedImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? PressedImage 
+        {
+            get => _pressedImage;
+            private set => _pressedImage = value;
+        }
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarPrintPreviewCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarPrintPreviewCommand.cs
@@ -42,24 +42,48 @@ namespace Krypton.Toolkit
         public ButtonSpecAny? ToolBarPrintPreviewButton
         {
             get => _printPreviewButtonSpec ?? new ButtonSpecAny();
-            set { _printPreviewButtonSpec = value; UpdateImage(KryptonManager.CurrentGlobalPaletteMode); }
+            set
+            {
+                _printPreviewButtonSpec = value;
+                UpdateImage(KryptonManager.CurrentGlobalPaletteMode);
+            }
         }
 
         /// <summary>Gets the active image.</summary>
         /// <value>The active image.</value>
-        public Image? ActiveImage { get => _activeImage; private set => _activeImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? ActiveImage 
+        {
+            get => _activeImage;
+            private set => _activeImage = value;
+        }
 
         /// <summary>Gets the disabled image.</summary>
         /// <value>The disabled image.</value>
-        public Image? DisabledImage { get => _disabledImage; private set => _disabledImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? DisabledImage 
+        {
+            get => _disabledImage;
+            private set => _disabledImage = value;
+        }
 
         /// <summary>Gets the normal image.</summary>
         /// <value>The normal image.</value>
-        public Image? NormalImage { get => _normalImage; private set => _normalImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? NormalImage 
+        {
+            get => _normalImage;
+            private set => _normalImage = value;
+        }
 
         /// <summary>Gets the pressed image.</summary>
         /// <value>The pressed image.</value>
-        public Image? PressedImage { get => _pressedImage; private set => _pressedImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? PressedImage 
+        {
+            get => _pressedImage;
+            private set => _pressedImage = value;
+        }
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarQuickPrintCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarQuickPrintCommand.cs
@@ -42,24 +42,48 @@ namespace Krypton.Toolkit
         public ButtonSpecAny? ToolBarQuickPrintButton
         {
             get => _quickPrintButtonSpec ?? new ButtonSpecAny();
-            set { _quickPrintButtonSpec = value; UpdateImage(KryptonManager.CurrentGlobalPaletteMode); }
+            set
+            {
+                _quickPrintButtonSpec = value;
+                UpdateImage(KryptonManager.CurrentGlobalPaletteMode);
+            }
         }
 
         /// <summary>Gets the active image.</summary>
         /// <value>The active image.</value>
-        public Image? ActiveImage { get => _activeImage; private set => _activeImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? ActiveImage 
+        {
+            get => _activeImage;
+            private set => _activeImage = value;
+        }
 
         /// <summary>Gets the disabled image.</summary>
         /// <value>The disabled image.</value>
-        public Image? DisabledImage { get => _disabledImage; private set => _disabledImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? DisabledImage 
+        {
+            get => _disabledImage;
+            private set => _disabledImage = value;
+        }
 
         /// <summary>Gets the normal image.</summary>
         /// <value>The normal image.</value>
-        public Image? NormalImage { get => _normalImage; private set => _normalImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? NormalImage 
+        {
+            get => _normalImage;
+            private set => _normalImage = value;
+        }
 
         /// <summary>Gets the pressed image.</summary>
         /// <value>The pressed image.</value>
-        public Image? PressedImage { get => _pressedImage; private set => _pressedImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? PressedImage 
+        {
+            get => _pressedImage;
+            private set => _pressedImage = value;
+        }
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarRedoCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarRedoCommand.cs
@@ -42,24 +42,48 @@ namespace Krypton.Toolkit
         public ButtonSpecAny? ToolBarRedoButton
         {
             get => _redoButtonSpec ?? new ButtonSpecAny();
-            set { _redoButtonSpec = value; UpdateImage(KryptonManager.CurrentGlobalPaletteMode); }
+            set
+            {
+                _redoButtonSpec = value;
+                UpdateImage(KryptonManager.CurrentGlobalPaletteMode);
+            }
         }
 
         /// <summary>Gets the active image.</summary>
         /// <value>The active image.</value>
-        public Image? ActiveImage { get => _activeImage; private set => _activeImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? ActiveImage 
+        {
+            get => _activeImage;
+            private set => _activeImage = value;
+        }
 
         /// <summary>Gets the disabled image.</summary>
         /// <value>The disabled image.</value>
-        public Image? DisabledImage { get => _disabledImage; private set => _disabledImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? DisabledImage 
+        {
+            get => _disabledImage;
+            private set => _disabledImage = value;
+        }
 
         /// <summary>Gets the normal image.</summary>
         /// <value>The normal image.</value>
-        public Image? NormalImage { get => _normalImage; private set => _normalImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? NormalImage 
+        {
+            get => _normalImage;
+            private set => _normalImage = value;
+        }
 
         /// <summary>Gets the pressed image.</summary>
         /// <value>The pressed image.</value>
-        public Image? PressedImage { get => _pressedImage; private set => _pressedImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? PressedImage 
+        {
+            get => _pressedImage;
+            private set => _pressedImage = value;
+        }
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarSaveAllCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarSaveAllCommand.cs
@@ -39,7 +39,16 @@ namespace Krypton.Toolkit
 
         /// <summary>Gets the button spec style.</summary>
         /// <value>The button spec style.</value>
-        public PaletteButtonSpecStyle ButtonSpecStyle { get => _style; private set { _style = value; UpdateButtonSpec(); } }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public PaletteButtonSpecStyle ButtonSpecStyle 
+        {
+            get => _style;
+            private set
+            {
+                _style = value;
+                UpdateButtonSpec();
+            }
+        }
 
         /// <summary>Gets or sets the save all button.</summary>
         /// <value>The save all button.</value>
@@ -48,24 +57,48 @@ namespace Krypton.Toolkit
         public ButtonSpecAny? ToolBarSaveAllButton
         {
             get => _saveAllButtonSpec ?? new ButtonSpecAny();
-            set { _saveAllButtonSpec = value; UpdateImage(KryptonManager.CurrentGlobalPaletteMode); }
+            set
+            {
+                _saveAllButtonSpec = value;
+                UpdateImage(KryptonManager.CurrentGlobalPaletteMode);
+            }
         }
 
         /// <summary>Gets the active image.</summary>
         /// <value>The active image.</value>
-        public Image? ActiveImage { get => _activeImage; private set => _activeImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? ActiveImage 
+        {
+            get => _activeImage;
+            private set => _activeImage = value;
+        }
 
         /// <summary>Gets the disabled image.</summary>
         /// <value>The disabled image.</value>
-        public Image? DisabledImage { get => _disabledImage; private set => _disabledImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? DisabledImage 
+        {
+            get => _disabledImage;
+            private set => _disabledImage = value;
+        }
 
         /// <summary>Gets the normal image.</summary>
         /// <value>The normal image.</value>
-        public Image? NormalImage { get => _normalImage; private set => _normalImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? NormalImage 
+        {
+            get => _normalImage;
+            private set => _normalImage = value;
+        }
 
         /// <summary>Gets the pressed image.</summary>
         /// <value>The pressed image.</value>
-        public Image? PressedImage { get => _pressedImage; private set => _pressedImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? PressedImage 
+        {
+            get => _pressedImage;
+            private set => _pressedImage = value;
+        }
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarSaveAsCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarSaveAsCommand.cs
@@ -42,24 +42,44 @@ namespace Krypton.Toolkit
         public ButtonSpecAny? ToolBarSaveAsButton
         {
             get => _saveAsButtonSpec ?? new ButtonSpecAny();
-            set { _saveAsButtonSpec = value; UpdateImage(KryptonManager.CurrentGlobalPaletteMode); }
+            set
+            {
+                _saveAsButtonSpec = value;
+                UpdateImage(KryptonManager.CurrentGlobalPaletteMode);
+            }
         }
 
         /// <summary>Gets the active image.</summary>
         /// <value>The active image.</value>
-        public Image? ActiveImage { get => _activeImage; private set => _activeImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? ActiveImage {
+            get => _activeImage;
+            private set => _activeImage = value;
+        }
 
         /// <summary>Gets the disabled image.</summary>
         /// <value>The disabled image.</value>
-        public Image? DisabledImage { get => _disabledImage; private set => _disabledImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? DisabledImage {
+            get => _disabledImage;
+            private set => _disabledImage = value;
+        }
 
         /// <summary>Gets the normal image.</summary>
         /// <value>The normal image.</value>
-        public Image? NormalImage { get => _normalImage; private set => _normalImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? NormalImage {
+            get => _normalImage;
+            private set => _normalImage = value;
+        }
 
         /// <summary>Gets the pressed image.</summary>
         /// <value>The pressed image.</value>
-        public Image? PressedImage { get => _pressedImage; private set => _pressedImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? PressedImage {
+            get => _pressedImage;
+            private set => _pressedImage = value;
+        }
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarSaveCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarSaveCommand.cs
@@ -42,24 +42,48 @@ namespace Krypton.Toolkit
         public ButtonSpecAny? ToolBarSaveButton
         {
             get => _saveButtonSpec ?? new ButtonSpecAny();
-            set { _saveButtonSpec = value; UpdateImage(KryptonManager.CurrentGlobalPaletteMode); }
+            set
+            {
+                _saveButtonSpec = value;
+                UpdateImage(KryptonManager.CurrentGlobalPaletteMode);
+            }
         }
 
         /// <summary>Gets the active image.</summary>
         /// <value>The active image.</value>
-        public Image? ActiveImage { get => _activeImage; private set => _activeImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? ActiveImage 
+        {
+            get => _activeImage;
+            private set => _activeImage = value;
+        }
 
         /// <summary>Gets the disabled image.</summary>
         /// <value>The disabled image.</value>
-        public Image? DisabledImage { get => _disabledImage; private set => _disabledImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? DisabledImage 
+        {
+            get => _disabledImage;
+            private set => _disabledImage = value;
+        }
 
         /// <summary>Gets the normal image.</summary>
         /// <value>The normal image.</value>
-        public Image? NormalImage { get => _normalImage; private set => _normalImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? NormalImage 
+        {
+            get => _normalImage;
+            private set => _normalImage = value;
+        }
 
         /// <summary>Gets the pressed image.</summary>
         /// <value>The pressed image.</value>
-        public Image? PressedImage { get => _pressedImage; private set => _pressedImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? PressedImage 
+        {
+            get => _pressedImage;
+            private set => _pressedImage = value;
+        }
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarUndoCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonIntegratedToolbarUndoCommand.cs
@@ -42,24 +42,48 @@ namespace Krypton.Toolkit
         public ButtonSpecAny? ToolBarUndoButton
         {
             get => _undoButtonSpec ?? new ButtonSpecAny();
-            set { _undoButtonSpec = value; UpdateImage(KryptonManager.CurrentGlobalPaletteMode); }
+            set
+            {
+                _undoButtonSpec = value;
+                UpdateImage(KryptonManager.CurrentGlobalPaletteMode);
+            }
         }
 
         /// <summary>Gets the active image.</summary>
         /// <value>The active image.</value>
-        public Image? ActiveImage { get => _activeImage; private set => _activeImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? ActiveImage
+        {
+            get => _activeImage;
+            private set => _activeImage = value;
+        }
 
         /// <summary>Gets the disabled image.</summary>
         /// <value>The disabled image.</value>
-        public Image? DisabledImage { get => _disabledImage; private set => _disabledImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? DisabledImage 
+        {
+            get => _disabledImage;
+            private set => _disabledImage = value;
+        }
 
         /// <summary>Gets the normal image.</summary>
         /// <value>The normal image.</value>
-        public Image? NormalImage { get => _normalImage; private set => _normalImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? NormalImage 
+        {
+            get => _normalImage;
+            private set => _normalImage = value;
+        }
 
         /// <summary>Gets the pressed image.</summary>
         /// <value>The pressed image.</value>
-        public Image? PressedImage { get => _pressedImage; private set => _pressedImage = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public Image? PressedImage 
+        {
+            get => _pressedImage;
+            private set => _pressedImage = value;
+        }
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLinkWrapLabel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLinkWrapLabel.cs
@@ -152,6 +152,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color BackColor
         {
             get => base.BackColor;
@@ -165,6 +166,7 @@ namespace Krypton.Toolkit
         [Bindable(false)]
         [AmbientValue(null)]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Font Font
         {
             get => base.Font;
@@ -176,6 +178,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color ForeColor
         {
             get => base.ForeColor;
@@ -187,6 +190,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override BorderStyle BorderStyle
         {
             get => base.BorderStyle;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListBox.cs
@@ -107,11 +107,13 @@ namespace Krypton.Toolkit
             /// <summary>
             /// Gets the item index the mouse is over.
             /// </summary>
+            [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
             public int MouseIndex { get; private set; }
 
             /// <summary>
             /// Gets and sets if the mouse is currently over the combo box.
             /// </summary>
+            [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
             public bool MouseOver
             {
                 get => _mouseOver;
@@ -140,6 +142,7 @@ namespace Krypton.Toolkit
             /// <summary>
             /// Gets and sets the drawing mode of the checked list box.
             /// </summary>
+            [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
             public override DrawMode DrawMode
             {
                 get => DrawMode.OwnerDrawVariable;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListView.cs
@@ -107,6 +107,7 @@ namespace Krypton.Toolkit
             /// <summary>
             /// Gets and sets if the mouse is currently over the combo box.
             /// </summary>
+            [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
             public bool MouseOver
             {
                 get => _mouseOver;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonManager.cs
@@ -406,6 +406,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the global flag that decides if palette colors are applied to toolstrips.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public static bool ApplyToolstrips
         {
             get => _globalApplyToolstrips;
@@ -436,6 +437,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the global flag that decides if form chrome should be customized.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public static bool UseThemeFormChromeBorderWidth
         {
             get => _globalUseThemeFormChromeBorderWidth;
@@ -960,11 +962,13 @@ namespace Krypton.Toolkit
         /// <summary>
         /// What is the CurrentGlobalPaletteMode in use
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public static PaletteMode CurrentGlobalPaletteMode { get; private set; } = ThemeManager.DefaultGlobalPalette;
 
         /// <summary>
         /// Access the Current Palette
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public static PaletteBase CurrentGlobalPalette { get; private set; } = GetPaletteForMode(CurrentGlobalPaletteMode);
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs
@@ -36,6 +36,7 @@ namespace Krypton.Toolkit
             #endregion
 
             #region Property
+            [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
             public string? Hint
             {
                 get => _hint;
@@ -87,6 +88,7 @@ namespace Krypton.Toolkit
             /// <summary>
             /// Gets and sets if the mouse is currently over the combo box.
             /// </summary>
+            [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
             public bool MouseOver
             {
                 get => _mouseOver;
@@ -566,6 +568,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets if the control is in the tab chain.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public new bool TabStop
         {
             get => _maskedTextBox.TabStop;
@@ -600,6 +603,7 @@ namespace Krypton.Toolkit
         /// Gets a value indicating whether the control has input focus.
         /// </summary>
         [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public override bool Focused => MaskedTextBox.Focused;
 
         /// <summary>
@@ -607,6 +611,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override bool AutoSize
         {
             get => _autoSize;
@@ -631,6 +636,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color BackColor
         {
             get => base.BackColor;
@@ -644,6 +650,7 @@ namespace Krypton.Toolkit
         [Bindable(false)]
         [AmbientValue(null)]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Font Font
         {
             get => base.Font;
@@ -655,6 +662,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color ForeColor
         {
             get => base.ForeColor;
@@ -680,6 +688,7 @@ namespace Krypton.Toolkit
         [Editor(@"System.Windows.Forms.Design.MaskedTextBoxTextEditor", typeof(UITypeEditor))]
         [RefreshProperties(RefreshProperties.All)]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public override string Text
         {
             get => _maskedTextBox.Text;
@@ -689,6 +698,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the associated context menu strip.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public override ContextMenuStrip? ContextMenuStrip
         {
             get => base.ContextMenuStrip;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMonthCalendar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMonthCalendar.cs
@@ -1202,6 +1202,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public int MonthlyBoldedDatesMask { get; private set; }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
@@ -74,6 +74,7 @@ namespace Krypton.Toolkit
             /// <summary>
             /// Gets and sets if the mouse is currently over the combo box.
             /// </summary>
+            [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
             public bool MouseOver
             {
                 get => _mouseOver;
@@ -180,6 +181,7 @@ namespace Krypton.Toolkit
             /// <summary>
             /// Gets or sets a value indicating whether a value has been entered by the user.
             /// </summary>
+            [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
             protected internal bool InternalUserEdit
             {
                 get => UserEdit;
@@ -914,6 +916,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets if the control is in the tab chain.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public new bool TabStop
         {
             get => _numericUpDown.TabStop;
@@ -955,6 +958,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color BackColor
         {
             get => base.BackColor;
@@ -968,6 +972,7 @@ namespace Krypton.Toolkit
         [Bindable(false)]
         [AmbientValue(null)]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Font Font
         {
             get => base.Font;
@@ -979,6 +984,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color ForeColor
         {
             get => base.ForeColor;
@@ -1016,6 +1022,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the associated context menu strip.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public override ContextMenuStrip? ContextMenuStrip
         {
             get => base.ContextMenuStrip;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonOutlookGrid.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonOutlookGrid.cs
@@ -247,10 +247,10 @@ namespace Krypton.Toolkit
         /// Gets or sets the previous selected group row
         /// </summary>
         [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public int PreviousSelectedGroupRow
         {
             get => _previousGroupRowSelected;
-
             set => _previousGroupRowSelected = value;
         }
 
@@ -265,6 +265,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <value>OutlookGridGroupCollection.</value>
         [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public OutlookGridGroupCollection GroupCollection
         {
             get => _groupCollection;
@@ -326,6 +327,7 @@ namespace Krypton.Toolkit
         /// <value>
         /// The fill mode.
         /// </value>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public GridFillMode FillMode
         {
             get => _fillMode;
@@ -339,10 +341,13 @@ namespace Krypton.Toolkit
             }
         }
 
+        /// <summary>
+        /// Indicates wether the component should draw right to left for RTL languagues.
+        /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public RightToLeftLayout RightToLeftLayout
         {
             get => _rightToLeftLayout;
-
             set => _rightToLeftLayout = value;
         }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPrintDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPrintDialog.cs
@@ -48,6 +48,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Changes the title of the common Print Dialog
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public string Title
         {
             get => _commonDialogHandler.Title;
@@ -57,6 +58,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Changes the default Icon to Developer set
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public Icon Icon
         {
             get => _commonDialogHandler.Icon;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonProgressBar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonProgressBar.cs
@@ -808,6 +808,7 @@ namespace Krypton.Toolkit
         /// <inheritdoc />
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override bool AllowDrop
         {
             get => base.AllowDrop;
@@ -817,6 +818,7 @@ namespace Krypton.Toolkit
         /// <inheritdoc />
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color BackColor
         {
             get => base.BackColor;
@@ -827,6 +829,7 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [AllowNull, MaybeNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Image BackgroundImage
         {
             get => base.BackgroundImage;
@@ -845,6 +848,7 @@ namespace Krypton.Toolkit
         /// <inheritdoc />
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override ImageLayout BackgroundImageLayout
         {
             get => base.BackgroundImageLayout;
@@ -865,6 +869,7 @@ namespace Krypton.Toolkit
         /// <see langword="true" /> if the control, when it receives focus, causes validation to be performed on any controls that require validation; otherwise, <see langword="false" />. The default is <see langword="true" />.</returns>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public new bool CausesValidation
         {
             get => base.CausesValidation;
@@ -884,6 +889,7 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [AllowNull, MaybeNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override ContextMenuStrip ContextMenuStrip
         {
             get => base.ContextMenuStrip!;
@@ -903,6 +909,7 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Font Font
         {
             // base.Font will always return a Font
@@ -924,6 +931,7 @@ namespace Krypton.Toolkit
         /// <inheritdoc />
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color ForeColor
         {
             get => base.ForeColor;
@@ -934,6 +942,7 @@ namespace Krypton.Toolkit
         /// <returns>One of the <see cref="T:System.Windows.Forms.ImeMode" /> values.</returns>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public new ImeMode ImeMode
         {
             get => base.ImeMode;
@@ -974,6 +983,7 @@ namespace Krypton.Toolkit
         /// <returns>true if the user can set the focus to the control by using the TAB key; otherwise, false. The default is true.</returns>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public new bool TabStop
         {
             get => base.TabStop;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonProgressBarToolStripItem.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonProgressBarToolStripItem.cs
@@ -190,12 +190,22 @@ namespace Krypton.Toolkit
         /// <inheritdoc />
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override Color BackColor { get => base.BackColor; set => base.BackColor = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public override Color BackColor 
+        {
+            get => base.BackColor;
+            set => base.BackColor = value;
+        }
 
         /// <inheritdoc />
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override Color ForeColor { get => base.ForeColor; set => base.ForeColor = value; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public override Color ForeColor 
+        {
+            get => base.ForeColor;
+            set => base.ForeColor = value;
+        }
 
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
@@ -73,6 +73,7 @@ namespace Krypton.Toolkit
             /// <summary>
             /// Gets and sets if the mouse is currently over the combo box.
             /// </summary>
+            [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
             public bool MouseOver
             {
                 get => _mouseOver;
@@ -566,6 +567,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets if the control is in the tab chain.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public new bool TabStop
         {
             get => _richTextBox.TabStop;
@@ -606,6 +608,7 @@ namespace Krypton.Toolkit
         /// Gets or sets the ability to drag/drop onto the control.
         /// </summary>
         [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public override bool AllowDrop
         {
             get => base.AllowDrop;
@@ -631,6 +634,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color BackColor
         {
             get => base.BackColor;
@@ -644,6 +648,7 @@ namespace Krypton.Toolkit
         [Bindable(false)]
         [AmbientValue(null)]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Font Font
         {
             get => base.Font;
@@ -655,6 +660,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color ForeColor
         {
             get => base.ForeColor;
@@ -700,6 +706,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the associated context menu strip.
         /// </summary>
+        [DefaultValue(null)]
         public override ContextMenuStrip? ContextMenuStrip
         {
             get => base.ContextMenuStrip;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonScrollBar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonScrollBar.cs
@@ -109,6 +109,7 @@ namespace Krypton.Toolkit
 
         /// <summary>Gets or sets the width of the scroll bar.</summary>
         /// <value>The width of the scroll bar.</value>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public int ScrollBarWidth
         {
             get => Width; 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonSeparator.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonSeparator.cs
@@ -201,6 +201,7 @@ namespace Krypton.Toolkit
         [Bindable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden )]
         public override string Text
         {
             get => base.Text;
@@ -212,6 +213,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color BackColor
         {
             get => base.BackColor;
@@ -225,6 +227,7 @@ namespace Krypton.Toolkit
         [Bindable(false)]
         [AmbientValue(null)]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Font Font
         {
             get => base.Font;
@@ -236,6 +239,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color ForeColor
         {
             get => base.ForeColor;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonSplitContainer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonSplitContainer.cs
@@ -182,6 +182,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public new string Name
         {
             get => base.Name;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonSplitterPanel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonSplitterPanel.cs
@@ -374,6 +374,7 @@ namespace Krypton.Toolkit
         #region Internal
         internal KryptonSplitContainer Owner { get; }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         internal bool Collapsed { get; set; }
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonStatusStrip.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonStatusStrip.cs
@@ -16,6 +16,7 @@ namespace Krypton.Toolkit
     public class KryptonStatusStrip : StatusStrip
     {
         #region Properties
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)] 
         public ToolStripProgressBar[] ProgressBars { get; set; }
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTableLayoutPanel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTableLayoutPanel.cs
@@ -58,6 +58,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color BackColor
         {
             get => _backGroundPanel.BackColor;
@@ -81,6 +82,7 @@ namespace Krypton.Toolkit
         [Bindable(false)]
         [AmbientValue(null)]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Font Font
         {
             get => base.Font;
@@ -92,6 +94,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color ForeColor
         {
             get => base.ForeColor;
@@ -103,6 +106,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Image? BackgroundImage
         {
             get => base.BackgroundImage;
@@ -114,6 +118,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override ImageLayout BackgroundImageLayout
         {
             get => base.BackgroundImageLayout;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialogCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialogCommand.cs
@@ -205,6 +205,7 @@ namespace Krypton.Toolkit
         [Category(@"Appearance")]
         [Description(@"Command image transparent color.")]
         [KryptonDefaultColor]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public Color ImageTransparentColor
         {
             get => _imageTransparentColor;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
@@ -67,6 +67,7 @@ namespace Krypton.Toolkit
             /// <summary>
             /// Gets and sets if the mouse is currently over the combo box.
             /// </summary>
+            [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
             public bool MouseOver
             {
                 get => _mouseOver;
@@ -595,6 +596,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets if the control is in the tab chain.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public new bool TabStop
         {
             get => _textBox.TabStop;
@@ -655,6 +657,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Always)]
+        [DefaultValue(null)]
         public override bool AutoSize
         {
             get => _autoSize;
@@ -685,6 +688,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color BackColor
         {
             get => base.BackColor;
@@ -698,6 +702,7 @@ namespace Krypton.Toolkit
         [Bindable(false)]
         [AmbientValue(null)]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Font Font
         {
             get => base.Font;
@@ -709,6 +714,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color ForeColor
         {
             get => base.ForeColor;
@@ -733,6 +739,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Editor(typeof(MultilineStringEditor), typeof(UITypeEditor))]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public override string Text
         {
             get => _textBox.Text;
@@ -742,6 +749,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the associated context menu strip.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public override ContextMenuStrip? ContextMenuStrip
         {
             get => base.ContextMenuStrip;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTrackBar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTrackBar.cs
@@ -103,6 +103,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public new ImeMode ImeMode
         {
             get => base.ImeMode;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
@@ -105,6 +105,7 @@ namespace Krypton.Toolkit
             /// <summary>
             /// Gets and sets if the mouse is currently over the combo box.
             /// </summary>
+            [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
             public bool MouseOver
             {
                 get => _mouseOver;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonWrapLabel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonWrapLabel.cs
@@ -154,6 +154,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color BackColor
         {
             get => base.BackColor;
@@ -167,6 +168,7 @@ namespace Krypton.Toolkit
         [Bindable(false)]
         [AmbientValue(null)]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Font Font
         {
             get => base.Font;
@@ -178,6 +180,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color ForeColor
         {
             get => base.ForeColor;
@@ -189,6 +192,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override BorderStyle BorderStyle
         {
             get => base.BorderStyle;
@@ -200,6 +204,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public new FlatStyle FlatStyle
         {
             get => base.FlatStyle;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareForm.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareForm.Designer.cs
@@ -56,7 +56,7 @@
             this.kryptonPanel1.Location = new System.Drawing.Point(0, 0);
             this.kryptonPanel1.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonPanel1.Name = "kryptonPanel1";
-            this.kryptonPanel1.Size = new System.Drawing.Size(219, 64);
+            this.kryptonPanel1.Size = new System.Drawing.Size(223, 52);
             this.kryptonPanel1.TabIndex = 2;
             // 
             // tableLayoutPanel1
@@ -76,7 +76,7 @@
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(219, 64);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(223, 52);
             this.tableLayoutPanel1.TabIndex = 0;
             // 
             // _panelButtons
@@ -88,11 +88,11 @@
             this._panelButtons.Controls.Add(this._button1);
             this._panelButtons.Controls.Add(this._button2);
             this._panelButtons.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._panelButtons.Location = new System.Drawing.Point(0, 43);
+            this._panelButtons.Location = new System.Drawing.Point(0, 31);
             this._panelButtons.Margin = new System.Windows.Forms.Padding(0);
             this._panelButtons.Name = "_panelButtons";
             this._panelButtons.PanelBackStyle = Krypton.Toolkit.PaletteBackStyle.PanelAlternate;
-            this._panelButtons.Size = new System.Drawing.Size(219, 21);
+            this._panelButtons.Size = new System.Drawing.Size(223, 21);
             this._panelButtons.TabIndex = 0;
             // 
             // _borderEdge
@@ -102,7 +102,7 @@
             this._borderEdge.Location = new System.Drawing.Point(0, 0);
             this._borderEdge.Margin = new System.Windows.Forms.Padding(2);
             this._borderEdge.Name = "_borderEdge";
-            this._borderEdge.Size = new System.Drawing.Size(219, 1);
+            this._borderEdge.Size = new System.Drawing.Size(223, 1);
             this._borderEdge.Text = "kryptonBorderEdge1";
             // 
             // _button4
@@ -111,7 +111,7 @@
             this._button4.AutoSize = true;
             this._button4.Enabled = false;
             this._button4.IgnoreAltF4 = false;
-            this._button4.Location = new System.Drawing.Point(219, 0);
+            this._button4.Location = new System.Drawing.Point(223, 0);
             this._button4.Margin = new System.Windows.Forms.Padding(0);
             this._button4.MinimumSize = new System.Drawing.Size(38, 21);
             this._button4.Name = "_button4";
@@ -127,7 +127,7 @@
             this._button3.AutoSize = true;
             this._button3.Enabled = false;
             this._button3.IgnoreAltF4 = false;
-            this._button3.Location = new System.Drawing.Point(182, 0);
+            this._button3.Location = new System.Drawing.Point(186, 0);
             this._button3.Margin = new System.Windows.Forms.Padding(0);
             this._button3.MinimumSize = new System.Drawing.Size(38, 21);
             this._button3.Name = "_button3";
@@ -143,7 +143,7 @@
             this._button1.AutoSize = true;
             this._button1.Enabled = false;
             this._button1.IgnoreAltF4 = false;
-            this._button1.Location = new System.Drawing.Point(106, 0);
+            this._button1.Location = new System.Drawing.Point(110, 0);
             this._button1.Margin = new System.Windows.Forms.Padding(0);
             this._button1.MinimumSize = new System.Drawing.Size(38, 21);
             this._button1.Name = "_button1";
@@ -159,7 +159,7 @@
             this._button2.AutoSize = true;
             this._button2.Enabled = false;
             this._button2.IgnoreAltF4 = false;
-            this._button2.Location = new System.Drawing.Point(144, 0);
+            this._button2.Location = new System.Drawing.Point(148, 0);
             this._button2.Margin = new System.Windows.Forms.Padding(0);
             this._button2.MinimumSize = new System.Drawing.Size(38, 21);
             this._button2.Name = "_button2";
@@ -173,10 +173,10 @@
             // 
             this._messageIcon.BackColor = System.Drawing.Color.Transparent;
             this._messageIcon.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._messageIcon.Location = new System.Drawing.Point(178, 4);
+            this._messageIcon.Location = new System.Drawing.Point(182, 4);
             this._messageIcon.Margin = new System.Windows.Forms.Padding(8, 4, 4, 4);
             this._messageIcon.Name = "_messageIcon";
-            this._messageIcon.Size = new System.Drawing.Size(33, 35);
+            this._messageIcon.Size = new System.Drawing.Size(33, 23);
             this._messageIcon.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
             this._messageIcon.TabIndex = 0;
             this._messageIcon.TabStop = false;
@@ -188,7 +188,7 @@
             this.kpnlContentArea.Location = new System.Drawing.Point(4, 12);
             this.kpnlContentArea.Margin = new System.Windows.Forms.Padding(4, 12, 4, 12);
             this.kpnlContentArea.Name = "kpnlContentArea";
-            this.kpnlContentArea.Size = new System.Drawing.Size(166, 19);
+            this.kpnlContentArea.Size = new System.Drawing.Size(170, 7);
             this.kpnlContentArea.TabIndex = 1;
             // 
             // krtbMessageText
@@ -201,7 +201,7 @@
             this.krtbMessageText.Name = "krtbMessageText";
             this.krtbMessageText.ReadOnly = true;
             this.krtbMessageText.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.None;
-            this.krtbMessageText.Size = new System.Drawing.Size(150, 19);
+            this.krtbMessageText.Size = new System.Drawing.Size(170, 7);
             this.krtbMessageText.StateCommon.Border.DrawBorders = Krypton.Toolkit.PaletteDrawBorders.None;
             this.krtbMessageText.TabIndex = 0;
             this.krtbMessageText.TabStop = false;
@@ -212,7 +212,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(219, 64);
+            this.ClientSize = new System.Drawing.Size(223, 52);
             this.Controls.Add(this.kryptonPanel1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.KeyPreview = true;
@@ -233,7 +233,6 @@
             ((System.ComponentModel.ISupportInitialize)(this._messageIcon)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.kpnlContentArea)).EndInit();
             this.kpnlContentArea.ResumeLayout(false);
-            this.kpnlContentArea.PerformLayout();
             this.ResumeLayout(false);
 
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareForm.cs
@@ -29,6 +29,7 @@ namespace Krypton.Toolkit
 
         #region Public
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public KryptonMessageBoxResult MessageBoxResult { get; set; }
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareFormDep.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareFormDep.Designer.cs
@@ -57,7 +57,7 @@
             this.kryptonPanel1.Location = new System.Drawing.Point(0, 0);
             this.kryptonPanel1.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonPanel1.Name = "kryptonPanel1";
-            this.kryptonPanel1.Size = new System.Drawing.Size(219, 64);
+            this.kryptonPanel1.Size = new System.Drawing.Size(223, 52);
             this.kryptonPanel1.TabIndex = 2;
             // 
             // tableLayoutPanel1
@@ -77,7 +77,7 @@
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(219, 64);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(223, 52);
             this.tableLayoutPanel1.TabIndex = 0;
             // 
             // _panelButtons
@@ -89,11 +89,11 @@
             this._panelButtons.Controls.Add(this._button1);
             this._panelButtons.Controls.Add(this._button2);
             this._panelButtons.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._panelButtons.Location = new System.Drawing.Point(0, 43);
+            this._panelButtons.Location = new System.Drawing.Point(0, 31);
             this._panelButtons.Margin = new System.Windows.Forms.Padding(0);
             this._panelButtons.Name = "_panelButtons";
             this._panelButtons.PanelBackStyle = Krypton.Toolkit.PaletteBackStyle.PanelAlternate;
-            this._panelButtons.Size = new System.Drawing.Size(219, 21);
+            this._panelButtons.Size = new System.Drawing.Size(223, 21);
             this._panelButtons.TabIndex = 0;
             // 
             // _borderEdge
@@ -103,7 +103,7 @@
             this._borderEdge.Location = new System.Drawing.Point(0, 0);
             this._borderEdge.Margin = new System.Windows.Forms.Padding(2);
             this._borderEdge.Name = "_borderEdge";
-            this._borderEdge.Size = new System.Drawing.Size(219, 1);
+            this._borderEdge.Size = new System.Drawing.Size(223, 1);
             this._borderEdge.Text = "kryptonBorderEdge1";
             // 
             // _button4
@@ -112,7 +112,7 @@
             this._button4.AutoSize = true;
             this._button4.Enabled = false;
             this._button4.IgnoreAltF4 = false;
-            this._button4.Location = new System.Drawing.Point(219, 0);
+            this._button4.Location = new System.Drawing.Point(223, 0);
             this._button4.Margin = new System.Windows.Forms.Padding(0);
             this._button4.MinimumSize = new System.Drawing.Size(38, 21);
             this._button4.Name = "_button4";
@@ -128,7 +128,7 @@
             this._button3.AutoSize = true;
             this._button3.Enabled = false;
             this._button3.IgnoreAltF4 = false;
-            this._button3.Location = new System.Drawing.Point(182, 0);
+            this._button3.Location = new System.Drawing.Point(186, 0);
             this._button3.Margin = new System.Windows.Forms.Padding(0);
             this._button3.MinimumSize = new System.Drawing.Size(38, 21);
             this._button3.Name = "_button3";
@@ -144,7 +144,7 @@
             this._button1.AutoSize = true;
             this._button1.Enabled = false;
             this._button1.IgnoreAltF4 = false;
-            this._button1.Location = new System.Drawing.Point(106, 0);
+            this._button1.Location = new System.Drawing.Point(110, 0);
             this._button1.Margin = new System.Windows.Forms.Padding(0);
             this._button1.MinimumSize = new System.Drawing.Size(38, 21);
             this._button1.Name = "_button1";
@@ -160,7 +160,7 @@
             this._button2.AutoSize = true;
             this._button2.Enabled = false;
             this._button2.IgnoreAltF4 = false;
-            this._button2.Location = new System.Drawing.Point(144, 0);
+            this._button2.Location = new System.Drawing.Point(148, 0);
             this._button2.Margin = new System.Windows.Forms.Padding(0);
             this._button2.MinimumSize = new System.Drawing.Size(38, 21);
             this._button2.Name = "_button2";
@@ -174,10 +174,10 @@
             // 
             this._messageIcon.BackColor = System.Drawing.Color.Transparent;
             this._messageIcon.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._messageIcon.Location = new System.Drawing.Point(178, 4);
+            this._messageIcon.Location = new System.Drawing.Point(182, 4);
             this._messageIcon.Margin = new System.Windows.Forms.Padding(8, 4, 4, 4);
             this._messageIcon.Name = "_messageIcon";
-            this._messageIcon.Size = new System.Drawing.Size(33, 35);
+            this._messageIcon.Size = new System.Drawing.Size(33, 23);
             this._messageIcon.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
             this._messageIcon.TabIndex = 0;
             this._messageIcon.TabStop = false;
@@ -190,7 +190,7 @@
             this.kpnlContentArea.Location = new System.Drawing.Point(4, 12);
             this.kpnlContentArea.Margin = new System.Windows.Forms.Padding(4, 12, 4, 12);
             this.kpnlContentArea.Name = "kpnlContentArea";
-            this.kpnlContentArea.Size = new System.Drawing.Size(166, 19);
+            this.kpnlContentArea.Size = new System.Drawing.Size(170, 7);
             this.kpnlContentArea.TabIndex = 1;
             // 
             // krtbMessageText
@@ -203,7 +203,7 @@
             this.krtbMessageText.Name = "krtbMessageText";
             this.krtbMessageText.ReadOnly = true;
             this.krtbMessageText.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.None;
-            this.krtbMessageText.Size = new System.Drawing.Size(150, 19);
+            this.krtbMessageText.Size = new System.Drawing.Size(170, 7);
             this.krtbMessageText.StateCommon.Border.DrawBorders = Krypton.Toolkit.PaletteDrawBorders.None;
             this.krtbMessageText.TabIndex = 0;
             this.krtbMessageText.TabStop = false;
@@ -219,7 +219,7 @@
             this.klwlblMessageText.LabelStyle = Krypton.Toolkit.LabelStyle.AlternateControl;
             this.klwlblMessageText.Location = new System.Drawing.Point(0, 0);
             this.klwlblMessageText.Name = "klwlblMessageText";
-            this.klwlblMessageText.Size = new System.Drawing.Size(166, 19);
+            this.klwlblMessageText.Size = new System.Drawing.Size(170, 7);
             this.klwlblMessageText.Text = "Message Text";
             this.klwlblMessageText.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
@@ -227,7 +227,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(219, 64);
+            this.ClientSize = new System.Drawing.Size(223, 52);
             this.Controls.Add(this.kryptonPanel1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.KeyPreview = true;
@@ -248,7 +248,6 @@
             ((System.ComponentModel.ISupportInitialize)(this._messageIcon)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.kpnlContentArea)).EndInit();
             this.kpnlContentArea.ResumeLayout(false);
-            this.kpnlContentArea.PerformLayout();
             this.ResumeLayout(false);
 
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareFormDep.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareFormDep.cs
@@ -46,6 +46,7 @@ namespace Krypton.Toolkit
 
         #region Public
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public KryptonMessageBoxResult MessageBoxResult
         {
             get => _messageBoxResult;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContainerControlBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContainerControlBase.cs
@@ -165,6 +165,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets the ContextMenuStrip associated with this control.
         /// </summary>
+        [DefaultValue(null)]
         public override ContextMenuStrip? ContextMenuStrip
         {
             [DebuggerStepThrough]
@@ -391,6 +392,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Image? BackgroundImage
         {
             get => base.BackgroundImage;
@@ -402,6 +404,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override ImageLayout BackgroundImageLayout
         {
             get => base.BackgroundImageLayout;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContextMenu.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContextMenu.cs
@@ -314,6 +314,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the horizontal setting used to position the menu.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public KryptonContextMenuPositionH ShowHorz
         {
             get => _provider.ProviderShowHorz;
@@ -323,6 +324,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the vertical setting used to position the menu.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public KryptonContextMenuPositionV ShowVert
         {
             get => _provider.ProviderShowVert;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualControlBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualControlBase.cs
@@ -394,6 +394,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Image? BackgroundImage
         {
             get => base.BackgroundImage;
@@ -405,6 +406,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override ImageLayout BackgroundImageLayout
         {
             get => base.BackgroundImageLayout;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualControlContainment.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualControlContainment.cs
@@ -57,6 +57,7 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [Bindable(false)]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public override bool AllowDrop
         {
             get => base.AllowDrop;
@@ -69,6 +70,7 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [Bindable(false)]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public override bool AutoSize
         {
             get => base.AutoSize;
@@ -82,6 +84,7 @@ namespace Krypton.Toolkit
         [Bindable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override string Text
         {
             get => base.Text;
@@ -93,6 +96,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color BackColor
         {
             get => base.BackColor;
@@ -106,6 +110,7 @@ namespace Krypton.Toolkit
         [Bindable(false)]
         [AmbientValue(null)]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Font Font
         {
             get => base.Font;
@@ -117,6 +122,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color ForeColor
         {
             get => base.ForeColor;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxForm.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxForm.Designer.cs
@@ -69,7 +69,7 @@ namespace Krypton.Toolkit
             this._messageIcon.Location = new System.Drawing.Point(8, 4);
             this._messageIcon.Margin = new System.Windows.Forms.Padding(8, 4, 4, 4);
             this._messageIcon.Name = "_messageIcon";
-            this._messageIcon.Size = new System.Drawing.Size(33, 35);
+            this._messageIcon.Size = new System.Drawing.Size(33, 23);
             this._messageIcon.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
             this._messageIcon.TabIndex = 0;
             this._messageIcon.TabStop = false;
@@ -83,11 +83,11 @@ namespace Krypton.Toolkit
             this._panelButtons.Controls.Add(this._button1);
             this._panelButtons.Controls.Add(this._button2);
             this._panelButtons.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._panelButtons.Location = new System.Drawing.Point(0, 43);
+            this._panelButtons.Location = new System.Drawing.Point(0, 31);
             this._panelButtons.Margin = new System.Windows.Forms.Padding(0);
             this._panelButtons.Name = "_panelButtons";
             this._panelButtons.PanelBackStyle = Krypton.Toolkit.PaletteBackStyle.PanelAlternate;
-            this._panelButtons.Size = new System.Drawing.Size(203, 21);
+            this._panelButtons.Size = new System.Drawing.Size(207, 21);
             this._panelButtons.TabIndex = 0;
             // 
             // _borderEdge
@@ -97,7 +97,7 @@ namespace Krypton.Toolkit
             this._borderEdge.Location = new System.Drawing.Point(0, 0);
             this._borderEdge.Margin = new System.Windows.Forms.Padding(2);
             this._borderEdge.Name = "_borderEdge";
-            this._borderEdge.Size = new System.Drawing.Size(203, 1);
+            this._borderEdge.Size = new System.Drawing.Size(207, 1);
             this._borderEdge.Text = "kryptonBorderEdge1";
             // 
             // _button4
@@ -106,7 +106,7 @@ namespace Krypton.Toolkit
             this._button4.AutoSize = true;
             this._button4.Enabled = false;
             this._button4.IgnoreAltF4 = false;
-            this._button4.Location = new System.Drawing.Point(203, 0);
+            this._button4.Location = new System.Drawing.Point(207, 0);
             this._button4.Margin = new System.Windows.Forms.Padding(0);
             this._button4.MinimumSize = new System.Drawing.Size(38, 21);
             this._button4.Name = "_button4";
@@ -122,7 +122,7 @@ namespace Krypton.Toolkit
             this._button3.AutoSize = true;
             this._button3.Enabled = false;
             this._button3.IgnoreAltF4 = false;
-            this._button3.Location = new System.Drawing.Point(166, 0);
+            this._button3.Location = new System.Drawing.Point(170, 0);
             this._button3.Margin = new System.Windows.Forms.Padding(0);
             this._button3.MinimumSize = new System.Drawing.Size(38, 21);
             this._button3.Name = "_button3";
@@ -138,7 +138,7 @@ namespace Krypton.Toolkit
             this._button1.AutoSize = true;
             this._button1.Enabled = false;
             this._button1.IgnoreAltF4 = false;
-            this._button1.Location = new System.Drawing.Point(90, 0);
+            this._button1.Location = new System.Drawing.Point(94, 0);
             this._button1.Margin = new System.Windows.Forms.Padding(0);
             this._button1.MinimumSize = new System.Drawing.Size(38, 21);
             this._button1.Name = "_button1";
@@ -154,7 +154,7 @@ namespace Krypton.Toolkit
             this._button2.AutoSize = true;
             this._button2.Enabled = false;
             this._button2.IgnoreAltF4 = false;
-            this._button2.Location = new System.Drawing.Point(128, 0);
+            this._button2.Location = new System.Drawing.Point(132, 0);
             this._button2.Margin = new System.Windows.Forms.Padding(0);
             this._button2.MinimumSize = new System.Drawing.Size(38, 21);
             this._button2.Name = "_button2";
@@ -171,7 +171,7 @@ namespace Krypton.Toolkit
             this.kryptonPanel1.Location = new System.Drawing.Point(0, 0);
             this.kryptonPanel1.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonPanel1.Name = "kryptonPanel1";
-            this.kryptonPanel1.Size = new System.Drawing.Size(203, 64);
+            this.kryptonPanel1.Size = new System.Drawing.Size(207, 52);
             this.kryptonPanel1.TabIndex = 1;
             // 
             // tableLayoutPanel1
@@ -190,7 +190,7 @@ namespace Krypton.Toolkit
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(203, 64);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(207, 52);
             this.tableLayoutPanel1.TabIndex = 0;
             // 
             // kpnlContentArea
@@ -200,7 +200,7 @@ namespace Krypton.Toolkit
             this.kpnlContentArea.Location = new System.Drawing.Point(49, 12);
             this.kpnlContentArea.Margin = new System.Windows.Forms.Padding(4, 12, 4, 12);
             this.kpnlContentArea.Name = "kpnlContentArea";
-            this.kpnlContentArea.Size = new System.Drawing.Size(150, 19);
+            this.kpnlContentArea.Size = new System.Drawing.Size(154, 7);
             this.kpnlContentArea.TabIndex = 1;
             // 
             // krtbMessageText
@@ -213,7 +213,7 @@ namespace Krypton.Toolkit
             this.krtbMessageText.Name = "krtbMessageText";
             this.krtbMessageText.ReadOnly = true;
             this.krtbMessageText.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.None;
-            this.krtbMessageText.Size = new System.Drawing.Size(150, 19);
+            this.krtbMessageText.Size = new System.Drawing.Size(154, 7);
             this.krtbMessageText.StateCommon.Border.DrawBorders = Krypton.Toolkit.PaletteDrawBorders.None;
             this.krtbMessageText.TabIndex = 0;
             this.krtbMessageText.TabStop = false;
@@ -224,7 +224,7 @@ namespace Krypton.Toolkit
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(203, 64);
+            this.ClientSize = new System.Drawing.Size(207, 52);
             this.Controls.Add(this.kryptonPanel1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.KeyPreview = true;
@@ -236,8 +236,8 @@ namespace Krypton.Toolkit
             this.ShowInTaskbar = false;
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.AnyKeyDown);
             this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.OnFormClosed);
+            this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.AnyKeyDown);
             ((System.ComponentModel.ISupportInitialize)(this._messageIcon)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this._panelButtons)).EndInit();
             this._panelButtons.ResumeLayout(false);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxForm.cs
@@ -36,6 +36,7 @@ namespace Krypton.Toolkit
 
         #region Public
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public KryptonMessageBoxResult MessageBoxResult { get; set; }
 
         #endregion
@@ -761,6 +762,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the ignoring of Alt+F4
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)] 
         public bool IgnoreAltF4 { get; set; }
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxFormDep.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxFormDep.Designer.cs
@@ -70,7 +70,7 @@ namespace Krypton.Toolkit
             this._messageIcon.Location = new System.Drawing.Point(8, 4);
             this._messageIcon.Margin = new System.Windows.Forms.Padding(8, 4, 4, 4);
             this._messageIcon.Name = "_messageIcon";
-            this._messageIcon.Size = new System.Drawing.Size(33, 35);
+            this._messageIcon.Size = new System.Drawing.Size(33, 23);
             this._messageIcon.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
             this._messageIcon.TabIndex = 0;
             this._messageIcon.TabStop = false;
@@ -84,11 +84,11 @@ namespace Krypton.Toolkit
             this._panelButtons.Controls.Add(this._button1);
             this._panelButtons.Controls.Add(this._button2);
             this._panelButtons.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._panelButtons.Location = new System.Drawing.Point(0, 43);
+            this._panelButtons.Location = new System.Drawing.Point(0, 31);
             this._panelButtons.Margin = new System.Windows.Forms.Padding(0);
             this._panelButtons.Name = "_panelButtons";
             this._panelButtons.PanelBackStyle = Krypton.Toolkit.PaletteBackStyle.PanelAlternate;
-            this._panelButtons.Size = new System.Drawing.Size(203, 21);
+            this._panelButtons.Size = new System.Drawing.Size(207, 21);
             this._panelButtons.TabIndex = 0;
             // 
             // _borderEdge
@@ -98,7 +98,7 @@ namespace Krypton.Toolkit
             this._borderEdge.Location = new System.Drawing.Point(0, 0);
             this._borderEdge.Margin = new System.Windows.Forms.Padding(2);
             this._borderEdge.Name = "_borderEdge";
-            this._borderEdge.Size = new System.Drawing.Size(203, 1);
+            this._borderEdge.Size = new System.Drawing.Size(207, 1);
             this._borderEdge.Text = "kryptonBorderEdge1";
             // 
             // _button4
@@ -107,7 +107,7 @@ namespace Krypton.Toolkit
             this._button4.AutoSize = true;
             this._button4.Enabled = false;
             this._button4.IgnoreAltF4 = false;
-            this._button4.Location = new System.Drawing.Point(203, 0);
+            this._button4.Location = new System.Drawing.Point(207, 0);
             this._button4.Margin = new System.Windows.Forms.Padding(0);
             this._button4.MinimumSize = new System.Drawing.Size(38, 21);
             this._button4.Name = "_button4";
@@ -123,7 +123,7 @@ namespace Krypton.Toolkit
             this._button3.AutoSize = true;
             this._button3.Enabled = false;
             this._button3.IgnoreAltF4 = false;
-            this._button3.Location = new System.Drawing.Point(166, 0);
+            this._button3.Location = new System.Drawing.Point(170, 0);
             this._button3.Margin = new System.Windows.Forms.Padding(0);
             this._button3.MinimumSize = new System.Drawing.Size(38, 21);
             this._button3.Name = "_button3";
@@ -139,7 +139,7 @@ namespace Krypton.Toolkit
             this._button1.AutoSize = true;
             this._button1.Enabled = false;
             this._button1.IgnoreAltF4 = false;
-            this._button1.Location = new System.Drawing.Point(90, 0);
+            this._button1.Location = new System.Drawing.Point(94, 0);
             this._button1.Margin = new System.Windows.Forms.Padding(0);
             this._button1.MinimumSize = new System.Drawing.Size(38, 21);
             this._button1.Name = "_button1";
@@ -155,7 +155,7 @@ namespace Krypton.Toolkit
             this._button2.AutoSize = true;
             this._button2.Enabled = false;
             this._button2.IgnoreAltF4 = false;
-            this._button2.Location = new System.Drawing.Point(128, 0);
+            this._button2.Location = new System.Drawing.Point(132, 0);
             this._button2.Margin = new System.Windows.Forms.Padding(0);
             this._button2.MinimumSize = new System.Drawing.Size(38, 21);
             this._button2.Name = "_button2";
@@ -172,7 +172,7 @@ namespace Krypton.Toolkit
             this.kryptonPanel1.Location = new System.Drawing.Point(0, 0);
             this.kryptonPanel1.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonPanel1.Name = "kryptonPanel1";
-            this.kryptonPanel1.Size = new System.Drawing.Size(203, 64);
+            this.kryptonPanel1.Size = new System.Drawing.Size(207, 52);
             this.kryptonPanel1.TabIndex = 1;
             // 
             // tableLayoutPanel1
@@ -191,7 +191,7 @@ namespace Krypton.Toolkit
             this.tableLayoutPanel1.RowCount = 2;
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(203, 64);
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(207, 52);
             this.tableLayoutPanel1.TabIndex = 0;
             // 
             // kpnlContentArea
@@ -202,7 +202,7 @@ namespace Krypton.Toolkit
             this.kpnlContentArea.Location = new System.Drawing.Point(49, 12);
             this.kpnlContentArea.Margin = new System.Windows.Forms.Padding(4, 12, 4, 12);
             this.kpnlContentArea.Name = "kpnlContentArea";
-            this.kpnlContentArea.Size = new System.Drawing.Size(150, 19);
+            this.kpnlContentArea.Size = new System.Drawing.Size(154, 7);
             this.kpnlContentArea.TabIndex = 1;
             // 
             // krtbMessageText
@@ -215,7 +215,7 @@ namespace Krypton.Toolkit
             this.krtbMessageText.Name = "krtbMessageText";
             this.krtbMessageText.ReadOnly = true;
             this.krtbMessageText.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.None;
-            this.krtbMessageText.Size = new System.Drawing.Size(150, 19);
+            this.krtbMessageText.Size = new System.Drawing.Size(154, 7);
             this.krtbMessageText.StateCommon.Border.DrawBorders = Krypton.Toolkit.PaletteDrawBorders.None;
             this.krtbMessageText.TabIndex = 0;
             this.krtbMessageText.TabStop = false;
@@ -229,7 +229,7 @@ namespace Krypton.Toolkit
             this.klwlblMessageText.LabelStyle = Krypton.Toolkit.LabelStyle.NormalControl;
             this.klwlblMessageText.Location = new System.Drawing.Point(0, 0);
             this.klwlblMessageText.Name = "klwlblMessageText";
-            this.klwlblMessageText.Size = new System.Drawing.Size(150, 19);
+            this.klwlblMessageText.Size = new System.Drawing.Size(154, 7);
             this.klwlblMessageText.Text = "Message Text";
             this.klwlblMessageText.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
@@ -237,7 +237,7 @@ namespace Krypton.Toolkit
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(203, 64);
+            this.ClientSize = new System.Drawing.Size(207, 52);
             this.Controls.Add(this.kryptonPanel1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.KeyPreview = true;
@@ -249,8 +249,8 @@ namespace Krypton.Toolkit
             this.ShowInTaskbar = false;
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.AnyKeyDown);
             this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.OnFormClosed);
+            this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.AnyKeyDown);
             ((System.ComponentModel.ISupportInitialize)(this._messageIcon)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this._panelButtons)).EndInit();
             this._panelButtons.ResumeLayout(false);
@@ -260,7 +260,6 @@ namespace Krypton.Toolkit
             this.tableLayoutPanel1.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.kpnlContentArea)).EndInit();
             this.kpnlContentArea.ResumeLayout(false);
-            this.kpnlContentArea.PerformLayout();
             this.ResumeLayout(false);
 
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxFormDep.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxFormDep.cs
@@ -49,6 +49,7 @@ namespace Krypton.Toolkit
 
         #region Public
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public KryptonMessageBoxResult MessageBoxResult
         {
             get => _messageBoxResult;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPanel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPanel.cs
@@ -429,6 +429,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Image? BackgroundImage
         {
             get => base.BackgroundImage;
@@ -440,6 +441,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override ImageLayout BackgroundImageLayout
         {
             get => base.BackgroundImageLayout;
@@ -533,6 +535,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color BackColor
         {
             get => base.BackColor;
@@ -546,6 +549,7 @@ namespace Krypton.Toolkit
         [Bindable(false)]
         [AmbientValue(null)]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Font Font
         {
             get => base.Font;
@@ -557,6 +561,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color ForeColor
         {
             get => base.ForeColor;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPopup.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPopup.cs
@@ -320,6 +320,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public EventHandler? DismissedDelegate { get; set; }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualSimple.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualSimple.cs
@@ -108,6 +108,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color BackColor
         {
             get => base.BackColor;
@@ -121,6 +122,7 @@ namespace Krypton.Toolkit
         [Bindable(false)]
         [AmbientValue(null)]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Font Font
         {
             get => base.Font;
@@ -132,6 +134,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color ForeColor
         {
             get => base.ForeColor;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualSimpleBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualSimpleBase.cs
@@ -108,6 +108,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color BackColor
         {
             get => base.BackColor;
@@ -121,6 +122,7 @@ namespace Krypton.Toolkit
         [Bindable(false)]
         [AmbientValue(null)]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Font Font
         {
             get => base.Font;
@@ -132,6 +134,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color ForeColor
         {
             get => base.ForeColor;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualTaskDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualTaskDialog.cs
@@ -30,6 +30,7 @@ namespace Krypton.Toolkit
             /// <summary>
             /// Gets and sets the ignoring of Alt+F4
             /// </summary>
+            [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)] 
             public bool IgnoreAltF4 { get; set; }
 
             #endregion
@@ -1182,7 +1183,7 @@ namespace Krypton.Toolkit
             this._panelMain.Dock = System.Windows.Forms.DockStyle.Top;
             this._panelMain.Location = new System.Drawing.Point(0, 0);
             this._panelMain.Name = "_panelMain";
-            this._panelMain.Size = new System.Drawing.Size(790, 72);
+            this._panelMain.Size = new System.Drawing.Size(811, 72);
             this._panelMain.TabIndex = 0;
             // 
             // _panelMainSpacer
@@ -1294,7 +1295,7 @@ namespace Krypton.Toolkit
             this._panelButtons.Margin = new System.Windows.Forms.Padding(0);
             this._panelButtons.Name = "_panelButtons";
             this._panelButtons.PanelBackStyle = Krypton.Toolkit.PaletteBackStyle.PanelAlternate;
-            this._panelButtons.Size = new System.Drawing.Size(790, 46);
+            this._panelButtons.Size = new System.Drawing.Size(811, 46);
             this._panelButtons.TabIndex = 1;
             // 
             // _checkBox
@@ -1311,7 +1312,7 @@ namespace Krypton.Toolkit
             this._panelButtonsBorderTop.Dock = System.Windows.Forms.DockStyle.Top;
             this._panelButtonsBorderTop.Location = new System.Drawing.Point(0, 0);
             this._panelButtonsBorderTop.Name = "_panelButtonsBorderTop";
-            this._panelButtonsBorderTop.Size = new System.Drawing.Size(790, 1);
+            this._panelButtonsBorderTop.Size = new System.Drawing.Size(811, 1);
             this._panelButtonsBorderTop.Text = "kryptonBorderEdge1";
             // 
             // _buttonOK
@@ -1320,12 +1321,13 @@ namespace Krypton.Toolkit
             this._buttonOK.AutoSize = true;
             this._buttonOK.DialogResult = System.Windows.Forms.DialogResult.OK;
             this._buttonOK.IgnoreAltF4 = false;
-            this._buttonOK.Location = new System.Drawing.Point(681, 9);
+            this._buttonOK.Location = new System.Drawing.Point(702, 9);
             this._buttonOK.Margin = new System.Windows.Forms.Padding(0);
             this._buttonOK.MinimumSize = new System.Drawing.Size(50, 26);
             this._buttonOK.Name = "_buttonOK";
             this._buttonOK.Size = new System.Drawing.Size(50, 26);
             this._buttonOK.TabIndex = 1;
+            this._buttonOK.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this._buttonOK.Values.Text = "OK";
             // 
             // _buttonYes
@@ -1334,12 +1336,13 @@ namespace Krypton.Toolkit
             this._buttonYes.AutoSize = true;
             this._buttonYes.DialogResult = System.Windows.Forms.DialogResult.Yes;
             this._buttonYes.IgnoreAltF4 = false;
-            this._buttonYes.Location = new System.Drawing.Point(581, 9);
+            this._buttonYes.Location = new System.Drawing.Point(602, 9);
             this._buttonYes.Margin = new System.Windows.Forms.Padding(0);
             this._buttonYes.MinimumSize = new System.Drawing.Size(50, 26);
             this._buttonYes.Name = "_buttonYes";
             this._buttonYes.Size = new System.Drawing.Size(50, 26);
             this._buttonYes.TabIndex = 2;
+            this._buttonYes.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this._buttonYes.Values.Text = "Yes";
             // 
             // _buttonNo
@@ -1348,12 +1351,13 @@ namespace Krypton.Toolkit
             this._buttonNo.AutoSize = true;
             this._buttonNo.DialogResult = System.Windows.Forms.DialogResult.No;
             this._buttonNo.IgnoreAltF4 = false;
-            this._buttonNo.Location = new System.Drawing.Point(531, 9);
+            this._buttonNo.Location = new System.Drawing.Point(552, 9);
             this._buttonNo.Margin = new System.Windows.Forms.Padding(0);
             this._buttonNo.MinimumSize = new System.Drawing.Size(50, 26);
             this._buttonNo.Name = "_buttonNo";
             this._buttonNo.Size = new System.Drawing.Size(50, 26);
             this._buttonNo.TabIndex = 3;
+            this._buttonNo.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this._buttonNo.Values.Text = "No";
             // 
             // _buttonRetry
@@ -1362,12 +1366,13 @@ namespace Krypton.Toolkit
             this._buttonRetry.AutoSize = true;
             this._buttonRetry.DialogResult = System.Windows.Forms.DialogResult.Retry;
             this._buttonRetry.IgnoreAltF4 = false;
-            this._buttonRetry.Location = new System.Drawing.Point(631, 9);
+            this._buttonRetry.Location = new System.Drawing.Point(652, 9);
             this._buttonRetry.Margin = new System.Windows.Forms.Padding(0);
             this._buttonRetry.MinimumSize = new System.Drawing.Size(50, 26);
             this._buttonRetry.Name = "_buttonRetry";
             this._buttonRetry.Size = new System.Drawing.Size(50, 26);
             this._buttonRetry.TabIndex = 5;
+            this._buttonRetry.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this._buttonRetry.Values.Text = "Retry";
             // 
             // _buttonCancel
@@ -1376,12 +1381,13 @@ namespace Krypton.Toolkit
             this._buttonCancel.AutoSize = true;
             this._buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this._buttonCancel.IgnoreAltF4 = false;
-            this._buttonCancel.Location = new System.Drawing.Point(474, 9);
+            this._buttonCancel.Location = new System.Drawing.Point(495, 9);
             this._buttonCancel.Margin = new System.Windows.Forms.Padding(0);
             this._buttonCancel.MinimumSize = new System.Drawing.Size(50, 26);
             this._buttonCancel.Name = "_buttonCancel";
             this._buttonCancel.Size = new System.Drawing.Size(57, 26);
             this._buttonCancel.TabIndex = 4;
+            this._buttonCancel.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this._buttonCancel.Values.Text = "Cancel";
             // 
             // _buttonClose
@@ -1389,12 +1395,13 @@ namespace Krypton.Toolkit
             this._buttonClose.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this._buttonClose.AutoSize = true;
             this._buttonClose.IgnoreAltF4 = false;
-            this._buttonClose.Location = new System.Drawing.Point(731, 9);
+            this._buttonClose.Location = new System.Drawing.Point(752, 9);
             this._buttonClose.Margin = new System.Windows.Forms.Padding(0);
             this._buttonClose.MinimumSize = new System.Drawing.Size(50, 26);
             this._buttonClose.Name = "_buttonClose";
             this._buttonClose.Size = new System.Drawing.Size(50, 26);
             this._buttonClose.TabIndex = 6;
+            this._buttonClose.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this._buttonClose.Values.Text = "Close";
             // 
             // _panelFooter
@@ -1407,7 +1414,7 @@ namespace Krypton.Toolkit
             this._panelFooter.Location = new System.Drawing.Point(0, 118);
             this._panelFooter.Name = "_panelFooter";
             this._panelFooter.PanelBackStyle = Krypton.Toolkit.PaletteBackStyle.PanelAlternate;
-            this._panelFooter.Size = new System.Drawing.Size(790, 49);
+            this._panelFooter.Size = new System.Drawing.Size(811, 49);
             this._panelFooter.TabIndex = 2;
             // 
             // _linkLabelFooter
@@ -1446,7 +1453,7 @@ namespace Krypton.Toolkit
             this._panelFooterBorderTop.Dock = System.Windows.Forms.DockStyle.Top;
             this._panelFooterBorderTop.Location = new System.Drawing.Point(0, 0);
             this._panelFooterBorderTop.Name = "_panelFooterBorderTop";
-            this._panelFooterBorderTop.Size = new System.Drawing.Size(790, 1);
+            this._panelFooterBorderTop.Size = new System.Drawing.Size(811, 1);
             this._panelFooterBorderTop.Text = "kryptonBorderEdge1";
             // 
             // VisualTaskDialog
@@ -1454,7 +1461,7 @@ namespace Krypton.Toolkit
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoScroll = true;
-            this.ClientSize = new System.Drawing.Size(790, 172);
+            this.ClientSize = new System.Drawing.Size(828, 160);
             this.Controls.Add(this._panelFooter);
             this.Controls.Add(this._panelButtons);
             this.Controls.Add(this._panelMain);

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Editors/PaletteDrawBordersEditor.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Editors/PaletteDrawBordersEditor.cs
@@ -47,7 +47,7 @@ namespace Krypton.Toolkit
                 if (provider.GetService(typeof(IWindowsFormsEditorService)) is IWindowsFormsEditorService service)
                 {
                     // Create the custom control used to edit value
-                    var selector = new PaletteDrawBordersSelector
+                    PaletteDrawBordersSelector selector = new() 
                     {
                         // Populate selector with starting value
                         Value = (PaletteDrawBorders)value

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Other/OverrideComboBoxStyleDropDownStyle.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Other/OverrideComboBoxStyleDropDownStyle.cs
@@ -31,7 +31,7 @@ namespace Krypton.Toolkit
         {
             if (provider?.GetService(typeof(IWindowsFormsEditorService)) is IWindowsFormsEditorService svc)
             {
-                var ctrl = new UserControl();
+                UserControl ctrl = new ();
                 ListBox clb = new ListBox { Dock = DockStyle.Fill };
                 
                 if (clb is not null && value is not null)

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Other/PaletteDrawBordersSelector.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Other/PaletteDrawBordersSelector.cs
@@ -26,6 +26,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the value being edited.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public PaletteDrawBorders Value
         {
             get

--- a/Source/Krypton Components/Krypton.Toolkit/General/OutlookGrid/CustomColumns/KryptonDataGridViewFormattingColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/OutlookGrid/CustomColumns/KryptonDataGridViewFormattingColumn.cs
@@ -52,6 +52,7 @@ namespace Krypton.Toolkit
 
         /// <summary>Gets or sets a value indicating whether [contrast text color].</summary>
         /// <value><c>true</c> if [contrast text color]; otherwise, <c>false</c>.</value>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public bool ContrastTextColor
         {
             get => _contrastTextColor; 

--- a/Source/Krypton Components/Krypton.Toolkit/General/OutlookGrid/CustomColumns/KryptonDataGridViewPercentageColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/OutlookGrid/CustomColumns/KryptonDataGridViewPercentageColumn.cs
@@ -55,6 +55,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Overrides CellTemplate
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override DataGridViewCell? CellTemplate
         {
             get => base.CellTemplate;

--- a/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/HScrollSkin.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/HScrollSkin.cs
@@ -47,12 +47,14 @@ namespace Krypton.Toolkit
             set => __win = value;
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         internal virtual KryptonScrollBar VScrollBar1
         {
             get => _VScrollBar1;
             set => _VScrollBar1 = value;
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         internal virtual KryptonScrollBar HScrollBar1
         {
             get => _HScrollBar1;

--- a/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/VScrollSkin.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Scroll Bars/VScrollSkin.cs
@@ -48,12 +48,14 @@ namespace Krypton.Toolkit
             set => __win = value;
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         internal virtual KryptonScrollBar VScrollBar1
         {
             get => _vScrollBar1;
             set => _vScrollBar1 = value;
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         internal virtual KryptonScrollBar HScrollBar1
         {
             get => _hScrollBar1;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirect.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirect.cs
@@ -39,6 +39,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the redirection target.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual PaletteBase? Target
         {
             get => _target;
@@ -51,6 +52,7 @@ namespace Krypton.Toolkit
         /// Gets a value indicating if KryptonForm instances should UseThemeFormChromeBorderWidth.
         /// </summary>
         /// <returns>InheritBool value.</returns>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override InheritBool UseThemeFormChromeBorderWidth
         {
             get => _target!.UseThemeFormChromeBorderWidth;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Base/PaletteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Base/PaletteBase.cs
@@ -1785,11 +1785,13 @@ namespace Krypton.Toolkit
         /// <value>The name of the theme.</value>
         [Description(@"Gets or sets the name of the theme.")]
         [DisallowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public string ThemeName { get; set; }
 
         /// <summary>Gets or sets the type of the base palette.</summary>
         /// <value>The type of the base palette.</value>
         [Description(@"Gets or sets the type of the base palette.")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public BasePaletteType BasePaletteType { get; set; }
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectBreadCrumb.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectBreadCrumb.cs
@@ -35,6 +35,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets if the left border should be removed.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public bool Left { get; set; }
 
         #endregion
@@ -43,6 +44,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets if the right border should be removed.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public bool Right { get; set; }
 
         #endregion
@@ -51,6 +53,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets if the top and bottom borders should be removed.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public bool TopBottom { get; set; }
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/View Base/InternalToastButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Base/InternalToastButton.cs
@@ -27,6 +27,7 @@ namespace Krypton.Toolkit
 
         #region Public
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool IsActionButton
         {
             get => _isActionButton;
@@ -41,6 +42,7 @@ namespace Krypton.Toolkit
             }
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool IsDismissButton
         {
             get => _isDismissButton;
@@ -55,6 +57,7 @@ namespace Krypton.Toolkit
             }
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public string ProcessPath
         {
             get => _processPath;
@@ -62,6 +65,7 @@ namespace Krypton.Toolkit
             set => _processPath = value;
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public VisualToastNotificationBaseForm? Owner
         {
             get => _owner;
@@ -69,6 +73,7 @@ namespace Krypton.Toolkit
             set => _owner = value;
         }
 
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public KryptonToastNotificationResult NotificationResult
         {
             get => _notificationResult;
@@ -168,6 +173,7 @@ namespace Krypton.Toolkit
 
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public override IKryptonCommand? KryptonCommand { get; set; }
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/View Base/TaskDialogMessageButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Base/TaskDialogMessageButton.cs
@@ -20,6 +20,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the ignoring of Alt+F4
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)] 
         public bool IgnoreAltF4 { get; set; }
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/View Base/ViewControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Base/ViewControl.cs
@@ -76,6 +76,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets access to the view layout control.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public ViewLayoutControl ViewLayoutControl { get; set; }
 
         #endregion
@@ -116,6 +117,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets if the background is transparent.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public bool TransparentBackground { get; set; }
 
         #endregion
@@ -124,6 +126,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets a value indicating if the control is in design mode.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public bool InDesignMode { get; set; }
 
         #endregion

--- a/Source/Krypton Components/Krypton.Workspace/Controls Workspace/KryptonWorkspace.cs
+++ b/Source/Krypton Components/Krypton.Workspace/Controls Workspace/KryptonWorkspace.cs
@@ -312,6 +312,7 @@ namespace Krypton.Workspace
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public override bool AllowDrop
         {
             get => base.AllowDrop;
@@ -324,6 +325,7 @@ namespace Krypton.Workspace
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public override bool AutoSize
         {
             get => base.AutoSize;
@@ -337,6 +339,7 @@ namespace Krypton.Workspace
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Bindable(false)]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override string Text
         {
             get => base.Text;
@@ -349,6 +352,7 @@ namespace Krypton.Workspace
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color BackColor
         {
             get => base.BackColor;
@@ -363,6 +367,7 @@ namespace Krypton.Workspace
         [Bindable(false)]
         [AmbientValue(null)]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Font Font
         {
             get => base.Font;
@@ -375,6 +380,7 @@ namespace Krypton.Workspace
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color ForeColor
         {
             get => base.ForeColor;
@@ -434,7 +440,7 @@ namespace Krypton.Workspace
         /// </summary>
         [Category(@"Visuals")]
         [Description(@"Determines the compacting options to be applied.")]
-        //[DefaultValue(typeof(CompactFlags), "All")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public CompactFlags CompactFlags
         {
             get => _compactFlags;
@@ -476,7 +482,7 @@ namespace Krypton.Workspace
         [Category(@"Visuals")]
         [Description(@"Determines the thickness of the splitters.")]
         [Localizable(true)]
-        //[DefaultValue(typeof(int), "5")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public int SplitterWidth
         {
             get => _splitterWidth;
@@ -526,7 +532,7 @@ namespace Krypton.Workspace
         /// </summary>
         [Category(@"Visuals")]
         [Description(@"Container background style.")]
-        //[DefaultValue(typeof(PaletteBackStyle), "PanelClient")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public PaletteBackStyle ContainerBackStyle
         {
             get => StateCommon.BackStyle;
@@ -546,7 +552,7 @@ namespace Krypton.Workspace
         /// </summary>
         [Category(@"Visuals")]
         [Description(@"Separator style.")]
-        //[DefaultValue(typeof(SeparatorStyle), "Low Profile")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public SeparatorStyle SeparatorStyle
         {
             get => _separatorStyle;

--- a/Source/Krypton Components/Krypton.Workspace/Controls Workspace/KryptonWorkspaceCell.cs
+++ b/Source/Krypton Components/Krypton.Workspace/Controls Workspace/KryptonWorkspaceCell.cs
@@ -207,6 +207,7 @@ namespace Krypton.Workspace
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public bool WorkspaceVisible { get; private set; }
 
         /// <summary>
@@ -214,6 +215,7 @@ namespace Krypton.Workspace
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public bool WorkspaceAllowResizing { get; private set; }
 
         /// <summary>
@@ -228,6 +230,7 @@ namespace Krypton.Workspace
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public Size WorkspacePreferredSize => IsDisposed ? Size.Empty : GetPreferredSize(WorkspaceMinSize);
 
         /// <summary>
@@ -254,6 +257,7 @@ namespace Krypton.Workspace
         /// <summary>
         /// Gets or sets the size that is the lower limit that GetPreferredSize can specify.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public override Size MinimumSize
         {
             get => base.MinimumSize;
@@ -271,6 +275,7 @@ namespace Krypton.Workspace
         /// <summary>
         /// Gets or sets the size that is the upper limit that GetPreferredSize can specify.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public override Size MaximumSize
         {
             get => base.MaximumSize;
@@ -385,6 +390,7 @@ namespace Krypton.Workspace
         /// </summary>
         [Category(@"Appearance")]
         [Description(@"The unique name of the workspace cell.")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public string UniqueName
         {
             [DebuggerStepThrough]

--- a/Source/Krypton Components/Krypton.Workspace/Controls Workspace/KryptonWorkspaceSequence.cs
+++ b/Source/Krypton Components/Krypton.Workspace/Controls Workspace/KryptonWorkspaceSequence.cs
@@ -199,6 +199,7 @@ namespace Krypton.Workspace
         /// </summary>
         [Category(@"Appearance")]
         [Description(@"The unique name of the workspace sequence.")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public string UniqueName
         {
             [DebuggerStepThrough]
@@ -251,6 +252,7 @@ namespace Krypton.Workspace
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public Size WorkspaceActualSize { get; internal set; }
 
         /// <summary>
@@ -577,6 +579,7 @@ namespace Krypton.Workspace
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] 
         public KryptonWorkspace WorkspaceControl { get; set; }
 
         /// <summary>


### PR DESCRIPTION
[Issue 1840-remove-dn9-warnings](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1840)
- Changes to nullability annotations
- https://learn.microsoft.com/en-us/dotnet/core/compatibility/windows-forms/9.0/nullability-changes
- No change log provided.

![compile-results](https://github.com/user-attachments/assets/45312bee-eb6e-4838-84b1-2e69d22694db)
