### PR TITLE
- `PaletteDataGridViewAll` Now exposes the border value via `PaletteB…

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2025-11-xx - Build 2511 - November 2025
+* Implemented [#519](https://github.com/Krypton-Suite/Standard-Toolkit/issues/519), `PaletteDataGridViewAll` does not expose the border value of the `private readonly PaletteDouble _background`
 * Resolved [#240](https://github.com/Krypton-Suite/Standard-Toolkit/issues/240), **[Breaking Change]** `KryptonRichTextBox` Why is it not possible to have the `ButtonSpecs` aligned to the top of a control
     - `ButtonSpecs` have been removed from the `KryptonRichTextBox`
 	- Use another layout to align in the designers

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteDataGridViewAll.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteDataGridViewAll.cs
@@ -90,7 +90,21 @@ namespace Krypton.Toolkit
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public virtual PaletteBack Background => _background.Back;
 
-        private bool ShouldSerializeBackground() => !_background.IsDefault;
+        private bool ShouldSerializeBackground() => !_background.Back.IsDefault;
+
+        #endregion
+
+        #region PaletteBorder
+        /// <summary>
+        /// Gets access to the data grid view background palette details.
+        /// </summary>
+        [KryptonPersist]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining data grid view border appearance.")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+        public virtual PaletteBorder PaletteBorder => _background.Border;
+
+        private bool ShouldSerializePaletteBorder() => !_background.Border.IsDefault;
 
         #endregion
     }


### PR DESCRIPTION
…order` designer value

#519

![image](https://github.com/user-attachments/assets/9fdef186-5a9b-495c-81dd-d1327eedf3b1)
