### PR TITLE
- `KryptonTreeView` Node crosses are now Dpi Scaled

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2025-02-01 - Build 2502 (Patch 5) - February 2025
+* Resolved [#1964](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1964), `KryptonTreeView` Node crosses are not Dpi Scaled
 * Resolved [#560](https://github.com/Krypton-Suite/Standard-Toolkit/issues/560), CheckBox Images are not scaled with dpi Awareness
 * Resolved [#565](https://github.com/Krypton-Suite/Standard-Toolkit/issues/565), GroupBox icons are not scaled for dpi awareness
 * Resolved [#559](https://github.com/Krypton-Suite/Standard-Toolkit/issues/559), Header group icon is not scaled for dpi awareness

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
@@ -2220,10 +2220,10 @@ namespace Krypton.Toolkit
                             // Do we draw any plus/minus images in indent bounds?
                             if (ShowPlusMinus && (e.Node.Nodes.Count > 0))
                             {
-                                Image? drawImage = _redirectImages.GetTreeViewImage(e.Node.IsExpanded);
+                                Image? drawImage = _redirectImages?.GetTreeViewImage(e.Node.IsExpanded);
                                 if (drawImage != null)
                                 {
-                                    float dpiFactor = DeviceDpi / 96F;
+                                    float dpiFactor = g.DpiX / 96F;
                                     drawImage = CommonHelper.ScaleImageForSizedDisplay(drawImage,
                                         drawImage.Width * dpiFactor,
                                         drawImage.Height * dpiFactor, false);
@@ -2290,6 +2290,10 @@ namespace Krypton.Toolkit
 
                                 if (drawImage != null)
                                 {
+                                    float dpiFactor = g.DpiX / 96F;
+                                    drawImage = CommonHelper.ScaleImageForSizedDisplay(drawImage,
+                                        drawImage.Width * dpiFactor,
+                                        drawImage.Height * dpiFactor, false);
                                     g.DrawImage(drawImage, _layoutImage.ClientRectangle);
                                 }
                             }
@@ -2304,6 +2308,10 @@ namespace Krypton.Toolkit
                         {
                             if (drawStateImage != null)
                             {
+                                float dpiFactor = g.DpiX / 96F;
+                                drawStateImage = CommonHelper.ScaleImageForSizedDisplay(drawStateImage,
+                                    drawStateImage.Width * dpiFactor,
+                                    drawStateImage.Height * dpiFactor, false);
                                 g.DrawImage(drawStateImage, _layoutImageState.ClientRectangle);
                             }
                         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
@@ -2223,6 +2223,10 @@ namespace Krypton.Toolkit
                                 Image? drawImage = _redirectImages.GetTreeViewImage(e.Node.IsExpanded);
                                 if (drawImage != null)
                                 {
+                                    float dpiFactor = DeviceDpi / 96F;
+                                    drawImage = CommonHelper.ScaleImageForSizedDisplay(drawImage,
+                                        drawImage.Width * dpiFactor,
+                                        drawImage.Height * dpiFactor, false);
                                     g.DrawImage(drawImage, new Rectangle(indentBounds.X + ((indentBounds.Width - drawImage.Width) / 2) - 1,
                                         indentBounds.Y + ((indentBounds.Height - drawImage.Height) / 2),
                                         drawImage.Width, drawImage.Height));

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectTreeView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteRedirectTreeView.cs
@@ -48,7 +48,7 @@ namespace Krypton.Toolkit
             Debug.Assert(plusMinusImages != null);
 
             // Remember incoming targets
-            _plusMinusImages = plusMinusImages;
+            _plusMinusImages = plusMinusImages!;
             _checkboxImages = checkboxImages;
         }
         #endregion
@@ -61,9 +61,11 @@ namespace Krypton.Toolkit
         /// <returns>Appropriate image for drawing; otherwise null.</returns>
         public override Image? GetTreeViewImage(bool expanded)
         {
-            Image? retImage = (expanded ? _plusMinusImages.Minus : _plusMinusImages.Plus) ?? Target.GetTreeViewImage(expanded);
-
-            // Not found, then inherit from target
+            Image? retImage = (expanded 
+                                  ? _plusMinusImages.Minus 
+                                  : _plusMinusImages.Plus)
+                              // Not found, then inherit from target
+                              ?? Target?.GetTreeViewImage(expanded);
 
             return retImage;
         }


### PR DESCRIPTION
- Some compile warnings

#1964

![image](https://github.com/user-attachments/assets/3d78e6d5-db4e-401c-936d-6353924fcb01)
