### PR TITLE
1784-V95-KryptonDataGridView-reorders-Columns-during-debugging

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2025-02-01 - Build 2502 (Version 95 - Patch 1) - February 2025
+* Resolved [#1784](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1784), `KryptonDataGridView` Auto generation of columns is not serialized correctly.
 * Resolved [#1964](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1964), `KryptonTreeView` Node crosses are not Dpi Scaled
 * Resolved [#560](https://github.com/Krypton-Suite/Standard-Toolkit/issues/560), CheckBox Images are not scaled with dpi Awareness
 * Resolved [#565](https://github.com/Krypton-Suite/Standard-Toolkit/issues/565), GroupBox icons are not scaled for dpi awareness

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -17,8 +17,12 @@ namespace Krypton.Toolkit
     /// </summary>
     [ToolboxItem(true)]
     [ToolboxBitmap(typeof(KryptonDataGridView), "ToolboxBitmaps.KryptonDataGridView.bmp")]
-    [DesignerCategory(@"code")]
-    [Designer(typeof(KryptonDataGridViewDesigner))]
+    [DesignerCategory(@"Code")]
+    //[Designer(typeof(KryptonDataGridViewDesigner))] do not use for now. use the the winforms editor
+    [Designer($"System.Windows.Forms.Design.DataGridViewDesigner")]
+    [DefaultEvent(nameof(CellContentClick))]
+    [ComplexBindingProperties(nameof(DataSource), nameof(DataMember))]
+    [Docking(DockingBehavior.Ask)]
     [Description(@"Display rows and columns of data of a grid you can customize.")]
     public class KryptonDataGridView : DataGridView
     {
@@ -350,13 +354,12 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Public
-        [Browsable(false)]
-        [Description(@"When true and AutoGenerateColumns is true the KryptonDataGridView will use Krypton column types, when false the standard WinForms column types.")]
+        [Browsable(true)]
+        [Category(@"Behavior")]
+        [Description(@"When true the KryptonDataGridView will, upon connecting a data source, convert WinForms column types to Krypton column types, when false the standard WinForms column types.")]
         [DefaultValue(true)]
-        public bool AutoGenerateKryptonColumns 
-        {
-            get;
-            set;
+        public bool AutoGenerateKryptonColumns {
+            get; set;
         } = true;
 
         /// <summary>Gets or sets the <see cref="T:System.Windows.Forms.ContextMenuStrip" /> associated with this control.</summary>
@@ -1010,54 +1013,11 @@ namespace Krypton.Toolkit
 
         #region Protected Override
         /// <inheritdoc/>
-        protected override void OnDataMemberChanged(EventArgs e)
-        {
-            base.OnDataMemberChanged(e);
-
-            if (AutoGenerateColumns
-                && AutoGenerateKryptonColumns
-                && DataSource is not null)
-            {
-                ReplaceDefaultColumsWithKryptonColumns();
-            }
-        }
-
-        /// <inheritdoc/>
-        protected override void OnDataSourceChanged(EventArgs e)
-        {
-            base.OnDataSourceChanged(e);
-
-            if (AutoGenerateColumns
-                && AutoGenerateKryptonColumns
-                && DataSource is not null)
-            {
-                ReplaceDefaultColumsWithKryptonColumns();
-            }
-        }
-
-        /// <inheritdoc/>
-        protected override void OnAutoGenerateColumnsChanged(EventArgs e)
-        {
-            // First handle the base the event
-            base.OnAutoGenerateColumnsChanged(e);
-
-            // If needed convert the winforms columns to Krypton columns
-            if (AutoGenerateColumns
-                && AutoGenerateKryptonColumns
-                && DataSource is not null)
-            {
-                ReplaceDefaultColumsWithKryptonColumns();
-            }
-        }
-
-        /// <inheritdoc/>
         protected override void OnDataBindingComplete(DataGridViewBindingCompleteEventArgs e)
         {
             base.OnDataBindingComplete(e);
 
-            if (AutoGenerateColumns
-                && AutoGenerateKryptonColumns
-                && DataSource is not null)
+            if (AutoGenerateKryptonColumns && DataSource is not null)
             {
                 ReplaceDefaultColumsWithKryptonColumns();
             }
@@ -1719,44 +1679,62 @@ namespace Krypton.Toolkit
         private void ReplaceDefaultColumsWithKryptonColumns()
         {
             DataGridViewColumn currentColumn;
-            KryptonDataGridViewTextBoxColumn newColumn;
-            List<int> columnsProcessed = [];
             int index;
+            IComponentChangeService? changeService = null;
+            IDesignerHost? designerHost = null;
 
-            for (int i = 0 ; i < ColumnCount ; i++)
+            if (this.DesignMode)
+            {
+                changeService = GetService(typeof(IComponentChangeService)) as IComponentChangeService;
+                designerHost = this.Site!.GetService(typeof(IDesignerHost)) as IDesignerHost;
+                changeService?.OnComponentChanging(this, null);
+            }
+
+            for (int i = 0; i < ColumnCount; i++)
             {
                 currentColumn = Columns[i];
 
-                /* 
-                 * Auto generated columns are always of type System.Windows.Forms.DataGridViewTextBoxColumn.
-                 * Only columns that are of type DataGridViewTextBoxColumn and have the DataPropertyName set will be converted to krypton Columns.
-                 */
                 if (currentColumn is DataGridViewTextBoxColumn && currentColumn.DataPropertyName.Length > 0)
                 {
                     index = currentColumn.Index;
-                    columnsProcessed.Add(index);
 
-                    newColumn = new KryptonDataGridViewTextBoxColumn
-                    {
-                        Name = currentColumn.Name,
-                        DataPropertyName = currentColumn.DataPropertyName,
-                        HeaderText = currentColumn.HeaderText,
-                        Width = currentColumn.Width
-                    };
+                    var newColumn = this.DesignMode
+                        ? designerHost?.CreateComponent(typeof(KryptonDataGridViewTextBoxColumn)) as KryptonDataGridViewTextBoxColumn
+                        : new KryptonDataGridViewTextBoxColumn();
+
+                    newColumn!.Name = currentColumn.Name;
+                    newColumn.DataPropertyName = currentColumn.DataPropertyName;
+                    newColumn.HeaderText = currentColumn.HeaderText;
+                    newColumn.Width = currentColumn.Width;
+                    newColumn.AutoSizeMode = DataGridViewAutoSizeColumnMode.DisplayedCells;
 
                     Columns.RemoveAt(index);
                     Columns.Insert(index, newColumn);
+
+                    designerHost?.DestroyComponent(currentColumn);
+                }
+                else if (currentColumn is DataGridViewCheckBoxColumn && currentColumn.DataPropertyName.Length > 0)
+                {
+                    index = currentColumn.Index;
+
+                    var newColumn = this.DesignMode
+                        ? designerHost?.CreateComponent(typeof(KryptonDataGridViewCheckBoxColumn)) as KryptonDataGridViewCheckBoxColumn
+                        : new KryptonDataGridViewCheckBoxColumn();
+
+                    newColumn!.Name = currentColumn.Name;
+                    newColumn.DataPropertyName = currentColumn.DataPropertyName;
+                    newColumn.HeaderText = currentColumn.HeaderText;
+                    newColumn.Width = currentColumn.Width;
+                    newColumn.AutoSizeMode = DataGridViewAutoSizeColumnMode.DisplayedCells;
+
+                    Columns.RemoveAt(index);
+                    Columns.Insert(index, newColumn);
+
+                    designerHost?.DestroyComponent(currentColumn);
                 }
             }
 
-            /*
-             * After the columns have been replaced they need a little help so they have the same width as when only Winforms columns would've been auto added.
-             * Setting this value in the above for loop does not work.
-             */
-            for (int i = 0 ; i < columnsProcessed.Count ; i++)
-            {
-                Columns[columnsProcessed[i]].AutoSizeMode = DataGridViewAutoSizeColumnMode.DisplayedCells;
-            }
+            changeService?.OnComponentChanged(this, null, null, null);
         }
 
         private void SetupVisuals()

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewCellIndicatorImage.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewCellIndicatorImage.cs
@@ -1,0 +1,169 @@
+﻿#region BSD License
+/*
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
+ *  
+ */
+#endregion
+
+namespace Krypton.Toolkit
+{
+    /// <summary>
+    /// This class is used  within advanved columns that make use of embedded controls.
+    /// </summary>
+    [ToolboxItem(false)]
+    internal class KryptonDataGridViewCellIndicatorImage : IDisposable
+    {
+        #region Fields
+        // Cell indicator image
+        private Image? _image = null;
+        // Size of the image which is always square
+        private int _size;
+        // Datagridview the column belongs to.
+        private KryptonDataGridView? _dataGridView;
+        // State of disposal
+        private bool _disposed = false;
+        
+        // type and state of the image
+        private PaletteRibbonGalleryButton _paletteRibbonGalleryButton = PaletteRibbonGalleryButton.Down;
+        private PaletteState _paletteState = PaletteState.Normal;
+        #endregion Fields
+
+        #region Identity
+        /// <summary>
+        /// Default constructor.
+        /// </summary>
+        /// <param name="imageSize">The image size in pixels. Which will always be used to square the image. Default is 14.</param>
+        public KryptonDataGridViewCellIndicatorImage(int imageSize = 14)
+        {
+            _size = imageSize;
+
+            UpdateCellIndicatorImage(true);
+            KryptonManager.GlobalPaletteChanged += OnKryptonManagerGlobalPaletteChanged;
+        }
+        #endregion Identity
+
+        #region Public
+        /// <summary>
+        /// Reference to the column's DataGridView.<br/>
+        /// Set this property via the column's 'protected override void OnDataGridViewChanged()'.
+        /// </summary>
+        public KryptonDataGridView? DataGridView
+        { 
+            get => _dataGridView;
+
+            set
+            {
+                if (_dataGridView != value)
+                {
+                    if (_dataGridView is not null)
+                    {
+                        _dataGridView.PaletteChanged -= OnDataGridViewPaletteChanged;
+                    }
+
+                    _dataGridView = value;
+
+                    if (_dataGridView is not null)
+                    {
+                        _dataGridView.PaletteChanged += OnDataGridViewPaletteChanged;
+                        UpdateCellIndicatorImage(false);
+                    }
+                }
+            }
+        }
+        
+        /// <summary>
+        /// Cell indicator image.
+        /// </summary>
+        public virtual Image? Image => _image;
+
+        /// <inheritdoc/>>
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        /// <inheritdoc cref="Dispose()"/>
+        public void Dispose(bool disposing)
+        {
+            // If the column is disposed at runtime the eventhandlers need to unsubscribe from the grid and kmananger
+            try
+            {
+                if (!_disposed && disposing)
+                {
+                    // Since the DataGridView property is controlled internally,
+                    // use the cached reference to unsubscribe from the event
+                    if (_dataGridView is not null)
+                    {
+                        _dataGridView.PaletteChanged -= OnDataGridViewPaletteChanged;
+                    }
+
+                    KryptonManager.GlobalPaletteChanged -= OnKryptonManagerGlobalPaletteChanged;
+                    _dataGridView = null;
+
+                    _disposed = true;
+                }
+            }
+            catch { }
+        }
+        #endregion Public
+
+        #region Private
+        /// <summary>
+        /// Subscribe this handler to: KryptonDataGridView.PaletteChanged
+        /// </summary>
+        /// <param name="sender">Not used.</param>
+        /// <param name="e">Not used.</param>
+        private void OnDataGridViewPaletteChanged(object? sender, EventArgs e) => UpdateCellIndicatorImage(false);
+
+        /// <summary>
+        /// Subscribe this handler to: KryptonManager.GlobalPaletteChanged
+        /// </summary>
+        /// <param name="sender">Not used.</param>
+        /// <param name="e">Not used.</param>
+        private void OnKryptonManagerGlobalPaletteChanged(object? sender, EventArgs e) => UpdateCellIndicatorImage(true);
+
+        /// <summary>
+        /// Updates the cell indicator image based on the source from where the theme change originated.
+        /// </summary>
+        /// <param name="updateFromKryptonManager">True if KryptonManager fired the theme change, otherwise from KryptonDataGridView.</param>
+        private void UpdateCellIndicatorImage(bool updateFromKryptonManager)
+        {
+            if (updateFromKryptonManager)
+            {
+                // Probably the case used most, so first to check.
+                _image = KryptonManager.CurrentGlobalPalette.GetGalleryButtonImage(_paletteRibbonGalleryButton, _paletteState)!;
+                ResizeCellIndicatorImage();
+            }
+            else if (DataGridView is KryptonDataGridView dataGridView)
+            {
+                if (dataGridView.Palette is not null && dataGridView.PaletteMode == PaletteMode.Custom)
+                {
+                    // The grid has a custom palette instance assigned to it and PaletteMode is Custom
+                    _image = dataGridView.Palette.GetGalleryButtonImage(_paletteRibbonGalleryButton, _paletteState);
+                }
+                else
+                {
+                    // Fetch through KryptonManager using the locally set palette mode
+                    _image = KryptonManager
+                        .GetPaletteForMode(dataGridView.PaletteMode)
+                        .GetGalleryButtonImage(_paletteRibbonGalleryButton, _paletteState)!;
+                }
+
+                ResizeCellIndicatorImage();
+            }
+        }
+
+        /// <summary>
+        /// This method may only be used by UpdateCellIndicatorImage()
+        /// </summary>
+        private void ResizeCellIndicatorImage()
+        {
+            if (_image is not null && (_image.Width != _size || _image.Height != _size))
+            {
+                _image = new Bitmap(_image, _size, _size);
+            }
+        }
+        #endregion Private
+    }
+}

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewUtilities.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewUtilities.cs
@@ -1,0 +1,76 @@
+﻿#region BSD License
+/*
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2024 - 2025. All rights reserved.
+ *  
+ */
+#endregion
+
+namespace Krypton.Toolkit
+{
+
+    internal class KryptonDataGridViewUtilities
+    {
+        internal static class TextFormatFlagsCellStyleAlignments
+        {
+            // Calculate these once for use in ComputeTextFormatFlagsForCellStyleAlignment()
+            private const TextFormatFlags baseMask = TextFormatFlags.NoPrefix | TextFormatFlags.PreserveGraphicsClipping;
+
+            internal const TextFormatFlags TopLeft_RightToLeft = baseMask | TextFormatFlags.Top | TextFormatFlags.Right | TextFormatFlags.RightToLeft;
+            internal const TextFormatFlags TopLeft_LeftToRight = baseMask | TextFormatFlags.Top | TextFormatFlags.Left;
+            internal const TextFormatFlags TopCenter = baseMask | TextFormatFlags.Top | TextFormatFlags.HorizontalCenter;
+            internal const TextFormatFlags TopRight_RightToLeft = baseMask | TextFormatFlags.Top | TextFormatFlags.Left | TextFormatFlags.RightToLeft;
+            internal const TextFormatFlags TopRight_LeftToRight = baseMask | TextFormatFlags.Top | TextFormatFlags.Right;
+
+            internal const TextFormatFlags MiddleLeft_RightToLeft = baseMask | TextFormatFlags.VerticalCenter | TextFormatFlags.Right | TextFormatFlags.RightToLeft;
+            internal const TextFormatFlags MiddleLeft_LeftToRight = baseMask | TextFormatFlags.VerticalCenter | TextFormatFlags.Left;
+            internal const TextFormatFlags MiddleCenter = baseMask | TextFormatFlags.VerticalCenter | TextFormatFlags.HorizontalCenter;
+            internal const TextFormatFlags MiddleRight_RightToLeft = baseMask | TextFormatFlags.VerticalCenter | TextFormatFlags.Left | TextFormatFlags.RightToLeft;
+            internal const TextFormatFlags MiddleRight_LeftToRight = baseMask | TextFormatFlags.VerticalCenter | TextFormatFlags.Right;
+
+            internal const TextFormatFlags BottomLeft_RightToLeft = baseMask | TextFormatFlags.Bottom | TextFormatFlags.Right | TextFormatFlags.RightToLeft;
+            internal const TextFormatFlags BottomLeft_LeftToRight = baseMask | TextFormatFlags.Bottom | TextFormatFlags.Left;
+            internal const TextFormatFlags BottomCenter = baseMask | TextFormatFlags.Bottom | TextFormatFlags.HorizontalCenter;
+            internal const TextFormatFlags BottomRight_RightToLeft = baseMask | TextFormatFlags.Bottom | TextFormatFlags.Left | TextFormatFlags.RightToLeft;
+            internal const TextFormatFlags BottomRight_Lefttoright = baseMask | TextFormatFlags.Bottom | TextFormatFlags.Right;
+
+            internal const TextFormatFlags DefaultAlignment = baseMask | TextFormatFlags.HorizontalCenter | TextFormatFlags.VerticalCenter;
+        }
+
+        internal static TextFormatFlags ComputeTextFormatFlagsForCellStyleAlignment(
+            bool rightToLeft,
+            DataGridViewContentAlignment alignment,
+            DataGridViewTriState wrapMode)
+        {
+            // This routine has been copied from the dotnet winforms project and slightly rewritten to reduce computing masks
+            // Licensed to the .NET Foundation under one or more agreements.
+            // The .NET Foundation licenses this file to you under the MIT license.
+            TextFormatFlags tff = alignment switch
+            {
+                DataGridViewContentAlignment.TopLeft when rightToLeft => TextFormatFlagsCellStyleAlignments.TopLeft_RightToLeft,
+                DataGridViewContentAlignment.TopLeft when !rightToLeft => TextFormatFlagsCellStyleAlignments.TopLeft_LeftToRight,
+                DataGridViewContentAlignment.TopCenter => TextFormatFlagsCellStyleAlignments.TopCenter,
+                DataGridViewContentAlignment.TopRight when rightToLeft => TextFormatFlagsCellStyleAlignments.TopRight_RightToLeft,
+                DataGridViewContentAlignment.TopRight when !rightToLeft => TextFormatFlagsCellStyleAlignments.TopRight_LeftToRight,
+
+                DataGridViewContentAlignment.MiddleLeft when rightToLeft => TextFormatFlagsCellStyleAlignments.MiddleLeft_RightToLeft,
+                DataGridViewContentAlignment.MiddleLeft when !rightToLeft => TextFormatFlagsCellStyleAlignments.MiddleLeft_LeftToRight,
+                DataGridViewContentAlignment.MiddleCenter => TextFormatFlagsCellStyleAlignments.MiddleCenter,
+                DataGridViewContentAlignment.MiddleRight when rightToLeft => TextFormatFlagsCellStyleAlignments.MiddleRight_RightToLeft,
+                DataGridViewContentAlignment.MiddleRight when !rightToLeft => TextFormatFlagsCellStyleAlignments.MiddleRight_LeftToRight,
+
+                DataGridViewContentAlignment.BottomLeft when rightToLeft => TextFormatFlagsCellStyleAlignments.BottomLeft_RightToLeft,
+                DataGridViewContentAlignment.BottomLeft when !rightToLeft => TextFormatFlagsCellStyleAlignments.BottomLeft_LeftToRight,
+                DataGridViewContentAlignment.BottomCenter => TextFormatFlagsCellStyleAlignments.BottomCenter,
+                DataGridViewContentAlignment.BottomRight when rightToLeft => TextFormatFlagsCellStyleAlignments.BottomRight_RightToLeft,
+                DataGridViewContentAlignment.BottomRight when !rightToLeft => TextFormatFlagsCellStyleAlignments.BottomRight_Lefttoright,
+                _ => TextFormatFlagsCellStyleAlignments.DefaultAlignment
+            };
+
+            return  tff | (wrapMode == DataGridViewTriState.False
+                ? TextFormatFlags.SingleLine
+                : TextFormatFlags.WordBreak);
+
+        }
+    }
+}


### PR DESCRIPTION
[Issue 1784-KryptonDataGridView-reorders-Columns-during-debugging](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1784)
- Fixes the autogenerating of columns
- The grid now uses the Winforms control designer, the current one hampers auto generating columns.
- Adds the property `AutoGenerateKryptonColumns` and makes it available in the properties window.
- And the change log

![compile-results](https://github.com/user-attachments/assets/69fcd6a2-cab1-4196-88b3-5d90372b3678)
