### PR TITLE
1908-V95-KryptonDataGridViewDateTimePickerCell-updates

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDateTimePickerCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDateTimePickerCell.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2024. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
@@ -18,12 +18,9 @@ namespace Krypton.Toolkit
     public class KryptonDataGridViewDateTimePickerCell : DataGridViewTextBoxCell
     {
         #region Static Fields
-        [ThreadStatic]
-        private static KryptonDateTimePicker _paintingDateTime;
         private static readonly DateTimeConverter _dtc = new DateTimeConverter();
         private static readonly Type _defaultEditType = typeof(KryptonDataGridViewDateTimePickerEditingControl);
         private static readonly Type _defaultValueType = typeof(DateTime);
-        private static readonly Size _sizeLarge = new Size(10000, 10000);
         #endregion
 
         #region Instance Fields
@@ -52,17 +49,6 @@ namespace Krypton.Toolkit
         /// </summary>
         public KryptonDataGridViewDateTimePickerCell()
         {
-            // Create a thread specific KryptonDateTimePicker control used for the painting of the non-edited cells
-            if (_paintingDateTime == null)
-            {
-                _paintingDateTime = new KryptonDateTimePicker
-                {
-                    ShowBorder = false
-                };
-                _paintingDateTime.StateCommon.Border.Width = 0;
-                _paintingDateTime.StateCommon.Border.Draw = InheritBool.False;
-            }
-
             // Set the default values of the properties:
             _showCheckBox = false;
             _showUpDown = false;
@@ -513,9 +499,7 @@ namespace Krypton.Toolkit
                 }
                 else
                 {
-                    var dt = (DateTime)_dtc.ConvertFromInvariantString(initialFormattedValueStr)!;
-
-                    if (dt != null)
+                    if (_dtc.ConvertFromInvariantString(initialFormattedValueStr) is DateTime dt)
                     {
                         dateTime.Value = dt;
                     }
@@ -548,13 +532,10 @@ namespace Krypton.Toolkit
             {
                 return string.Empty;
             }
-            else
+            
+            if (value is DateTime dt)
             {
-                var dt = (DateTime)value;
-                if (dt != null)
-                {
-                    return _dtc.ConvertToInvariantString(dt);
-                }
+                return _dtc.ConvertToInvariantString(dt);
             }
 
             return base.GetFormattedValue(value, rowIndex, ref cellStyle, valueTypeConverter, formattedValueTypeConverter, context);
@@ -583,32 +564,74 @@ namespace Krypton.Toolkit
                 return string.IsNullOrEmpty(stringValue) ? DBNull.Value : _dtc.ConvertFromInvariantString(stringValue)!;
             }
         }
-
-        /// <summary>
-        /// Custom implementation of the PositionEditingControl method called by the DataGridView control when it
-        /// needs to relocate and/or resize the editing control.
-        /// </summary>
-        public override void PositionEditingControl(bool setLocation,
-            bool setSize,
-            Rectangle cellBounds,
-            Rectangle cellClip,
-            DataGridViewCellStyle cellStyle,
-            bool singleVerticalBorderAdded,
-            bool singleHorizontalBorderAdded,
-            bool isFirstDisplayedColumn,
-            bool isFirstDisplayedRow)
-        {
-            Rectangle editingControlBounds = PositionEditingPanel(cellBounds, cellClip, cellStyle,
-                singleVerticalBorderAdded, singleHorizontalBorderAdded,
-                isFirstDisplayedColumn, isFirstDisplayedRow);
-
-            editingControlBounds = GetAdjustedEditingControlBounds(editingControlBounds, cellStyle);
-            DataGridView!.EditingControl!.Location = new Point(editingControlBounds.X, editingControlBounds.Y);
-            DataGridView.EditingControl.Size = new Size(editingControlBounds.Width, editingControlBounds.Height);
-        }
         #endregion
 
         #region Protected
