### PR TITLE
1909-KryptonDataGridViewComboBoxCell-empty-DropDown-list

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxCell.cs
@@ -313,7 +313,7 @@ namespace Krypton.Toolkit
             {
                 var comboColumn = OwningColumn as KryptonDataGridViewComboBoxColumn;
 
-                if (comboColumn is not null && comboColumn.DataSource is not null)
+                if (comboColumn is not null && comboColumn.DataSource is null)
                 {
                     var strings = new object[comboColumn.Items.Count];
 


### PR DESCRIPTION
[Issue 1909-KryptonDataGridViewComboBoxCell-empty-DropDown-list](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1909)
- Corrects a glitch on the previous PR.

![compile-results](https://github.com/user-attachments/assets/3f8a81b5-5077-40d8-95a7-94a7f110f743)
