### PR TITLE
1784 v100 krypton data grid view reorders columns during debugging

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2025-11-xx - Build 2511 - November 2025
+* Resolved [#1784](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1784), `KryptonDataGridView` Auto generation of columns is not serialized correctly.
 * Resolved [#1977](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1977), When a control is set to anchor to the bottom, the control can be stretched beyond the form bottom.
 * Resolved [#1964](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1964), `KryptonTreeView` Node crosses are not Dpi Scaled
 * Implemented [#1968](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1968), Open up 'ExceptionHandler' for public use

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -1015,48 +1015,6 @@ namespace Krypton.Toolkit
 
         #region Protected Override
         /// <inheritdoc/>
-        //protected override void OnDataMemberChanged(EventArgs e)
-        //{
-        //    base.OnDataMemberChanged(e);
-
-        //    if (AutoGenerateColumns
-        //        && AutoGenerateKryptonColumns
-        //        && DataSource is not null)
-        //    {
-        //        ReplaceDefaultColumsWithKryptonColumns();
-        //    }
-        //}
-
-        /// <inheritdoc/>
-        //protected override void OnDataSourceChanged(EventArgs e)
-        //{
-
-        //    base.OnDataSourceChanged(e);
-
-        //    if (AutoGenerateColumns
-        //        && AutoGenerateKryptonColumns
-        //        && DataSource is not null)
-        //    {
-        //        ReplaceDefaultColumsWithKryptonColumns();
-        //    }
-        //}
-
-        /// <inheritdoc/>
-        //protected override void OnAutoGenerateColumnsChanged(EventArgs e)
-        //{
-        //    // First handle the base the event
-        //    base.OnAutoGenerateColumnsChanged(e);
-
-        //    // If needed convert the winforms columns to Krypton columns
-        //    if (AutoGenerateColumns
-        //        && AutoGenerateKryptonColumns
-        //        && DataSource is not null)
-        //    {
-        //        ReplaceDefaultColumsWithKryptonColumns();
-        //    }
-        //}
-
-        /// <inheritdoc/>
         protected override void OnDataBindingComplete(DataGridViewBindingCompleteEventArgs e)
         {
             base.OnDataBindingComplete(e);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -23,7 +23,6 @@ namespace Krypton.Toolkit
     [DefaultEvent(nameof(CellContentClick))]
     [ComplexBindingProperties(nameof(DataSource), nameof(DataMember))]
     [Docking(DockingBehavior.Ask)]
-
     [Description(@"Display rows and columns of data of a grid you can customize.")]
     public class KryptonDataGridView : DataGridView
     {
@@ -1681,7 +1680,6 @@ namespace Krypton.Toolkit
         private void ReplaceDefaultColumsWithKryptonColumns()
         {
             DataGridViewColumn currentColumn;
-            List<int> columnsProcessed = [];
             int index;
             IComponentChangeService? changeService = null;
             IDesignerHost? designerHost = null;
@@ -1704,7 +1702,6 @@ namespace Krypton.Toolkit
                 if (currentColumn is DataGridViewTextBoxColumn && currentColumn.DataPropertyName.Length > 0)
                 {
                     index = currentColumn.Index;
-                    columnsProcessed.Add(index);
 
                     var newColumn = this.DesignMode
                         ? designerHost?.CreateComponent(typeof(KryptonDataGridViewTextBoxColumn)) as KryptonDataGridViewTextBoxColumn 
@@ -1724,7 +1721,6 @@ namespace Krypton.Toolkit
                 else if (currentColumn is DataGridViewCheckBoxColumn && currentColumn.DataPropertyName.Length > 0)
                 {
                     index = currentColumn.Index;
-                    columnsProcessed.Add(index);
 
                     var newColumn = this.DesignMode
                         ? designerHost?.CreateComponent(typeof(KryptonDataGridViewCheckBoxColumn)) as KryptonDataGridViewCheckBoxColumn 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -1019,11 +1019,8 @@ namespace Krypton.Toolkit
         {
             base.OnDataBindingComplete(e);
 
-            if (//AutoGenerateColumns
-                 AutoGenerateKryptonColumns
-                && DataSource is not null)
+            if (AutoGenerateKryptonColumns && DataSource is not null)
             {
-
                 ReplaceDefaultColumsWithKryptonColumns();
             }
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -17,8 +17,13 @@ namespace Krypton.Toolkit
     /// </summary>
     [ToolboxItem(true)]
     [ToolboxBitmap(typeof(KryptonDataGridView), "ToolboxBitmaps.KryptonDataGridView.bmp")]
-    [DesignerCategory(@"code")]
-    [Designer(typeof(KryptonDataGridViewDesigner))]
+    [DesignerCategory(@"Code")]
+    //[Designer(typeof(KryptonDataGridViewDesigner))] do not use for now. use the the winforms editor
+    [Designer($"System.Windows.Forms.Design.DataGridViewDesigner")]
+    [DefaultEvent(nameof(CellContentClick))]
+    [ComplexBindingProperties(nameof(DataSource), nameof(DataMember))]
+    [Docking(DockingBehavior.Ask)]
+
     [Description(@"Display rows and columns of data of a grid you can customize.")]
     public class KryptonDataGridView : DataGridView
     {
@@ -1010,55 +1015,57 @@ namespace Krypton.Toolkit
 
         #region Protected Override
         /// <inheritdoc/>
-        protected override void OnDataMemberChanged(EventArgs e)
-        {
-            base.OnDataMemberChanged(e);
+        //protected override void OnDataMemberChanged(EventArgs e)
+        //{
+        //    base.OnDataMemberChanged(e);
 
-            if (AutoGenerateColumns
-                && AutoGenerateKryptonColumns
-                && DataSource is not null)
-            {
-                ReplaceDefaultColumsWithKryptonColumns();
-            }
-        }
-
-        /// <inheritdoc/>
-        protected override void OnDataSourceChanged(EventArgs e)
-        {
-            base.OnDataSourceChanged(e);
-
-            if (AutoGenerateColumns
-                && AutoGenerateKryptonColumns
-                && DataSource is not null)
-            {
-                ReplaceDefaultColumsWithKryptonColumns();
-            }
-        }
+        //    if (AutoGenerateColumns
+        //        && AutoGenerateKryptonColumns
+        //        && DataSource is not null)
+        //    {
+        //        ReplaceDefaultColumsWithKryptonColumns();
+        //    }
+        //}
 
         /// <inheritdoc/>
-        protected override void OnAutoGenerateColumnsChanged(EventArgs e)
-        {
-            // First handle the base the event
-            base.OnAutoGenerateColumnsChanged(e);
+        //protected override void OnDataSourceChanged(EventArgs e)
+        //{
 
-            // If needed convert the winforms columns to Krypton columns
-            if (AutoGenerateColumns
-                && AutoGenerateKryptonColumns
-                && DataSource is not null)
-            {
-                ReplaceDefaultColumsWithKryptonColumns();
-            }
-        }
+        //    base.OnDataSourceChanged(e);
+
+        //    if (AutoGenerateColumns
+        //        && AutoGenerateKryptonColumns
+        //        && DataSource is not null)
+        //    {
+        //        ReplaceDefaultColumsWithKryptonColumns();
+        //    }
+        //}
+
+        /// <inheritdoc/>
+        //protected override void OnAutoGenerateColumnsChanged(EventArgs e)
+        //{
+        //    // First handle the base the event
+        //    base.OnAutoGenerateColumnsChanged(e);
+
+        //    // If needed convert the winforms columns to Krypton columns
+        //    if (AutoGenerateColumns
+        //        && AutoGenerateKryptonColumns
+        //        && DataSource is not null)
+        //    {
+        //        ReplaceDefaultColumsWithKryptonColumns();
+        //    }
+        //}
 
         /// <inheritdoc/>
         protected override void OnDataBindingComplete(DataGridViewBindingCompleteEventArgs e)
         {
             base.OnDataBindingComplete(e);
 
-            if (AutoGenerateColumns
-                && AutoGenerateKryptonColumns
+            if (//AutoGenerateColumns
+                 AutoGenerateKryptonColumns
                 && DataSource is not null)
             {
+
                 ReplaceDefaultColumsWithKryptonColumns();
             }
         }
@@ -1719,9 +1726,17 @@ namespace Krypton.Toolkit
         private void ReplaceDefaultColumsWithKryptonColumns()
         {
             DataGridViewColumn currentColumn;
-            KryptonDataGridViewTextBoxColumn newColumn;
             List<int> columnsProcessed = [];
             int index;
+            IComponentChangeService? changeService = null;
+            IDesignerHost? designerHost = null;
+
+            if (this.DesignMode)
+            {
+                changeService = GetService(typeof(IComponentChangeService)) as IComponentChangeService;
+                designerHost = this.Site!.GetService(typeof(IDesignerHost)) as IDesignerHost;
+                changeService?.OnComponentChanging(this, null);
+            }
 
             for (int i = 0 ; i < ColumnCount ; i++)
             {
@@ -1736,27 +1751,44 @@ namespace Krypton.Toolkit
                     index = currentColumn.Index;
                     columnsProcessed.Add(index);
 
-                    newColumn = new KryptonDataGridViewTextBoxColumn
-                    {
-                        Name = currentColumn.Name,
-                        DataPropertyName = currentColumn.DataPropertyName,
-                        HeaderText = currentColumn.HeaderText,
-                        Width = currentColumn.Width
-                    };
+                    var newColumn = this.DesignMode
+                        ? designerHost?.CreateComponent(typeof(KryptonDataGridViewTextBoxColumn)) as KryptonDataGridViewTextBoxColumn 
+                        : new KryptonDataGridViewTextBoxColumn();
+
+                    newColumn!.Name = currentColumn.Name;
+                    newColumn.DataPropertyName = currentColumn.DataPropertyName;
+                    newColumn.HeaderText = currentColumn.HeaderText;
+                    newColumn.Width = currentColumn.Width;
+                    newColumn.AutoSizeMode = DataGridViewAutoSizeColumnMode.DisplayedCells;
 
                     Columns.RemoveAt(index);
                     Columns.Insert(index, newColumn);
+
+                    designerHost?.DestroyComponent(currentColumn);
+                }
+                else if (currentColumn is DataGridViewCheckBoxColumn && currentColumn.DataPropertyName.Length > 0)
+                {
+                    index = currentColumn.Index;
+                    columnsProcessed.Add(index);
+
+                    var newColumn = this.DesignMode
+                        ? designerHost?.CreateComponent(typeof(KryptonDataGridViewCheckBoxColumn)) as KryptonDataGridViewCheckBoxColumn 
+                        : new KryptonDataGridViewCheckBoxColumn();
+
+                    newColumn!.Name = currentColumn.Name;
+                    newColumn.DataPropertyName = currentColumn.DataPropertyName;
+                    newColumn.HeaderText = currentColumn.HeaderText;
+                    newColumn.Width = currentColumn.Width;
+                    newColumn.AutoSizeMode = DataGridViewAutoSizeColumnMode.DisplayedCells;
+
+                    Columns.RemoveAt(index);
+                    Columns.Insert(index, newColumn);
+
+                    designerHost?.DestroyComponent(currentColumn);
                 }
             }
 
-            /*
-             * After the columns have been replaced they need a little help so they have the same width as when only Winforms columns would've been auto added.
-             * Setting this value in the above for loop does not work.
-             */
-            for (int i = 0 ; i < columnsProcessed.Count ; i++)
-            {
-                Columns[columnsProcessed[i]].AutoSizeMode = DataGridViewAutoSizeColumnMode.DisplayedCells;
-            }
+            changeService?.OnComponentChanged(this, null, null, null);
         }
 
         private void SetupVisuals()


### PR DESCRIPTION
[Issue 1784-KryptonDataGridView-reorders-Columns-during-debugging](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1784)
- Fixes the autogenerating of columns
- The grid now uses the Winforms control designer, the current one hampers auto generating columns.
- And the change log

![compile-results](https://github.com/user-attachments/assets/0fc3d91b-dccb-48d4-b63f-bd86b3b522b7)

