### PR TITLE
2023-V85-kryptonDataGridView-IconSpec-image-not-updated-after-change

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2025-02-01 - Build 2502 (Patch 5) - February 2025
+* Resolved [#2023](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2023), `KryptonDataGridView` IconSpecs do not get a repaint when changed at run-time.
 * Resolved [#561](https://github.com/Krypton-Suite/Standard-Toolkit/issues/561), MenuItem images are not scaled with dpi Awareness
 * Resolved [#1784](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1784), `KryptonDataGridView` Auto generation of columns is not serialized correctly.
 * Resolved [#1964](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1964), `KryptonTreeView` Node crosses are not Dpi Scaled

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewIconColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewIconColumn.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
@@ -39,8 +39,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets the icon to display.
         /// </summary>
-        public Image? Icon
-        {
+        public Image? Icon {
             get;
             set;
         }
@@ -48,8 +47,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets or sets the alignment of the icon.
         /// </summary>
-        public IconAlignment Alignment
-        {
+        public IconAlignment Alignment {
             get;
             set;
         }
@@ -81,24 +79,55 @@ namespace Krypton.Toolkit
         /// Gets the list of icon specifications.
         /// </summary>
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-        List<IconSpec> IconSpecs
-        {
+        ObservableCollection<IconSpec> IconSpecs {
             get;
         }
     }
 
     public abstract class KryptonDataGridViewIconColumn : DataGridViewColumn, IIconCell
     {
+        private KryptonDataGridView? _dataGridView = null;
+
         #region Identity
 
         /// <summary>
         /// Initialize a new instance of the KryptonDataGridViewTextBoxColumn class.
         /// </summary>
         protected KryptonDataGridViewIconColumn(DataGridViewCell cellTemplate)
-            : base(cellTemplate) =>
-            IconSpecs = new List<IconSpec>();
+            : base(cellTemplate)
+        {
+            IconSpecs = [];
+        }
 
         #endregion
+
+        protected override void OnDataGridViewChanged()
+        {
+            IconSpecs.CollectionChanged -= OnIconSpecsCollectionChanged;
+
+            // KDGV needs a column refresh only
+            if (DataGridView is KryptonDataGridView dataGridView)
+            {
+                _dataGridView = dataGridView;
+                IconSpecs.CollectionChanged += OnIconSpecsCollectionChanged;
+            }
+            else
+            {
+                _dataGridView = null;
+            }
+
+            base.OnDataGridViewChanged();
+        }
+
+        /// <summary>
+        /// Will inform the KGDV that the column needs a repaint. 
+        /// </summary>
+        /// <param name="sender">Not used.</param>
+        /// <param name="e">Not used.</param>
+        private void OnIconSpecsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            _dataGridView?.InvalidateColumn(this.Index);
+        }
 
         /// <summary>
         /// Create a cloned copy of the column.
@@ -110,7 +139,7 @@ namespace Krypton.Toolkit
 
             foreach (IconSpec sp in IconSpecs)
             {
-                cloned.IconSpecs.Add(sp.Clone() as IconSpec);
+                cloned.IconSpecs.Add((sp.Clone() as IconSpec)!);
             }
 
             return cloned;
@@ -120,10 +149,8 @@ namespace Krypton.Toolkit
         /// Gets the collection of the icon specifications.
         /// </summary>
         [Category(@"Data")]
-        [Description(@"Set of extra icons to appear with control.")]
+        [Description(@"Set of extra icons to appear on the column header.")]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-        public List<IconSpec> IconSpecs { get; }
-
+        public ObservableCollection<IconSpec> IconSpecs { get; }
     }
-
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxCell.cs
@@ -15,7 +15,7 @@ namespace Krypton.Toolkit
     /// <summary>
     /// Displays editable text information in a KryptonDataGridView control.
     /// </summary>
-    public class KryptonDataGridViewTextBoxCell : DataGridViewTextBoxCell, IIconCell
+    public class KryptonDataGridViewTextBoxCell : DataGridViewTextBoxCell
     {
         #region Instance Fields
         private bool _multiline;
@@ -77,13 +77,10 @@ namespace Krypton.Toolkit
         public override object Clone()
         {
             var cloned = base.Clone() as KryptonDataGridViewTextBoxCell;
-            foreach (IconSpec sp in IconSpecs)
-            {
-                cloned.IconSpecs.Add(sp.Clone() as IconSpec);
-            }
 
             cloned.Multiline = Multiline;
             cloned.MultilineStringEditor = MultilineStringEditor;
+
             return cloned;
         }
 
@@ -321,13 +318,5 @@ namespace Krypton.Toolkit
             }
         }
         #endregion
-
-        /// <summary>
-        /// Gets the collection of the icon specifications.
-        /// </summary>
-        [Category(@"Data")]
-        [Description(@"Set of extra icons to appear with control.")]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-        public List<IconSpec> IconSpecs { get; } = new List<IconSpec>();
     }
 }


### PR DESCRIPTION
[Issue 2023-kryptonDataGridView-IconSpec-image-not-updated-after-change](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2023)
- Remove incorrect and overlooked IIConCell implementation from KryptonDataGridViewTextBoxCell as IconSpecs are implemented at the column level.
- Resolved freshing of the IconSpecs collection
- And the change log


![compile-results](https://github.com/user-attachments/assets/5ca87b14-66ee-4cb9-add4-5dc28fd432b5)
