### PR TITLE
- Automatically add a an internal `KryptonPanel` to `KryptonForms

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2025-11-xx - Build 2511 - November 2025
+* Implemented [#1177](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1177), Is it possible to have the KForm back colour as the KPanel colour
 * Resolved [#1900](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1900), Remove Obsolete `KryptonMessageBoxDep` from V100 code base
 * Resolved [#1211](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1211), Button 'drop down' arrows should use palette text colour 
 * Resolved [#1212](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1212), **[Breaking Change]** `KColorButton` 'drop-down' arrow should be drawn

--- a/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonFloatingWindow.cs
+++ b/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonFloatingWindow.cs
@@ -45,6 +45,7 @@ namespace Krypton.Docking
         /// <param name="useMinimiseBox">Allow window to be minimised.</param>
         public KryptonFloatingWindow(Form owner, KryptonFloatspace? floatspace, bool useMinimiseBox = false)
         {
+            SetInheritedControlOverride();
             // Set the owner of the window so that minimizing the owner will do the same to this
             Owner = owner;
 

--- a/Source/Krypton Components/Krypton.Docking/Krypton.Docking 2022.csproj
+++ b/Source/Krypton Components/Krypton.Docking/Krypton.Docking 2022.csproj
@@ -1,120 +1,121 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<Choose>
-		<When Condition="'$(Configuration)' == 'Nightly' Or '$(Configuration)' == 'Canary' Or '$(Configuration)' == 'Debug'">
-			<PropertyGroup>
-				<TargetFrameworks>net462;net47;net471;net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
-			</PropertyGroup>
-		</When>
-		<Otherwise>
-			<PropertyGroup>
-				<TargetFrameworks>net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+  <Choose>
+    <When Condition="'$(Configuration)' == 'Nightly' Or '$(Configuration)' == 'Canary' Or '$(Configuration)' == 'Debug'">
+      <PropertyGroup>
+        <TargetFrameworks>net462;net47;net471;net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <TargetFrameworks>net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
 
-				<TargetFrameworks Condition="'$(TFMs)' == 'all'">net462;net47;net471;net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
-			</PropertyGroup>
-		</Otherwise>
-	</Choose>
+        <TargetFrameworks Condition="'$(TFMs)' == 'all'">net462;net47;net471;net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
 
-	<PropertyGroup>
-		<OutputType>Library</OutputType>
-		<RootNamespace>Krypton.Docking</RootNamespace>
-		<AssemblyName>Krypton.Docking</AssemblyName>
-		<!-- Set the CheckEolTargetFramework property to false to fix the warning -->
-		<CheckEolTargetFramework>false</CheckEolTargetFramework>
-		<ApplicationIcon>Krypton.ico</ApplicationIcon>
-		<DelaySign>false</DelaySign>
-		<UseWindowsForms>true</UseWindowsForms>
-		<PlatformTarget>AnyCPU</PlatformTarget>
-		<EnableNETAnalyzers>true</EnableNETAnalyzers>
-		<NeutralLanguage>en</NeutralLanguage>
-		<DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
-		<Configurations>Debug;Release;Installer;Nightly;Canary</Configurations>
-		<Nullable>enable</Nullable>
-		<!--https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/warning-waves-->
-		<WarningLevel>8</WarningLevel>
-		<AnalysisLevel>latest</AnalysisLevel>
-		<AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
-		<!--https://learn.microsoft.com/en-us/visualstudio/designers/disable-dpi-awareness?view=vs-2022-->
-		<ForceDesignerDPIUnaware>true</ForceDesignerDPIUnaware>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Krypton.Docking</RootNamespace>
+    <AssemblyName>Krypton.Docking</AssemblyName>
+    <!-- Set the CheckEolTargetFramework property to false to fix the warning -->
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <ApplicationIcon>Krypton.ico</ApplicationIcon>
+    <DelaySign>false</DelaySign>
+    <UseWindowsForms>true</UseWindowsForms>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <NeutralLanguage>en</NeutralLanguage>
+    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
+    <Configurations>Debug;Release;Installer;Nightly;Canary</Configurations>
+    <Nullable>enable</Nullable>
+    <!--https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/warning-waves-->
+    <WarningLevel>8</WarningLevel>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
+    <!--https://learn.microsoft.com/en-us/visualstudio/designers/disable-dpi-awareness?view=vs-2022-->
+    <ForceDesignerDPIUnaware>true</ForceDesignerDPIUnaware>
+    <ApplicationHighDpiMode>SystemAware</ApplicationHighDpiMode>
+  </PropertyGroup>
 
-	<PropertyGroup>
-		<PackageId>Krypton.Docking</PackageId>
-		<Description>This is the docking module.</Description>
-	</PropertyGroup>
+  <PropertyGroup>
+    <PackageId>Krypton.Docking</PackageId>
+    <Description>This is the docking module.</Description>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<Reference Include="System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="$(TargetFramework.StartsWith('net4'))">
-			<SpecificVersion>True</SpecificVersion>
-			<Version>4.0.0.0</Version>
-			<!-- Designers for the `TFMs != net4` are "Pulled in" via Visual studios ".nuget\packages\microsoft.windowsdesktop.app.ref" -->
-		</Reference>
-	</ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="$(TargetFramework.StartsWith('net4'))">
+      <SpecificVersion>True</SpecificVersion>
+      <Version>4.0.0.0</Version>
+      <!-- Designers for the `TFMs != net4` are "Pulled in" via Visual studios ".nuget\packages\microsoft.windowsdesktop.app.ref" -->
+    </Reference>
+  </ItemGroup>
 
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Nightly|net48|AnyCPU'">
-		<Optimize>True</Optimize>
-	</PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Nightly|net48|AnyCPU'">
+    <Optimize>True</Optimize>
+  </PropertyGroup>
 
-	<PropertyGroup>
-		<SourceRevisionId>build$([System.DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ss:fffZ"))</SourceRevisionId>
-	</PropertyGroup>
+  <PropertyGroup>
+    <SourceRevisionId>build$([System.DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ss:fffZ"))</SourceRevisionId>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<Compile Include="..\Krypton.Toolkit\General\GlobalSuppressions.cs" Link="General\GlobalSuppressions.cs" />
-		<Compile Include="..\Krypton.Toolkit\General\PlatformInvoke.cs">
-			<Link>General\PlatformInvoke.cs</Link>
-		</Compile>
-		<Compile Include="..\Krypton.Toolkit\Utilities\AllowNullAttribute.cs" Link="General\AllowNullAttribute.cs" />
-		<Compile Update="Elements Base\DockingElementClosedCollection.cs">
-			<SubType>Component</SubType>
-		</Compile>
-		<Compile Update="Elements Base\DockingElementOpenCollection.cs">
-			<SubType>Component</SubType>
-		</Compile>
-		<Compile Update="Elements Base\DockingElement.cs">
-			<SubType>Component</SubType>
-		</Compile>
-		<Compile Update="General\ObscureControl.cs">
-			<SubType>Component</SubType>
-		</Compile>
-		<Compile Update="Resources\GenericImageResources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>GenericImageResources.resx</DependentUpon>
-		</Compile>
-	</ItemGroup>
-	<ItemGroup>
-		<Content Include="Krypton.ico" Pack="false" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonDockableNavigator.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonDockableWorkspace.bmp" />
-		<EmbeddedResource Include="ToolboxBitmaps\KryptonDockingManager.bmp" />
-	</ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\Krypton.Toolkit\General\GlobalSuppressions.cs" Link="General\GlobalSuppressions.cs" />
+    <Compile Include="..\Krypton.Toolkit\General\PlatformInvoke.cs">
+      <Link>General\PlatformInvoke.cs</Link>
+    </Compile>
+    <Compile Include="..\Krypton.Toolkit\Utilities\AllowNullAttribute.cs" Link="General\AllowNullAttribute.cs" />
+    <Compile Update="Elements Base\DockingElementClosedCollection.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Update="Elements Base\DockingElementOpenCollection.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Update="Elements Base\DockingElement.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Update="General\ObscureControl.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Update="Resources\GenericImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>GenericImageResources.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Krypton.ico" Pack="false" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonDockableNavigator.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonDockableWorkspace.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonDockingManager.bmp" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\Krypton.Navigator\Krypton.Navigator 2022.csproj" />
-		<ProjectReference Include="..\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />
-		<ProjectReference Include="..\Krypton.Workspace\Krypton.Workspace 2022.csproj" />
-	</ItemGroup>
-	<ItemGroup>
-		<EmbeddedResource Update="Resources\GenericImageResources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>GenericImageResources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-	</ItemGroup>
-	<PropertyGroup>
-		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<OutputPath>..\..\..\Bin\$(Configuration)\</OutputPath>
-	</PropertyGroup>
-	<PropertyGroup>
-		<NoWarn>1701;1702</NoWarn>
-		<SignAssembly>True</SignAssembly>
-		<AssemblyOriginatorKeyFile>StrongKrypton.snk</AssemblyOriginatorKeyFile>
-		<PackageLicenseFile>License.md</PackageLicenseFile>
-		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-	</PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Krypton.Navigator\Krypton.Navigator 2022.csproj" />
+    <ProjectReference Include="..\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />
+    <ProjectReference Include="..\Krypton.Workspace\Krypton.Workspace 2022.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Update="Resources\GenericImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>GenericImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <OutputPath>..\..\..\Bin\$(Configuration)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <NoWarn>1701;1702</NoWarn>
+    <SignAssembly>True</SignAssembly>
+    <AssemblyOriginatorKeyFile>StrongKrypton.snk</AssemblyOriginatorKeyFile>
+    <PackageLicenseFile>License.md</PackageLicenseFile>
+    <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
+  </PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)'!='Debug'">
-		<Optimize>True</Optimize>
-	</PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'!='Debug'">
+    <Optimize>True</Optimize>
+  </PropertyGroup>
 
 </Project>

--- a/Source/Krypton Components/Krypton.Navigator/Dragging/DropDockingIndicatorsSquare.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Dragging/DropDockingIndicatorsSquare.cs
@@ -42,6 +42,7 @@ namespace Krypton.Navigator
                                            bool showTop, bool showBottom,
                                            bool showMiddle)
         {
+            SetInheritedControlOverride();
             _paletteDragDrop = paletteDragDrop;
             _renderer = renderer;
 

--- a/Source/Krypton Components/Krypton.Navigator/Dragging/DropSolidWindow.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Dragging/DropSolidWindow.cs
@@ -31,6 +31,7 @@ namespace Krypton.Navigator
         /// <param name="renderer">Drawing renderer.</param>
         public DropSolidWindow(IPaletteDragDrop paletteDragDrop, IRenderer renderer)
         {
+            SetInheritedControlOverride();
             _paletteDragDrop = paletteDragDrop;
             _renderer = renderer;
 

--- a/Source/Krypton Components/Krypton.Navigator/Krypton.Navigator 2022.csproj
+++ b/Source/Krypton Components/Krypton.Navigator/Krypton.Navigator 2022.csproj
@@ -1,114 +1,115 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <Choose>
-        <When Condition="'$(Configuration)' == 'Nightly' Or '$(Configuration)' == 'Canary' Or '$(Configuration)' == 'Debug'">
-            <PropertyGroup>
-                <TargetFrameworks>net462;net47;net471;net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
-            </PropertyGroup>
-        </When>
-        <Otherwise>
-            <PropertyGroup>
-                <TargetFrameworks>net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+  <Choose>
+    <When Condition="'$(Configuration)' == 'Nightly' Or '$(Configuration)' == 'Canary' Or '$(Configuration)' == 'Debug'">
+      <PropertyGroup>
+        <TargetFrameworks>net462;net47;net471;net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <TargetFrameworks>net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
 
-                <TargetFrameworks Condition="'$(TFMs)' == 'all'">net462;net47;net471;net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
-            </PropertyGroup>
-        </Otherwise>
-    </Choose>
+        <TargetFrameworks Condition="'$(TFMs)' == 'all'">net462;net47;net471;net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
 
-    <PropertyGroup>
-        <OutputType>Library</OutputType>
-        <RootNamespace>Krypton.Navigator</RootNamespace>
-        <AssemblyName>Krypton.Navigator</AssemblyName>
-        <!-- Set the CheckEolTargetFramework property to false to fix the warning -->
-        <CheckEolTargetFramework>false</CheckEolTargetFramework>
-        <SignAssembly>True</SignAssembly>
-        <AssemblyOriginatorKeyFile>StrongKrypton.snk</AssemblyOriginatorKeyFile>
-        <ApplicationIcon>Krypton.ico</ApplicationIcon>
-        <DelaySign>false</DelaySign>
-        <UseWindowsForms>true</UseWindowsForms>
-        <PlatformTarget>AnyCPU</PlatformTarget>
-        <EnableNETAnalyzers>true</EnableNETAnalyzers>
-        <NeutralLanguage>en</NeutralLanguage>
-        <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
-        <Configurations>Debug;Release;Installer;Nightly;Canary</Configurations>
-        <Nullable>enable</Nullable>
-        <!--https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/warning-waves-->
-        <WarningLevel>8</WarningLevel>
-        <AnalysisLevel>latest</AnalysisLevel>
-        <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
-        <!--https://learn.microsoft.com/en-us/visualstudio/designers/disable-dpi-awareness?view=vs-2022-->
-        <ForceDesignerDPIUnaware>true</ForceDesignerDPIUnaware>
-    </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Krypton.Navigator</RootNamespace>
+    <AssemblyName>Krypton.Navigator</AssemblyName>
+    <!-- Set the CheckEolTargetFramework property to false to fix the warning -->
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <SignAssembly>True</SignAssembly>
+    <AssemblyOriginatorKeyFile>StrongKrypton.snk</AssemblyOriginatorKeyFile>
+    <ApplicationIcon>Krypton.ico</ApplicationIcon>
+    <DelaySign>false</DelaySign>
+    <UseWindowsForms>true</UseWindowsForms>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <NeutralLanguage>en</NeutralLanguage>
+    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
+    <Configurations>Debug;Release;Installer;Nightly;Canary</Configurations>
+    <Nullable>enable</Nullable>
+    <!--https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/warning-waves-->
+    <WarningLevel>8</WarningLevel>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
+    <!--https://learn.microsoft.com/en-us/visualstudio/designers/disable-dpi-awareness?view=vs-2022-->
+    <ForceDesignerDPIUnaware>true</ForceDesignerDPIUnaware>
+    <ApplicationHighDpiMode>SystemAware</ApplicationHighDpiMode>
+  </PropertyGroup>
 
-    <PropertyGroup>
-        <PackageId>Krypton.Navigator</PackageId>
-        <Description>This is the navigator module.</Description>
-    </PropertyGroup>
+  <PropertyGroup>
+    <PackageId>Krypton.Navigator</PackageId>
+    <Description>This is the navigator module.</Description>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <Reference Include="System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="$(TargetFramework.StartsWith('net4'))">
-            <SpecificVersion>True</SpecificVersion>
-            <Version>4.0.0.0</Version>
-            <!-- Designers for the `TFMs != net4` are "Pulled in" via Visual studios ".nuget\packages\microsoft.windowsdesktop.app.ref" -->
-        </Reference>
-    </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="$(TargetFramework.StartsWith('net4'))">
+      <SpecificVersion>True</SpecificVersion>
+      <Version>4.0.0.0</Version>
+      <!-- Designers for the `TFMs != net4` are "Pulled in" via Visual studios ".nuget\packages\microsoft.windowsdesktop.app.ref" -->
+    </Reference>
+  </ItemGroup>
 
-    <ItemGroup>
-        <Compile Include="..\Krypton.Toolkit\General\GlobalSuppressions.cs" Link="General\GlobalSuppressions.cs" />
-        <Compile Include="..\Krypton.Toolkit\General\PlatformInvoke.cs">
-            <Link>General\PlatformInvoke.cs</Link>
-        </Compile>
-        <Compile Include="..\Krypton.Toolkit\Utilities\AllowNullAttribute.cs" Link="General\AllowNullAttribute.cs" />
-        <Compile Update="ButtonSpecs\ButtonSpecNavigator.cs" />
-        <Compile Update="ButtonSpecs\ButtonSpecNavFixed.cs" />
-        <Compile Update="ButtonSpecs\ButtonSpecNavClose.cs" />
-        <Compile Update="ButtonSpecs\ButtonSpecNavPrevious.cs" />
-        <Compile Update="ButtonSpecs\ButtonSpecNavNext.cs" />
-        <Compile Update="ButtonSpecs\ButtonSpecNavContext.cs" />
-        <Compile Update="Resources\CursorResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>CursorResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="Resources\GeneralImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>GeneralImageResources.resx</DependentUpon>
-        </Compile>
-    </ItemGroup>
-    <ItemGroup>
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonNavigator.bmp" />
-    </ItemGroup>
-    <ItemGroup>
-        <Content Include="Krypton.ico" Pack="false" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonPage.bmp" />
-    </ItemGroup>
-    <ItemGroup>
-        <Compile Remove="Palette\PaletteNavigatorOtherOverride.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <ProjectReference Include="..\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />
-    </ItemGroup>
-    <ItemGroup>
-        <EmbeddedResource Update="Resources\CursorResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>CursorResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="Resources\GeneralImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>GeneralImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-    </ItemGroup>
-    <PropertyGroup>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <OutputPath>..\..\..\Bin\$(Configuration)\</OutputPath>
-    </PropertyGroup>
-    <PropertyGroup>
-        <NoWarn>1701;1702</NoWarn>
-    </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\Krypton.Toolkit\General\GlobalSuppressions.cs" Link="General\GlobalSuppressions.cs" />
+    <Compile Include="..\Krypton.Toolkit\General\PlatformInvoke.cs">
+      <Link>General\PlatformInvoke.cs</Link>
+    </Compile>
+    <Compile Include="..\Krypton.Toolkit\Utilities\AllowNullAttribute.cs" Link="General\AllowNullAttribute.cs" />
+    <Compile Update="ButtonSpecs\ButtonSpecNavigator.cs" />
+    <Compile Update="ButtonSpecs\ButtonSpecNavFixed.cs" />
+    <Compile Update="ButtonSpecs\ButtonSpecNavClose.cs" />
+    <Compile Update="ButtonSpecs\ButtonSpecNavPrevious.cs" />
+    <Compile Update="ButtonSpecs\ButtonSpecNavNext.cs" />
+    <Compile Update="ButtonSpecs\ButtonSpecNavContext.cs" />
+    <Compile Update="Resources\CursorResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>CursorResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="Resources\GeneralImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>GeneralImageResources.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonNavigator.bmp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Krypton.ico" Pack="false" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonPage.bmp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="Palette\PaletteNavigatorOtherOverride.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Update="Resources\CursorResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>CursorResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Resources\GeneralImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>GeneralImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <OutputPath>..\..\..\Bin\$(Configuration)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <NoWarn>1701;1702</NoWarn>
+  </PropertyGroup>
 
-    <PropertyGroup Condition="'$(Configuration)'!='Debug'">
-        <Optimize>True</Optimize>
-    </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'!='Debug'">
+    <Optimize>True</Optimize>
+  </PropertyGroup>
 
 </Project>

--- a/Source/Krypton Components/Krypton.Navigator/Navigator/KryptonPageFormEditFlags.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Navigator/KryptonPageFormEditFlags.cs
@@ -24,6 +24,7 @@ namespace Krypton.Navigator
         /// </summary>
         public KryptonPageFormEditFlags()
         {
+            SetInheritedControlOverride();
             InitializeComponent();
         }
 
@@ -33,6 +34,7 @@ namespace Krypton.Navigator
         /// <param name="page">Reference to page to display flags for.</param>
         public KryptonPageFormEditFlags(KryptonPage? page)
         {
+            SetInheritedControlOverride();
             _page = page;
             InitializeComponent();
         }

--- a/Source/Krypton Components/Krypton.Navigator/Page/KryptonPage.cs
+++ b/Source/Krypton Components/Krypton.Navigator/Page/KryptonPage.cs
@@ -143,8 +143,7 @@ namespace Krypton.Navigator
             : this(text, null, null)
         {
         }
-
-
+        
         /// <summary>
         /// Initialize a new instance of the KryptonPage class.
         /// </summary>
@@ -154,7 +153,6 @@ namespace Krypton.Navigator
             : this(text, null, uniqueName ?? string.Empty)
         {
         }
-
 
         /// <summary>
         /// Initialize a new instance of the KryptonPage class.
@@ -168,7 +166,6 @@ namespace Krypton.Navigator
         public KryptonPage(string text, Bitmap? imageSmall, string? uniqueName)
             : this(text, imageSmall, uniqueName, new Size(150, 50))
         {
-
         }
 
         /// <summary>
@@ -454,10 +451,7 @@ namespace Krypton.Navigator
             }
         }
 
-        /// <summary>
-        /// Resets the TextTitle property to its default value.
-        /// </summary>
-        public void ResetTextTitle() => TextTitle = null;
+        private void ResetTextTitle() => TextTitle = null;
 
         /// <summary>
         /// Gets and sets the description text for the page.
@@ -483,10 +477,7 @@ namespace Krypton.Navigator
             }
         }
 
-        /// <summary>
-        /// Resets the TextDescription property to its default value.
-        /// </summary>
-        public void ResetTextDescription() => TextDescription = null;
+        private void ResetTextDescription() => TextDescription = null;
 
         /// <summary>
         /// Gets and sets the small image for the page.
@@ -510,10 +501,7 @@ namespace Krypton.Navigator
             }
         }
 
-        /// <summary>
-        /// Resets the ImageSmall property to its default value.
-        /// </summary>
-        public void ResetImageSmall() => ImageSmall = null;
+        private void ResetImageSmall() => ImageSmall = null;
 
         /// <summary>
         /// Gets and sets the medium image for the page.
@@ -537,10 +525,7 @@ namespace Krypton.Navigator
             }
         }
 
-        /// <summary>
-        /// Resets the ImageMedium property to its default value.
-        /// </summary>
-        public void ResetImageMedium() => ImageMedium = null;
+        private void ResetImageMedium() => ImageMedium = null;
 
         /// <summary>
         /// Gets and sets the large image for the page.
@@ -564,10 +549,7 @@ namespace Krypton.Navigator
             }
         }
 
-        /// <summary>
-        /// Resets the ImageLarge property to its default value.
-        /// </summary>
-        public void ResetImageLarge() => ImageLarge = null;
+        private void ResetImageLarge() => ImageLarge = null;
 
         /// <summary>
         /// Gets and sets the page tooltip image.
@@ -591,11 +573,7 @@ namespace Krypton.Navigator
         }
 
         private bool ShouldSerializeToolTipImage() => ToolTipImage != null;
-
-        /// <summary>
-        /// Resets the ToolTipImage property to its default value.
-        /// </summary>
-        public void ResetToolTipImage() => ToolTipImage = null;
+        private void ResetToolTipImage() => ToolTipImage = null;
 
         /// <summary>
         /// Gets and sets the tooltip image transparent color.
@@ -619,11 +597,7 @@ namespace Krypton.Navigator
         }
 
         private bool ShouldSerializeToolTipImageTransparentColor() => ToolTipImageTransparentColor != Color.Empty;
-
-        /// <summary>
-        /// Resets the ToolTipImageTransparentColor property to its default value.
-        /// </summary>
-        public void ResetToolTipImageTransparentColor() => ToolTipImageTransparentColor = Color.Empty;
+        private void ResetToolTipImageTransparentColor() => ToolTipImageTransparentColor = Color.Empty;
 
         /// <summary>
         /// Gets and sets the page tooltip title text.
@@ -648,12 +622,7 @@ namespace Krypton.Navigator
         }
 
         private bool ShouldSerializeToolTipTitle() => ToolTipTitle != string.Empty;
-
-        /// <summary>
-        /// Resets the ToolTipTitle property to its default value.
-        /// </summary>
-        public void ResetToolTipTitle()
-        => ToolTipTitle = string.Empty;
+        private void ResetToolTipTitle() => ToolTipTitle = string.Empty;
 
         /// <summary>
         /// Gets and sets the page tooltip body text.
@@ -678,11 +647,7 @@ namespace Krypton.Navigator
         }
 
         private bool ShouldSerializeToolTipBody() => ToolTipBody != string.Empty;
-
-        /// <summary>
-        /// Resets the ToolTipBody property to its default value.
-        /// </summary>
-        public void ResetToolTipBody() => ToolTipBody = string.Empty;
+        private void ResetToolTipBody() => ToolTipBody = string.Empty;
 
         /// <summary>
         /// Gets and sets the tooltip label style.
@@ -705,11 +670,7 @@ namespace Krypton.Navigator
         }
 
         private bool ShouldSerializeToolTipStyle() => ToolTipStyle != LabelStyle.ToolTip;
-
-        /// <summary>
-        /// Resets the ToolTipStyle property to its default value.
-        /// </summary>
-        public void ResetToolTipStyle() => ToolTipStyle = LabelStyle.ToolTip;
+        private void ResetToolTipStyle() => ToolTipStyle = LabelStyle.ToolTip;
 
         #region ToolTipShadow
         /// <summary>
@@ -721,7 +682,6 @@ namespace Krypton.Navigator
         public bool ToolTipShadow { get; set; } = true; // Backward compatible -> "Material Design" suggests this to be false
 
         private bool ShouldSerializeToolTipShadow() => !ToolTipShadow;
-
         private void ResetToolTipShadow() => ToolTipShadow = true;
         #endregion
 
@@ -741,10 +701,7 @@ namespace Krypton.Navigator
             set => _uniqueName = value;
         }
 
-        /// <summary>
-        /// Resets the UniqueName property to its default value.
-        /// </summary>
-        public void ResetUniqueName() => UniqueName = CommonHelper.UniqueString;
+        private void ResetUniqueName() => UniqueName = CommonHelper.UniqueString;
 
         /// <summary>
         /// Fix the control to a particular palette state.

--- a/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonGallery.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonGallery.cs
@@ -319,6 +319,7 @@ namespace Krypton.Ribbon
         [Category(@"Visuals")]
         [Description(@"Collection of images for display and selection.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+        [DefaultValue(null)]
         public ImageList? ImageList
         {
             get => _imageList;

--- a/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonRibbon.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controls Ribbon/KryptonRibbon.cs
@@ -2359,7 +2359,7 @@ namespace Krypton.Ribbon
 
         internal KeyTipInfoList GenerateKeyTipsAtTopLevel()
         {
-            // Make sure all the elements in current ribbon have been synched 
+            // Make sure all the elements in current ribbon have been synced 
             // and created so that the generated contents are accurate
             Refresh();
 

--- a/Source/Krypton Components/Krypton.Ribbon/Controls Visuals/KeyTipControl.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Controls Visuals/KeyTipControl.cs
@@ -35,6 +35,7 @@ namespace Krypton.Ribbon
                              KeyTipInfoList keyTips,
                              bool showDisabled)
         {
+            SetInheritedControlOverride();
             _ribbon = ribbon;
             _showDisabled = showDisabled;
 
@@ -45,6 +46,8 @@ namespace Krypton.Ribbon
             FormBorderStyle = FormBorderStyle.None;
             ShowInTaskbar = false;
             TransparencyKey = GlobalStaticValues.TRANSPARENCY_KEY_COLOR;
+            StateCommon!.Border.DrawBorders = PaletteDrawBorders.None;
+            StateCommon!.Border.Width = 0;
 #pragma warning disable CS0618 // Type or member is obsolete
             UseDropShadow = false;
 #pragma warning restore CS0618 // Type or member is obsolete
@@ -114,7 +117,7 @@ namespace Krypton.Ribbon
                                                        _ribbon.StateCommon.RibbonKeyTip.Content));
             }
 
-            // Inflate the enclosing rect to account for maximum expected key tip
+            // Inflate the enclosing rect to account for maximum expected key tip size
             enclosingRect.Inflate(50, 50);
 
             // Remove any prefix characters
@@ -207,7 +210,7 @@ namespace Krypton.Ribbon
         /// </summary>
         /// <param name="pevent">An PaintEventArgs containing the event data.</param>
         protected override void OnPaintBackground(PaintEventArgs pevent) =>
-            // Magenta is the transparent color
+            // Magenta is the transparent color => GlobalStaticValues.TRANSPARENCY_KEY_COLOR
             pevent.Graphics.FillRectangle(Brushes.Magenta, pevent.ClipRectangle);
 
         /// <summary>
@@ -255,12 +258,9 @@ namespace Krypton.Ribbon
 
             using (var renderContext = new RenderContext(this, e.Graphics, e.ClipRectangle, _ribbon.Renderer))
             {
-                foreach (ViewDrawRibbonKeyTip viewKeyTip in _viewList)
+                foreach (ViewDrawRibbonKeyTip viewKeyTip in _viewList.Where(viewKeyTip => viewKeyTip.Visible))
                 {
-                    if (viewKeyTip.Visible)
-                    {
-                        viewKeyTip.Render(renderContext);
-                    }
+                    viewKeyTip.Render(renderContext);
                 }
             }
         }

--- a/Source/Krypton Components/Krypton.Ribbon/Krypton.Ribbon 2022.csproj
+++ b/Source/Krypton Components/Krypton.Ribbon/Krypton.Ribbon 2022.csproj
@@ -1,140 +1,141 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <Choose>
-        <When Condition="'$(Configuration)' == 'Nightly' Or '$(Configuration)' == 'Canary' Or '$(Configuration)' == 'Debug'">
-            <PropertyGroup>
-                <TargetFrameworks>net462;net47;net471;net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
-            </PropertyGroup>
-        </When>
-        <Otherwise>
-            <PropertyGroup>
-                <TargetFrameworks>net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+  <Choose>
+    <When Condition="'$(Configuration)' == 'Nightly' Or '$(Configuration)' == 'Canary' Or '$(Configuration)' == 'Debug'">
+      <PropertyGroup>
+        <TargetFrameworks>net462;net47;net471;net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <TargetFrameworks>net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
 
-                <TargetFrameworks Condition="'$(TFMs)' == 'all'">net462;net47;net471;net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
-            </PropertyGroup>
-        </Otherwise>
-    </Choose>
+        <TargetFrameworks Condition="'$(TFMs)' == 'all'">net462;net47;net471;net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
 
-    <PropertyGroup>
-        <OutputType>Library</OutputType>
-        <RootNamespace>Krypton.Ribbon</RootNamespace>
-        <AssemblyName>Krypton.Ribbon</AssemblyName>
-        <!-- Set the CheckEolTargetFramework property to false to fix the warning -->
-        <CheckEolTargetFramework>false</CheckEolTargetFramework>
-        <SignAssembly>True</SignAssembly>
-        <AssemblyOriginatorKeyFile>StrongKrypton.snk</AssemblyOriginatorKeyFile>
-        <ApplicationIcon>Krypton.ico</ApplicationIcon>
-        <DelaySign>false</DelaySign>
-        <UseWindowsForms>true</UseWindowsForms>
-        <PlatformTarget>AnyCPU</PlatformTarget>
-        <EnableNETAnalyzers>true</EnableNETAnalyzers>
-        <NeutralLanguage>en</NeutralLanguage>
-        <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
-        <Configurations>Debug;Release;Installer;Nightly;Canary</Configurations>
-        <Nullable>enable</Nullable>
-        <!--https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/warning-waves-->
-        <WarningLevel>8</WarningLevel>
-        <AnalysisLevel>latest</AnalysisLevel>
-        <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
-        <!--https://learn.microsoft.com/en-us/visualstudio/designers/disable-dpi-awareness?view=vs-2022-->
-        <ForceDesignerDPIUnaware>true</ForceDesignerDPIUnaware>
-    </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Krypton.Ribbon</RootNamespace>
+    <AssemblyName>Krypton.Ribbon</AssemblyName>
+    <!-- Set the CheckEolTargetFramework property to false to fix the warning -->
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <SignAssembly>True</SignAssembly>
+    <AssemblyOriginatorKeyFile>StrongKrypton.snk</AssemblyOriginatorKeyFile>
+    <ApplicationIcon>Krypton.ico</ApplicationIcon>
+    <DelaySign>false</DelaySign>
+    <UseWindowsForms>true</UseWindowsForms>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <NeutralLanguage>en</NeutralLanguage>
+    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
+    <Configurations>Debug;Release;Installer;Nightly;Canary</Configurations>
+    <Nullable>enable</Nullable>
+    <!--https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/warning-waves-->
+    <WarningLevel>8</WarningLevel>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
+    <!--https://learn.microsoft.com/en-us/visualstudio/designers/disable-dpi-awareness?view=vs-2022-->
+    <ForceDesignerDPIUnaware>true</ForceDesignerDPIUnaware>
+    <ApplicationHighDpiMode>SystemAware</ApplicationHighDpiMode>
+  </PropertyGroup>
 
-    <PropertyGroup>
-        <PackageId>Krypton.Ribbon</PackageId>
-        <Description>This is the ribbon module.</Description>
-    </PropertyGroup>
+  <PropertyGroup>
+    <PackageId>Krypton.Ribbon</PackageId>
+    <Description>This is the ribbon module.</Description>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <Compile Remove="NewFolder\**" />
-        <EmbeddedResource Remove="NewFolder\**" />
-        <None Remove="NewFolder\**" />
-    </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="NewFolder\**" />
+    <EmbeddedResource Remove="NewFolder\**" />
+    <None Remove="NewFolder\**" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <Reference Include="System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="$(TargetFramework.StartsWith('net4'))">
-            <SpecificVersion>True</SpecificVersion>
-            <Version>4.0.0.0</Version>
-            <!-- Designers for the `TFMs != net4` are "Pulled in" via Visual studios ".nuget\packages\microsoft.windowsdesktop.app.ref" -->
-        </Reference>
-    </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="$(TargetFramework.StartsWith('net4'))">
+      <SpecificVersion>True</SpecificVersion>
+      <Version>4.0.0.0</Version>
+      <!-- Designers for the `TFMs != net4` are "Pulled in" via Visual studios ".nuget\packages\microsoft.windowsdesktop.app.ref" -->
+    </Reference>
+  </ItemGroup>
 
-    <ItemGroup>
-        <Compile Include="..\Krypton.Toolkit\General\GlobalSuppressions.cs" Link="General\GlobalSuppressions.cs" />
-        <Compile Include="..\Krypton.Toolkit\General\PlatformInvoke.cs">
-            <Link>General\PlatformInvoke.cs</Link>
-        </Compile>
-        <Compile Include="..\Krypton.Toolkit\Utilities\AllowNullAttribute.cs" Link="General\AllowNullAttribute.cs" />
-        <Compile Update="ButtonSpec\ButtonSpecAppMenu.cs" />
-        <Compile Update="ButtonSpec\ButtonSpecMdiChildFixed.cs" />
-        <Compile Update="ButtonSpec\ButtonSpecMdiChildClose.cs" />
-        <Compile Update="ButtonSpec\ButtonSpecMdiChildRestore.cs" />
-        <Compile Update="ButtonSpec\ButtonSpecMdiChildMin.cs" />
-        <Compile Update="ButtonSpec\ButtonSpecMinimizeRibbon.cs" />
-        <Compile Update="ButtonSpec\ButtonSpecExpandRibbon.cs" />
-        <Compile Update="Resources\GenericImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>GenericImageResources.resx</DependentUpon>
-        </Compile>
-        <Service Include="{94E38DFF-614B-4cbd-B67C-F211BB35CE8B}" />
-    </ItemGroup>
-    <ItemGroup>
-        <Content Include="Krypton.ico" Pack="false" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupDateTimePicker.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupDomainUpDown.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupNumericUpDown.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonGalleryRange.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonGallery.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupColorButton.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupClusterColorButton.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupMaskedTextBox.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonRecentDoc.png" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupRichTextBox.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupComboBox.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupTextBox.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupCustomControl.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupRadioButton.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupCheckBox.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupLabel.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupClusterButton.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupLines.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupCluster.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupTriple.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupButton.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupSeparator.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonQATButton.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonContext.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroup.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonTab.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbon.bmp" />
-    </ItemGroup>
-    <ItemGroup>
-        <Compile Remove="Controls Ribbon Install\KryptonGalleryLicence.cs" />
-        <Compile Remove="View Layout Demo\ViewLayoutRibbonAppButton.cs" />
-        <Compile Remove="View Layout Demo\ViewLayoutRibbonAppTab.cs" />
-        <Compile Remove="View Layout Install\ViewLayoutRibbonAppButton.cs" />
-        <Compile Remove="View Layout Install\ViewLayoutRibbonAppTab.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <ProjectReference Include="..\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />
-    </ItemGroup>
-    <ItemGroup>
-        <EmbeddedResource Update="Resources\GenericImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>GenericImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-    </ItemGroup>
-    <PropertyGroup>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <OutputPath>..\..\..\Bin\$(Configuration)\</OutputPath>
-    </PropertyGroup>
-    <PropertyGroup>
-        <NoWarn>1701;1702</NoWarn>
-    </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\Krypton.Toolkit\General\GlobalSuppressions.cs" Link="General\GlobalSuppressions.cs" />
+    <Compile Include="..\Krypton.Toolkit\General\PlatformInvoke.cs">
+      <Link>General\PlatformInvoke.cs</Link>
+    </Compile>
+    <Compile Include="..\Krypton.Toolkit\Utilities\AllowNullAttribute.cs" Link="General\AllowNullAttribute.cs" />
+    <Compile Update="ButtonSpec\ButtonSpecAppMenu.cs" />
+    <Compile Update="ButtonSpec\ButtonSpecMdiChildFixed.cs" />
+    <Compile Update="ButtonSpec\ButtonSpecMdiChildClose.cs" />
+    <Compile Update="ButtonSpec\ButtonSpecMdiChildRestore.cs" />
+    <Compile Update="ButtonSpec\ButtonSpecMdiChildMin.cs" />
+    <Compile Update="ButtonSpec\ButtonSpecMinimizeRibbon.cs" />
+    <Compile Update="ButtonSpec\ButtonSpecExpandRibbon.cs" />
+    <Compile Update="Resources\GenericImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>GenericImageResources.resx</DependentUpon>
+    </Compile>
+    <Service Include="{94E38DFF-614B-4cbd-B67C-F211BB35CE8B}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Krypton.ico" Pack="false" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupDateTimePicker.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupDomainUpDown.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupNumericUpDown.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonGalleryRange.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonGallery.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupColorButton.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupClusterColorButton.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupMaskedTextBox.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonRecentDoc.png" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupRichTextBox.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupComboBox.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupTextBox.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupCustomControl.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupRadioButton.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupCheckBox.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupLabel.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupClusterButton.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupLines.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupCluster.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupTriple.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupButton.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroupSeparator.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonQATButton.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonContext.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonGroup.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbonTab.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonRibbon.bmp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="Controls Ribbon Install\KryptonGalleryLicence.cs" />
+    <Compile Remove="View Layout Demo\ViewLayoutRibbonAppButton.cs" />
+    <Compile Remove="View Layout Demo\ViewLayoutRibbonAppTab.cs" />
+    <Compile Remove="View Layout Install\ViewLayoutRibbonAppButton.cs" />
+    <Compile Remove="View Layout Install\ViewLayoutRibbonAppTab.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Update="Resources\GenericImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>GenericImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <OutputPath>..\..\..\Bin\$(Configuration)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <NoWarn>1701;1702</NoWarn>
+  </PropertyGroup>
 
-    <PropertyGroup Condition="'$(Configuration)'!='Debug'">
-        <Optimize>True</Optimize>
-    </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'!='Debug'">
+    <Optimize>True</Optimize>
+  </PropertyGroup>
 
 </Project>

--- a/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonTabs.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/View Layout/ViewLayoutRibbonTabs.cs
@@ -252,7 +252,6 @@ namespace Krypton.Ribbon
                 // Only interested in tab views
                 if (child is ViewDrawRibbonTab viewTab)
                 {
-
                     // Get the screen location of the view tab
                     Rectangle tabRect = viewTab.OwningControl!.RectangleToScreen(viewTab.ClientRectangle);
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/Base/VisualToastNotificationBaseForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/Base/VisualToastNotificationBaseForm.cs
@@ -47,6 +47,7 @@ namespace Krypton.Toolkit
         /// <summary>Initializes a new instance of the <see cref="VisualToastNotificationBaseForm" /> class.</summary>
         public VisualToastNotificationBaseForm()
         {
+            SetInheritedControlOverride();
             InitializeComponent();
 
             _notificationResult = KryptonToastNotificationResult.None;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Outlook Grid/VisualCustomFormatRuleForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Outlook Grid/VisualCustomFormatRuleForm.cs
@@ -55,6 +55,7 @@ namespace Krypton.Toolkit
         /// <param name="conditionalFormatType">Type of the conditional format.</param>
         public VisualCustomFormatRuleForm(EnumConditionalFormatType conditionalFormatType)
         {
+            SetInheritedControlOverride();
             InitializeComponent();
 
             _conditionalFormatType = conditionalFormatType;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Outlook Grid/VisualCustomFormatRuleRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Outlook Grid/VisualCustomFormatRuleRtlAwareForm.cs
@@ -41,6 +41,7 @@ namespace Krypton.Toolkit
 
         public VisualCustomFormatRuleRtlAwareForm(EnumConditionalFormatType conditionalFormatType)
         {
+            SetInheritedControlOverride();
             InitializeComponent();
 
             _conditionalFormatType = conditionalFormatType;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualAboutBoxRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualAboutBoxRtlAwareForm.cs
@@ -13,6 +13,7 @@ namespace Krypton.Toolkit
     {
         public VisualAboutBoxRtlAwareForm()
         {
+            SetInheritedControlOverride();
             InitializeComponent();
         }
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualInputBoxRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualInputBoxRtlAwareForm.cs
@@ -21,11 +21,13 @@ namespace Krypton.Toolkit
 
         public VisualInputBoxRtlAwareForm()
         {
+            SetInheritedControlOverride();
             InitializeComponent();
         }
 
         public VisualInputBoxRtlAwareForm(KryptonInputBoxData inputBoxData)
         {
+            SetInheritedControlOverride();
             _inputBoxData = inputBoxData;
 
             InitializeComponent();

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareForm.cs
@@ -38,6 +38,7 @@ namespace Krypton.Toolkit
 
         public VisualMessageBoxRtlAwareForm()
         {
+            SetInheritedControlOverride();
             InitializeComponent();
         }
 
@@ -49,6 +50,7 @@ namespace Krypton.Toolkit
             bool? showHelpButton,
             bool? showCloseButton)
         {
+            SetInheritedControlOverride();
             // Store incoming values
             _text = CommonHelper.NormalizeLineBreaks(text ?? string.Empty);
             _caption = caption;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualThemeBrowserFormRtlAware.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualThemeBrowserFormRtlAware.cs
@@ -22,6 +22,7 @@ namespace Krypton.Toolkit
         /// <param name="themeBrowserData">The data to create the <see cref="VisualThemeBrowserFormRtlAware"/> UI.</param>
         public VisualThemeBrowserFormRtlAware(KryptonThemeBrowserData themeBrowserData)
         {
+            SetInheritedControlOverride();
             InitializeComponent();
 
             _themeBrowserData = themeBrowserData;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualAboutBoxForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualAboutBoxForm.cs
@@ -25,6 +25,7 @@ namespace Krypton.Toolkit
 
         public VisualAboutBoxForm(KryptonAboutBoxData aboutBoxData)
         {
+            SetInheritedControlOverride();
             InitializeComponent();
 
             _aboutBoxData = aboutBoxData;
@@ -38,6 +39,7 @@ namespace Krypton.Toolkit
 
         public VisualAboutBoxForm(KryptonAboutBoxData aboutBoxData, KryptonAboutToolkitData aboutToolkitData)
         {
+            SetInheritedControlOverride();
             InitializeComponent();
 
             _showToolkitButton = aboutBoxData.ShowToolkitInformation ?? false;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualInformationBoxForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualInformationBoxForm.cs
@@ -13,6 +13,7 @@ namespace Krypton.Toolkit
     {
         public VisualInformationBoxForm()
         {
+            SetInheritedControlOverride();
             InitializeComponent();
         }
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualInputBoxForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualInputBoxForm.cs
@@ -30,6 +30,7 @@ namespace Krypton.Toolkit
         /// </summary>
         public VisualInputBoxForm()
         {
+            SetInheritedControlOverride();
             InitializeComponent();
         }
 
@@ -37,6 +38,7 @@ namespace Krypton.Toolkit
         /// <param name="inputBoxData">The input box data.</param>
         public VisualInputBoxForm(KryptonInputBoxData inputBoxData)
         {
+            SetInheritedControlOverride();
             InitializeComponent();
 
             _inputBoxData = inputBoxData;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxForm.cs
@@ -46,6 +46,7 @@ namespace Krypton.Toolkit
 
         public VisualMessageBoxForm()
         {
+            SetInheritedControlOverride();
             InitializeComponent();
         }
 
@@ -57,6 +58,7 @@ namespace Krypton.Toolkit
                                        bool? showHelpButton,
                                        bool? showCloseButton)
         {
+            SetInheritedControlOverride();
             // Store incoming values
             _text = CommonHelper.NormalizeLineBreaks(text ?? string.Empty);
             _caption = caption;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMultilineStringEditor.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMultilineStringEditor.cs
@@ -33,6 +33,7 @@ namespace Krypton.Toolkit
         /// <param name="owner"></param>
         public MultilineStringEditor1(KryptonTextBox owner)
         {
+            SetInheritedControlOverride();
             SuspendLayout();
             _textBox = new KryptonTextBox { Dock = DockStyle.Fill, Multiline = true };
             _textBox.StateCommon.Border.Draw = InheritBool.False;
@@ -70,7 +71,6 @@ namespace Krypton.Toolkit
             Show();
         }
         #endregion
-
 
         #region Protected Override
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMultilineStringEditorForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMultilineStringEditorForm.cs
@@ -28,6 +28,7 @@ namespace Krypton.Toolkit
 
         public VisualMultilineStringEditorForm()
         {
+            SetInheritedControlOverride();
             InitializeComponent();
 
             InitialSetup();
@@ -37,6 +38,7 @@ namespace Krypton.Toolkit
 
         public VisualMultilineStringEditorForm(string[]? contents, StringCollection? collection, bool? useRichTextBox, string? headerText, string? windowTitle)
         {
+            SetInheritedControlOverride();
             InitializeComponent();
 
             _contents = contents ?? [string.Empty];

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualSplashScreenForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualSplashScreenForm.cs
@@ -33,6 +33,7 @@ namespace Krypton.Toolkit
         /// <param name="splashScreenData">The splash screen data.</param>
         public VisualSplashScreenForm(KryptonSplashScreenData splashScreenData)
         {
+            SetInheritedControlOverride();
             InitializeComponent();
 
             _splashScreenData = splashScreenData;
@@ -46,6 +47,7 @@ namespace Krypton.Toolkit
         /// <param name="nextWindow">The next window.</param>
         public VisualSplashScreenForm(Assembly entryAssembly, bool showProgressBar, int? timeOut, Image applicationLogo, IWin32Window? nextWindow)
         {
+            SetInheritedControlOverride();
             InitializeComponent();
 
             _entryAssembly = entryAssembly;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualTaskDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualTaskDialog.cs
@@ -123,6 +123,7 @@ namespace Krypton.Toolkit
         /// <exception cref="ArgumentNullException"></exception>
         public VisualTaskDialog(KryptonTaskDialog taskDialog)
         {
+            SetInheritedControlOverride();
             // Must provide a valid reference
 
             _taskDialog = taskDialog ??

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualTaskDialogForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualTaskDialogForm.cs
@@ -48,6 +48,7 @@ namespace Krypton.Toolkit
         /// <exception cref="System.ArgumentNullException">taskDialog</exception>
         public VisualTaskDialogForm(KryptonTaskDialog taskDialog)
         {
+            SetInheritedControlOverride();
             // Must provide a valid reference
 
             _taskDialog = taskDialog ??

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualThemeBrowserForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualThemeBrowserForm.cs
@@ -22,6 +22,7 @@ namespace Krypton.Toolkit
         /// <param name="themeBrowserData">The data to provide to the <see cref="VisualThemeBrowserForm"/>.</param>
         public VisualThemeBrowserForm(KryptonThemeBrowserData themeBrowserData)
         {
+            SetInheritedControlOverride();
             InitializeComponent();
 
             _themeBrowserData = themeBrowserData;

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/UX/KryptonCheckButtonCollectionForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/UX/KryptonCheckButtonCollectionForm.cs
@@ -58,6 +58,7 @@ namespace Krypton.Toolkit
         public KryptonCheckButtonCollectionForm()
             : this(null)
         {
+            SetInheritedControlOverride();
         }
 
         /// <summary>
@@ -65,6 +66,7 @@ namespace Krypton.Toolkit
         /// </summary>
         public KryptonCheckButtonCollectionForm(KryptonCheckSet? checkSet)
         {
+            SetInheritedControlOverride();
             // Remember the owning control
             _checkSet = checkSet;
 

--- a/Source/Krypton Components/Krypton.Toolkit/General/ModalWaitDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/ModalWaitDialog.cs
@@ -42,6 +42,7 @@ namespace Krypton.Toolkit
         /// </summary>
         public ModalWaitDialog()
         {
+            SetInheritedControlOverride();
             InitializeComponent();
 
             // Remove redraw flicker by using double buffering
@@ -58,6 +59,7 @@ namespace Krypton.Toolkit
         /// <param name="maximumProgressValue">The maximum progress value.</param>
         public ModalWaitDialog(bool? showProgressBar, int? minimumProgressValue, int? maximumProgressValue)
         {
+            SetInheritedControlOverride();
             InitializeComponent();
 
             _showProgressBar = showProgressBar ?? false;

--- a/Source/Krypton Components/Krypton.Toolkit/Krypton.Toolkit 2022.csproj
+++ b/Source/Krypton Components/Krypton.Toolkit/Krypton.Toolkit 2022.csproj
@@ -1,888 +1,889 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <Choose>
-        <When Condition="'$(Configuration)' == 'Nightly' Or '$(Configuration)' == 'Canary' Or '$(Configuration)' == 'Debug'">
-            <PropertyGroup>
-                <TargetFrameworks>net462;net47;net471;net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
-            </PropertyGroup>
-        </When>
-        <Otherwise>
-            <PropertyGroup>
-                <TargetFrameworks>net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+  <Choose>
+    <When Condition="'$(Configuration)' == 'Nightly' Or '$(Configuration)' == 'Canary' Or '$(Configuration)' == 'Debug'">
+      <PropertyGroup>
+        <TargetFrameworks>net462;net47;net471;net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <TargetFrameworks>net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
 
-                <TargetFrameworks Condition="'$(TFMs)' == 'all'">net462;net47;net471;net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
-            </PropertyGroup>
-        </Otherwise>
-    </Choose>
+        <TargetFrameworks Condition="'$(TFMs)' == 'all'">net462;net47;net471;net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
 
-    <PropertyGroup>
-        <OutputType>Library</OutputType>
-        <RootNamespace>Krypton.Toolkit</RootNamespace>
-        <AssemblyName>Krypton.Toolkit</AssemblyName>
-        <!-- Set the CheckEolTargetFramework property to false to fix the warning -->
-        <CheckEolTargetFramework>false</CheckEolTargetFramework>
-        <SignAssembly>True</SignAssembly>
-        <AssemblyOriginatorKeyFile>StrongKrypton.snk</AssemblyOriginatorKeyFile>
-        <ApplicationIcon>Krypton.ico</ApplicationIcon>
-        <DelaySign>false</DelaySign>
-        <UseWindowsForms>true</UseWindowsForms>
-        <PlatformTarget>AnyCPU</PlatformTarget>
-        <EnableNETAnalyzers>true</EnableNETAnalyzers>
-        <NeutralLanguage>en</NeutralLanguage>
-        <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
-        <NoWarn>1701;1702</NoWarn>
-        <Configurations>Debug;Release;Installer;Nightly;Canary</Configurations>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <OutputPath>..\..\..\Bin\$(Configuration)\</OutputPath>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <Nullable>enable</Nullable>
-        <!--https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/warning-waves-->
-        <WarningLevel>8</WarningLevel>
-        <AnalysisLevel>latest</AnalysisLevel>
-        <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
-        <!--https://learn.microsoft.com/en-us/visualstudio/designers/disable-dpi-awareness?view=vs-2022-->
-        <ForceDesignerDPIUnaware>true</ForceDesignerDPIUnaware>
-    </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Krypton.Toolkit</RootNamespace>
+    <AssemblyName>Krypton.Toolkit</AssemblyName>
+    <!-- Set the CheckEolTargetFramework property to false to fix the warning -->
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <SignAssembly>True</SignAssembly>
+    <AssemblyOriginatorKeyFile>StrongKrypton.snk</AssemblyOriginatorKeyFile>
+    <ApplicationIcon>Krypton.ico</ApplicationIcon>
+    <DelaySign>false</DelaySign>
+    <UseWindowsForms>true</UseWindowsForms>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <NeutralLanguage>en</NeutralLanguage>
+    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
+    <NoWarn>1701;1702</NoWarn>
+    <Configurations>Debug;Release;Installer;Nightly;Canary</Configurations>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <OutputPath>..\..\..\Bin\$(Configuration)\</OutputPath>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Nullable>enable</Nullable>
+    <!--https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/warning-waves-->
+    <WarningLevel>8</WarningLevel>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
+    <!--https://learn.microsoft.com/en-us/visualstudio/designers/disable-dpi-awareness?view=vs-2022-->
+    <ForceDesignerDPIUnaware>true</ForceDesignerDPIUnaware>
+    <ApplicationHighDpiMode>SystemAware</ApplicationHighDpiMode>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <Reference Include="System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="$(TargetFramework.StartsWith('net4'))">
-            <SpecificVersion>True</SpecificVersion>
-            <Version>4.0.0.0</Version>
-            <!-- Designers for the `TFMs != net4` are "Pulled in" via Visual studios ".nuget\packages\microsoft.windowsdesktop.app.ref" -->
-        </Reference>
-    </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="$(TargetFramework.StartsWith('net4'))">
+      <SpecificVersion>True</SpecificVersion>
+      <Version>4.0.0.0</Version>
+      <!-- Designers for the `TFMs != net4` are "Pulled in" via Visual studios ".nuget\packages\microsoft.windowsdesktop.app.ref" -->
+    </Reference>
+  </ItemGroup>
 
-    <PropertyGroup>
-        <PackageId>Krypton.Toolkit</PackageId>
-        <Description>This is the core toolkit module.</Description>
-    </PropertyGroup>
+  <PropertyGroup>
+    <PackageId>Krypton.Toolkit</PackageId>
+    <Description>This is the core toolkit module.</Description>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <Compile Update="ButtonSpec\ButtonSpecFormFixed.cs">
-            <SubType>Component</SubType>
-        </Compile>
-        <Compile Update="ButtonSpec\ButtonSpecFormWindowClose.cs">
-            <SubType>Component</SubType>
-        </Compile>
-        <Compile Update="ButtonSpec\ButtonSpecFormWindowMin.cs">
-            <SubType>Component</SubType>
-        </Compile>
-        <Compile Update="ButtonSpec\ButtonSpecFormWindowMax.cs">
-            <SubType>Component</SubType>
-        </Compile>
-        <Compile Update="ButtonSpec\ButtonSpecCalendar.cs">
-            <SubType>Component</SubType>
-        </Compile>
-        <Compile Update="Controls Toolkit\KryptonColorDialog.cs" />
-        <Compile Update="Controls Toolkit\KryptonPrintDialog.cs" />
-        <Compile Update="Designers\Other\PaletteDrawBordersSelector.cs" />
-        <Compile Update="Controls Toolkit\KryptonBreadCrumbItem.cs">
-            <SubType>Component</SubType>
-        </Compile>
-        <Compile Update="Controls Toolkit\KryptonListItem.cs">
-            <SubType>Component</SubType>
-        </Compile>
-        <Compile Update="ContextMenu\KryptonContextMenuItemBase.cs" />
-        <Compile Update="ButtonSpec\ButtonSpecAny.cs">
-            <SubType>Component</SubType>
-        </Compile>
-        <Compile Update="ButtonSpec\ButtonSpec.cs">
-            <SubType>Component</SubType>
-        </Compile>
-        <Compile Update="Palette Builtin\Office 2007\Non Official Themes\PaletteOffice2007White.cs" />
-        <Compile Update="Palette Builtin\Office 2010\Non Official Themes\PaletteOffice2010White.cs" />
-        <Compile Update="Palette Builtin\Office 2013\Non Official Themes\PaletteOffice2013AccessLegacy.cs">
-            <SubType>Component</SubType>
-        </Compile>
-        <Compile Update="Palette Builtin\Office 2013\Bases\PaletteOffice2013Base.cs" />
-        <Compile Update="Palette Builtin\Office 2013\Official Themes\PaletteOffice2013White.cs" />
-        <Compile Update="Palette Builtin\Microsoft 365\Bases\PaletteMicrosoft365Base.cs" />
-        <Compile Update="Palette Builtin\Office 365\Non Official Themes\PaletteOffice365AccessLegacy.cs">
-            <SubType>Component</SubType>
-        </Compile>
-        <Compile Update="Palette Builtin\Microsoft 365\Non Official Themes\PaletteOffice365Blue.cs" />
-        <Compile Update="Palette Builtin\Microsoft 365\Official Themes\PaletteMicrosoft365Black.cs" />
-        <Compile Update="Palette Builtin\Microsoft 365\Official Themes\PaletteOffice365Silver.cs" />
-        <Compile Update="Palette Builtin\Microsoft 365\Official Themes\PaletteOffice365White.cs" />
-        <Compile Update="Palette Builtin\PaletteVisualStudio2020Base.cs">
-            <SubType>Component</SubType>
-        </Compile>
-        <Compile Update="Palette Builtin\Office 2010\Official Themes\PaletteOffice2010Black.cs" />
-        <Compile Update="Palette Builtin\Office 2010\Official Themes\PaletteOffice2010Blue.cs" />
-        <Compile Update="Palette Builtin\Office 2010\Official Themes\PaletteOffice2010Silver.cs" />
-        <Compile Update="Palette Builtin\Office 2010\Bases\PaletteOffice2010Base.cs" />
-        <Compile Update="Palette Builtin\Sparkle\Official Themes\PaletteSparklePurple.cs" />
-        <Compile Update="Palette Builtin\Sparkle\Base\PaletteSparkleBase.cs" />
-        <Compile Update="Palette Builtin\Sparkle\Official Themes\PaletteSparkleOrange.cs" />
-        <Compile Update="Palette Builtin\Sparkle\Official Themes\PaletteSparkleBlue.cs" />
-        <Compile Update="Palette Builtin\Office 2007\Official Themes\PaletteOffice2007Black.cs" />
-        <Compile Update="Palette Builtin\Office 2007\Official Themes\PaletteOffice2007Silver.cs" />
-        <Compile Update="Palette Builtin\Office 2007\Official Themes\PaletteOffice2007Blue.cs" />
-        <Compile Update="Palette Builtin\Office 2007\Bases\PaletteOffice2007Base.cs" />
-        <Compile Update="Properties\Resources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>Resources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="Rendering\RenderOffice2013.cs">
-            <SubType>Component</SubType>
-        </Compile>
-        <Compile Update="Rendering\RenderMicrosoft365.cs">
-            <SubType>Component</SubType>
-        </Compile>
-        <Compile Update="Rendering\RenderOffice2007.cs">
-            <SubType>Component</SubType>
-        </Compile>
-        <Compile Update="Rendering\RenderSparkle.cs">
-            <SubType>Component</SubType>
-        </Compile>
-        <Compile Update="ButtonSpec\ButtonSpecHeaderGroup.cs">
-            <SubType>Component</SubType>
-        </Compile>
-        <Compile Update="Controls Toolkit\KryptonManager.cs">
-            <SubType>Component</SubType>
-        </Compile>
-        <Compile Update="Palette Builtin\Professional\PaletteProfessionalSystem.cs" />
-        <Compile Update="Palette Builtin\Base\PaletteBase.cs" />
-        <Compile Update="Rendering\RenderOffice2010.cs">
-            <SubType>Component</SubType>
-        </Compile>
-        <Compile Update="Rendering\RenderProfessional.cs">
-            <SubType>Component</SubType>
-        </Compile>
-        <Compile Update="Palette Builtin\Professional\PaletteProfessionalOffice2003.cs" />
-        <Compile Update="Rendering\RenderBase.cs">
-            <SubType>Component</SubType>
-        </Compile>
-        <Compile Update="Rendering\RenderStandard.cs">
-            <SubType>Component</SubType>
-        </Compile>
-        <Compile Update="ResourceFiles\AboutToolkit\AboutToolkitImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>AboutToolkitImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\Arrows\BlueArrowResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>BlueArrowResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\Arrows\Office2010ArrowResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>Office2010ArrowResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\Arrows\RibbonArrowImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>RibbonArrowImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\Arrows\SortArrowImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>SortArrowImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\ButtonSpecs\ProfessionalButtonSpecResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>ProfessionalButtonSpecResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\CheckBoxes\CheckBoxStripResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>CheckBoxStripResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\ColourScales\ColourScaleImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>ColourScaleImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\CommandLink\CommandLinkImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>CommandLinkImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\ControlBox\Microsoft365ControlBoxResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>Microsoft365ControlBoxResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\ControlBox\Office2003ControlBoxResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>Office2003ControlBoxResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\ControlBox\Office2007ControlBoxResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>Office2007ControlBoxResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\ControlBox\Office2010ControlBoxResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>Office2010ControlBoxResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\ControlBox\Office2013ControlBoxResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>Office2013ControlBoxResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\ControlBox\ProfessionalControlBoxResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>ProfessionalControlBoxResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\ControlBox\SparkleControlBoxResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>SparkleControlBoxResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\Cursors\CursorResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>CursorResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\DataBars\DataBarImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>DataBarImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\Dialogs\DialogImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>DialogImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\DropDown\DropDownArrowImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>DropDownArrowImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\Elements\ElementsImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>ElementsImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\Gallery\GalleryImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>GalleryImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\Generic\GenericImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>GenericImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\Generic\GenericKryptonImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>GenericKryptonImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\Generic\GenericOffice2007ImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>GenericOffice2007ImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\Generic\GenericProfessionalImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>GenericProfessionalImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\Generic\GenericSparkleImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>GenericSparkleImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\Generic\GenericWhiteImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>GenericWhiteImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\Grid\GridImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>GridImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\Logos\ToolkitLogoImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>ToolkitLogoImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\MDI\GenericMDIImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>GenericMDIImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\MDI\Office2010MDIImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>Office2010MDIImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\MessageBox\MessageBoxImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>MessageBoxImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\OutlookGrid\OutlookGridImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>OutlookGridImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\OutlookGrid\Strings\OutlookGridStringResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>OutlookGridStringResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\PaletteSchemas\PaletteSchemaResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>PaletteSchemaResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\Pendants\ProfessionalPendantImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>ProfessionalPendantImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\Pin\ProfessionalPinImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>ProfessionalPinImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\RadioButtons\Office2007RadioButtonImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>Office2007RadioButtonImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\RadioButtons\Office2010RadioButtonImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>Office2010RadioButtonImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\RadioButtons\SparkleRadioButtonImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>SparkleRadioButtonImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\RadioButtons\VisualStudioRadioButtonImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>VisualStudioRadioButtonImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\SizeGripStyles\SizeGripStyleResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>SizeGripStyleResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\Sort\SortingImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>SortingImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\Stars\StarImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>StarImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\TaskDialog\TaskDialogImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>TaskDialogImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\ToastNotification\ToastNotificationImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>ToastNotificationImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\Toolbars\GenericToolbarImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>GenericToolbarImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\Toolbars\Microsoft365ToolbarImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>Microsoft365ToolbarImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\Toolbars\Office2003ToolbarImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>Office2003ToolbarImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\Toolbars\Office2007ToolbarImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>Office2007ToolbarImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\Toolbars\Office2010ToolbarImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>Office2010ToolbarImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\Toolbars\Office2013ToolbarImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>Office2013ToolbarImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\Toolbars\Office2016ToolbarImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>Office2016ToolbarImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\Toolbars\Office2019ToolbarImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>Office2019ToolbarImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\Toolbars\SystemToolbarImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>SystemToolbarImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\Toolbars\VisualStudioToolbarImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>VisualStudioToolbarImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\TreeItems\TreeItemImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>TreeItemImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\UAC\UACShieldIconResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>UACShieldIconResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\VisualStudio\VisualStudioImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>VisualStudioImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="ResourceFiles\WindowsLogos\WindowsLogoImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>WindowsLogoImageResources.resx</DependentUpon>
-        </Compile>
-        <Compile Update="View Base\ViewControl.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonButton.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonTreeView.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonInputBox.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonTaskDialogCommand.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonTaskDialog.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonMessageBox.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonTrackBar.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonManager.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonHeaderGroup.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonGroup.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonHeader.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonPanel.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonLabel.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonPalette.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonSplitContainer.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonCheckButton.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonCheckSet.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonBorderEdge.bmp" />
-        <Content Include="Krypton.ico" Pack="false" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonGroupBox.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonWrapLabel.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonSeparator.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonDateTimePicker.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonMonthCalendar.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonBreadCrumbItem.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonDomainUpDown.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonBreadCrumb.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonNumericUpDown.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonContextMenuImageSelect.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonCommand.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonCheckedListBox.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonListBox.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonColorButton.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonDropButton.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonContextMenuColorColumns.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonMaskedTextBox.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonContextMenuItem.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonContextMenuItems.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonContextMenuSeparator.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonContextMenuHeading.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonContextMenu.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonRichTextBox.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonComboBox.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonTextBox.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonDataGridView.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonRadioButton.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonCheckBox.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonButtonSpec.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonGroupPanel.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonForm.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonLinkLabel.bmp" />
-    </ItemGroup>
-    <ItemGroup>
-        <Compile Remove="Controls Toolkit\KryptonByteViewer.cs" />
-        <Compile Remove="Controls Toolkit\KryptonDataGridViewBinaryCell.cs" />
-        <Compile Remove="Controls Toolkit\KryptonDataGridViewBinaryColumn.cs" />
-        <Compile Remove="Controls Toolkit\KryptonInputBoxNew.cs" />
-        <Compile Remove="Toolkit\KryptonBorderEdgeActionList.cs" />
-        <Compile Remove="Toolkit\KryptonBorderEdgeDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonBreadCrumbActionList.cs" />
-        <Compile Remove="Toolkit\KryptonBreadCrumbDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonBreadCrumbItemDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonBreadCrumbItemsEditor.cs" />
-        <Compile Remove="Toolkit\KryptonButtonActionList.cs" />
-        <Compile Remove="Toolkit\KryptonButtonDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonCheckBoxActionList.cs" />
-        <Compile Remove="Toolkit\KryptonCheckBoxDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonCheckButtonActionList.cs" />
-        <Compile Remove="Toolkit\KryptonCheckButtonCollectionEditor.cs" />
-        <Compile Remove="Toolkit\KryptonCheckButtonCollectionForm.cs" />
-        <Compile Remove="Toolkit\KryptonCheckButtonCollectionForm.Designer.cs" />
-        <Compile Remove="Toolkit\KryptonCheckButtonDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonCheckedListBoxActionList.cs" />
-        <Compile Remove="Toolkit\KryptonCheckedListBoxDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonCheckSetActionList.cs" />
-        <Compile Remove="Toolkit\KryptonCheckSetDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonColorButtonActionList.cs" />
-        <Compile Remove="Toolkit\KryptonColorButtonDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonComboBoxActionList.cs" />
-        <Compile Remove="Toolkit\KryptonComboBoxColumnDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonComboBoxDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonCommandActionList.cs" />
-        <Compile Remove="Toolkit\KryptonCommandDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonContextMenuActionList.cs" />
-        <Compile Remove="Toolkit\KryptonContextMenuCollectionEditor.cs" />
-        <Compile Remove="Toolkit\KryptonContextMenuDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonContextMenuItemCollectionEditor.cs" />
-        <Compile Remove="Toolkit\KryptonContextMenuItemDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonContextMenuItemsDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonDataGridViewDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonDateTimePickerActionList.cs" />
-        <Compile Remove="Toolkit\KryptonDateTimePickerColumnDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonDateTimePickerDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonDesignerActionItem.cs" />
-        <Compile Remove="Toolkit\KryptonDomainUpDownActionList.cs" />
-        <Compile Remove="Toolkit\KryptonDomainUpDownColumnDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonDomainUpDownDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonDropButtonActionList.cs" />
-        <Compile Remove="Toolkit\KryptonDropButtonDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonGroupActionList.cs" />
-        <Compile Remove="Toolkit\KryptonGroupBoxActionList.cs" />
-        <Compile Remove="Toolkit\KryptonGroupBoxDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonGroupDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonGroupPanelDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonHeaderActionList.cs" />
-        <Compile Remove="Toolkit\KryptonHeaderDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonHeaderGroupActionList.cs" />
-        <Compile Remove="Toolkit\KryptonHeaderGroupDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonLabelActionList.cs" />
-        <Compile Remove="Toolkit\KryptonLabelDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonLinkLabelActionList.cs" />
-        <Compile Remove="Toolkit\KryptonLinkLabelDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonListBoxActionList.cs" />
-        <Compile Remove="Toolkit\KryptonListBoxDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonManagerActionList.cs" />
-        <Compile Remove="Toolkit\KryptonManagerDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonMaskedTextBoxActionList.cs" />
-        <Compile Remove="Toolkit\KryptonMaskedTextBoxColumnDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonMaskedTextBoxDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonMonthCalendarActionList.cs" />
-        <Compile Remove="Toolkit\KryptonMonthCalendarDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonNumericUpDownActionList.cs" />
-        <Compile Remove="Toolkit\KryptonNumericUpDownColumnDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonNumericUpDownDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonPaletteActionList.cs" />
-        <Compile Remove="Toolkit\KryptonPaletteDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonPanelActionList.cs" />
-        <Compile Remove="Toolkit\KryptonPanelDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonRadioButtonActionList.cs" />
-        <Compile Remove="Toolkit\KryptonRadioButtonDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonRichTextBoxActionList.cs" />
-        <Compile Remove="Toolkit\KryptonRichTextBoxDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonSeparatorActionList.cs" />
-        <Compile Remove="Toolkit\KryptonSeparatorDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonSplitContainerActionList.cs" />
-        <Compile Remove="Toolkit\KryptonSplitContainerBehavior.cs" />
-        <Compile Remove="Toolkit\KryptonSplitContainerDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonSplitContainerGlyph.cs" />
-        <Compile Remove="Toolkit\KryptonSplitterPanelDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonTextBoxActionList.cs" />
-        <Compile Remove="Toolkit\KryptonTextBoxColumnDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonTextBoxDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonTrackBarActionList.cs" />
-        <Compile Remove="Toolkit\KryptonTrackBarDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonTreeViewActionList.cs" />
-        <Compile Remove="Toolkit\KryptonTreeViewDesigner.cs" />
-        <Compile Remove="Toolkit\KryptonWrapLabelActionList.cs" />
-        <Compile Remove="Toolkit\KryptonWrapLabelDesigner.cs" />
-        <Compile Remove="Toolkit\PaletteDrawBordersEditor.cs" />
-        <Compile Remove="Toolkit\PaletteDrawBordersSelector.cs" />
-        <Compile Remove="Toolkit\PaletteDrawBordersSelector.Designer.cs" />
-        <EmbeddedResource Remove="Controls Toolkit\KryptonInputBoxNew.resx" />
-        <EmbeddedResource Remove="Toolkit\KryptonCheckButtonCollectionForm.resx" />
-        <EmbeddedResource Remove="Toolkit\PaletteDrawBordersSelector.resx" />
-    </ItemGroup>
-    <ItemGroup>
-        <None Remove="Controls Toolkit\KryptonButton.bmp" />
-        <None Remove="ToolboxBitmaps\KryptonButton.bmp" />
-    </ItemGroup>
-    <ItemGroup>
-        <EmbeddedResource Update="Properties\Resources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\AboutToolkit\AboutToolkitImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>AboutToolkitImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\Arrows\BlueArrowResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>BlueArrowResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\Arrows\Office2010ArrowResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>Office2010ArrowResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\Arrows\RibbonArrowImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>RibbonArrowImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\Arrows\SortArrowImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>SortArrowImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\ButtonSpecs\ProfessionalButtonSpecResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>ProfessionalButtonSpecResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\CheckBoxes\CheckBoxStripResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>CheckBoxStripResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\ColourScales\ColourScaleImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>ColourScaleImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\CommandLink\CommandLinkImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>CommandLinkImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\ControlBox\Microsoft365ControlBoxResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>Microsoft365ControlBoxResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\ControlBox\Office2003ControlBoxResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>Office2003ControlBoxResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\ControlBox\Office2007ControlBoxResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>Office2007ControlBoxResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\ControlBox\Office2010ControlBoxResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>Office2010ControlBoxResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\ControlBox\Office2013ControlBoxResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>Office2013ControlBoxResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\ControlBox\ProfessionalControlBoxResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>ProfessionalControlBoxResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\ControlBox\SparkleControlBoxResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>SparkleControlBoxResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\Cursors\CursorResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>CursorResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\DataBars\DataBarImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>DataBarImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\Dialogs\DialogImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>DialogImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\DropDown\DropDownArrowImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>DropDownArrowImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\Elements\ElementsImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>ElementsImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\Gallery\GalleryImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>GalleryImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\Generic\GenericImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>GenericImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\Generic\GenericKryptonImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>GenericKryptonImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\Generic\GenericOffice2007ImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>GenericOffice2007ImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\Generic\GenericProfessionalImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>GenericProfessionalImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\Generic\GenericSparkleImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>GenericSparkleImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\Generic\GenericWhiteImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>GenericWhiteImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\Grid\GridImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>GridImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\Logos\ToolkitLogoImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>ToolkitLogoImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\MDI\GenericMDIImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>GenericMDIImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\MDI\Office2010MDIImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>Office2010MDIImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\MessageBox\MessageBoxImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>MessageBoxImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\OutlookGrid\OutlookGridImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>OutlookGridImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\OutlookGrid\Strings\OutlookGridStringResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>OutlookGridStringResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\PaletteSchemas\PaletteSchemaResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>PaletteSchemaResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\Pendants\ProfessionalPendantImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>ProfessionalPendantImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\Pin\ProfessionalPinImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>ProfessionalPinImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\RadioButtons\Office2007RadioButtonImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>Office2007RadioButtonImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\RadioButtons\Office2010RadioButtonImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>Office2010RadioButtonImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\RadioButtons\SparkleRadioButtonImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>SparkleRadioButtonImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\RadioButtons\VisualStudioRadioButtonImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>VisualStudioRadioButtonImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\SizeGripStyles\SizeGripStyleResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>SizeGripStyleResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\Sort\SortingImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>SortingImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\Stars\StarImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>StarImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\TaskDialog\TaskDialogImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>TaskDialogImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\ToastNotification\ToastNotificationImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>ToastNotificationImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\Toolbars\GenericToolbarImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>GenericToolbarImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\Toolbars\Microsoft365ToolbarImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>Microsoft365ToolbarImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\Toolbars\Office2003ToolbarImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>Office2003ToolbarImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\Toolbars\Office2007ToolbarImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>Office2007ToolbarImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\Toolbars\Office2010ToolbarImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>Office2010ToolbarImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\Toolbars\Office2013ToolbarImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>Office2013ToolbarImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\Toolbars\Office2016ToolbarImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>Office2016ToolbarImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\Toolbars\Office2019ToolbarImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>Office2019ToolbarImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\Toolbars\SystemToolbarImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>SystemToolbarImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\Toolbars\VisualStudioToolbarImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>VisualStudioToolbarImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\TreeItems\TreeItemImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>TreeItemImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\UAC\UACShieldIconResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>UACShieldIconResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\VisualStudio\VisualStudioImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>VisualStudioImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-        <EmbeddedResource Update="ResourceFiles\WindowsLogos\WindowsLogoImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>WindowsLogoImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-    </ItemGroup>
-    <ItemGroup>
-        <None Update="../../../Assets/PNG/NuGet Package Icons/Krypton Stable.png" Link="Krypton Stable.png" />
-    </ItemGroup>
-    <ItemGroup>
-        <Folder Include="Storage\Images\Generic\" />
-    </ItemGroup>
+  <ItemGroup>
+    <Compile Update="ButtonSpec\ButtonSpecFormFixed.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Update="ButtonSpec\ButtonSpecFormWindowClose.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Update="ButtonSpec\ButtonSpecFormWindowMin.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Update="ButtonSpec\ButtonSpecFormWindowMax.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Update="ButtonSpec\ButtonSpecCalendar.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Update="Controls Toolkit\KryptonColorDialog.cs" />
+    <Compile Update="Controls Toolkit\KryptonPrintDialog.cs" />
+    <Compile Update="Designers\Other\PaletteDrawBordersSelector.cs" />
+    <Compile Update="Controls Toolkit\KryptonBreadCrumbItem.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Update="Controls Toolkit\KryptonListItem.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Update="ContextMenu\KryptonContextMenuItemBase.cs" />
+    <Compile Update="ButtonSpec\ButtonSpecAny.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Update="ButtonSpec\ButtonSpec.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Update="Palette Builtin\Office 2007\Non Official Themes\PaletteOffice2007White.cs" />
+    <Compile Update="Palette Builtin\Office 2010\Non Official Themes\PaletteOffice2010White.cs" />
+    <Compile Update="Palette Builtin\Office 2013\Non Official Themes\PaletteOffice2013AccessLegacy.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Update="Palette Builtin\Office 2013\Bases\PaletteOffice2013Base.cs" />
+    <Compile Update="Palette Builtin\Office 2013\Official Themes\PaletteOffice2013White.cs" />
+    <Compile Update="Palette Builtin\Microsoft 365\Bases\PaletteMicrosoft365Base.cs" />
+    <Compile Update="Palette Builtin\Office 365\Non Official Themes\PaletteOffice365AccessLegacy.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Update="Palette Builtin\Microsoft 365\Non Official Themes\PaletteOffice365Blue.cs" />
+    <Compile Update="Palette Builtin\Microsoft 365\Official Themes\PaletteMicrosoft365Black.cs" />
+    <Compile Update="Palette Builtin\Microsoft 365\Official Themes\PaletteOffice365Silver.cs" />
+    <Compile Update="Palette Builtin\Microsoft 365\Official Themes\PaletteOffice365White.cs" />
+    <Compile Update="Palette Builtin\PaletteVisualStudio2020Base.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Update="Palette Builtin\Office 2010\Official Themes\PaletteOffice2010Black.cs" />
+    <Compile Update="Palette Builtin\Office 2010\Official Themes\PaletteOffice2010Blue.cs" />
+    <Compile Update="Palette Builtin\Office 2010\Official Themes\PaletteOffice2010Silver.cs" />
+    <Compile Update="Palette Builtin\Office 2010\Bases\PaletteOffice2010Base.cs" />
+    <Compile Update="Palette Builtin\Sparkle\Official Themes\PaletteSparklePurple.cs" />
+    <Compile Update="Palette Builtin\Sparkle\Base\PaletteSparkleBase.cs" />
+    <Compile Update="Palette Builtin\Sparkle\Official Themes\PaletteSparkleOrange.cs" />
+    <Compile Update="Palette Builtin\Sparkle\Official Themes\PaletteSparkleBlue.cs" />
+    <Compile Update="Palette Builtin\Office 2007\Official Themes\PaletteOffice2007Black.cs" />
+    <Compile Update="Palette Builtin\Office 2007\Official Themes\PaletteOffice2007Silver.cs" />
+    <Compile Update="Palette Builtin\Office 2007\Official Themes\PaletteOffice2007Blue.cs" />
+    <Compile Update="Palette Builtin\Office 2007\Bases\PaletteOffice2007Base.cs" />
+    <Compile Update="Properties\Resources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="Rendering\RenderOffice2013.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Update="Rendering\RenderMicrosoft365.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Update="Rendering\RenderOffice2007.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Update="Rendering\RenderSparkle.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Update="ButtonSpec\ButtonSpecHeaderGroup.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Update="Controls Toolkit\KryptonManager.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Update="Palette Builtin\Professional\PaletteProfessionalSystem.cs" />
+    <Compile Update="Palette Builtin\Base\PaletteBase.cs" />
+    <Compile Update="Rendering\RenderOffice2010.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Update="Rendering\RenderProfessional.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Update="Palette Builtin\Professional\PaletteProfessionalOffice2003.cs" />
+    <Compile Update="Rendering\RenderBase.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Update="Rendering\RenderStandard.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Update="ResourceFiles\AboutToolkit\AboutToolkitImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>AboutToolkitImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\Arrows\BlueArrowResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>BlueArrowResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\Arrows\Office2010ArrowResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Office2010ArrowResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\Arrows\RibbonArrowImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>RibbonArrowImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\Arrows\SortArrowImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>SortArrowImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\ButtonSpecs\ProfessionalButtonSpecResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ProfessionalButtonSpecResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\CheckBoxes\CheckBoxStripResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>CheckBoxStripResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\ColourScales\ColourScaleImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ColourScaleImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\CommandLink\CommandLinkImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>CommandLinkImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\ControlBox\Microsoft365ControlBoxResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Microsoft365ControlBoxResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\ControlBox\Office2003ControlBoxResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Office2003ControlBoxResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\ControlBox\Office2007ControlBoxResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Office2007ControlBoxResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\ControlBox\Office2010ControlBoxResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Office2010ControlBoxResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\ControlBox\Office2013ControlBoxResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Office2013ControlBoxResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\ControlBox\ProfessionalControlBoxResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ProfessionalControlBoxResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\ControlBox\SparkleControlBoxResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>SparkleControlBoxResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\Cursors\CursorResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>CursorResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\DataBars\DataBarImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>DataBarImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\Dialogs\DialogImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>DialogImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\DropDown\DropDownArrowImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>DropDownArrowImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\Elements\ElementsImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ElementsImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\Gallery\GalleryImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>GalleryImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\Generic\GenericImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>GenericImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\Generic\GenericKryptonImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>GenericKryptonImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\Generic\GenericOffice2007ImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>GenericOffice2007ImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\Generic\GenericProfessionalImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>GenericProfessionalImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\Generic\GenericSparkleImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>GenericSparkleImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\Generic\GenericWhiteImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>GenericWhiteImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\Grid\GridImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>GridImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\Logos\ToolkitLogoImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ToolkitLogoImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\MDI\GenericMDIImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>GenericMDIImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\MDI\Office2010MDIImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Office2010MDIImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\MessageBox\MessageBoxImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>MessageBoxImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\OutlookGrid\OutlookGridImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>OutlookGridImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\OutlookGrid\Strings\OutlookGridStringResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>OutlookGridStringResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\PaletteSchemas\PaletteSchemaResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>PaletteSchemaResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\Pendants\ProfessionalPendantImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ProfessionalPendantImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\Pin\ProfessionalPinImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ProfessionalPinImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\RadioButtons\Office2007RadioButtonImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Office2007RadioButtonImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\RadioButtons\Office2010RadioButtonImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Office2010RadioButtonImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\RadioButtons\SparkleRadioButtonImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>SparkleRadioButtonImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\RadioButtons\VisualStudioRadioButtonImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>VisualStudioRadioButtonImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\SizeGripStyles\SizeGripStyleResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>SizeGripStyleResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\Sort\SortingImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>SortingImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\Stars\StarImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>StarImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\TaskDialog\TaskDialogImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>TaskDialogImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\ToastNotification\ToastNotificationImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ToastNotificationImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\Toolbars\GenericToolbarImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>GenericToolbarImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\Toolbars\Microsoft365ToolbarImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Microsoft365ToolbarImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\Toolbars\Office2003ToolbarImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Office2003ToolbarImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\Toolbars\Office2007ToolbarImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Office2007ToolbarImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\Toolbars\Office2010ToolbarImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Office2010ToolbarImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\Toolbars\Office2013ToolbarImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Office2013ToolbarImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\Toolbars\Office2016ToolbarImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Office2016ToolbarImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\Toolbars\Office2019ToolbarImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Office2019ToolbarImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\Toolbars\SystemToolbarImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>SystemToolbarImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\Toolbars\VisualStudioToolbarImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>VisualStudioToolbarImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\TreeItems\TreeItemImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>TreeItemImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\UAC\UACShieldIconResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>UACShieldIconResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\VisualStudio\VisualStudioImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>VisualStudioImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="ResourceFiles\WindowsLogos\WindowsLogoImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>WindowsLogoImageResources.resx</DependentUpon>
+    </Compile>
+    <Compile Update="View Base\ViewControl.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonButton.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonTreeView.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonInputBox.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonTaskDialogCommand.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonTaskDialog.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonMessageBox.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonTrackBar.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonManager.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonHeaderGroup.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonGroup.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonHeader.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonPanel.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonLabel.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonPalette.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonSplitContainer.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonCheckButton.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonCheckSet.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonBorderEdge.bmp" />
+    <Content Include="Krypton.ico" Pack="false" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonGroupBox.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonWrapLabel.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonSeparator.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonDateTimePicker.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonMonthCalendar.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonBreadCrumbItem.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonDomainUpDown.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonBreadCrumb.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonNumericUpDown.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonContextMenuImageSelect.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonCommand.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonCheckedListBox.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonListBox.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonColorButton.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonDropButton.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonContextMenuColorColumns.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonMaskedTextBox.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonContextMenuItem.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonContextMenuItems.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonContextMenuSeparator.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonContextMenuHeading.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonContextMenu.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonRichTextBox.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonComboBox.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonTextBox.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonDataGridView.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonRadioButton.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonCheckBox.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonButtonSpec.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonGroupPanel.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonForm.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonLinkLabel.bmp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="Controls Toolkit\KryptonByteViewer.cs" />
+    <Compile Remove="Controls Toolkit\KryptonDataGridViewBinaryCell.cs" />
+    <Compile Remove="Controls Toolkit\KryptonDataGridViewBinaryColumn.cs" />
+    <Compile Remove="Controls Toolkit\KryptonInputBoxNew.cs" />
+    <Compile Remove="Toolkit\KryptonBorderEdgeActionList.cs" />
+    <Compile Remove="Toolkit\KryptonBorderEdgeDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonBreadCrumbActionList.cs" />
+    <Compile Remove="Toolkit\KryptonBreadCrumbDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonBreadCrumbItemDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonBreadCrumbItemsEditor.cs" />
+    <Compile Remove="Toolkit\KryptonButtonActionList.cs" />
+    <Compile Remove="Toolkit\KryptonButtonDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonCheckBoxActionList.cs" />
+    <Compile Remove="Toolkit\KryptonCheckBoxDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonCheckButtonActionList.cs" />
+    <Compile Remove="Toolkit\KryptonCheckButtonCollectionEditor.cs" />
+    <Compile Remove="Toolkit\KryptonCheckButtonCollectionForm.cs" />
+    <Compile Remove="Toolkit\KryptonCheckButtonCollectionForm.Designer.cs" />
+    <Compile Remove="Toolkit\KryptonCheckButtonDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonCheckedListBoxActionList.cs" />
+    <Compile Remove="Toolkit\KryptonCheckedListBoxDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonCheckSetActionList.cs" />
+    <Compile Remove="Toolkit\KryptonCheckSetDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonColorButtonActionList.cs" />
+    <Compile Remove="Toolkit\KryptonColorButtonDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonComboBoxActionList.cs" />
+    <Compile Remove="Toolkit\KryptonComboBoxColumnDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonComboBoxDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonCommandActionList.cs" />
+    <Compile Remove="Toolkit\KryptonCommandDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonContextMenuActionList.cs" />
+    <Compile Remove="Toolkit\KryptonContextMenuCollectionEditor.cs" />
+    <Compile Remove="Toolkit\KryptonContextMenuDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonContextMenuItemCollectionEditor.cs" />
+    <Compile Remove="Toolkit\KryptonContextMenuItemDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonContextMenuItemsDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonDataGridViewDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonDateTimePickerActionList.cs" />
+    <Compile Remove="Toolkit\KryptonDateTimePickerColumnDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonDateTimePickerDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonDesignerActionItem.cs" />
+    <Compile Remove="Toolkit\KryptonDomainUpDownActionList.cs" />
+    <Compile Remove="Toolkit\KryptonDomainUpDownColumnDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonDomainUpDownDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonDropButtonActionList.cs" />
+    <Compile Remove="Toolkit\KryptonDropButtonDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonGroupActionList.cs" />
+    <Compile Remove="Toolkit\KryptonGroupBoxActionList.cs" />
+    <Compile Remove="Toolkit\KryptonGroupBoxDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonGroupDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonGroupPanelDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonHeaderActionList.cs" />
+    <Compile Remove="Toolkit\KryptonHeaderDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonHeaderGroupActionList.cs" />
+    <Compile Remove="Toolkit\KryptonHeaderGroupDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonLabelActionList.cs" />
+    <Compile Remove="Toolkit\KryptonLabelDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonLinkLabelActionList.cs" />
+    <Compile Remove="Toolkit\KryptonLinkLabelDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonListBoxActionList.cs" />
+    <Compile Remove="Toolkit\KryptonListBoxDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonManagerActionList.cs" />
+    <Compile Remove="Toolkit\KryptonManagerDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonMaskedTextBoxActionList.cs" />
+    <Compile Remove="Toolkit\KryptonMaskedTextBoxColumnDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonMaskedTextBoxDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonMonthCalendarActionList.cs" />
+    <Compile Remove="Toolkit\KryptonMonthCalendarDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonNumericUpDownActionList.cs" />
+    <Compile Remove="Toolkit\KryptonNumericUpDownColumnDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonNumericUpDownDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonPaletteActionList.cs" />
+    <Compile Remove="Toolkit\KryptonPaletteDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonPanelActionList.cs" />
+    <Compile Remove="Toolkit\KryptonPanelDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonRadioButtonActionList.cs" />
+    <Compile Remove="Toolkit\KryptonRadioButtonDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonRichTextBoxActionList.cs" />
+    <Compile Remove="Toolkit\KryptonRichTextBoxDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonSeparatorActionList.cs" />
+    <Compile Remove="Toolkit\KryptonSeparatorDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonSplitContainerActionList.cs" />
+    <Compile Remove="Toolkit\KryptonSplitContainerBehavior.cs" />
+    <Compile Remove="Toolkit\KryptonSplitContainerDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonSplitContainerGlyph.cs" />
+    <Compile Remove="Toolkit\KryptonSplitterPanelDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonTextBoxActionList.cs" />
+    <Compile Remove="Toolkit\KryptonTextBoxColumnDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonTextBoxDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonTrackBarActionList.cs" />
+    <Compile Remove="Toolkit\KryptonTrackBarDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonTreeViewActionList.cs" />
+    <Compile Remove="Toolkit\KryptonTreeViewDesigner.cs" />
+    <Compile Remove="Toolkit\KryptonWrapLabelActionList.cs" />
+    <Compile Remove="Toolkit\KryptonWrapLabelDesigner.cs" />
+    <Compile Remove="Toolkit\PaletteDrawBordersEditor.cs" />
+    <Compile Remove="Toolkit\PaletteDrawBordersSelector.cs" />
+    <Compile Remove="Toolkit\PaletteDrawBordersSelector.Designer.cs" />
+    <EmbeddedResource Remove="Controls Toolkit\KryptonInputBoxNew.resx" />
+    <EmbeddedResource Remove="Toolkit\KryptonCheckButtonCollectionForm.resx" />
+    <EmbeddedResource Remove="Toolkit\PaletteDrawBordersSelector.resx" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="Controls Toolkit\KryptonButton.bmp" />
+    <None Remove="ToolboxBitmaps\KryptonButton.bmp" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Update="Properties\Resources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\AboutToolkit\AboutToolkitImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>AboutToolkitImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\Arrows\BlueArrowResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>BlueArrowResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\Arrows\Office2010ArrowResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Office2010ArrowResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\Arrows\RibbonArrowImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>RibbonArrowImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\Arrows\SortArrowImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>SortArrowImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\ButtonSpecs\ProfessionalButtonSpecResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>ProfessionalButtonSpecResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\CheckBoxes\CheckBoxStripResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>CheckBoxStripResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\ColourScales\ColourScaleImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>ColourScaleImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\CommandLink\CommandLinkImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>CommandLinkImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\ControlBox\Microsoft365ControlBoxResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Microsoft365ControlBoxResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\ControlBox\Office2003ControlBoxResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Office2003ControlBoxResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\ControlBox\Office2007ControlBoxResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Office2007ControlBoxResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\ControlBox\Office2010ControlBoxResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Office2010ControlBoxResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\ControlBox\Office2013ControlBoxResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Office2013ControlBoxResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\ControlBox\ProfessionalControlBoxResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>ProfessionalControlBoxResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\ControlBox\SparkleControlBoxResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>SparkleControlBoxResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\Cursors\CursorResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>CursorResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\DataBars\DataBarImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>DataBarImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\Dialogs\DialogImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>DialogImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\DropDown\DropDownArrowImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>DropDownArrowImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\Elements\ElementsImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>ElementsImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\Gallery\GalleryImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>GalleryImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\Generic\GenericImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>GenericImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\Generic\GenericKryptonImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>GenericKryptonImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\Generic\GenericOffice2007ImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>GenericOffice2007ImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\Generic\GenericProfessionalImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>GenericProfessionalImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\Generic\GenericSparkleImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>GenericSparkleImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\Generic\GenericWhiteImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>GenericWhiteImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\Grid\GridImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>GridImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\Logos\ToolkitLogoImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>ToolkitLogoImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\MDI\GenericMDIImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>GenericMDIImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\MDI\Office2010MDIImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Office2010MDIImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\MessageBox\MessageBoxImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>MessageBoxImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\OutlookGrid\OutlookGridImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>OutlookGridImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\OutlookGrid\Strings\OutlookGridStringResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>OutlookGridStringResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\PaletteSchemas\PaletteSchemaResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>PaletteSchemaResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\Pendants\ProfessionalPendantImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>ProfessionalPendantImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\Pin\ProfessionalPinImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>ProfessionalPinImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\RadioButtons\Office2007RadioButtonImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Office2007RadioButtonImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\RadioButtons\Office2010RadioButtonImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Office2010RadioButtonImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\RadioButtons\SparkleRadioButtonImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>SparkleRadioButtonImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\RadioButtons\VisualStudioRadioButtonImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>VisualStudioRadioButtonImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\SizeGripStyles\SizeGripStyleResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>SizeGripStyleResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\Sort\SortingImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>SortingImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\Stars\StarImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>StarImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\TaskDialog\TaskDialogImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>TaskDialogImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\ToastNotification\ToastNotificationImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>ToastNotificationImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\Toolbars\GenericToolbarImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>GenericToolbarImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\Toolbars\Microsoft365ToolbarImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Microsoft365ToolbarImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\Toolbars\Office2003ToolbarImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Office2003ToolbarImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\Toolbars\Office2007ToolbarImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Office2007ToolbarImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\Toolbars\Office2010ToolbarImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Office2010ToolbarImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\Toolbars\Office2013ToolbarImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Office2013ToolbarImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\Toolbars\Office2016ToolbarImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Office2016ToolbarImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\Toolbars\Office2019ToolbarImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Office2019ToolbarImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\Toolbars\SystemToolbarImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>SystemToolbarImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\Toolbars\VisualStudioToolbarImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>VisualStudioToolbarImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\TreeItems\TreeItemImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>TreeItemImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\UAC\UACShieldIconResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>UACShieldIconResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\VisualStudio\VisualStudioImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>VisualStudioImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="ResourceFiles\WindowsLogos\WindowsLogoImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>WindowsLogoImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="../../../Assets/PNG/NuGet Package Icons/Krypton Stable.png" Link="Krypton Stable.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Storage\Images\Generic\" />
+  </ItemGroup>
 
-    <PropertyGroup Condition="'$(Configuration)'!='Debug'">
-        <Optimize>True</Optimize>
-    </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'!='Debug'">
+    <Optimize>True</Optimize>
+  </PropertyGroup>
 
 </Project>

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDefinitions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteDefinitions.cs
@@ -3070,7 +3070,7 @@ namespace Krypton.Toolkit
         BottomRight,
 
         /// <summary>
-        /// Specifies image should be stretch to fix area.
+        /// Specifies image should be stretch to fit area.
         /// </summary>
         Stretch,
 

--- a/Source/Krypton Components/Krypton.Workspace/Krypton.Workspace 2022.csproj
+++ b/Source/Krypton Components/Krypton.Workspace/Krypton.Workspace 2022.csproj
@@ -1,101 +1,102 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <Choose>
-        <When Condition="'$(Configuration)' == 'Nightly' Or '$(Configuration)' == 'Canary' Or '$(Configuration)' == 'Debug'">
-            <PropertyGroup>
-                <TargetFrameworks>net462;net47;net471;net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
-            </PropertyGroup>
-        </When>
-        <Otherwise>
-            <PropertyGroup>
-                <TargetFrameworks>net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+  <Choose>
+    <When Condition="'$(Configuration)' == 'Nightly' Or '$(Configuration)' == 'Canary' Or '$(Configuration)' == 'Debug'">
+      <PropertyGroup>
+        <TargetFrameworks>net462;net47;net471;net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <TargetFrameworks>net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
 
-                <TargetFrameworks Condition="'$(TFMs)' == 'all'">net462;net47;net471;net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
-            </PropertyGroup>
-        </Otherwise>
-    </Choose>
+        <TargetFrameworks Condition="'$(TFMs)' == 'all'">net462;net47;net471;net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
 
-    <PropertyGroup>
-        <OutputType>Library</OutputType>
-        <RootNamespace>Krypton.Workspace</RootNamespace>
-        <AssemblyName>Krypton.Workspace</AssemblyName>
-        <!-- Set the CheckEolTargetFramework property to false to fix the warning -->
-        <CheckEolTargetFramework>false</CheckEolTargetFramework>
-        <SignAssembly>True</SignAssembly>
-        <AssemblyOriginatorKeyFile>StrongKrypton.snk</AssemblyOriginatorKeyFile>
-        <ApplicationIcon>Krypton.ico</ApplicationIcon>
-        <DelaySign>false</DelaySign>
-        <UseWindowsForms>true</UseWindowsForms>
-        <PlatformTarget>AnyCPU</PlatformTarget>
-        <EnableNETAnalyzers>true</EnableNETAnalyzers>
-        <NeutralLanguage>en</NeutralLanguage>
-        <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
-        <Configurations>Debug;Release;Installer;Nightly;Canary</Configurations>
-        <Nullable>enable</Nullable>
-        <!--https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/warning-waves-->
-        <WarningLevel>8</WarningLevel>
-        <AnalysisLevel>latest</AnalysisLevel>
-        <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
-        <!--https://learn.microsoft.com/en-us/visualstudio/designers/disable-dpi-awareness?view=vs-2022-->
-        <ForceDesignerDPIUnaware>true</ForceDesignerDPIUnaware>
-    </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Krypton.Workspace</RootNamespace>
+    <AssemblyName>Krypton.Workspace</AssemblyName>
+    <!-- Set the CheckEolTargetFramework property to false to fix the warning -->
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <SignAssembly>True</SignAssembly>
+    <AssemblyOriginatorKeyFile>StrongKrypton.snk</AssemblyOriginatorKeyFile>
+    <ApplicationIcon>Krypton.ico</ApplicationIcon>
+    <DelaySign>false</DelaySign>
+    <UseWindowsForms>true</UseWindowsForms>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <NeutralLanguage>en</NeutralLanguage>
+    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
+    <Configurations>Debug;Release;Installer;Nightly;Canary</Configurations>
+    <Nullable>enable</Nullable>
+    <!--https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/warning-waves-->
+    <WarningLevel>8</WarningLevel>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
+    <!--https://learn.microsoft.com/en-us/visualstudio/designers/disable-dpi-awareness?view=vs-2022-->
+    <ForceDesignerDPIUnaware>true</ForceDesignerDPIUnaware>
+    <ApplicationHighDpiMode>SystemAware</ApplicationHighDpiMode>
+  </PropertyGroup>
 
-    <PropertyGroup>
-        <PackageId>Krypton.Workspace</PackageId>
-        <Description>This is the workspace module.</Description>
-    </PropertyGroup>
+  <PropertyGroup>
+    <PackageId>Krypton.Workspace</PackageId>
+    <Description>This is the workspace module.</Description>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <Reference Include="System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="$(TargetFramework.StartsWith('net4'))">
-            <SpecificVersion>True</SpecificVersion>
-            <Version>4.0.0.0</Version>
-            <!-- Designers for the `TFMs != net4` are "Pulled in" via Visual studios ".nuget\packages\microsoft.windowsdesktop.app.ref" -->
-        </Reference>
-    </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="$(TargetFramework.StartsWith('net4'))">
+      <SpecificVersion>True</SpecificVersion>
+      <Version>4.0.0.0</Version>
+      <!-- Designers for the `TFMs != net4` are "Pulled in" via Visual studios ".nuget\packages\microsoft.windowsdesktop.app.ref" -->
+    </Reference>
+  </ItemGroup>
 
-    <ItemGroup>
-        <Service Include="{94E38DFF-614B-4cbd-B67C-F211BB35CE8B}" />
-    </ItemGroup>
+  <ItemGroup>
+    <Service Include="{94E38DFF-614B-4cbd-B67C-F211BB35CE8B}" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <Content Include="Krypton.ico" Pack="false" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonWorkspaceSequence.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonWorkspaceCell.bmp" />
-        <EmbeddedResource Include="ToolboxBitmaps\KryptonWorkspace.bmp" />
-    </ItemGroup>
-    <ItemGroup>
-        <ProjectReference Include="..\Krypton.Navigator\Krypton.Navigator 2022.csproj" />
-        <ProjectReference Include="..\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />
-    </ItemGroup>
-    <ItemGroup>
-        <Compile Remove="Palette Demo\WorkspacePageMenuBase.cs" />
-        <Compile Remove="Palette Install\WorkspacePageMenuBase.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <Compile Include="..\Krypton.Toolkit\Utilities\AllowNullAttribute.cs" Link="General\AllowNullAttribute.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <Compile Update="Resources\GeneralImageResources.Designer.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>GeneralImageResources.resx</DependentUpon>
-        </Compile>
-    </ItemGroup>
-    <ItemGroup>
-        <EmbeddedResource Update="Resources\GeneralImageResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>GeneralImageResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-    </ItemGroup>
-    <PropertyGroup>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <OutputPath>..\..\..\Bin\$(Configuration)\</OutputPath>
-    </PropertyGroup>
-    <PropertyGroup>
-        <NoWarn>1701;1702</NoWarn>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)'!='Debug'">
-        <Optimize>True</Optimize>
-    </PropertyGroup>
+  <ItemGroup>
+    <Content Include="Krypton.ico" Pack="false" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonWorkspaceSequence.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonWorkspaceCell.bmp" />
+    <EmbeddedResource Include="ToolboxBitmaps\KryptonWorkspace.bmp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Krypton.Navigator\Krypton.Navigator 2022.csproj" />
+    <ProjectReference Include="..\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="Palette Demo\WorkspacePageMenuBase.cs" />
+    <Compile Remove="Palette Install\WorkspacePageMenuBase.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\Krypton.Toolkit\Utilities\AllowNullAttribute.cs" Link="General\AllowNullAttribute.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Update="Resources\GeneralImageResources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>GeneralImageResources.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Update="Resources\GeneralImageResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>GeneralImageResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <OutputPath>..\..\..\Bin\$(Configuration)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <NoWarn>1701;1702</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'!='Debug'">
+    <Optimize>True</Optimize>
+  </PropertyGroup>
 
 </Project>

--- a/Source/Krypton Components/TestForm/ButtonsTest.Designer.cs
+++ b/Source/Krypton Components/TestForm/ButtonsTest.Designer.cs
@@ -39,6 +39,7 @@ namespace TestForm
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ButtonsTest));
             this.kryptonPanel1 = new Krypton.Toolkit.KryptonPanel();
+            this.kbtnButtonStyles = new Krypton.Toolkit.KryptonButton();
             this.kryptonThemeComboBox1 = new Krypton.Toolkit.KryptonThemeComboBox();
             this.kryptonColorButton1 = new Krypton.Toolkit.KryptonColorButton();
             this.kcbtnDropDown = new Krypton.Toolkit.KryptonColorButton();
@@ -56,7 +57,6 @@ namespace TestForm
             this.kryptonButton3 = new Krypton.Toolkit.KryptonButton();
             this.kryptonButton1 = new Krypton.Toolkit.KryptonButton();
             this.buttonSpecAny1 = new Krypton.Toolkit.ButtonSpecAny();
-            this.kbtnButtonStyles = new Krypton.Toolkit.KryptonButton();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).BeginInit();
             this.kryptonPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonThemeComboBox1)).BeginInit();
@@ -78,18 +78,31 @@ namespace TestForm
             this.kryptonPanel1.Controls.Add(this.kryptonButton1);
             this.kryptonPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonPanel1.Location = new System.Drawing.Point(0, 0);
+            this.kryptonPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.kryptonPanel1.Name = "kryptonPanel1";
-            this.kryptonPanel1.Size = new System.Drawing.Size(522, 236);
+            this.kryptonPanel1.Size = new System.Drawing.Size(708, 280);
             this.kryptonPanel1.TabIndex = 0;
+            // 
+            // kbtnButtonStyles
+            // 
+            this.kbtnButtonStyles.Location = new System.Drawing.Point(187, 241);
+            this.kbtnButtonStyles.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.kbtnButtonStyles.Name = "kbtnButtonStyles";
+            this.kbtnButtonStyles.Size = new System.Drawing.Size(324, 31);
+            this.kbtnButtonStyles.TabIndex = 10;
+            this.kbtnButtonStyles.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnButtonStyles.Values.Text = "Button Styles";
+            this.kbtnButtonStyles.Click += new System.EventHandler(this.kbtnButtonStyles_Click);
             // 
             // kryptonThemeComboBox1
             // 
             this.kryptonThemeComboBox1.DefaultPalette = Krypton.Toolkit.PaletteMode.Microsoft365Blue;
             this.kryptonThemeComboBox1.DropDownWidth = 492;
             this.kryptonThemeComboBox1.IntegralHeight = false;
-            this.kryptonThemeComboBox1.Location = new System.Drawing.Point(18, 13);
+            this.kryptonThemeComboBox1.Location = new System.Drawing.Point(24, 16);
+            this.kryptonThemeComboBox1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.kryptonThemeComboBox1.Name = "kryptonThemeComboBox1";
-            this.kryptonThemeComboBox1.Size = new System.Drawing.Size(492, 22);
+            this.kryptonThemeComboBox1.Size = new System.Drawing.Size(656, 26);
             this.kryptonThemeComboBox1.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
             this.kryptonThemeComboBox1.TabIndex = 9;
             // 
@@ -97,9 +110,10 @@ namespace TestForm
             // 
             this.kryptonColorButton1.CustomColorPreviewShape = Krypton.Toolkit.KryptonColorButtonCustomColorPreviewShape.Circle;
             this.kryptonColorButton1.Enabled = false;
-            this.kryptonColorButton1.Location = new System.Drawing.Point(267, 165);
+            this.kryptonColorButton1.Location = new System.Drawing.Point(356, 203);
+            this.kryptonColorButton1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.kryptonColorButton1.Name = "kryptonColorButton1";
-            this.kryptonColorButton1.Size = new System.Drawing.Size(243, 25);
+            this.kryptonColorButton1.Size = new System.Drawing.Size(324, 31);
             this.kryptonColorButton1.TabIndex = 8;
             this.kryptonColorButton1.Values.Image = ((System.Drawing.Image)(resources.GetObject("kryptonColorButton1.Values.Image")));
             this.kryptonColorButton1.Values.RoundedCorners = 8;
@@ -108,9 +122,10 @@ namespace TestForm
             // kcbtnDropDown
             // 
             this.kcbtnDropDown.CustomColorPreviewShape = Krypton.Toolkit.KryptonColorButtonCustomColorPreviewShape.Circle;
-            this.kcbtnDropDown.Location = new System.Drawing.Point(18, 165);
+            this.kcbtnDropDown.Location = new System.Drawing.Point(24, 203);
+            this.kcbtnDropDown.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.kcbtnDropDown.Name = "kcbtnDropDown";
-            this.kcbtnDropDown.Size = new System.Drawing.Size(243, 25);
+            this.kcbtnDropDown.Size = new System.Drawing.Size(324, 31);
             this.kcbtnDropDown.TabIndex = 7;
             this.kcbtnDropDown.Values.Image = ((System.Drawing.Image)(resources.GetObject("kcbtnDropDown.Values.Image")));
             this.kcbtnDropDown.Values.RoundedCorners = 8;
@@ -121,9 +136,10 @@ namespace TestForm
             // 
             this.kryptonButton5.Enabled = false;
             this.kryptonButton5.KryptonContextMenu = this.kryptonContextMenu1;
-            this.kryptonButton5.Location = new System.Drawing.Point(267, 134);
+            this.kryptonButton5.Location = new System.Drawing.Point(356, 165);
+            this.kryptonButton5.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.kryptonButton5.Name = "kryptonButton5";
-            this.kryptonButton5.Size = new System.Drawing.Size(243, 25);
+            this.kryptonButton5.Size = new System.Drawing.Size(324, 31);
             this.kryptonButton5.TabIndex = 6;
             this.kryptonButton5.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton5.Values.Image = ((System.Drawing.Image)(resources.GetObject("kryptonButton5.Values.Image")));
@@ -142,26 +158,14 @@ namespace TestForm
             this.kryptonContextMenuItem1,
             this.kryptonContextMenuItem2,
             this.kryptonContextMenuItem3});
-            this.kryptonContextMenuItems1.Text = "";
-            // 
-            // kryptonContextMenuItem1
-            // 
-            this.kryptonContextMenuItem1.Text = "Choice 1";
-            // 
-            // kryptonContextMenuItem2
-            // 
-            this.kryptonContextMenuItem2.Text = "Choice 2";
-            // 
-            // kryptonContextMenuItem3
-            // 
-            this.kryptonContextMenuItem3.Text = "Choice 3";
             // 
             // kryptonButton6
             // 
             this.kryptonButton6.Enabled = false;
-            this.kryptonButton6.Location = new System.Drawing.Point(267, 103);
+            this.kryptonButton6.Location = new System.Drawing.Point(356, 127);
+            this.kryptonButton6.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.kryptonButton6.Name = "kryptonButton6";
-            this.kryptonButton6.Size = new System.Drawing.Size(243, 25);
+            this.kryptonButton6.Size = new System.Drawing.Size(324, 31);
             this.kryptonButton6.TabIndex = 4;
             this.kryptonButton6.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton6.Values.Image = ((System.Drawing.Image)(resources.GetObject("kryptonButton6.Values.Image")));
@@ -171,9 +175,10 @@ namespace TestForm
             // kryptonButton7
             // 
             this.kryptonButton7.KryptonContextMenu = this.kryptonContextMenu1;
-            this.kryptonButton7.Location = new System.Drawing.Point(18, 134);
+            this.kryptonButton7.Location = new System.Drawing.Point(24, 165);
+            this.kryptonButton7.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.kryptonButton7.Name = "kryptonButton7";
-            this.kryptonButton7.Size = new System.Drawing.Size(243, 25);
+            this.kryptonButton7.Size = new System.Drawing.Size(324, 31);
             this.kryptonButton7.TabIndex = 5;
             this.kryptonButton7.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton7.Values.Image = ((System.Drawing.Image)(resources.GetObject("kryptonButton7.Values.Image")));
@@ -183,9 +188,10 @@ namespace TestForm
             // 
             // kryptonButton8
             // 
-            this.kryptonButton8.Location = new System.Drawing.Point(18, 103);
+            this.kryptonButton8.Location = new System.Drawing.Point(24, 127);
+            this.kryptonButton8.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.kryptonButton8.Name = "kryptonButton8";
-            this.kryptonButton8.Size = new System.Drawing.Size(243, 25);
+            this.kryptonButton8.Size = new System.Drawing.Size(324, 31);
             this.kryptonButton8.TabIndex = 3;
             this.kryptonButton8.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton8.Values.Image = ((System.Drawing.Image)(resources.GetObject("kryptonButton8.Values.Image")));
@@ -196,9 +202,10 @@ namespace TestForm
             // 
             this.kryptonButton4.Enabled = false;
             this.kryptonButton4.KryptonContextMenu = this.kryptonContextMenu1;
-            this.kryptonButton4.Location = new System.Drawing.Point(267, 72);
+            this.kryptonButton4.Location = new System.Drawing.Point(356, 89);
+            this.kryptonButton4.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.kryptonButton4.Name = "kryptonButton4";
-            this.kryptonButton4.Size = new System.Drawing.Size(243, 25);
+            this.kryptonButton4.Size = new System.Drawing.Size(324, 31);
             this.kryptonButton4.TabIndex = 2;
             this.kryptonButton4.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton4.Values.ShowSplitOption = true;
@@ -207,9 +214,10 @@ namespace TestForm
             // kryptonButton2
             // 
             this.kryptonButton2.Enabled = false;
-            this.kryptonButton2.Location = new System.Drawing.Point(267, 41);
+            this.kryptonButton2.Location = new System.Drawing.Point(356, 50);
+            this.kryptonButton2.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.kryptonButton2.Name = "kryptonButton2";
-            this.kryptonButton2.Size = new System.Drawing.Size(243, 25);
+            this.kryptonButton2.Size = new System.Drawing.Size(324, 31);
             this.kryptonButton2.TabIndex = 1;
             this.kryptonButton2.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton2.Values.Text = "Disabled Button";
@@ -217,9 +225,10 @@ namespace TestForm
             // kryptonButton3
             // 
             this.kryptonButton3.KryptonContextMenu = this.kryptonContextMenu1;
-            this.kryptonButton3.Location = new System.Drawing.Point(18, 72);
+            this.kryptonButton3.Location = new System.Drawing.Point(24, 89);
+            this.kryptonButton3.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.kryptonButton3.Name = "kryptonButton3";
-            this.kryptonButton3.Size = new System.Drawing.Size(243, 25);
+            this.kryptonButton3.Size = new System.Drawing.Size(324, 31);
             this.kryptonButton3.TabIndex = 1;
             this.kryptonButton3.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton3.Values.ShowSplitOption = true;
@@ -227,9 +236,10 @@ namespace TestForm
             // 
             // kryptonButton1
             // 
-            this.kryptonButton1.Location = new System.Drawing.Point(18, 41);
+            this.kryptonButton1.Location = new System.Drawing.Point(24, 50);
+            this.kryptonButton1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.kryptonButton1.Name = "kryptonButton1";
-            this.kryptonButton1.Size = new System.Drawing.Size(243, 25);
+            this.kryptonButton1.Size = new System.Drawing.Size(324, 31);
             this.kryptonButton1.TabIndex = 0;
             this.kryptonButton1.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton1.Values.Text = "Normal Button";
@@ -239,25 +249,16 @@ namespace TestForm
             this.buttonSpecAny1.Text = "Test Text";
             this.buttonSpecAny1.UniqueName = "bad5983b9e7f4d82b15e55a1a19807bb";
             // 
-            // kbtnButtonStyles
-            // 
-            this.kbtnButtonStyles.Location = new System.Drawing.Point(140, 196);
-            this.kbtnButtonStyles.Name = "kbtnButtonStyles";
-            this.kbtnButtonStyles.Size = new System.Drawing.Size(243, 25);
-            this.kbtnButtonStyles.TabIndex = 10;
-            this.kbtnButtonStyles.Values.DropDownArrowColor = System.Drawing.Color.Empty;
-            this.kbtnButtonStyles.Values.Text = "Button Styles";
-            this.kbtnButtonStyles.Click += new System.EventHandler(this.kbtnButtonStyles_Click);
-            // 
             // ButtonsTest
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ButtonSpecs.Add(this.buttonSpecAny1);
-            this.ClientSize = new System.Drawing.Size(522, 236);
+            this.ClientSize = new System.Drawing.Size(708, 280);
             this.Controls.Add(this.kryptonPanel1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.Fixed3D;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "ButtonsTest";

--- a/Source/Krypton Components/TestForm/ButtonsTest.resx
+++ b/Source/Krypton Components/TestForm/ButtonsTest.resx
@@ -121,15 +121,15 @@
   <data name="kryptonColorButton1.Values.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
-        DAAACwwBP0AiyAAAAAd0SU1FB9gBEgI0L+a2mIYAAAASSURBVDhPY2AYBaNgFIwCCAAABBAAAUy7RlUA
-        AAAASUVORK5CYII=
+        DAAACwwBP0AiyAAAAAd0SU1FB9gBEgI0L+a2mIYAAAATSURBVDhPYxgFo2AUjAIwYGAAAAQQAAGnRHxj
+        AAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="kcbtnDropDown.Values.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
-        DQAACw0B7QfALAAAAAd0SU1FB9gBEgI0L+a2mIYAAAASSURBVDhPY2AYBaNgFIwCCAAABBAAAUy7RlUA
-        AAAASUVORK5CYII=
+        DAAACwwBP0AiyAAAAAd0SU1FB9gBEgI0L+a2mIYAAAATSURBVDhPYxgFo2AUjAIwYGAAAAQQAAGnRHxj
+        AAAAAElFTkSuQmCC
 </value>
   </data>
   <metadata name="kryptonContextMenu1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
@@ -138,73 +138,73 @@
   <data name="kryptonButton5.Values.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAK+SURBVDhPrZJbSJNhGMefbxusudxm4VJTZ07TLEwTupDA
-        iyi8sIsor7wXojuNuhzdjDxmoYE1nacWM1JSswTL8rQ5T2ubcy41N9xwit+XR0j0+8cWCA6qm37w8D68
-        7/N7eE9Ef+F2VZVkQK86Fj7/T7Ib7TfSDIHuXOPUms96YmV/lnrXB4X54XWH5OqGI7NrJ1WZ9ZO3Mpvd
-        hox2P9Q9B8jpXsKuJwpYI+w7GWyYmPaVfuHNQIdYbW4lWUjO0+iPXWhyOTOMvs10ox9pXTtQv15DvGEd
-        We2zYJ1RgJuABQKWGRw4BPhpY7bZLwIXgscrKK6PONs0v63u2kGycRVJL/1IavMjrmUNmQYnOIcCcBF4
-        ZzCYUA4vYXtUsDOgiT4eapCqm1tXGdehavXxiS3LSGxehlIfwPnWGbBWBTBD4O3E83YGvI2AOcLWoIDr
-        KyUpFRRrIhKfubmYtg0oGwK8UhdAtG4FsnoW6kYXtqalgIOCIg8rAV8JmCXsDhDbV3pKSoWFhcLsuiHX
-        OcM80vUOpDfakdZgQ/ILF3L0I/CaEsBNyMFZ5ODGgiHDD6scnl7FnCaPRKGL/P7uZNOmKwrsuAKsRcGz
-        Y6ERntF4XHo+iMQ6B9R100iuncKZ2imk6tzIetjZdviMW2/oGsYIsBH4CeIxQeAnid8xSRD/1A5RRQCS
-        Si8kFV6Iq1eg0LoRfefj9cMGQVY7RM2wCwALA5gYwEzghmRQ1UxCXOZBZNk3SCsWoXjsQ3zJh5YjcpBp
-        jVzBdgqHYQvKDDBC4D7LkVA5DpF2CZJHC4is9iPmXv/I5SLN708UjrVCqgwYRT0wB3dC4D7JEFtmAWn9
-        kGkXEVvS9z6jsDwm3DvCk/wUsV8v1O52097ekBxxlXZI7k/vn777tjw/JUUcXv9HfDV0xdEYa774wDio
-        LHp1NXz9v/EL/YSqQjqcEQUAAAAASUVORK5CYII=
+        YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAALBSURBVDhPjZFvSFNhFMYPi8zU6pMafoi2SkuwVPw7depy
+        trzpzDWydC7CqNkMK/sDYnNgKYXhh8gELZNQkwSVtrR0VqamVFYIBrUvYpH/yjSzEPb03uuFCox64HC5
+        vO/zO885Ly0lEEk0ccE7OI4zpiVzRt+gJDWRWSIe/12NnuSRHuu/R5564OnavVdR0OTA5HAl2svDYDIk
+        9koDOB2RzkO8viidTueiVHNlCo2+PlB73CE1XIHrsT7QwUFY7AvAbB3Q7Y/vHbFovaxEkUnpyM5QNWi4
+        xDK1Wr2CXhK5++4rdq48PQRJ3iAobwiU+xyU9QTm9q/AZC2c9/2BR3KgL5J9o/CjR4Hqwlg2KUvznsht
+        fWb5FOW/ZcZnINMAKKcflPkboN0fTnsknJ0MYI8ABsLRVKr4RHTSXQBIMy5N0YnhX2YjD+iGuY0BJnjA
+        ZsHs7IhgFc6ShOF2sQjgR9ioOzdN2S9Y7F6hM2+mZDvyW2aAsUo4W7zgtPmx8gVsm4BOX1Scjf4ijNBI
+        5KLNKRyxdHxjkeeE2HxnMzN3vQOw8IpBKoDxGywNX9eBqRqUFhhGidgSeZmy9Y34cAv4XCvMzMfGeKVg
+        fugALM0zsNhmYbHOoMg6hwt3p5CedfiOYOblFxCf0lwSAvRsYfOK1erFOl/DGWYm1QNQWhdoN6u0fqze
+        eRGJ0dtSRTsvsyRdq7JOWOMZhC2KXxibmY9tsTEAb2bPSlkDWGNoh0KtvcfecJloFuWdLD2VnTAyb48B
+        HocvLowHsNhCZ2Z2NXQjdNehUWO0l0x0/alVG5LkBUdUH6fbGMTOts0ARdZZlqAP7oYuhKQcHdsfJ4sS
+        ry+t5T5JgUa96vWbmq3AfB1K7ICbph5RnOG1XuETJF77l5K9ue2hVQ3V51FYdhMB8oSq3EDyFA//X+tk
+        YcqYYJlS/F1CRD8BOQO3yqWFS54AAAAASUVORK5CYII=
 </value>
   </data>
   <data name="kryptonButton6.Values.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAK+SURBVDhPrZJbSJNhGMefbxusudxm4VJTZ07TLEwTupDA
-        iyi8sIsor7wXojuNuhzdjDxmoYE1nacWM1JSswTL8rQ5T2ubcy41N9xwit+XR0j0+8cWCA6qm37w8D68
-        7/N7eE9Ef+F2VZVkQK86Fj7/T7Ib7TfSDIHuXOPUms96YmV/lnrXB4X54XWH5OqGI7NrJ1WZ9ZO3Mpvd
-        hox2P9Q9B8jpXsKuJwpYI+w7GWyYmPaVfuHNQIdYbW4lWUjO0+iPXWhyOTOMvs10ox9pXTtQv15DvGEd
-        We2zYJ1RgJuABQKWGRw4BPhpY7bZLwIXgscrKK6PONs0v63u2kGycRVJL/1IavMjrmUNmQYnOIcCcBF4
-        ZzCYUA4vYXtUsDOgiT4eapCqm1tXGdehavXxiS3LSGxehlIfwPnWGbBWBTBD4O3E83YGvI2AOcLWoIDr
-        KyUpFRRrIhKfubmYtg0oGwK8UhdAtG4FsnoW6kYXtqalgIOCIg8rAV8JmCXsDhDbV3pKSoWFhcLsuiHX
-        OcM80vUOpDfakdZgQ/ILF3L0I/CaEsBNyMFZ5ODGgiHDD6scnl7FnCaPRKGL/P7uZNOmKwrsuAKsRcGz
-        Y6ERntF4XHo+iMQ6B9R100iuncKZ2imk6tzIetjZdviMW2/oGsYIsBH4CeIxQeAnid8xSRD/1A5RRQCS
-        Si8kFV6Iq1eg0LoRfefj9cMGQVY7RM2wCwALA5gYwEzghmRQ1UxCXOZBZNk3SCsWoXjsQ3zJh5YjcpBp
-        jVzBdgqHYQvKDDBC4D7LkVA5DpF2CZJHC4is9iPmXv/I5SLN708UjrVCqgwYRT0wB3dC4D7JEFtmAWn9
-        kGkXEVvS9z6jsDwm3DvCk/wUsV8v1O52097ekBxxlXZI7k/vn777tjw/JUUcXv9HfDV0xdEYa774wDio
-        LHp1NXz9v/EL/YSqQjqcEQUAAAAASUVORK5CYII=
+        YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAALBSURBVDhPjZFvSFNhFMYPi8zU6pMafoi2SkuwVPw7depy
+        trzpzDWydC7CqNkMK/sDYnNgKYXhh8gELZNQkwSVtrR0VqamVFYIBrUvYpH/yjSzEPb03uuFCox64HC5
+        vO/zO885Ly0lEEk0ccE7OI4zpiVzRt+gJDWRWSIe/12NnuSRHuu/R5564OnavVdR0OTA5HAl2svDYDIk
+        9koDOB2RzkO8viidTueiVHNlCo2+PlB73CE1XIHrsT7QwUFY7AvAbB3Q7Y/vHbFovaxEkUnpyM5QNWi4
+        xDK1Wr2CXhK5++4rdq48PQRJ3iAobwiU+xyU9QTm9q/AZC2c9/2BR3KgL5J9o/CjR4Hqwlg2KUvznsht
+        fWb5FOW/ZcZnINMAKKcflPkboN0fTnsknJ0MYI8ABsLRVKr4RHTSXQBIMy5N0YnhX2YjD+iGuY0BJnjA
+        ZsHs7IhgFc6ShOF2sQjgR9ioOzdN2S9Y7F6hM2+mZDvyW2aAsUo4W7zgtPmx8gVsm4BOX1Scjf4ijNBI
+        5KLNKRyxdHxjkeeE2HxnMzN3vQOw8IpBKoDxGywNX9eBqRqUFhhGidgSeZmy9Y34cAv4XCvMzMfGeKVg
+        fugALM0zsNhmYbHOoMg6hwt3p5CedfiOYOblFxCf0lwSAvRsYfOK1erFOl/DGWYm1QNQWhdoN6u0fqze
+        eRGJ0dtSRTsvsyRdq7JOWOMZhC2KXxibmY9tsTEAb2bPSlkDWGNoh0KtvcfecJloFuWdLD2VnTAyb48B
+        HocvLowHsNhCZ2Z2NXQjdNehUWO0l0x0/alVG5LkBUdUH6fbGMTOts0ARdZZlqAP7oYuhKQcHdsfJ4sS
+        ry+t5T5JgUa96vWbmq3AfB1K7ICbph5RnOG1XuETJF77l5K9ue2hVQ3V51FYdhMB8oSq3EDyFA//X+tk
+        YcqYYJlS/F1CRD8BOQO3yqWFS54AAAAASUVORK5CYII=
 </value>
   </data>
   <data name="kryptonButton7.Values.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAK+SURBVDhPrZJbSJNhGMefbxusudxm4VJTZ07TLEwTupDA
-        iyi8sIsor7wXojuNuhzdjDxmoYE1nacWM1JSswTL8rQ5T2ubcy41N9xwit+XR0j0+8cWCA6qm37w8D68
-        7/N7eE9Ef+F2VZVkQK86Fj7/T7Ib7TfSDIHuXOPUms96YmV/lnrXB4X54XWH5OqGI7NrJ1WZ9ZO3Mpvd
-        hox2P9Q9B8jpXsKuJwpYI+w7GWyYmPaVfuHNQIdYbW4lWUjO0+iPXWhyOTOMvs10ox9pXTtQv15DvGEd
-        We2zYJ1RgJuABQKWGRw4BPhpY7bZLwIXgscrKK6PONs0v63u2kGycRVJL/1IavMjrmUNmQYnOIcCcBF4
-        ZzCYUA4vYXtUsDOgiT4eapCqm1tXGdehavXxiS3LSGxehlIfwPnWGbBWBTBD4O3E83YGvI2AOcLWoIDr
-        KyUpFRRrIhKfubmYtg0oGwK8UhdAtG4FsnoW6kYXtqalgIOCIg8rAV8JmCXsDhDbV3pKSoWFhcLsuiHX
-        OcM80vUOpDfakdZgQ/ILF3L0I/CaEsBNyMFZ5ODGgiHDD6scnl7FnCaPRKGL/P7uZNOmKwrsuAKsRcGz
-        Y6ERntF4XHo+iMQ6B9R100iuncKZ2imk6tzIetjZdviMW2/oGsYIsBH4CeIxQeAnid8xSRD/1A5RRQCS
-        Si8kFV6Iq1eg0LoRfefj9cMGQVY7RM2wCwALA5gYwEzghmRQ1UxCXOZBZNk3SCsWoXjsQ3zJh5YjcpBp
-        jVzBdgqHYQvKDDBC4D7LkVA5DpF2CZJHC4is9iPmXv/I5SLN708UjrVCqgwYRT0wB3dC4D7JEFtmAWn9
-        kGkXEVvS9z6jsDwm3DvCk/wUsV8v1O52097ekBxxlXZI7k/vn777tjw/JUUcXv9HfDV0xdEYa774wDio
-        LHp1NXz9v/EL/YSqQjqcEQUAAAAASUVORK5CYII=
+        YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAALBSURBVDhPjZFvSFNhFMYPi8zU6pMafoi2SkuwVPw7depy
+        trzpzDWydC7CqNkMK/sDYnNgKYXhh8gELZNQkwSVtrR0VqamVFYIBrUvYpH/yjSzEPb03uuFCox64HC5
+        vO/zO885Ly0lEEk0ccE7OI4zpiVzRt+gJDWRWSIe/12NnuSRHuu/R5564OnavVdR0OTA5HAl2svDYDIk
+        9koDOB2RzkO8viidTueiVHNlCo2+PlB73CE1XIHrsT7QwUFY7AvAbB3Q7Y/vHbFovaxEkUnpyM5QNWi4
+        xDK1Wr2CXhK5++4rdq48PQRJ3iAobwiU+xyU9QTm9q/AZC2c9/2BR3KgL5J9o/CjR4Hqwlg2KUvznsht
+        fWb5FOW/ZcZnINMAKKcflPkboN0fTnsknJ0MYI8ABsLRVKr4RHTSXQBIMy5N0YnhX2YjD+iGuY0BJnjA
+        ZsHs7IhgFc6ShOF2sQjgR9ioOzdN2S9Y7F6hM2+mZDvyW2aAsUo4W7zgtPmx8gVsm4BOX1Scjf4ijNBI
+        5KLNKRyxdHxjkeeE2HxnMzN3vQOw8IpBKoDxGywNX9eBqRqUFhhGidgSeZmy9Y34cAv4XCvMzMfGeKVg
+        fugALM0zsNhmYbHOoMg6hwt3p5CedfiOYOblFxCf0lwSAvRsYfOK1erFOl/DGWYm1QNQWhdoN6u0fqze
+        eRGJ0dtSRTsvsyRdq7JOWOMZhC2KXxibmY9tsTEAb2bPSlkDWGNoh0KtvcfecJloFuWdLD2VnTAyb48B
+        HocvLowHsNhCZ2Z2NXQjdNehUWO0l0x0/alVG5LkBUdUH6fbGMTOts0ARdZZlqAP7oYuhKQcHdsfJ4sS
+        ry+t5T5JgUa96vWbmq3AfB1K7ICbph5RnOG1XuETJF77l5K9ue2hVQ3V51FYdhMB8oSq3EDyFA//X+tk
+        YcqYYJlS/F1CRD8BOQO3yqWFS54AAAAASUVORK5CYII=
 </value>
   </data>
   <data name="kryptonButton8.Values.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAK+SURBVDhPrZJbSJNhGMefbxusudxm4VJTZ07TLEwTupDA
-        iyi8sIsor7wXojuNuhzdjDxmoYE1nacWM1JSswTL8rQ5T2ubcy41N9xwit+XR0j0+8cWCA6qm37w8D68
-        7/N7eE9Ef+F2VZVkQK86Fj7/T7Ib7TfSDIHuXOPUms96YmV/lnrXB4X54XWH5OqGI7NrJ1WZ9ZO3Mpvd
-        hox2P9Q9B8jpXsKuJwpYI+w7GWyYmPaVfuHNQIdYbW4lWUjO0+iPXWhyOTOMvs10ox9pXTtQv15DvGEd
-        We2zYJ1RgJuABQKWGRw4BPhpY7bZLwIXgscrKK6PONs0v63u2kGycRVJL/1IavMjrmUNmQYnOIcCcBF4
-        ZzCYUA4vYXtUsDOgiT4eapCqm1tXGdehavXxiS3LSGxehlIfwPnWGbBWBTBD4O3E83YGvI2AOcLWoIDr
-        KyUpFRRrIhKfubmYtg0oGwK8UhdAtG4FsnoW6kYXtqalgIOCIg8rAV8JmCXsDhDbV3pKSoWFhcLsuiHX
-        OcM80vUOpDfakdZgQ/ILF3L0I/CaEsBNyMFZ5ODGgiHDD6scnl7FnCaPRKGL/P7uZNOmKwrsuAKsRcGz
-        Y6ERntF4XHo+iMQ6B9R100iuncKZ2imk6tzIetjZdviMW2/oGsYIsBH4CeIxQeAnid8xSRD/1A5RRQCS
-        Si8kFV6Iq1eg0LoRfefj9cMGQVY7RM2wCwALA5gYwEzghmRQ1UxCXOZBZNk3SCsWoXjsQ3zJh5YjcpBp
-        jVzBdgqHYQvKDDBC4D7LkVA5DpF2CZJHC4is9iPmXv/I5SLN708UjrVCqgwYRT0wB3dC4D7JEFtmAWn9
-        kGkXEVvS9z6jsDwm3DvCk/wUsV8v1O52097ekBxxlXZI7k/vn777tjw/JUUcXv9HfDV0xdEYa774wDio
-        LHp1NXz9v/EL/YSqQjqcEQUAAAAASUVORK5CYII=
+        YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAALBSURBVDhPjZFvSFNhFMYPi8zU6pMafoi2SkuwVPw7depy
+        trzpzDWydC7CqNkMK/sDYnNgKYXhh8gELZNQkwSVtrR0VqamVFYIBrUvYpH/yjSzEPb03uuFCox64HC5
+        vO/zO885Ly0lEEk0ccE7OI4zpiVzRt+gJDWRWSIe/12NnuSRHuu/R5564OnavVdR0OTA5HAl2svDYDIk
+        9koDOB2RzkO8viidTueiVHNlCo2+PlB73CE1XIHrsT7QwUFY7AvAbB3Q7Y/vHbFovaxEkUnpyM5QNWi4
+        xDK1Wr2CXhK5++4rdq48PQRJ3iAobwiU+xyU9QTm9q/AZC2c9/2BR3KgL5J9o/CjR4Hqwlg2KUvznsht
+        fWb5FOW/ZcZnINMAKKcflPkboN0fTnsknJ0MYI8ABsLRVKr4RHTSXQBIMy5N0YnhX2YjD+iGuY0BJnjA
+        ZsHs7IhgFc6ShOF2sQjgR9ioOzdN2S9Y7F6hM2+mZDvyW2aAsUo4W7zgtPmx8gVsm4BOX1Scjf4ijNBI
+        5KLNKRyxdHxjkeeE2HxnMzN3vQOw8IpBKoDxGywNX9eBqRqUFhhGidgSeZmy9Y34cAv4XCvMzMfGeKVg
+        fugALM0zsNhmYbHOoMg6hwt3p5CedfiOYOblFxCf0lwSAvRsYfOK1erFOl/DGWYm1QNQWhdoN6u0fqze
+        eRGJ0dtSRTsvsyRdq7JOWOMZhC2KXxibmY9tsTEAb2bPSlkDWGNoh0KtvcfecJloFuWdLD2VnTAyb48B
+        HocvLowHsNhCZ2Z2NXQjdNehUWO0l0x0/alVG5LkBUdUH6fbGMTOts0ARdZZlqAP7oYuhKQcHdsfJ4sS
+        ry+t5T5JgUa96vWbmq3AfB1K7ICbph5RnOG1XuETJF77l5K9ue2hVQ3V51FYdhMB8oSq3EDyFA//X+tk
+        YcqYYJlS/F1CRD8BOQO3yqWFS54AAAAASUVORK5CYII=
 </value>
   </data>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">

--- a/Source/Krypton Components/TestForm/Main.Designer.cs
+++ b/Source/Krypton Components/TestForm/Main.Designer.cs
@@ -39,9 +39,10 @@ namespace TestForm
         {
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Main));
-            Krypton.Toolkit.KryptonInputBoxData kryptonInputBoxData4 = new Krypton.Toolkit.KryptonInputBoxData();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle4 = new System.Windows.Forms.DataGridViewCellStyle();
             this.kryptonPanel1 = new Krypton.Toolkit.KryptonPanel();
+            this.kryptonButton15 = new Krypton.Toolkit.KryptonButton();
+            this.kryptonRichTextBox1 = new Krypton.Toolkit.KryptonRichTextBox();
+            this.kryptonBorderEdge1 = new Krypton.Toolkit.KryptonBorderEdge();
             this.kryptonTableLayoutPanel1 = new Krypton.Toolkit.KryptonTableLayoutPanel();
             this.kryptonMaskedTextBox1 = new Krypton.Toolkit.KryptonMaskedTextBox();
             this.kryptonLinkWrapLabel1 = new Krypton.Toolkit.KryptonLinkWrapLabel();
@@ -52,8 +53,10 @@ namespace TestForm
             this.kryptonPage1 = new Krypton.Navigator.KryptonPage();
             this.kryptonPage2 = new Krypton.Navigator.KryptonPage();
             this.kryptonStatusStrip1 = new Krypton.Toolkit.KryptonStatusStrip();
+            this.toolStripStatusLabel1 = new System.Windows.Forms.ToolStripStatusLabel();
             this.kryptonProgressBar3 = new Krypton.Toolkit.KryptonProgressBar();
             this.dataGridView1 = new System.Windows.Forms.DataGridView();
+            this.Column1 = new Krypton.Toolkit.KryptonDataGridViewFormattingColumn();
             this.kryptonGallery1 = new Krypton.Ribbon.KryptonGallery();
             this.progressBar1 = new System.Windows.Forms.ProgressBar();
             this.kryptonProgressBar2 = new Krypton.Toolkit.KryptonProgressBar();
@@ -117,9 +120,6 @@ namespace TestForm
             this.kcmdOpenImage = new Krypton.Toolkit.KryptonCommand();
             this.kryptonDockingManager1 = new Krypton.Docking.KryptonDockingManager();
             this.kryptonFontDialog1 = new Krypton.Toolkit.KryptonFontDialog();
-            this.Column1 = new Krypton.Toolkit.KryptonDataGridViewFormattingColumn();
-            this.kryptonBorderEdge1 = new Krypton.Toolkit.KryptonBorderEdge();
-            this.kryptonRichTextBox1 = new Krypton.Toolkit.KryptonRichTextBox();
             this.kryptonColorDialog1 = new Krypton.Toolkit.KryptonColorDialog();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).BeginInit();
             this.kryptonPanel1.SuspendLayout();
@@ -133,6 +133,7 @@ namespace TestForm
             this.kryptonNavigator1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPage1)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPage2)).BeginInit();
+            this.kryptonStatusStrip1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonThemeComboBox1)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonComboBox1)).BeginInit();
@@ -141,6 +142,7 @@ namespace TestForm
             // 
             // kryptonPanel1
             // 
+            this.kryptonPanel1.Controls.Add(this.kryptonButton15);
             this.kryptonPanel1.Controls.Add(this.kryptonRichTextBox1);
             this.kryptonPanel1.Controls.Add(this.kryptonBorderEdge1);
             this.kryptonPanel1.Controls.Add(this.kryptonTableLayoutPanel1);
@@ -194,74 +196,102 @@ namespace TestForm
             this.kryptonPanel1.Controls.Add(this.textBox1);
             this.kryptonPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonPanel1.Location = new System.Drawing.Point(0, 0);
-            this.kryptonPanel1.Margin = new System.Windows.Forms.Padding(2);
+            this.kryptonPanel1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kryptonPanel1.Name = "kryptonPanel1";
-            this.kryptonPanel1.Size = new System.Drawing.Size(1214, 853);
+            this.kryptonPanel1.Size = new System.Drawing.Size(1629, 1015);
             this.kryptonPanel1.TabIndex = 0;
+            // 
+            // kryptonButton15
+            // 
+            this.kryptonButton15.Location = new System.Drawing.Point(223, 574);
+            this.kryptonButton15.Margin = new System.Windows.Forms.Padding(4);
+            this.kryptonButton15.Name = "kryptonButton15";
+            this.kryptonButton15.Size = new System.Drawing.Size(179, 31);
+            this.kryptonButton15.TabIndex = 68;
+            this.kryptonButton15.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kryptonButton15.Values.Text = "kryptonButton15";
+            this.kryptonButton15.Click += new System.EventHandler(this.kryptonButton15_Click);
+            // 
+            // kryptonRichTextBox1
+            // 
+            this.kryptonRichTextBox1.Location = new System.Drawing.Point(1086, 310);
+            this.kryptonRichTextBox1.Margin = new System.Windows.Forms.Padding(4);
+            this.kryptonRichTextBox1.Name = "kryptonRichTextBox1";
+            this.kryptonRichTextBox1.Size = new System.Drawing.Size(133, 118);
+            this.kryptonRichTextBox1.TabIndex = 64;
+            this.kryptonRichTextBox1.Text = "kryptonRichTextBox1";
+            // 
+            // kryptonBorderEdge1
+            // 
+            this.kryptonBorderEdge1.Location = new System.Drawing.Point(965, 331);
+            this.kryptonBorderEdge1.Margin = new System.Windows.Forms.Padding(4);
+            this.kryptonBorderEdge1.Name = "kryptonBorderEdge1";
+            this.kryptonBorderEdge1.Size = new System.Drawing.Size(67, 1);
+            this.kryptonBorderEdge1.Text = "kryptonBorderEdge1";
             // 
             // kryptonTableLayoutPanel1
             // 
-            this.kryptonTableLayoutPanel1.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("kryptonTableLayoutPanel1.BackgroundImage")));
-            this.kryptonTableLayoutPanel1.BackgroundImageLayout = System.Windows.Forms.ImageLayout.None;
             this.kryptonTableLayoutPanel1.ColumnCount = 2;
             this.kryptonTableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
             this.kryptonTableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.kryptonTableLayoutPanel1.Location = new System.Drawing.Point(568, 107);
+            this.kryptonTableLayoutPanel1.Location = new System.Drawing.Point(757, 132);
+            this.kryptonTableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonTableLayoutPanel1.Name = "kryptonTableLayoutPanel1";
             this.kryptonTableLayoutPanel1.RowCount = 2;
             this.kryptonTableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
             this.kryptonTableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.kryptonTableLayoutPanel1.Size = new System.Drawing.Size(126, 149);
+            this.kryptonTableLayoutPanel1.Size = new System.Drawing.Size(168, 183);
             this.kryptonTableLayoutPanel1.TabIndex = 61;
             // 
             // kryptonMaskedTextBox1
             // 
-            this.kryptonMaskedTextBox1.Location = new System.Drawing.Point(745, 509);
+            this.kryptonMaskedTextBox1.Location = new System.Drawing.Point(993, 626);
+            this.kryptonMaskedTextBox1.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonMaskedTextBox1.Name = "kryptonMaskedTextBox1";
-            this.kryptonMaskedTextBox1.Size = new System.Drawing.Size(100, 23);
+            this.kryptonMaskedTextBox1.Size = new System.Drawing.Size(133, 27);
             this.kryptonMaskedTextBox1.TabIndex = 60;
             this.kryptonMaskedTextBox1.Text = "kryptonMaskedTextBox1";
             // 
             // kryptonLinkWrapLabel1
             // 
-            this.kryptonLinkWrapLabel1.Font = new System.Drawing.Font("Segoe UI", 9F);
-            this.kryptonLinkWrapLabel1.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(30)))), ((int)(((byte)(57)))), ((int)(((byte)(91)))));
             this.kryptonLinkWrapLabel1.LabelStyle = Krypton.Toolkit.LabelStyle.AlternateControl;
-            this.kryptonLinkWrapLabel1.Location = new System.Drawing.Point(956, 532);
+            this.kryptonLinkWrapLabel1.Location = new System.Drawing.Point(1275, 655);
+            this.kryptonLinkWrapLabel1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.kryptonLinkWrapLabel1.Name = "kryptonLinkWrapLabel1";
-            this.kryptonLinkWrapLabel1.Size = new System.Drawing.Size(132, 15);
+            this.kryptonLinkWrapLabel1.Size = new System.Drawing.Size(149, 16);
             this.kryptonLinkWrapLabel1.Text = "kryptonLinkWrapLabel1";
             // 
             // kryptonScrollBar1
             // 
             this.kryptonScrollBar1.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(93)))), ((int)(((byte)(140)))), ((int)(((byte)(201)))));
             this.kryptonScrollBar1.DisabledBorderColor = System.Drawing.Color.Gray;
-            this.kryptonScrollBar1.Location = new System.Drawing.Point(1192, 144);
+            this.kryptonScrollBar1.Location = new System.Drawing.Point(1589, 177);
+            this.kryptonScrollBar1.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonScrollBar1.Name = "kryptonScrollBar1";
             this.kryptonScrollBar1.Opacity = 1D;
-            this.kryptonScrollBar1.ScrollBarWidth = 19;
-            this.kryptonScrollBar1.Size = new System.Drawing.Size(19, 200);
+            this.kryptonScrollBar1.ScrollBarWidth = 25;
+            this.kryptonScrollBar1.Size = new System.Drawing.Size(25, 246);
             this.kryptonScrollBar1.TabIndex = 58;
             // 
             // kryptonHeaderGroup1
             // 
-            this.kryptonHeaderGroup1.Location = new System.Drawing.Point(932, 449);
-            this.kryptonHeaderGroup1.Name = "kryptonHeaderGroup1";
-            this.kryptonHeaderGroup1.Size = new System.Drawing.Size(8, 8);
+            this.kryptonHeaderGroup1.Location = new System.Drawing.Point(1243, 553);
+            this.kryptonHeaderGroup1.Margin = new System.Windows.Forms.Padding(4);
+            this.kryptonHeaderGroup1.Size = new System.Drawing.Size(11, 10);
             this.kryptonHeaderGroup1.TabIndex = 57;
             // 
             // kryptonGroupBox1
             // 
-            this.kryptonGroupBox1.Location = new System.Drawing.Point(934, 285);
-            this.kryptonGroupBox1.Name = "kryptonGroupBox1";
-            this.kryptonGroupBox1.Size = new System.Drawing.Size(150, 150);
+            this.kryptonGroupBox1.Location = new System.Drawing.Point(1245, 351);
+            this.kryptonGroupBox1.Margin = new System.Windows.Forms.Padding(4);
+            this.kryptonGroupBox1.Size = new System.Drawing.Size(200, 185);
             this.kryptonGroupBox1.TabIndex = 56;
             // 
             // kryptonNavigator1
             // 
             this.kryptonNavigator1.ControlKryptonFormFeatures = false;
-            this.kryptonNavigator1.Location = new System.Drawing.Point(377, 423);
-            this.kryptonNavigator1.Name = "kryptonNavigator1";
+            this.kryptonNavigator1.Location = new System.Drawing.Point(503, 521);
+            this.kryptonNavigator1.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonNavigator1.NavigatorMode = Krypton.Navigator.NavigatorMode.BarTabGroup;
             this.kryptonNavigator1.Owner = null;
             this.kryptonNavigator1.PageBackStyle = Krypton.Toolkit.PaletteBackStyle.ControlClient;
@@ -278,9 +308,10 @@ namespace TestForm
             this.kryptonPage1.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
             this.kryptonPage1.Flags = 65534;
             this.kryptonPage1.LastVisibleSet = true;
-            this.kryptonPage1.MinimumSize = new System.Drawing.Size(150, 50);
+            this.kryptonPage1.Margin = new System.Windows.Forms.Padding(4);
+            this.kryptonPage1.MinimumSize = new System.Drawing.Size(200, 62);
             this.kryptonPage1.Name = "kryptonPage1";
-            this.kryptonPage1.Size = new System.Drawing.Size(248, 123);
+            this.kryptonPage1.Size = new System.Drawing.Size(248, 119);
             this.kryptonPage1.Text = "kryptonPage1";
             this.kryptonPage1.ToolTipTitle = "Page ToolTip";
             this.kryptonPage1.UniqueName = "ce0d4212352d492f87326b865cf7ee58";
@@ -290,28 +321,42 @@ namespace TestForm
             this.kryptonPage2.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
             this.kryptonPage2.Flags = 65534;
             this.kryptonPage2.LastVisibleSet = true;
-            this.kryptonPage2.MinimumSize = new System.Drawing.Size(150, 50);
+            this.kryptonPage2.Margin = new System.Windows.Forms.Padding(4);
+            this.kryptonPage2.MinimumSize = new System.Drawing.Size(200, 62);
             this.kryptonPage2.Name = "kryptonPage2";
-            this.kryptonPage2.Size = new System.Drawing.Size(150, 100);
+            this.kryptonPage2.Size = new System.Drawing.Size(200, 123);
             this.kryptonPage2.Text = "kryptonPage2";
             this.kryptonPage2.ToolTipTitle = "Page ToolTip";
             this.kryptonPage2.UniqueName = "ebeb9992794443abb28ab1a48133b9f8";
             // 
             // kryptonStatusStrip1
             // 
-            this.kryptonStatusStrip1.Location = new System.Drawing.Point(0, 831);
+            this.kryptonStatusStrip1.Font = new System.Drawing.Font("Segoe UI", 9F);
+            this.kryptonStatusStrip1.GripStyle = System.Windows.Forms.ToolStripGripStyle.Visible;
+            this.kryptonStatusStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
+            this.kryptonStatusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripStatusLabel1});
+            this.kryptonStatusStrip1.Location = new System.Drawing.Point(0, 989);
             this.kryptonStatusStrip1.Name = "kryptonStatusStrip1";
+            this.kryptonStatusStrip1.Padding = new System.Windows.Forms.Padding(1, 0, 19, 0);
             this.kryptonStatusStrip1.ProgressBars = null;
             this.kryptonStatusStrip1.RenderMode = System.Windows.Forms.ToolStripRenderMode.ManagerRenderMode;
-            this.kryptonStatusStrip1.Size = new System.Drawing.Size(1214, 22);
+            this.kryptonStatusStrip1.Size = new System.Drawing.Size(1629, 26);
             this.kryptonStatusStrip1.TabIndex = 54;
             this.kryptonStatusStrip1.Text = "kryptonStatusStrip1";
             // 
+            // toolStripStatusLabel1
+            // 
+            this.toolStripStatusLabel1.Name = "toolStripStatusLabel1";
+            this.toolStripStatusLabel1.Size = new System.Drawing.Size(151, 20);
+            this.toolStripStatusLabel1.Text = "toolStripStatusLabel1";
+            // 
             // kryptonProgressBar3
             // 
-            this.kryptonProgressBar3.Location = new System.Drawing.Point(469, 378);
+            this.kryptonProgressBar3.Location = new System.Drawing.Point(1208, 234);
+            this.kryptonProgressBar3.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonProgressBar3.Name = "kryptonProgressBar3";
-            this.kryptonProgressBar3.Size = new System.Drawing.Size(100, 26);
+            this.kryptonProgressBar3.Size = new System.Drawing.Size(133, 32);
             this.kryptonProgressBar3.StateCommon.Back.Color1 = System.Drawing.Color.Green;
             this.kryptonProgressBar3.StateDisabled.Back.ColorStyle = Krypton.Toolkit.PaletteColorStyle.OneNote;
             this.kryptonProgressBar3.StateNormal.Back.ColorStyle = Krypton.Toolkit.PaletteColorStyle.OneNote;
@@ -324,31 +369,46 @@ namespace TestForm
             this.dataGridView1.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.dataGridView1.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.Column1});
-            this.dataGridView1.Location = new System.Drawing.Point(882, 71);
+            this.dataGridView1.Location = new System.Drawing.Point(945, 20);
+            this.dataGridView1.Margin = new System.Windows.Forms.Padding(4);
             this.dataGridView1.Name = "dataGridView1";
-            this.dataGridView1.Size = new System.Drawing.Size(240, 150);
+            this.dataGridView1.RowHeadersWidth = 51;
+            this.dataGridView1.Size = new System.Drawing.Size(320, 185);
             this.dataGridView1.TabIndex = 52;
+            // 
+            // Column1
+            // 
+            this.Column1.ContrastTextColor = false;
+            this.Column1.DefaultCellStyle.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            this.Column1.HeaderText = "Column1";
+            this.Column1.MinimumWidth = 6;
+            this.Column1.Name = "Column1";
+            this.Column1.Width = 100;
             // 
             // kryptonGallery1
             // 
-            this.kryptonGallery1.ImageList = null;
-            this.kryptonGallery1.Location = new System.Drawing.Point(686, 378);
+            this.kryptonGallery1.ButtonStyle = Krypton.Toolkit.ButtonStyle.LowProfile;
+            this.kryptonGallery1.Location = new System.Drawing.Point(915, 465);
+            this.kryptonGallery1.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonGallery1.Name = "kryptonGallery1";
-            this.kryptonGallery1.Size = new System.Drawing.Size(240, 96);
+            this.kryptonGallery1.Padding = new System.Windows.Forms.Padding(4);
+            this.kryptonGallery1.Size = new System.Drawing.Size(320, 118);
             this.kryptonGallery1.TabIndex = 51;
             // 
             // progressBar1
             // 
-            this.progressBar1.Location = new System.Drawing.Point(778, 223);
+            this.progressBar1.Location = new System.Drawing.Point(1037, 274);
+            this.progressBar1.Margin = new System.Windows.Forms.Padding(4);
             this.progressBar1.Name = "progressBar1";
-            this.progressBar1.Size = new System.Drawing.Size(100, 23);
+            this.progressBar1.Size = new System.Drawing.Size(133, 28);
             this.progressBar1.TabIndex = 50;
             // 
             // kryptonProgressBar2
             // 
-            this.kryptonProgressBar2.Location = new System.Drawing.Point(814, 151);
+            this.kryptonProgressBar2.Location = new System.Drawing.Point(1037, 234);
+            this.kryptonProgressBar2.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonProgressBar2.Name = "kryptonProgressBar2";
-            this.kryptonProgressBar2.Size = new System.Drawing.Size(100, 26);
+            this.kryptonProgressBar2.Size = new System.Drawing.Size(133, 32);
             this.kryptonProgressBar2.StateCommon.Back.Color1 = System.Drawing.Color.Green;
             this.kryptonProgressBar2.StateDisabled.Back.ColorStyle = Krypton.Toolkit.PaletteColorStyle.OneNote;
             this.kryptonProgressBar2.StateNormal.Back.ColorStyle = Krypton.Toolkit.PaletteColorStyle.OneNote;
@@ -358,9 +418,10 @@ namespace TestForm
             // 
             // kryptonButton14
             // 
-            this.kryptonButton14.Location = new System.Drawing.Point(13, 466);
+            this.kryptonButton14.Location = new System.Drawing.Point(17, 574);
+            this.kryptonButton14.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonButton14.Name = "kryptonButton14";
-            this.kryptonButton14.Size = new System.Drawing.Size(134, 25);
+            this.kryptonButton14.Size = new System.Drawing.Size(179, 31);
             this.kryptonButton14.TabIndex = 47;
             this.kryptonButton14.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton14.Values.Text = "kryptonButton14";
@@ -368,9 +429,10 @@ namespace TestForm
             // 
             // kryptonButton13
             // 
-            this.kryptonButton13.Location = new System.Drawing.Point(13, 434);
+            this.kryptonButton13.Location = new System.Drawing.Point(17, 534);
+            this.kryptonButton13.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonButton13.Name = "kryptonButton13";
-            this.kryptonButton13.Size = new System.Drawing.Size(134, 25);
+            this.kryptonButton13.Size = new System.Drawing.Size(179, 31);
             this.kryptonButton13.TabIndex = 46;
             this.kryptonButton13.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton13.Values.Text = "kryptonButton13";
@@ -378,10 +440,10 @@ namespace TestForm
             // 
             // kbtnDialogs
             // 
-            this.kbtnDialogs.Location = new System.Drawing.Point(13, 408);
-            this.kbtnDialogs.Margin = new System.Windows.Forms.Padding(2);
+            this.kbtnDialogs.Location = new System.Drawing.Point(17, 502);
+            this.kbtnDialogs.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kbtnDialogs.Name = "kbtnDialogs";
-            this.kbtnDialogs.Size = new System.Drawing.Size(136, 20);
+            this.kbtnDialogs.Size = new System.Drawing.Size(181, 25);
             this.kbtnDialogs.TabIndex = 45;
             this.kbtnDialogs.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnDialogs.Values.Text = "Dialogs";
@@ -392,9 +454,10 @@ namespace TestForm
             this.kryptonThemeComboBox1.DefaultPalette = Krypton.Toolkit.PaletteMode.Microsoft365Blue;
             this.kryptonThemeComboBox1.DropDownWidth = 581;
             this.kryptonThemeComboBox1.IntegralHeight = false;
-            this.kryptonThemeComboBox1.Location = new System.Drawing.Point(-479, 16);
+            this.kryptonThemeComboBox1.Location = new System.Drawing.Point(0, 17);
+            this.kryptonThemeComboBox1.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonThemeComboBox1.Name = "kryptonThemeComboBox1";
-            this.kryptonThemeComboBox1.Size = new System.Drawing.Size(581, 22);
+            this.kryptonThemeComboBox1.Size = new System.Drawing.Size(355, 26);
             this.kryptonThemeComboBox1.TabIndex = 1;
             this.kryptonThemeComboBox1.SelectedIndexChanged += new System.EventHandler(this.kryptonThemeComboBox1_SelectedIndexChanged);
             // 
@@ -402,18 +465,19 @@ namespace TestForm
             // 
             this.kryptonComboBox1.DropDownWidth = 161;
             this.kryptonComboBox1.IntegralHeight = false;
-            this.kryptonComboBox1.Location = new System.Drawing.Point(265, 49);
+            this.kryptonComboBox1.Location = new System.Drawing.Point(353, 60);
+            this.kryptonComboBox1.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonComboBox1.Name = "kryptonComboBox1";
-            this.kryptonComboBox1.Size = new System.Drawing.Size(121, 22);
+            this.kryptonComboBox1.Size = new System.Drawing.Size(161, 26);
             this.kryptonComboBox1.TabIndex = 44;
             this.kryptonComboBox1.Text = "kryptonComboBox1";
             // 
             // kryptonButton12
             // 
-            this.kryptonButton12.Location = new System.Drawing.Point(11, 384);
-            this.kryptonButton12.Margin = new System.Windows.Forms.Padding(2);
+            this.kryptonButton12.Location = new System.Drawing.Point(15, 473);
+            this.kryptonButton12.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kryptonButton12.Name = "kryptonButton12";
-            this.kryptonButton12.Size = new System.Drawing.Size(136, 20);
+            this.kryptonButton12.Size = new System.Drawing.Size(181, 25);
             this.kryptonButton12.TabIndex = 39;
             this.kryptonButton12.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton12.Values.Text = "Fading Test";
@@ -423,19 +487,19 @@ namespace TestForm
             // 
             this.kryptonCheckBox1.Checked = true;
             this.kryptonCheckBox1.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.kryptonCheckBox1.Location = new System.Drawing.Point(342, 184);
-            this.kryptonCheckBox1.Margin = new System.Windows.Forms.Padding(2);
+            this.kryptonCheckBox1.Location = new System.Drawing.Point(456, 226);
+            this.kryptonCheckBox1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kryptonCheckBox1.Name = "kryptonCheckBox1";
-            this.kryptonCheckBox1.Size = new System.Drawing.Size(126, 20);
+            this.kryptonCheckBox1.Size = new System.Drawing.Size(153, 24);
             this.kryptonCheckBox1.TabIndex = 38;
             this.kryptonCheckBox1.Values.Text = "Show Close Button";
             // 
             // kryptonButton11
             // 
-            this.kryptonButton11.Location = new System.Drawing.Point(153, 184);
-            this.kryptonButton11.Margin = new System.Windows.Forms.Padding(2);
+            this.kryptonButton11.Location = new System.Drawing.Point(204, 226);
+            this.kryptonButton11.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kryptonButton11.Name = "kryptonButton11";
-            this.kryptonButton11.Size = new System.Drawing.Size(184, 20);
+            this.kryptonButton11.Size = new System.Drawing.Size(245, 25);
             this.kryptonButton11.TabIndex = 37;
             this.kryptonButton11.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton11.Values.Text = "Test Messagebox (no text)";
@@ -443,10 +507,10 @@ namespace TestForm
             // 
             // kryptonButton10
             // 
-            this.kryptonButton10.Location = new System.Drawing.Point(11, 362);
-            this.kryptonButton10.Margin = new System.Windows.Forms.Padding(2);
+            this.kryptonButton10.Location = new System.Drawing.Point(15, 446);
+            this.kryptonButton10.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kryptonButton10.Name = "kryptonButton10";
-            this.kryptonButton10.Size = new System.Drawing.Size(136, 20);
+            this.kryptonButton10.Size = new System.Drawing.Size(181, 25);
             this.kryptonButton10.TabIndex = 36;
             this.kryptonButton10.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton10.Values.Text = "Toast";
@@ -454,10 +518,10 @@ namespace TestForm
             // 
             // kryptonColorButton1
             // 
-            this.kryptonColorButton1.Location = new System.Drawing.Point(153, 107);
-            this.kryptonColorButton1.Margin = new System.Windows.Forms.Padding(2);
+            this.kryptonColorButton1.Location = new System.Drawing.Point(204, 132);
+            this.kryptonColorButton1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kryptonColorButton1.Name = "kryptonColorButton1";
-            this.kryptonColorButton1.Size = new System.Drawing.Size(246, 25);
+            this.kryptonColorButton1.Size = new System.Drawing.Size(328, 31);
             this.kryptonColorButton1.TabIndex = 35;
             this.kryptonColorButton1.Values.Image = ((System.Drawing.Image)(resources.GetObject("kryptonColorButton1.Values.Image")));
             this.kryptonColorButton1.Values.Text = "Drop Down Arrow Color";
@@ -465,10 +529,10 @@ namespace TestForm
             // 
             // kryptonButton9
             // 
-            this.kryptonButton9.Location = new System.Drawing.Point(11, 337);
-            this.kryptonButton9.Margin = new System.Windows.Forms.Padding(2);
+            this.kryptonButton9.Location = new System.Drawing.Point(15, 415);
+            this.kryptonButton9.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kryptonButton9.Name = "kryptonButton9";
-            this.kryptonButton9.Size = new System.Drawing.Size(137, 20);
+            this.kryptonButton9.Size = new System.Drawing.Size(183, 25);
             this.kryptonButton9.TabIndex = 34;
             this.kryptonButton9.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton9.Values.Text = "Command Links";
@@ -476,10 +540,10 @@ namespace TestForm
             // 
             // kryptonButton5
             // 
-            this.kryptonButton5.Location = new System.Drawing.Point(11, 312);
-            this.kryptonButton5.Margin = new System.Windows.Forms.Padding(2);
+            this.kryptonButton5.Location = new System.Drawing.Point(15, 384);
+            this.kryptonButton5.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kryptonButton5.Name = "kryptonButton5";
-            this.kryptonButton5.Size = new System.Drawing.Size(137, 20);
+            this.kryptonButton5.Size = new System.Drawing.Size(183, 25);
             this.kryptonButton5.TabIndex = 33;
             this.kryptonButton5.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton5.Values.Text = "Task Dialog";
@@ -487,10 +551,10 @@ namespace TestForm
             // 
             // kryptonButton8
             // 
-            this.kryptonButton8.Location = new System.Drawing.Point(11, 287);
-            this.kryptonButton8.Margin = new System.Windows.Forms.Padding(2);
+            this.kryptonButton8.Location = new System.Drawing.Point(15, 353);
+            this.kryptonButton8.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kryptonButton8.Name = "kryptonButton8";
-            this.kryptonButton8.Size = new System.Drawing.Size(137, 20);
+            this.kryptonButton8.Size = new System.Drawing.Size(183, 25);
             this.kryptonButton8.TabIndex = 32;
             this.kryptonButton8.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton8.Values.Text = "About Box";
@@ -500,10 +564,10 @@ namespace TestForm
             // 
             this.kcbtnSizableToolWindow.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.kcbtnSizableToolWindow.AutoSize = true;
-            this.kcbtnSizableToolWindow.Location = new System.Drawing.Point(10, 660);
-            this.kcbtnSizableToolWindow.Margin = new System.Windows.Forms.Padding(2);
+            this.kcbtnSizableToolWindow.Location = new System.Drawing.Point(13, 775);
+            this.kcbtnSizableToolWindow.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kcbtnSizableToolWindow.Name = "kcbtnSizableToolWindow";
-            this.kcbtnSizableToolWindow.Size = new System.Drawing.Size(150, 24);
+            this.kcbtnSizableToolWindow.Size = new System.Drawing.Size(200, 32);
             this.kcbtnSizableToolWindow.TabIndex = 31;
             this.kcbtnSizableToolWindow.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kcbtnSizableToolWindow.Values.Text = "SizableToolWindow";
@@ -513,10 +577,10 @@ namespace TestForm
             // 
             this.kcbtnFixedToolWindow.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.kcbtnFixedToolWindow.AutoSize = true;
-            this.kcbtnFixedToolWindow.Location = new System.Drawing.Point(231, 634);
-            this.kcbtnFixedToolWindow.Margin = new System.Windows.Forms.Padding(2);
+            this.kcbtnFixedToolWindow.Location = new System.Drawing.Point(308, 743);
+            this.kcbtnFixedToolWindow.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kcbtnFixedToolWindow.Name = "kcbtnFixedToolWindow";
-            this.kcbtnFixedToolWindow.Size = new System.Drawing.Size(134, 24);
+            this.kcbtnFixedToolWindow.Size = new System.Drawing.Size(179, 32);
             this.kcbtnFixedToolWindow.TabIndex = 30;
             this.kcbtnFixedToolWindow.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kcbtnFixedToolWindow.Values.Text = "FixedToolWindow";
@@ -525,10 +589,10 @@ namespace TestForm
             // kcbtnSizable
             // 
             this.kcbtnSizable.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.kcbtnSizable.Location = new System.Drawing.Point(121, 638);
-            this.kcbtnSizable.Margin = new System.Windows.Forms.Padding(2);
+            this.kcbtnSizable.Location = new System.Drawing.Point(161, 750);
+            this.kcbtnSizable.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kcbtnSizable.Name = "kcbtnSizable";
-            this.kcbtnSizable.Size = new System.Drawing.Size(106, 20);
+            this.kcbtnSizable.Size = new System.Drawing.Size(141, 25);
             this.kcbtnSizable.TabIndex = 29;
             this.kcbtnSizable.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kcbtnSizable.Values.Text = "Sizable";
@@ -537,10 +601,10 @@ namespace TestForm
             // kcbtnFixedDialog
             // 
             this.kcbtnFixedDialog.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.kcbtnFixedDialog.Location = new System.Drawing.Point(10, 638);
-            this.kcbtnFixedDialog.Margin = new System.Windows.Forms.Padding(2);
+            this.kcbtnFixedDialog.Location = new System.Drawing.Point(13, 750);
+            this.kcbtnFixedDialog.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kcbtnFixedDialog.Name = "kcbtnFixedDialog";
-            this.kcbtnFixedDialog.Size = new System.Drawing.Size(106, 20);
+            this.kcbtnFixedDialog.Size = new System.Drawing.Size(141, 25);
             this.kcbtnFixedDialog.TabIndex = 28;
             this.kcbtnFixedDialog.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kcbtnFixedDialog.Values.Text = "FixedDialog";
@@ -549,10 +613,10 @@ namespace TestForm
             // kcbtnFixed3D
             // 
             this.kcbtnFixed3D.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.kcbtnFixed3D.Location = new System.Drawing.Point(231, 611);
-            this.kcbtnFixed3D.Margin = new System.Windows.Forms.Padding(2);
+            this.kcbtnFixed3D.Location = new System.Drawing.Point(308, 717);
+            this.kcbtnFixed3D.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kcbtnFixed3D.Name = "kcbtnFixed3D";
-            this.kcbtnFixed3D.Size = new System.Drawing.Size(106, 20);
+            this.kcbtnFixed3D.Size = new System.Drawing.Size(141, 25);
             this.kcbtnFixed3D.TabIndex = 27;
             this.kcbtnFixed3D.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kcbtnFixed3D.Values.Text = "Fixed3D";
@@ -561,10 +625,10 @@ namespace TestForm
             // kcbtnFixedSingle
             // 
             this.kcbtnFixedSingle.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.kcbtnFixedSingle.Location = new System.Drawing.Point(121, 611);
-            this.kcbtnFixedSingle.Margin = new System.Windows.Forms.Padding(2);
+            this.kcbtnFixedSingle.Location = new System.Drawing.Point(161, 717);
+            this.kcbtnFixedSingle.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kcbtnFixedSingle.Name = "kcbtnFixedSingle";
-            this.kcbtnFixedSingle.Size = new System.Drawing.Size(106, 20);
+            this.kcbtnFixedSingle.Size = new System.Drawing.Size(141, 25);
             this.kcbtnFixedSingle.TabIndex = 26;
             this.kcbtnFixedSingle.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kcbtnFixedSingle.Values.Text = "FixedSingle";
@@ -573,10 +637,10 @@ namespace TestForm
             // kcbtnNone
             // 
             this.kcbtnNone.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.kcbtnNone.Location = new System.Drawing.Point(10, 611);
-            this.kcbtnNone.Margin = new System.Windows.Forms.Padding(2);
+            this.kcbtnNone.Location = new System.Drawing.Point(13, 717);
+            this.kcbtnNone.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kcbtnNone.Name = "kcbtnNone";
-            this.kcbtnNone.Size = new System.Drawing.Size(106, 20);
+            this.kcbtnNone.Size = new System.Drawing.Size(141, 25);
             this.kcbtnNone.TabIndex = 25;
             this.kcbtnNone.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kcbtnNone.Values.Text = "None";
@@ -584,22 +648,20 @@ namespace TestForm
             // 
             // kryptonButton7
             // 
-            this.kryptonButton7.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.kryptonButton7.Location = new System.Drawing.Point(193, 404);
-            this.kryptonButton7.Margin = new System.Windows.Forms.Padding(2);
+            this.kryptonButton7.Location = new System.Drawing.Point(404, 497);
+            this.kryptonButton7.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kryptonButton7.Name = "kryptonButton7";
-            this.kryptonButton7.Size = new System.Drawing.Size(68, 20);
+            this.kryptonButton7.Size = new System.Drawing.Size(91, 25);
             this.kryptonButton7.TabIndex = 17;
             this.kryptonButton7.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton7.Values.Text = "Export";
             // 
             // kryptonButton6
             // 
-            this.kryptonButton6.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.kryptonButton6.Location = new System.Drawing.Point(121, 404);
-            this.kryptonButton6.Margin = new System.Windows.Forms.Padding(2);
+            this.kryptonButton6.Location = new System.Drawing.Point(308, 497);
+            this.kryptonButton6.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kryptonButton6.Name = "kryptonButton6";
-            this.kryptonButton6.Size = new System.Drawing.Size(68, 20);
+            this.kryptonButton6.Size = new System.Drawing.Size(91, 25);
             this.kryptonButton6.TabIndex = 16;
             this.kryptonButton6.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton6.Values.Text = "Import";
@@ -607,10 +669,10 @@ namespace TestForm
             // kbtnExit
             // 
             this.kbtnExit.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.kbtnExit.Location = new System.Drawing.Point(835, 664);
-            this.kbtnExit.Margin = new System.Windows.Forms.Padding(2);
+            this.kbtnExit.Location = new System.Drawing.Point(1123, 782);
+            this.kbtnExit.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kbtnExit.Name = "kbtnExit";
-            this.kbtnExit.Size = new System.Drawing.Size(68, 20);
+            this.kbtnExit.Size = new System.Drawing.Size(91, 25);
             this.kbtnExit.TabIndex = 15;
             this.kbtnExit.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnExit.Values.Text = "Exit";
@@ -618,10 +680,10 @@ namespace TestForm
             // 
             // kryptonButton4
             // 
-            this.kryptonButton4.Location = new System.Drawing.Point(10, 158);
-            this.kryptonButton4.Margin = new System.Windows.Forms.Padding(2);
+            this.kryptonButton4.Location = new System.Drawing.Point(13, 194);
+            this.kryptonButton4.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kryptonButton4.Name = "kryptonButton4";
-            this.kryptonButton4.Size = new System.Drawing.Size(139, 20);
+            this.kryptonButton4.Size = new System.Drawing.Size(185, 25);
             this.kryptonButton4.TabIndex = 14;
             this.kryptonButton4.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton4.Values.Text = "Form 4";
@@ -629,10 +691,10 @@ namespace TestForm
             // 
             // kbtnVisualStudio2010Theme
             // 
-            this.kbtnVisualStudio2010Theme.Location = new System.Drawing.Point(10, 262);
-            this.kbtnVisualStudio2010Theme.Margin = new System.Windows.Forms.Padding(2);
+            this.kbtnVisualStudio2010Theme.Location = new System.Drawing.Point(13, 322);
+            this.kbtnVisualStudio2010Theme.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kbtnVisualStudio2010Theme.Name = "kbtnVisualStudio2010Theme";
-            this.kbtnVisualStudio2010Theme.Size = new System.Drawing.Size(227, 20);
+            this.kbtnVisualStudio2010Theme.Size = new System.Drawing.Size(303, 25);
             this.kbtnVisualStudio2010Theme.TabIndex = 13;
             this.kbtnVisualStudio2010Theme.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnVisualStudio2010Theme.Values.Text = "Visual Studio 2010 Theme (Form5)";
@@ -640,22 +702,20 @@ namespace TestForm
             // 
             // kchkUseProgressValueAsText
             // 
-            this.kchkUseProgressValueAsText.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.kchkUseProgressValueAsText.Location = new System.Drawing.Point(134, 352);
-            this.kchkUseProgressValueAsText.Margin = new System.Windows.Forms.Padding(2);
+            this.kchkUseProgressValueAsText.Location = new System.Drawing.Point(343, 433);
+            this.kchkUseProgressValueAsText.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kchkUseProgressValueAsText.Name = "kchkUseProgressValueAsText";
-            this.kchkUseProgressValueAsText.Size = new System.Drawing.Size(165, 20);
+            this.kchkUseProgressValueAsText.Size = new System.Drawing.Size(202, 24);
             this.kchkUseProgressValueAsText.TabIndex = 12;
             this.kchkUseProgressValueAsText.Values.Text = "Use progress value as text";
             this.kchkUseProgressValueAsText.CheckedChanged += new System.EventHandler(this.kchkUseProgressValueAsText_CheckedChanged);
             // 
             // kryptonProgressBar1
             // 
-            this.kryptonProgressBar1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.kryptonProgressBar1.Location = new System.Drawing.Point(121, 326);
-            this.kryptonProgressBar1.Margin = new System.Windows.Forms.Padding(2);
+            this.kryptonProgressBar1.Location = new System.Drawing.Point(308, 401);
+            this.kryptonProgressBar1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kryptonProgressBar1.Name = "kryptonProgressBar1";
-            this.kryptonProgressBar1.Size = new System.Drawing.Size(291, 21);
+            this.kryptonProgressBar1.Size = new System.Drawing.Size(388, 26);
             this.kryptonProgressBar1.StateCommon.Back.Color1 = System.Drawing.Color.Green;
             this.kryptonProgressBar1.StateDisabled.Back.ColorStyle = Krypton.Toolkit.PaletteColorStyle.OneNote;
             this.kryptonProgressBar1.StateNormal.Back.ColorStyle = Krypton.Toolkit.PaletteColorStyle.OneNote;
@@ -665,22 +725,21 @@ namespace TestForm
             // 
             // ktrkProgressValues
             // 
-            this.ktrkProgressValues.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.ktrkProgressValues.Location = new System.Drawing.Point(121, 298);
-            this.ktrkProgressValues.Margin = new System.Windows.Forms.Padding(2);
+            this.ktrkProgressValues.Location = new System.Drawing.Point(308, 367);
+            this.ktrkProgressValues.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.ktrkProgressValues.Maximum = 100;
             this.ktrkProgressValues.Name = "ktrkProgressValues";
-            this.ktrkProgressValues.Size = new System.Drawing.Size(291, 33);
+            this.ktrkProgressValues.Size = new System.Drawing.Size(388, 33);
             this.ktrkProgressValues.TabIndex = 10;
             this.ktrkProgressValues.TickStyle = System.Windows.Forms.TickStyle.Both;
             this.ktrkProgressValues.ValueChanged += new System.EventHandler(this.ktrkProgressValues_ValueChanged);
             // 
             // kryptonButton3
             // 
-            this.kryptonButton3.Location = new System.Drawing.Point(10, 236);
-            this.kryptonButton3.Margin = new System.Windows.Forms.Padding(2);
+            this.kryptonButton3.Location = new System.Drawing.Point(13, 290);
+            this.kryptonButton3.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kryptonButton3.Name = "kryptonButton3";
-            this.kryptonButton3.Size = new System.Drawing.Size(138, 20);
+            this.kryptonButton3.Size = new System.Drawing.Size(184, 25);
             this.kryptonButton3.TabIndex = 9;
             this.kryptonButton3.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton3.Values.Text = "ThemeBrowser Form";
@@ -688,10 +747,10 @@ namespace TestForm
             // 
             // kbtnIntegratedToolbar
             // 
-            this.kbtnIntegratedToolbar.Location = new System.Drawing.Point(10, 210);
-            this.kbtnIntegratedToolbar.Margin = new System.Windows.Forms.Padding(2);
+            this.kbtnIntegratedToolbar.Location = new System.Drawing.Point(13, 258);
+            this.kbtnIntegratedToolbar.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kbtnIntegratedToolbar.Name = "kbtnIntegratedToolbar";
-            this.kbtnIntegratedToolbar.Size = new System.Drawing.Size(227, 20);
+            this.kbtnIntegratedToolbar.Size = new System.Drawing.Size(303, 25);
             this.kbtnIntegratedToolbar.TabIndex = 8;
             this.kbtnIntegratedToolbar.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnIntegratedToolbar.Values.Text = "Integrated Toolbar (Form5)";
@@ -699,10 +758,10 @@ namespace TestForm
             // 
             // kbtnTestMessagebox
             // 
-            this.kbtnTestMessagebox.Location = new System.Drawing.Point(10, 184);
-            this.kbtnTestMessagebox.Margin = new System.Windows.Forms.Padding(2);
+            this.kbtnTestMessagebox.Location = new System.Drawing.Point(13, 226);
+            this.kbtnTestMessagebox.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kbtnTestMessagebox.Name = "kbtnTestMessagebox";
-            this.kbtnTestMessagebox.Size = new System.Drawing.Size(139, 20);
+            this.kbtnTestMessagebox.Size = new System.Drawing.Size(185, 25);
             this.kbtnTestMessagebox.TabIndex = 7;
             this.kbtnTestMessagebox.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnTestMessagebox.Values.Text = "Test Messagebox";
@@ -710,10 +769,10 @@ namespace TestForm
             // 
             // kryptonButton2
             // 
-            this.kryptonButton2.Location = new System.Drawing.Point(10, 132);
-            this.kryptonButton2.Margin = new System.Windows.Forms.Padding(2);
+            this.kryptonButton2.Location = new System.Drawing.Point(13, 162);
+            this.kryptonButton2.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kryptonButton2.Name = "kryptonButton2";
-            this.kryptonButton2.Size = new System.Drawing.Size(139, 25);
+            this.kryptonButton2.Size = new System.Drawing.Size(185, 31);
             this.kryptonButton2.TabIndex = 6;
             this.kryptonButton2.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton2.Values.Image = ((System.Drawing.Image)(resources.GetObject("kryptonButton2.Values.Image")));
@@ -724,10 +783,10 @@ namespace TestForm
             // kryptonButton1
             // 
             this.kryptonButton1.KryptonContextMenu = this.kryptonContextMenu1;
-            this.kryptonButton1.Location = new System.Drawing.Point(9, 107);
-            this.kryptonButton1.Margin = new System.Windows.Forms.Padding(2);
+            this.kryptonButton1.Location = new System.Drawing.Point(12, 132);
+            this.kryptonButton1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kryptonButton1.Name = "kryptonButton1";
-            this.kryptonButton1.Size = new System.Drawing.Size(139, 20);
+            this.kryptonButton1.Size = new System.Drawing.Size(185, 25);
             this.kryptonButton1.TabIndex = 5;
             this.kryptonButton1.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton1.Values.ShowSplitOption = true;
@@ -756,28 +815,27 @@ namespace TestForm
             // 
             // kryptonListBox1
             // 
-            this.kryptonListBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.kryptonListBox1.Location = new System.Drawing.Point(121, 11);
-            this.kryptonListBox1.Margin = new System.Windows.Forms.Padding(2);
+            this.kryptonListBox1.Location = new System.Drawing.Point(362, 17);
+            this.kryptonListBox1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kryptonListBox1.Name = "kryptonListBox1";
-            this.kryptonListBox1.Size = new System.Drawing.Size(291, 281);
+            this.kryptonListBox1.Size = new System.Drawing.Size(388, 346);
             this.kryptonListBox1.TabIndex = 2;
             // 
             // kryptonTextBox1
             // 
-            this.kryptonTextBox1.Location = new System.Drawing.Point(9, 84);
-            this.kryptonTextBox1.Margin = new System.Windows.Forms.Padding(2);
+            this.kryptonTextBox1.Location = new System.Drawing.Point(12, 103);
+            this.kryptonTextBox1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.kryptonTextBox1.Name = "kryptonTextBox1";
-            this.kryptonTextBox1.Size = new System.Drawing.Size(140, 23);
+            this.kryptonTextBox1.Size = new System.Drawing.Size(187, 27);
             this.kryptonTextBox1.TabIndex = 1;
             this.kryptonTextBox1.Text = "kryptonTextBox1";
             // 
             // textBox1
             // 
-            this.textBox1.Location = new System.Drawing.Point(41, 40);
-            this.textBox1.Margin = new System.Windows.Forms.Padding(2);
+            this.textBox1.Location = new System.Drawing.Point(55, 49);
+            this.textBox1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.textBox1.Name = "textBox1";
-            this.textBox1.Size = new System.Drawing.Size(58, 20);
+            this.textBox1.Size = new System.Drawing.Size(76, 22);
             this.textBox1.TabIndex = 0;
             // 
             // kcmdMessageboxTest
@@ -846,19 +904,6 @@ namespace TestForm
             this.kryptonTaskDialog1.UseNativeOSIcons = false;
             this.kryptonTaskDialog1.WindowTitle = null;
             // 
-            // kryptonInputBoxManager1
-            // 
-            kryptonInputBoxData4.Caption = null;
-            kryptonInputBoxData4.CueColor = null;
-            kryptonInputBoxData4.CueText = null;
-            kryptonInputBoxData4.CueTypeface = null;
-            kryptonInputBoxData4.DefaultResponse = null;
-            kryptonInputBoxData4.Owner = null;
-            kryptonInputBoxData4.Prompt = null;
-            kryptonInputBoxData4.UsePasswordOption = null;
-            kryptonInputBoxData4.UseRTLLayout = Krypton.Toolkit.KryptonUseRTLLayout.No;
-            this.kryptonInputBoxManager1.InputBoxData = kryptonInputBoxData4;
-            // 
             // kcmdOpenImage
             // 
             this.kcmdOpenImage.Text = "&...";
@@ -869,30 +914,7 @@ namespace TestForm
             this.kryptonFontDialog1.DisplayExtendedColorsButton = false;
             this.kryptonFontDialog1.DisplayIsPrinterFontDescription = false;
             this.kryptonFontDialog1.Icon = ((System.Drawing.Icon)(resources.GetObject("kryptonFontDialog1.Icon")));
-            // 
-            // Column1
-            // 
-            this.Column1.ContrastTextColor = false;
-            dataGridViewCellStyle4.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
-            this.Column1.DefaultCellStyle = dataGridViewCellStyle4;
-            this.Column1.HeaderText = "Column1";
-            this.Column1.Name = "Column1";
-            this.Column1.Width = 100;
-            // 
-            // kryptonBorderEdge1
-            // 
-            this.kryptonBorderEdge1.Location = new System.Drawing.Point(724, 269);
-            this.kryptonBorderEdge1.Name = "kryptonBorderEdge1";
-            this.kryptonBorderEdge1.Size = new System.Drawing.Size(50, 1);
-            this.kryptonBorderEdge1.Text = "kryptonBorderEdge1";
-            // 
-            // kryptonRichTextBox1
-            // 
-            this.kryptonRichTextBox1.Location = new System.Drawing.Point(809, 301);
-            this.kryptonRichTextBox1.Name = "kryptonRichTextBox1";
-            this.kryptonRichTextBox1.Size = new System.Drawing.Size(100, 96);
-            this.kryptonRichTextBox1.TabIndex = 64;
-            this.kryptonRichTextBox1.Text = "kryptonRichTextBox1";
+            this.kryptonFontDialog1.Title = null;
             // 
             // kryptonColorDialog1
             // 
@@ -902,7 +924,7 @@ namespace TestForm
             // 
             // Main
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ButtonSpecs.Add(this.buttonSpecAny1);
             this.ButtonSpecs.Add(this.buttonSpecAny2);
@@ -914,9 +936,9 @@ namespace TestForm
             this.ButtonSpecs.Add(this.buttonSpecAny8);
             this.ButtonSpecs.Add(this.buttonSpecAny9);
             this.ButtonSpecs.Add(this.buttonSpecAny10);
-            this.ClientSize = new System.Drawing.Size(1214, 853);
+            this.ClientSize = new System.Drawing.Size(1629, 1015);
             this.Controls.Add(this.kryptonPanel1);
-            this.Margin = new System.Windows.Forms.Padding(2);
+            this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.Name = "Main";
             this.Text = "Form1";
             this.WindowState = System.Windows.Forms.FormWindowState.Maximized;
@@ -933,6 +955,8 @@ namespace TestForm
             this.kryptonNavigator1.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPage1)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPage2)).EndInit();
+            this.kryptonStatusStrip1.ResumeLayout(false);
+            this.kryptonStatusStrip1.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonThemeComboBox1)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonComboBox1)).EndInit();
@@ -1023,5 +1047,7 @@ namespace TestForm
         private KryptonBorderEdge kryptonBorderEdge1;
         private KryptonRichTextBox kryptonRichTextBox1;
         private KryptonColorDialog kryptonColorDialog1;
+        private KryptonButton kryptonButton15;
+        private ToolStripStatusLabel toolStripStatusLabel1;
     }
 }

--- a/Source/Krypton Components/TestForm/Main.cs
+++ b/Source/Krypton Components/TestForm/Main.cs
@@ -378,5 +378,10 @@ namespace TestForm
         {
             
         }
+
+        private void kryptonButton15_Click(object sender, EventArgs e)
+        {
+            new PanelForm().ShowDialog(this);
+        }
     }
 }

--- a/Source/Krypton Components/TestForm/Main.resx
+++ b/Source/Krypton Components/TestForm/Main.resx
@@ -121,22 +121,6 @@
     <value>359, 53</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="kryptonTableLayoutPanel1.BackgroundImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-    <value>
-        iVBORw0KGgoAAAANSUhEUgAAAH4AAACVCAYAAACeoE7JAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wgAADsIBFShKgAAAAZ5JREFUeF7t1cEJgDAUBUHbTY32YBlpI6KgJytw5zBg8Lg8/jbGWI/9mO+397/f
-        2/Wg51781w/+Tfgo4aPc+CiLjxI+SvgoNz7K4qOEjxI+yo2Psvgo4aOEj3Ljoyw+Svgo4aPc+CiLjxI+
-        SvgoNz7K4qOEjxI+yo2Psvgo4aOEj3Ljoyw+Svgo4aPc+CiLjxI+SvgoNz7K4qOEjxI+yo2Psvgo4aOE
-        j3Ljoyw+Svgo4aPc+CiLjxI+SvgoNz7K4qOEjxI+yo2Psvgo4aOEj3Ljoyw+Svgo4aPc+CiLjxI+Svgo
-        Nz7K4qOEjxI+yo2Psvgo4aOEj3Ljoyw+Svgo4aPc+CiLjxI+SvgoNz7K4qOEjxI+yo2Psvgo4aOEj3Lj
-        oyw+Svgo4aPc+CiLjxI+SvgoNz7K4qOEjxI+yo2Psvgo4aOEj3Ljoyw+Svgo4aPc+CiLjxI+SvgoNz7K
-        4qOEjxI+yo2Psvgo4aOEj3Ljoyw+Svgo4aPc+CiLjxI+SvgoNz7K4qOEjxI+yo2Psvgo4aOEj3Ljoyw+
-        Svgo4ZPmOgFF3JvDuhyYbAAAAABJRU5ErkJggg==
-</value>
-  </data>
-  <metadata name="kryptonStatusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>359, 53</value>
-  </metadata>
   <data name="kryptonColorButton1.Values.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
@@ -150,19 +134,19 @@
   <data name="kryptonButton2.Values.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAK/SURBVDhPrZJbSNNRHMfPLrDmcpuFS21u5jTNwjShBwl8
-        iMKHeojyyfcgetOox9HLSKdmoYE1N28tZqSUZgmW5W3et7Y551Jzw43N4X95hUT/387mIKioHvrAl3P7
-        fb/8zuGQP3GtulrYb1AeiC3/nXy9/XKWMdhVaJoO+ayHAruzpGd1gFccO/6VQt1QfH7dlDK3YepqbrPb
-        mNPuh6p7DwVdS9j2JAAhgl0nB2tmTnugj3cl2CFQjbYScdRcpDYcONXkcuaYfOvZJj+yXm1B9TwEuXEV
-        ee2zYJw0wE2ABaplDvYcXHyzcTaZj1wXIte7dL0h7njT/KaKGtNNK0h76kdamx8pLSHkGp0IO6SAi4B1
-        RsSJzuEl2BzhbvWrEw9GAzJ1c6tK0yqUrT5W0bIMRfMyZIYgTrbOgLHSgBlqthOWtXPA2mjAHMHGADfc
-        W05ENEAdp3jkDie1rUHWGGRluiASdQGIGxio9C5sWESAgwbYCAsrNX+imiXY7idMb/kRESkpKeHl1w+6
-        ThjnkW1wIFtvR1ajDelPXCgwDMNrTkV4UoLwONVYRGJ8tUrg6ZHOqYsIP/qQX14fblp3JYCZkIIZl7LM
-        WHSEZ0SOM48HoKh3QFVvQXrdNI5RZercyLvb2RY1R9h4QS5gjLZG78dO0lYn6ThF2C2zEPKHdvC1QQir
-        vBBqvRDUBCDVuJF4493FmH2flQ5+M+xcYJy+tJlqlCA8KIaydgqCCg/iKz5DpF2E9L4P8rK3LTHbDyxq
-        iZTp5A3BFjFTDdOADxKkVk2Ar1mC8N4C4mv8SLrVN3y2VL3/iX7GqhXJgiZ+N0YjndCA92IkV4yDaPwQ
-        axaRXNb7JqekMilW/nseFGcI/AaeZruL7OwMSpBSZYfwtmX36M2XlcUZGYJY2d/x1ZJzDn3y6Ok7pgFZ
-        6bPzse3/DSHfAf2EqkKNe37BAAAAAElFTkSuQmCC
+        YQUAAAAJcEhZcwAAEnQAABJ0Ad5mH3gAAALBSURBVDhPjZFvSFNhFMYPi8zU6pMafoi2SkuwVPw7depy
+        trzpzDWydC7CqNkMK/sDYnNgKYXhh8gELZNQkwSVtrR0VqamVFYIBrUvYpH/yjSzEPb03uuFCox64HC5
+        vO/zO885Ly0lEEk0ccE7OI4zpiVzRt+gJDWRWSIe/12NnuSRHuu/R5564OnavVdR0OTA5HAl2svDYDIk
+        9koDOB2RzkO8viidTueiVHNlCo2+PlB73CE1XIHrsT7QwUFY7AvAbB3Q7Y/vHbFovaxEkUnpyM5QNWi4
+        xDK1Wr2CXhK5++4rdq48PQRJ3iAobwiU+xyU9QTm9q/AZC2c9/2BR3KgL5J9o/CjR4Hqwlg2KUvznsht
+        fWb5FOW/ZcZnINMAKKcflPkboN0fTnsknJ0MYI8ABsLRVKr4RHTSXQBIMy5N0YnhX2YjD+iGuY0BJnjA
+        ZsHs7IhgFc6ShOF2sQjgR9ioOzdN2S9Y7F6hM2+mZDvyW2aAsUo4W7zgtPmx8gVsm4BOX1Scjf4ijNBI
+        5KLNKRyxdHxjkeeE2HxnMzN3vQOw8IpBKoDxGywNX9eBqRqUFhhGidgSeZmy9Y34cAv4XCvMzMfGeKVg
+        fugALM0zsNhmYbHOoMg6hwt3p5CedfiOYOblFxCf0lwSAvRsYfOK1erFOl/DGWYm1QNQWhdoN6u0fqze
+        eRGJ0dtSRTsvsyRdq7JOWOMZhC2KXxibmY9tsTEAb2bPSlkDWGNoh0KtvcfecJloFuWdLD2VnTAyb48B
+        HocvLowHsNhCZ2Z2NXQjdNehUWO0l0x0/alVG5LkBUdUH6fbGMTOts0ARdZZlqAP7oYuhKQcHdsfJ4sS
+        ry+t5T5JgUa96vWbmq3AfB1K7ICbph5RnOG1XuETJF77l5K9ue2hVQ3V51FYdhMB8oSq3EDyFA//X+tk
+        YcqYYJlS/F1CRD8BOQO3yqWFS54AAAAASUVORK5CYII=
 </value>
   </data>
   <metadata name="kryptonContextMenu1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
@@ -185,33 +169,6 @@
   </metadata>
   <metadata name="kryptonInputBoxManager1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 53</value>
-  </metadata>
-  <metadata name="kryptonInputBoxData4.Owner" type="System.Resources.ResXNullRef, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value />
-  </metadata>
-  <metadata name="kryptonInputBoxData4.Prompt" type="System.Resources.ResXNullRef, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value />
-  </metadata>
-  <metadata name="kryptonInputBoxData4.Caption" type="System.Resources.ResXNullRef, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value />
-  </metadata>
-  <metadata name="kryptonInputBoxData4.DefaultResponse" type="System.Resources.ResXNullRef, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value />
-  </metadata>
-  <metadata name="kryptonInputBoxData4.CueText" type="System.Resources.ResXNullRef, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value />
-  </metadata>
-  <metadata name="kryptonInputBoxData4.CueColor" type="System.Resources.ResXNullRef, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value />
-  </metadata>
-  <metadata name="kryptonInputBoxData4.CueTypeface" type="System.Resources.ResXNullRef, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value />
-  </metadata>
-  <metadata name="kryptonInputBoxData4.UsePasswordOption" type="System.Resources.ResXNullRef, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value />
-  </metadata>
-  <metadata name="kryptonInputBoxData4.UseRTLLayout" type="Krypton.Toolkit.KryptonUseRTLLayout, Krypton.Toolkit, Version=100.24.11.321, Culture=neutral, PublicKeyToken=a87e673e9ecb6e8e">
-    <value>No</value>
   </metadata>
   <metadata name="kcmdOpenImage.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>213, 53</value>

--- a/Source/Krypton Components/TestForm/PanelForm.Designer.cs
+++ b/Source/Krypton Components/TestForm/PanelForm.Designer.cs
@@ -1,0 +1,67 @@
+﻿namespace TestForm
+{
+    partial class PanelForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.kryptonButton1 = new Krypton.Toolkit.KryptonButton();
+            this.SuspendLayout();
+            // 
+            // kryptonButton1
+            // 
+            this.kryptonButton1.Location = new System.Drawing.Point(142, 147);
+            this.kryptonButton1.Name = "kryptonButton1";
+            this.kryptonButton1.Size = new System.Drawing.Size(90, 25);
+            this.kryptonButton1.TabIndex = 0;
+            this.kryptonButton1.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kryptonButton1.Values.Text = "kryptonButton1";
+            // 
+            // PanelForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(813, 408);
+            this.Controls.Add(this.kryptonButton1);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.FormTitleAlign = Krypton.Toolkit.PaletteRelativeAlign.Inherit;
+            this.GroupBackStyle = Krypton.Toolkit.PaletteBackStyle.PanelClient;
+            this.GroupBorderStyle = Krypton.Toolkit.PaletteBorderStyle.FormMain;
+            this.HeaderStyle = Krypton.Toolkit.HeaderStyle.Form;
+            this.ImageStyle = Krypton.Toolkit.PaletteImageStyle.TopLeft;
+            this.MaximizeBox = false;
+            this.Name = "PanelForm";
+            this.Text = "PanelForm";
+            this.TitleStyle = Krypton.Toolkit.KryptonFormTitleStyle.Inherit;
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private KryptonButton kryptonButton1;
+    }
+}

--- a/Source/Krypton Components/TestForm/PanelForm.cs
+++ b/Source/Krypton Components/TestForm/PanelForm.cs
@@ -1,0 +1,10 @@
+﻿namespace TestForm
+{
+    public partial class PanelForm : KryptonForm
+    {
+        public PanelForm()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Source/Krypton Components/TestForm/PanelForm.resx
+++ b/Source/Krypton Components/TestForm/PanelForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Source/Krypton Components/TestForm/TestForm.csproj
+++ b/Source/Krypton Components/TestForm/TestForm.csproj
@@ -1,51 +1,53 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>WinExe</OutputType>
-		<TargetFrameworks>net462;net47;net471;net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
-		<Nullable>enable</Nullable>
-		<!--https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/warning-waves-->
-		<WarningLevel>8</WarningLevel>
-		<AnalysisLevel>latest</AnalysisLevel>
-		<UseWindowsForms>true</UseWindowsForms>
-		<AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFrameworks>net462;net47;net471;net472;net48;net481;net8.0-windows;net9.0-windows</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <!--https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/warning-waves-->
+    <WarningLevel>8</WarningLevel>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <UseWindowsForms>true</UseWindowsForms>
+    <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
+    <ForceDesignerDPIUnaware>true</ForceDesignerDPIUnaware>
+    <ApplicationHighDpiMode>SystemAware</ApplicationHighDpiMode>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\Krypton.Docking\Krypton.Docking 2022.csproj" />
-		<ProjectReference Include="..\Krypton.Navigator\Krypton.Navigator 2022.csproj" />
-		<ProjectReference Include="..\Krypton.Ribbon\Krypton.Ribbon 2022.csproj" />
-		<ProjectReference Include="..\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />
-		<ProjectReference Include="..\Krypton.Workspace\Krypton.Workspace 2022.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Krypton.Docking\Krypton.Docking 2022.csproj" />
+    <ProjectReference Include="..\Krypton.Navigator\Krypton.Navigator 2022.csproj" />
+    <ProjectReference Include="..\Krypton.Ribbon\Krypton.Ribbon 2022.csproj" />
+    <ProjectReference Include="..\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />
+    <ProjectReference Include="..\Krypton.Workspace\Krypton.Workspace 2022.csproj" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<Compile Update="Properties\Resources.Designer.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>Resources.resx</DependentUpon>
-		</Compile>
-	</ItemGroup>
+  <ItemGroup>
+    <Compile Update="Properties\Resources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
 
-	<ItemGroup>
-		<EmbeddedResource Update="Properties\Resources.resx">
-			<Generator>ResXFileCodeGenerator</Generator>
-			<LastGenOutput>Resources.Designer.cs</LastGenOutput>
-		</EmbeddedResource>
-	</ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Update="Properties\Resources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
 
-	<ItemGroup>
-		<Content Include="invoices.xml">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-		</Content>
-	</ItemGroup>
+  <ItemGroup>
+    <Content Include="invoices.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 
-	<ItemGroup>
-		<Reference Include="System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="$(TargetFramework.StartsWith('net4'))">
-			<SpecificVersion>True</SpecificVersion>
-			<Version>4.0.0.0</Version>
-			<!-- Designers for the `TFMs != net4` are "Pulled in" via Visual studios ".nuget\packages\microsoft.windowsdesktop.app.ref" -->
-		</Reference>
-	</ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="$(TargetFramework.StartsWith('net4'))">
+      <SpecificVersion>True</SpecificVersion>
+      <Version>4.0.0.0</Version>
+      <!-- Designers for the `TFMs != net4` are "Pulled in" via Visual studios ".nuget\packages\microsoft.windowsdesktop.app.ref" -->
+    </Reference>
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Make sure MDI and Ribbon applications still work
- Fix tooltip display in Ribbons
- Add `<ApplicationHighDpiMode>SystemAware` to projects
- Remove some ReSharper warnings

#1177

![image](https://github.com/user-attachments/assets/4c853c5e-74d3-45eb-af1f-67a7b99477d6)


Looks like some warnings need to be scoped with the TFM `#if` style code: I'll attempt that in the next PR!