+        ///<inheritdoc/>
+        protected override void Paint(Graphics graphics, Rectangle clipBounds, Rectangle cellBounds, int rowIndex, DataGridViewElementStates cellState, object? value,
+            object? formattedValue, string? errorText, DataGridViewCellStyle cellStyle, DataGridViewAdvancedBorderStyle advancedBorderStyle, DataGridViewPaintParts paintParts)
+        {
+            if (DataGridView is not null
+                && KryptonOwningColumn?.CellIndicatorImage is Image image)
+            {
+                int pos;
+                Rectangle textArea;
+                var righToLeft = DataGridView.RightToLeft == RightToLeft.Yes;
+
+                if (righToLeft)
+                {
+                    pos = cellBounds.Left;
+
+                    // The WinForms cell content always receives padding of one by default, custom padding is added tot that.
+                    textArea = new Rectangle(
+                        1 + cellBounds.Left + cellStyle.Padding.Left + image.Width,
+                        1 + cellBounds.Top + cellStyle.Padding.Top,
+                        cellBounds.Width - cellStyle.Padding.Left - cellStyle.Padding.Right - image.Width - 3,
+                        cellBounds.Height - cellStyle.Padding.Top - cellStyle.Padding.Bottom - 2);
+                }
+                else
+                {
+                    pos = cellBounds.Right - image.Width;
+
+                    // The WinForms cell content always receives padding of one by default, custom padding is added tot that.
+                    textArea = new Rectangle(
+                        1 + cellBounds.Left + cellStyle.Padding.Left,
+                        1 + cellBounds.Top + cellStyle.Padding.Top,
+                        cellBounds.Width - cellStyle.Padding.Left - cellStyle.Padding.Right - image.Width - 3,
+                        cellBounds.Height - cellStyle.Padding.Top - cellStyle.Padding.Bottom - 2);
+                }
+
+                // When the Krypton column is part of a WinForms DataGridView let the default paint routine paint the cell.
+                // Afterwards we paint the text and drop down image.
+                if (DataGridView is DataGridView)
+                {
+                    base.Paint(graphics, clipBounds, cellBounds, rowIndex, cellState, null, string.Empty, errorText, cellStyle, advancedBorderStyle, paintParts);
+                }
+
+                // Draw the drop down button, only if no ErrorText has been set.
+                // If the ErrorText is set, only the error icon is shown. Otherwise both are painted on the same spot.
+                if (ErrorText.Length == 0)
+                {
+                    graphics.DrawImage(image, new Point(pos, textArea.Top));
+
+                    if (DataGridView.Rows.SharedRow(rowIndex).Index != -1
+                        && formattedValue is string str
+                        && str.Length > 0
+                        && DateTime.TryParse(str, out DateTime dt))
+                    {
+                        formattedValue = dt.ToString(InheritedStyle.Format);
+                    }
+                }
+                else
+                {
+                    formattedValue = errorText;
+                }
+
+                TextRenderer.DrawText(graphics, formattedValue?.ToString() ?? string.Empty, cellStyle.Font, textArea, cellStyle.ForeColor,
+                    KryptonDataGridViewUtilities.ComputeTextFormatFlagsForCellStyleAlignment(righToLeft, cellStyle.Alignment, cellStyle.WrapMode));
+            }
+        }
+
         /// <summary>
         /// Customized implementation of the GetErrorIconBounds function in order to draw the potential 
         /// error icon next to the up/down buttons and not on top of them.
@@ -618,14 +641,10 @@ namespace Krypton.Toolkit
             const int ButtonsWidth = 16;
 
             Rectangle errorIconBounds = base.GetErrorIconBounds(graphics, cellStyle, rowIndex);
-            if (DataGridView!.RightToLeft == RightToLeft.Yes)
-            {
-                errorIconBounds.X = errorIconBounds.Left + ButtonsWidth;
-            }
-            else
-            {
-                errorIconBounds.X = errorIconBounds.Left - ButtonsWidth;
-            }
+
+            errorIconBounds.X = DataGridView!.RightToLeft == RightToLeft.Yes
+                ? errorIconBounds.Left + ButtonsWidth
+                : errorIconBounds.Left - ButtonsWidth;
 
             return errorIconBounds;
         }
@@ -650,86 +669,12 @@ namespace Krypton.Toolkit
 
             return preferredSize;
         }
-
-        /// <summary>
-        /// Custom paints the cell. The base implementation of the DataGridViewTextBoxCell type is called first,
-        /// dropping the icon error and content foreground parts. Those two parts are painted by this custom implementation.
-        /// In this sample, the non-edited KryptonDateTimePicker control is painted by using a call to Control.DrawToBitmap. This is
-        /// an easy solution for painting controls but it's not necessarily the most performant. An alternative would be to paint
-        /// the KryptonDateTimePicker control piece by piece (text and up/down buttons).
-        /// </summary>
-        protected override void Paint(Graphics graphics,
-                                      Rectangle clipBounds,
-                                      Rectangle cellBounds,
-                                      int rowIndex,
-                                      DataGridViewElementStates cellState,
-                                      object? value,
-                                      object? formattedValue,
-                                      string? errorText,
-                                      DataGridViewCellStyle cellStyle,
-                                      DataGridViewAdvancedBorderStyle advancedBorderStyle,
-                                      DataGridViewPaintParts paintParts)
-          {
-            if (DataGridView == null)
-            {
-                return;
-            }
-
-            _paintingDateTime.RightToLeft = DataGridView.RightToLeft;
-            _paintingDateTime.Format = Format;
-            _paintingDateTime.CustomFormat = CustomFormat;
-            _paintingDateTime.CustomNullText = CustomNullText;
-            _paintingDateTime.MaxDate = MaxDate;
-            _paintingDateTime.MinDate = MinDate;
-
-            var drawText = CustomNullText;
-            if ((value == null) || (value == DBNull.Value))
-            {
-                _paintingDateTime.ValueNullable = value;
-                _paintingDateTime.PerformLayout();
-            }
-            else
-            {
-                _paintingDateTime.Value = (DateTime)value;
-                _paintingDateTime.PerformLayout();
-                drawText = _paintingDateTime.Text;
-            }
-
-            base.Paint(graphics, clipBounds, cellBounds, rowIndex,
-                cellState, value, drawText, errorText,
-                cellStyle, advancedBorderStyle, paintParts);
-        }
         #endregion
 
         #region Private
 
         private KryptonDataGridViewDateTimePickerEditingControl EditingDateTimePicker => 
             DataGridView!.EditingControl as KryptonDataGridViewDateTimePickerEditingControl ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull(nameof(DataGridView.EditingControl)));
