### PR TITLE
Fixes-nullables and warnings and build errors.

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxColumn.cs
@@ -124,8 +124,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        //[AllowNull, MaybeNull]
-        public override DataGridViewCell CellTemplate
+        public override DataGridViewCell? CellTemplate
         {
             // base.CellTemplate can be null for getter and setter
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonProgressBar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonProgressBar.cs
@@ -829,8 +829,7 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        //[AllowNull, MaybeNull]
-        public override Image BackgroundImage
+        public override Image? BackgroundImage
         {
             get => base.BackgroundImage;
             set => base.BackgroundImage = value;
@@ -889,8 +888,7 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        //[AllowNull, MaybeNull]
-        public override ContextMenuStrip ContextMenuStrip
+        public override ContextMenuStrip? ContextMenuStrip
         {
             get => base.ContextMenuStrip!;
             set => base.ContextMenuStrip = value;

--- a/Source/Krypton Components/Krypton.Toolkit/Krypton.Toolkit 2022.csproj
+++ b/Source/Krypton Components/Krypton.Toolkit/Krypton.Toolkit 2022.csproj
@@ -46,9 +46,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="Krypton.Toolkit">
-      <HintPath>obj\Debug\net462\Krypton.Toolkit.dll</HintPath>
-    </Reference>
     <Reference Include="System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="$(TargetFramework.StartsWith('net4'))">
       <SpecificVersion>True</SpecificVersion>
       <Version>4.0.0.0</Version>


### PR DESCRIPTION
Fixes-nullables and warnings and build errors.
No ticket associated.

@Smurf-IV, @Ahmed-Abdelhameed  & @PWagner1 

The warnings have been removed and also the build problems.

It was the `HintPath` again. Anybody knows where this comes from and how to get rid of it permanently?

```xml
    <Reference Include="Krypton.Toolkit">
      <HintPath>obj\Debug\net462\Krypton.Toolkit.dll</HintPath>
    </Reference>
```

This fix should be part of the canary build that was merged lately.

![compile-results](https://github.com/user-attachments/assets/c0ec6447-fb74-49ba-8833-1dc9ee808aff)
