### PR TITLE
1909-KryptonDataGridViewComboBoxCell-empty-DropDown-list

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2025-02-01 - Build 2502 (Patch 5) - February 2025
+* Resolved [#1909](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1909), `KryptonDataGridViewComboBoxCell` displays an empty drop-down list on the first new row.
 * Resolved [#1241](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1241), `KryptonDataGridViewComboBoxColumn` ignores `ValueMember` in data binding. 
 * Resolved [#1910](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1910), `Workspace Persistence` -> "Save to array" Causes an exception in `Toolkit.XmlHelper.Image.Save`
 * Resolved [#1211](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1211), Button 'drop down' arrows should use palette text colour 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxCell.cs
@@ -313,7 +313,7 @@ namespace Krypton.Toolkit
             {
                 var comboColumn = OwningColumn as KryptonDataGridViewComboBoxColumn;
 
-                if (comboColumn is not null && comboColumn.DataSource is not null)
+                if (comboColumn is not null && comboColumn.DataSource is null)
                 {
                     var strings = new object[comboColumn.Items.Count];
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxCell.cs
@@ -311,11 +311,13 @@ namespace Krypton.Toolkit
 
             if (DataGridView.EditingControl is KryptonComboBox comboBox)
             {
-                if (OwningColumn is KryptonDataGridViewComboBoxColumn { DataSource: null } comboColumn)
+                var comboColumn = OwningColumn as KryptonDataGridViewComboBoxColumn;
+
+                if (comboColumn is not null && comboColumn.DataSource is not null)
                 {
                     var strings = new object[comboColumn.Items.Count];
 
-                    for (var i = 0; i < strings.Length; i++)
+                    for (var i = 0 ; i < strings.Length ; i++)
                     {
                         strings[i] = comboColumn.Items[i];
                     }
@@ -323,7 +325,7 @@ namespace Krypton.Toolkit
                     comboBox.Items.AddRange(strings);
 
                     var autoAppend = new string[comboColumn.AutoCompleteCustomSource.Count];
-                    for (var j = 0; j < autoAppend.Length; j++)
+                    for (var j = 0 ; j < autoAppend.Length ; j++)
                     {
                         autoAppend[j] = comboColumn.AutoCompleteCustomSource[j];
                     }
@@ -340,7 +342,7 @@ namespace Krypton.Toolkit
                 comboBox.AutoCompleteMode = AutoCompleteMode;
                 comboBox.DisplayMember = DisplayMember;
                 comboBox.ValueMember = ValueMember;
-                comboBox.DataSource = DataSource;
+                comboBox.DataSource = comboColumn?.DataSource;
 
                 if (initialFormattedValue is not string initialFormattedValueStr)
                 {


### PR DESCRIPTION
[Issue 1909-KryptonDataGridViewComboBoxCell-empty-DropDown-list](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1909)
- Resolves the dropdown list problem
- And the change log

![compile-results](https://github.com/user-attachments/assets/f64fc526-2960-4c26-b2d4-dece6837b148)