-
-        private Rectangle GetAdjustedEditingControlBounds(Rectangle editingControlBounds,
-            DataGridViewCellStyle cellStyle)
-        {
-            // Adjust the vertical location of the editing control:
-            var preferredHeight = _paintingDateTime.GetPreferredSize(_sizeLarge).Height + 2;
-            if (preferredHeight < editingControlBounds.Height)
-            {
-                switch (cellStyle.Alignment)
-                {
-                    case DataGridViewContentAlignment.MiddleLeft:
-                    case DataGridViewContentAlignment.MiddleCenter:
-                    case DataGridViewContentAlignment.MiddleRight:
-                        editingControlBounds.Y += (editingControlBounds.Height - preferredHeight) / 2;
-                        break;
-                    case DataGridViewContentAlignment.BottomLeft:
-                    case DataGridViewContentAlignment.BottomCenter:
-                    case DataGridViewContentAlignment.BottomRight:
-                        editingControlBounds.Y += editingControlBounds.Height - preferredHeight;
-                        break;
-                }
-            }
-
-            return editingControlBounds;
-        }
 
         private void OnCommonChange()
         {
@@ -750,7 +695,6 @@ namespace Krypton.Toolkit
             rowIndex != -1 && DataGridView is { EditingControl: KryptonDataGridViewDateTimePickerEditingControl control }
                            && (rowIndex == ((IDataGridViewEditingControl)control).EditingControlRowIndex);
 
-        private static bool PartPainted(DataGridViewPaintParts paintParts, DataGridViewPaintParts paintPart) => (paintParts & paintPart) != 0;
         #endregion
 
         #region Internal
@@ -906,6 +850,11 @@ namespace Krypton.Toolkit
                 EditingDateTimePicker.CalendarTodayDate = value;
             }
         }
+
+        /// <summary>
+        /// Type casted version of OwningColumn
+        /// </summary>
+        internal KryptonDataGridViewDateTimePickerColumn? KryptonOwningColumn => OwningColumn as KryptonDataGridViewDateTimePickerColumn;
         #endregion
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDateTimePickerColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDateTimePickerColumn.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2024. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
@@ -20,11 +20,12 @@ namespace Krypton.Toolkit
     public class KryptonDataGridViewDateTimePickerColumn : KryptonDataGridViewIconColumn
     {
         #region Instance Fields
-
         private readonly DateTimeList _annualDates;
         private readonly DateTimeList _monthlyDates;
         private readonly DateTimeList _dates;
-        #endregion
+       // Cell indicator image instance
+        private readonly KryptonDataGridViewCellIndicatorImage _kryptonDataGridViewCellIndicatorImage;
+         #endregion
 
         #region Identity
         /// <summary>
@@ -36,6 +37,7 @@ namespace Krypton.Toolkit
             _annualDates = [];
             _monthlyDates = [];
             _dates = [];
+            _kryptonDataGridViewCellIndicatorImage = new();
         }
 
         /// <summary>
@@ -894,8 +896,23 @@ namespace Krypton.Toolkit
         /// Small utility function that returns the template cell as a KryptonDataGridViewDateTimePickerCell
         /// </summary>
         private KryptonDataGridViewDateTimePickerCell? DateTimePickerCellTemplate => CellTemplate as KryptonDataGridViewDateTimePickerCell;
-
         #endregion
 
+        #region Internal
+        /// <summary>
+        /// Provides the cell indicator images to the cells from from this column instance.<br/>
+        /// For internal use only.
+        /// </summary>
+        internal Image? CellIndicatorImage => _kryptonDataGridViewCellIndicatorImage.Image;
+        #endregion Internal
+
+        #region Protected
+        /// <inheritdoc/>
+        protected override void OnDataGridViewChanged()
+        {
+            _kryptonDataGridViewCellIndicatorImage.DataGridView = DataGridView as KryptonDataGridView;
+            base.OnDataGridViewChanged();
+        }
+        #endregion Protected
     }
 }


### PR DESCRIPTION
[Issue 1908-V95-KDGV-Columns-show-no-indicator-on-inactive-cell](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1908)
- KryptonDataGridViewDateTimePickerCell updates
- Change log entry will be provided when 1908 is fully completed

![compile-results](https://github.com/user-attachments/assets/9d4eb42a-c053-4b3f-aeb4-d39d72106db4)
