### PR TITLE
1909-KryptonDataGridViewComboBoxCell-empty-DropDown-list

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2025-11-xx - Build 2511 - November 2025
+* Resolved [#1909](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1909), `KryptonDataGridViewComboBoxCell` displays an empty drop-down list on the first new row.
 * Implemented [#1177](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1177), Is it possible to have the KForm back colour as the KPanel colour
 * Resolved [#1900](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1900), Remove Obsolete `KryptonMessageBoxDep` from V100 code base
 * Resolved [#1211](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1211), Button 'drop down' arrows should use palette text colour 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxCell.cs
@@ -311,11 +311,13 @@ namespace Krypton.Toolkit
 
             if (DataGridView!.EditingControl is KryptonComboBox comboBox)
             {
-                if (OwningColumn is KryptonDataGridViewComboBoxColumn { DataSource: null } comboColumn)
+                var comboColumn = OwningColumn as KryptonDataGridViewComboBoxColumn;
+
+                if (comboColumn is not null && comboColumn.DataSource is not null)
                 {
                     var strings = new object[comboColumn.Items.Count];
 
-                    for (var i = 0; i < strings.Length; i++)
+                    for (var i = 0 ; i < strings.Length ; i++)
                     {
                         strings[i] = comboColumn.Items[i];
                     }
@@ -323,7 +325,7 @@ namespace Krypton.Toolkit
                     comboBox.Items.AddRange(strings);
 
                     var autoAppend = new string[comboColumn.AutoCompleteCustomSource.Count];
-                    for (var j = 0; j < autoAppend.Length; j++)
+                    for (var j = 0 ; j < autoAppend.Length ; j++)
                     {
                         autoAppend[j] = comboColumn.AutoCompleteCustomSource[j];
                     }
@@ -340,7 +342,7 @@ namespace Krypton.Toolkit
                 comboBox.AutoCompleteMode = AutoCompleteMode;
                 comboBox.DisplayMember = DisplayMember;
                 comboBox.ValueMember = ValueMember;
-                comboBox.DataSource = DataSource;
+                comboBox.DataSource = comboColumn?.DataSource;
 
                 comboBox.Text = initialFormattedValue as string ?? string.Empty;
             }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -268,6 +268,7 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [AllowNull]
         public override Font Font
         {
             get => base.Font;


### PR DESCRIPTION
[Issue 1909-KryptonDataGridViewComboBoxCell-empty-DropDown-list](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1909)
- Resolves the dropdown list problem
- Removes one warning from KryptonForm
- And the change log

![compile-results](https://github.com/user-attachments/assets/fbb7dd15-c047-4a0d-839f-fa64c13a3b37)
