### PR TITLE
1908-V100-KDGV-ComboBoxColumn-updates

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxCell.cs
@@ -415,7 +415,7 @@ namespace Krypton.Toolkit
                 }
                 else
                 {
-                    text = errorText;
+                    text = ErrorText;
                 }
 
                 // Cell display text

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxCell.cs
@@ -407,13 +407,19 @@ namespace Krypton.Toolkit
 
                 // Draw the drop down button, only if no ErrorText has been set.
                 // If the ErrorText is set, only the error icon is shown. Otherwise both are painted on the same spot.
+                string text;
                 if (ErrorText.Length == 0)
                 {
                     graphics.DrawImage(image, new Point(pos, textArea.Top));
+                    text = _selectedItemText;
+                }
+                else
+                {
+                    text = errorText;
                 }
 
                 // Cell display text
-                TextRenderer.DrawText(graphics, _selectedItemText, cellStyle.Font, textArea, cellStyle.ForeColor,
+                TextRenderer.DrawText(graphics, text, cellStyle.Font, textArea, cellStyle.ForeColor,
                     KryptonDataGridViewUtilities.ComputeTextFormatFlagsForCellStyleAlignment(righToLeft, cellStyle.Alignment, cellStyle.WrapMode));
             }
         }


### PR DESCRIPTION
[Issue 1908-V100-KDGV-Columns-show-no-indicator-on-inactive-cell](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1908)
- Adds display of the Errortext to the KryptonDataGridViewComboBoxCell.
- Change log entry will be provided when 1908 is fully completed

![compile-results](https://github.com/user-attachments/assets/e0165f1a-74e9-4bb5-b1c4-9e5e77b1f4d3)
