### PR TITLE
1909-KryptonDataGridViewComboBoxCell-empty-DropDown-list

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxCell.cs
@@ -313,7 +313,7 @@ namespace Krypton.Toolkit
             {
                 var comboColumn = OwningColumn as KryptonDataGridViewComboBoxColumn;
 
-                if (comboColumn is not null && comboColumn.DataSource is not null)
+                if (comboColumn is not null && comboColumn.DataSource is null)
                 {
                     var strings = new object[comboColumn.Items.Count];
 


### PR DESCRIPTION
[Issue 1909-KryptonDataGridViewComboBoxCell-empty-DropDown-list](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1909)
- Corrects a glitch in the previous PR.


![compile-results](https://github.com/user-attachments/assets/58278260-5c8b-41eb-bfdf-31400c153498)





