### PR TITLE
2037-KryptonDataGridView-Sync-V85-and-V95-with-V100

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -1761,6 +1761,8 @@ namespace Krypton.Toolkit
 
             // Set the palette to the defaults as specified by the PaletteMode property
             _localPalette = null;
+            // start off with global mode as default
+            _paletteMode = PaletteMode.Global;
             SetPalette(KryptonManager.GetPaletteForMode(_paletteMode));
 
             // Create constant target for resolving palette delegates


### PR DESCRIPTION
[Issue 2037-KryptonDataGridView-Sync-V85-and-V95-with-V100](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2037)
- KDGV did not default to the Global palette on initialization.
- Change log entry will be provided when KDGV is fully completed

![compile-results](https://github.com/user-attachments/assets/4493353d-8ee6-40dd-8177-9223ab6fdbb1)
