### PR TITLE
- `KryptonTreeView` Node crosses are now Dpi Scaled

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2025-02-01 - Build 2502 (Version 95 - Patch 1) - February 2025
+* Resolved [#1964](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1964), `KryptonTreeView` Node crosses are not Dpi Scaled
 * Resolved [#560](https://github.com/Krypton-Suite/Standard-Toolkit/issues/560), CheckBox Images are not scaled with dpi Awareness
 * Resolved [#565](https://github.com/Krypton-Suite/Standard-Toolkit/issues/565), GroupBox icons are not scaled for dpi awareness
 * Resolved [#559](https://github.com/Krypton-Suite/Standard-Toolkit/issues/559), Header group icon is not scaled for dpi awareness
@@ -193,6 +194,7 @@
 =======
 
 # 2025-02-01 - Build 2502 (Patch 5) - February 2025
+* Resolved [#1964](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1964), `KryptonTreeView` Node crosses are not Dpi Scaled
 * Resolved [#560](https://github.com/Krypton-Suite/Standard-Toolkit/issues/560), CheckBox Images are not scaled with dpi Awareness
 * Resolved [#565](https://github.com/Krypton-Suite/Standard-Toolkit/issues/565), GroupBox icons are not scaled for dpi awareness
 * Resolved [#559](https://github.com/Krypton-Suite/Standard-Toolkit/issues/559), Header group icon is not scaled for dpi awareness

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
@@ -2272,6 +2272,10 @@ namespace Krypton.Toolkit
                                 Image? drawImage = _redirectImages!.GetTreeViewImage(e.Node.IsExpanded);
                                 if (drawImage != null)
                                 {
+                                    float dpiFactor = g.DpiX / 96F;
+                                    drawImage = CommonHelper.ScaleImageForSizedDisplay(drawImage,
+                                        drawImage.Width * dpiFactor,
+                                        drawImage.Height * dpiFactor, false)!;
                                     g.DrawImage(drawImage, new Rectangle(indentBounds.X + ((indentBounds.Width - drawImage.Width) / 2) - 1,
                                         indentBounds.Y + ((indentBounds.Height - drawImage.Height) / 2),
                                         drawImage.Width, drawImage.Height));
@@ -2335,6 +2339,10 @@ namespace Krypton.Toolkit
 
                                 if (drawImage != null)
                                 {
+                                    float dpiFactor = g.DpiX / 96F;
+                                    drawImage = CommonHelper.ScaleImageForSizedDisplay(drawImage,
+                                        drawImage.Width * dpiFactor,
+                                        drawImage.Height * dpiFactor, false)!;
                                     g.DrawImage(drawImage, _layoutImage.ClientRectangle);
                                 }
                             }
@@ -2349,6 +2357,10 @@ namespace Krypton.Toolkit
                         {
                             if (drawStateImage != null)
                             {
+                                float dpiFactor = g.DpiX / 96F;
+                                drawStateImage = CommonHelper.ScaleImageForSizedDisplay(drawStateImage,
+                                    drawStateImage.Width * dpiFactor,
+                                    drawStateImage.Height * dpiFactor, false)!;
                                 g.DrawImage(drawStateImage, _layoutImageState.ClientRectangle);
                             }
                         }

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
@@ -2401,7 +2401,7 @@ namespace Krypton.Toolkit
             {
                 float dpiFactor = context.Graphics.DpiY / 96f;
                 drawImage = CommonHelper.ScaleImageForSizedDisplay(drawImage, drawImage.Width * dpiFactor,
-                    drawImage.Height * dpiFactor, false);
+                    drawImage.Height * dpiFactor, false)!;
                 // Find the offset to center the image
                 var xOffset = (displayRect.Width - drawImage.Width) / 2;
                 var yOffset = (displayRect.Height - drawImage.Height) / 2;
@@ -2497,7 +2497,7 @@ namespace Krypton.Toolkit
             {
                 float dpiFactor = context.Graphics.DpiY / 96f;
                 drawImage = CommonHelper.ScaleImageForSizedDisplay(drawImage, drawImage.Width * dpiFactor,
-                    drawImage.Height * dpiFactor, false);
+                    drawImage.Height * dpiFactor, false)!;
                 // Find the offset to center the image
                 var xOffset = (displayRect.Width - drawImage.Width) / 2;
                 var yOffset = (displayRect.Height - drawImage.Height) / 2;


### PR DESCRIPTION
- Some compile warnings

#1964

![image](https://github.com/user-attachments/assets/de1a2c8d-af45-41f2-a7f4-656296a97fb9)
