### PR TITLE
1840-remove-dn9-warnings

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonButton.cs
@@ -101,7 +101,7 @@ namespace Krypton.Toolkit
             set => base.ImeMode = value;
         }
 
-        /*/// <summary>Gets or sets a value indicating whether [show split option].</summary>
+        /// <summary>Gets or sets a value indicating whether [show split option].</summary>
         /// <value><c>true</c> if [show split option]; otherwise, <c>false</c>.</value>
         [Category(@"Visuals")]
         [DefaultValue(false)]

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLinkWrapLabel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLinkWrapLabel.cs
@@ -202,6 +202,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public new FlatStyle FlatStyle
         {
             get => base.FlatStyle;


### PR DESCRIPTION
[Issue 1840-remove-dn9-warnings](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1840)
- Corrects incorrectly resolved merge conflict
- And a few overlooked wfo1000's

![compile-results](https://github.com/user-attachments/assets/bf3b8341-c632-4ba5-a8a6-c74e66291aa5)
