### PR TITLE
1784-V100-KryptonDataGridView-reorders-Columns-during-debugging

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -354,13 +354,13 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Public
-        [Browsable(false)]
-        [Description(@"When true and AutoGenerateColumns is true the KryptonDataGridView will use Krypton column types, when false the standard WinForms column types.")]
+        [Browsable(true)]
+        [Category(@"Behavior")]
+        [Description(@"When true the KryptonDataGridView will, upon connecting a data source, convert WinForms column types to Krypton column types, when false the standard WinForms column types.")]
         [DefaultValue(true)]
         public bool AutoGenerateKryptonColumns 
         {
-            get;
-            set;
+            get; set;
         } = true;
 
         /// <summary>Gets or sets the <see cref="T:System.Windows.Forms.ContextMenuStrip" /> associated with this control.</summary>


### PR DESCRIPTION
[Issue 1784-KryptonDataGridView-reorders-Columns-during-debugging](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1784)
- Amends PR #1986
- Makes `AutoGenerateKryptonColumns` available in the properties window. 
- Corrects the description of `AutoGenerateKryptonColumns`

![compile-results](https://github.com/user-attachments/assets/7fc46728-707b-446b-b5b4-9ef0f7aa57c2)
