### PR TITLE
- PaletteDataGridViewAll Now exposes the border value via `PaletteBor…

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2025-02-01 - Build 2502 (Version 95 - Patch 1) - February 2025
+* Implemented [#519](https://github.com/Krypton-Suite/Standard-Toolkit/issues/519), `PaletteDataGridViewAll` does not expose the border value of the `private readonly PaletteDouble _background`
 * Resolved [#1905](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1905), `Sparkle` Themes have an issue with the Background
 * Resolved [#980](https://github.com/Krypton-Suite/Standard-Toolkit/issues/980), `KryptonDockableNavigator` with pages without `AllowConfigSave` flag are incorrectly saved
 * Resolved [#1909](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1909), `KryptonDataGridViewComboBoxCell` displays an empty drop-down list on the first new row.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteDataGridViewAll.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteDataGridViewAll.cs
@@ -90,7 +90,21 @@ namespace Krypton.Toolkit
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public virtual PaletteBack Background => _background.Back;
 
-        private bool ShouldSerializeBackground() => !_background.IsDefault;
+        private bool ShouldSerializeBackground() => !_background.Back.IsDefault;
+
+        #endregion
+
+        #region PaletteBorder
+        /// <summary>
+        /// Gets access to the data grid view background palette details.
+        /// </summary>
+        [KryptonPersist]
+        [Category(@"Visuals")]
+        [Description(@"Overrides for defining data grid view border appearance.")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+        public virtual PaletteBorder PaletteBorder => _background.Border;
+
+        private bool ShouldSerializePaletteBorder() => !_background.Border.IsDefault;
 
         #endregion
     }


### PR DESCRIPTION
…der` designer value

#519

![image](https://github.com/user-attachments/assets/be43fd74-1731-44d3-9d5c-46ed78dbdca3)
