### PR TITLE
1909-KryptonDataGridViewComboBoxCell-empty-DropDown-list

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2025-02-01 - Build 2502 (Version 95 - Patch 1) - February 2025
+* Resolved [#1909](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1909), `KryptonDataGridViewComboBoxCell` displays an empty drop-down list on the first new row.
 * Resolved [#1900](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1211), **Deprecate** -Remove `KryptonMessageBoxDep` from V100 code base
 * Resolved [#1211](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1211), Button 'drop down' arrows should use palette text colour 
 * Resolved [#1212](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1212), **[Breaking Change]** `KColorButton` 'drop-down' arrow should be drawn

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxCell.cs
@@ -311,7 +311,9 @@ namespace Krypton.Toolkit
 
             if (DataGridView!.EditingControl is KryptonComboBox comboBox)
             {
-                if (OwningColumn is KryptonDataGridViewComboBoxColumn { DataSource: null } comboColumn)
+                var comboColumn = OwningColumn as KryptonDataGridViewComboBoxColumn;
+
+                if (comboColumn is not null && comboColumn.DataSource is not null)
                 {
                     var strings = new object[comboColumn.Items.Count];
 
@@ -340,7 +342,7 @@ namespace Krypton.Toolkit
                 comboBox.AutoCompleteMode = AutoCompleteMode;
                 comboBox.DisplayMember = DisplayMember;
                 comboBox.ValueMember = ValueMember;
-                comboBox.DataSource = DataSource;
+                comboBox.DataSource = comboColumn?.DataSource;
 
                 comboBox.Text = initialFormattedValue as string ?? string.Empty;
             }


### PR DESCRIPTION
[Issue 1909-KryptonDataGridViewComboBoxCell-empty-DropDown-list](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1909)
- Resolves the dropdown list problem
- And the change log

![compile-results](https://github.com/user-attachments/assets/4271f719-bdcb-4ec9-8c0b-e86e5b018acf)
