### PR TITLE
1241-KryptonDataGridViewComboBoxColumn-Ignores-ValueMember-in-Binding

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxEditingControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxEditingControl.cs
@@ -112,7 +112,26 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Returns the current value of the editing control.
         /// </summary>
-        public virtual object? GetEditingControlFormattedValue(DataGridViewDataErrorContexts context) => Text;
+        public virtual object GetEditingControlFormattedValue(DataGridViewDataErrorContexts context)
+        {
+            if (SelectedIndex > -1)
+            {
+                if (SelectedValue is not null
+                    && ValueMember is not null
+                    && ValueMember.Length > 0)
+                {
+                    return SelectedValue.ToString() ?? string.Empty;
+                }
+
+                if (SelectedItem is not null)
+                {
+                    return SelectedItem.ToString() ?? string.Empty;
+                }
+            }
+
+            // For all other cases, return an empty string
+            return string.Empty;
+        }
 
         /// <summary>
         /// Called by the grid to give the editing control a chance to prepare itself for the editing session.


### PR DESCRIPTION
[Issue 1241-KryptonDataGridViewComboBoxColumn-Ignores-ValueMember-in-Binding](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1241)
- Resolves the returned text when ValueMember is set
- And the change log

![compile-results](https://github.com/user-attachments/assets/89205c27-4d6f-493f-b36c-945c2a3ffe63)
