### PR TITLE
2023-kryptonDataGridView-IconSpec-image-not-updated-after-change

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxCell.cs
@@ -15,7 +15,7 @@ namespace Krypton.Toolkit
     /// <summary>
     /// Displays editable text information in a KryptonDataGridView control.
     /// </summary>
-    public class KryptonDataGridViewTextBoxCell : DataGridViewTextBoxCell, IIconCell
+    public class KryptonDataGridViewTextBoxCell : DataGridViewTextBoxCell
     {
         #region Instance Fields
         private bool _multiline;
@@ -77,13 +77,10 @@ namespace Krypton.Toolkit
         public override object Clone()
         {
             var cloned = (KryptonDataGridViewTextBoxCell)base.Clone();
-            foreach (IconSpec sp in IconSpecs)
-            {
-                cloned.IconSpecs.Add((IconSpec)sp.Clone());
-            }
-
+ 
             cloned.Multiline = Multiline;
             cloned.MultilineStringEditor = MultilineStringEditor;
+            
             return cloned;
         }
 
@@ -301,13 +298,5 @@ namespace Krypton.Toolkit
             }
         }
         #endregion
-
-        /// <summary>
-        /// Gets the collection of the icon specifications.
-        /// </summary>
-        [Category(@"Data")]
-        [Description(@"Set of extra icons to appear with control.")]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-        public ObservableCollection<IconSpec> IconSpecs { get; } = [];
     }
 }


### PR DESCRIPTION
[Issue 2023-kryptonDataGridView-IconSpec-image-not-updated-after-change](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2023)
- Remove incorrect and overlooked IIConCell implementation from KryptonDataGridViewTextBoxCell as IconSpecs are implemented at the column level.
- No changelog provided as the previous PR to 2023 does that.

![compile-results](https://github.com/user-attachments/assets/0d2b26c0-f318-4f12-81b0-c0515188348e)
