### PR TITLE
2023-kryptonDataGridView-IconSpec-image-not-updated-after-change

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,7 +3,8 @@
 =======
 
 ## 2025-11-xx - Build 2511 - November 2025
-* Resolved [#2018](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2018) Corrects `KryptonDataGridView` palette switching difficulties.
+* Resolved [#2023](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2023), `KryptonDataGridView` IconSpecs do not get a repaint when changed at run-time.
+* Resolved [#2018](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2018), Corrects `KryptonDataGridView` palette switching difficulties.
 * Resolved [#561](https://github.com/Krypton-Suite/Standard-Toolkit/issues/561), MenuItem images are not scaled with dpi Awareness
 * Resolved [#2010](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2010), `KryptonDataGridView` columns with editing controls do not react to local palette changes.
 * Resolved [#2009](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2009), `KryptonCombBox` does not display the `CueHint`

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewIconColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewIconColumn.cs
@@ -81,7 +81,7 @@ namespace Krypton.Toolkit
         /// Gets the list of icon specifications.
         /// </summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-        List<IconSpec> IconSpecs
+        ObservableCollection<IconSpec> IconSpecs 
         {
             get;
         }
@@ -89,16 +89,43 @@ namespace Krypton.Toolkit
 
     public abstract class KryptonDataGridViewIconColumn : DataGridViewColumn, IIconCell
     {
+        private KryptonDataGridView? _kryptonDataGridView = null;
         #region Identity
 
         /// <summary>
         /// Initialize a new instance of the KryptonDataGridViewTextBoxColumn class.
         /// </summary>
         protected KryptonDataGridViewIconColumn(DataGridViewCell cellTemplate)
-            : base(cellTemplate) =>
+            : base(cellTemplate)
+        {
             IconSpecs = [];
+        }
 
         #endregion
+
+        protected override void OnDataGridViewChanged()
+        {
+            Debug.Print($"OnDataGridViewChanged: {(DataGridView?.ToString() ?? "is null")}");
+            IconSpecs.CollectionChanged -= OnIconSpecsCollectionChanged;
+
+            // KDGV needs a column refresh only
+            if (DataGridView is KryptonDataGridView)
+            {
+                IconSpecs.CollectionChanged += OnIconSpecsCollectionChanged;
+            }
+
+            base.OnDataGridViewChanged();
+        }
+
+        /// <summary>
+        /// Will inform the KGDV that the column needs a repaint. 
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void OnIconSpecsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            (DataGridView as KryptonDataGridView)?.InvalidateColumn(this.Index);
+        }
 
         /// <summary>
         /// Create a cloned copy of the column.
@@ -120,9 +147,9 @@ namespace Krypton.Toolkit
         /// Gets the collection of the icon specifications.
         /// </summary>
         [Category(@"Data")]
-        [Description(@"Set of extra icons to appear with control.")]
+        [Description(@"Set of extra icons to appear on the column header.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-        public List<IconSpec> IconSpecs { get; }
+        public ObservableCollection<IconSpec> IconSpecs { get; }
 
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewIconColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewIconColumn.cs
@@ -89,7 +89,6 @@ namespace Krypton.Toolkit
 
     public abstract class KryptonDataGridViewIconColumn : DataGridViewColumn, IIconCell
     {
-        private KryptonDataGridView? _kryptonDataGridView = null;
         #region Identity
 
         /// <summary>
@@ -105,7 +104,6 @@ namespace Krypton.Toolkit
 
         protected override void OnDataGridViewChanged()
         {
-            Debug.Print($"OnDataGridViewChanged: {(DataGridView?.ToString() ?? "is null")}");
             IconSpecs.CollectionChanged -= OnIconSpecsCollectionChanged;
 
             // KDGV needs a column refresh only

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewIconColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewIconColumn.cs
@@ -90,6 +90,7 @@ namespace Krypton.Toolkit
     public abstract class KryptonDataGridViewIconColumn : DataGridViewColumn, IIconCell
     {
         private KryptonDataGridView? _dataGridView = null;
+
         #region Identity
 
         /// <summary>
@@ -128,7 +129,7 @@ namespace Krypton.Toolkit
         /// <param name="e">Not used.</param>
         private void OnIconSpecsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
-            _dataGridView   ?.InvalidateColumn(this.Index);
+            _dataGridView?.InvalidateColumn(this.Index);
         }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewIconColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewIconColumn.cs
@@ -89,6 +89,7 @@ namespace Krypton.Toolkit
 
     public abstract class KryptonDataGridViewIconColumn : DataGridViewColumn, IIconCell
     {
+        private KryptonDataGridView? _dataGridView = null;
         #region Identity
 
         /// <summary>
@@ -107,9 +108,14 @@ namespace Krypton.Toolkit
             IconSpecs.CollectionChanged -= OnIconSpecsCollectionChanged;
 
             // KDGV needs a column refresh only
-            if (DataGridView is KryptonDataGridView)
+            if (DataGridView is KryptonDataGridView dataGridView)
             {
+                _dataGridView = dataGridView;
                 IconSpecs.CollectionChanged += OnIconSpecsCollectionChanged;
+            }
+            else
+            {
+                _dataGridView = null;
             }
 
             base.OnDataGridViewChanged();
@@ -122,7 +128,7 @@ namespace Krypton.Toolkit
         /// <param name="e">Not used.</param>
         private void OnIconSpecsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
-            (DataGridView as KryptonDataGridView)?.InvalidateColumn(this.Index);
+            _dataGridView   ?.InvalidateColumn(this.Index);
         }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewIconColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewIconColumn.cs
@@ -118,8 +118,8 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Will inform the KGDV that the column needs a repaint. 
         /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
+        /// <param name="sender">Not used.</param>
+        /// <param name="e">Not used.</param>
         private void OnIconSpecsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             (DataGridView as KryptonDataGridView)?.InvalidateColumn(this.Index);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxCell.cs
@@ -308,6 +308,6 @@ namespace Krypton.Toolkit
         [Category(@"Data")]
         [Description(@"Set of extra icons to appear with control.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-        public List<IconSpec> IconSpecs { get; } = [];
+        public ObservableCollection<IconSpec> IconSpecs { get; } = [];
     }
 }


### PR DESCRIPTION
[Issue 2023-kryptonDataGridView-IconSpec-image-not-updated-after-change](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2023)
- Resolved freshing of the IconSpecs collection
- And the change log

![compile-results](https://github.com/user-attachments/assets/4816337b-16ce-4529-8c10-1aab07441a20)
