### PR TITLE
1979 kryptonform temporary fix

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -214,6 +214,10 @@ namespace Krypton.Toolkit
             _useDropShadow = false;
 #pragma warning restore CS0618
             TransparencyKey = GlobalStaticValues.TRANSPARENCY_KEY_COLOR; // Bug #1749
+
+            // #1979 Temporary fix
+            base.PaletteChanged += (s, e) => _internalKryptonPanel.PaletteMode = PaletteMode;
+            // END #1979 Temporary fix
         }
 
         private float GetDpiFactor()
@@ -1988,5 +1992,9 @@ namespace Krypton.Toolkit
             return form.IsInAdministratorMode;
         }
         #endregion
+
+        #region #1979 Temporary Fix
+        public KryptonPanel InternalPanel => _internalKryptonPanel;
+        #endregion #1979 Temporary Fix
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -245,8 +245,11 @@ namespace Krypton.Toolkit
 
                 // Unhook from the global static events
                 KryptonManager.GlobalPaletteChanged -= OnGlobalPaletteChanged;
-                KryptonManager.GlobalUseThemeFormChromeBorderWidthChanged -=
-                    OnGlobalUseThemeFormChromeBorderWidthChanged;
+                KryptonManager.GlobalUseThemeFormChromeBorderWidthChanged -= OnGlobalUseThemeFormChromeBorderWidthChanged;
+
+                // #1979 Temporary fix
+                base.PaletteChanged -= (s, e) => _internalKryptonPanel.PaletteMode = PaletteMode;
+                // END #1979 Temporary fix
 
                 // Clear down the cached bitmap
                 if (_cacheBitmap != null)


### PR DESCRIPTION
[Issue 1979](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1979)
- Temporary fix to make the internal panel react to local theme changes and expose the panel as property so it can be configured.
- Enables PelttemodeChanges
- Add the Property `InternalPanel`

![compile-results](https://github.com/user-attachments/assets/4cd8c426-a45d-4f1d-80ec-e2f5044c7ab1)
