### PR TITLE
2037-V95-KryptonDataGridView-Sync-V85-and-V95-with-V100

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2024. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
@@ -985,7 +985,7 @@ namespace Krypton.Toolkit
         /// Gets or sets the text for the control.
         /// </summary>
         [AllowNull]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        [DesignerSerializationVisibility( DesignerSerializationVisibility.Visible)]
         public override string Text
         {
             get => DomainUpDown.Text;
@@ -995,7 +995,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the associated context menu strip.
         /// </summary>
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        [DesignerSerializationVisibility( DesignerSerializationVisibility.Visible)]
         public override ContextMenuStrip? ContextMenuStrip
         {
             get => base.ContextMenuStrip;
@@ -1793,7 +1793,11 @@ namespace Krypton.Toolkit
         private void InvalidateChildren()
         {
             DomainUpDown.Invalidate();
-            PI.RedrawWindow(Handle, IntPtr.Zero, IntPtr.Zero, 0x85);
+
+            if (!IsDisposed && !Disposing)
+            {
+                PI.RedrawWindow(Handle, IntPtr.Zero, IntPtr.Zero, 0x85);
+            }
         }
 
         private void SubclassEditControl()

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2024. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
@@ -1922,7 +1922,11 @@ namespace Krypton.Toolkit
             if (NumericUpDown != null)
             {
                 NumericUpDown.Invalidate();
-                PI.RedrawWindow(Handle, IntPtr.Zero, IntPtr.Zero, 0x85);
+
+                if (!IsDisposed && !Disposing)
+                {
+                    PI.RedrawWindow(Handle, IntPtr.Zero, IntPtr.Zero, 0x85);
+                }
             }
         }
 


### PR DESCRIPTION
[Issue 2037-KryptonDataGridView-Sync-V85-and-V95-with-V100](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2037)
- Sync KryptonDataGridView and changed components with alpha branch
- Fixes a null reference exception for KDomainUpDown and KNumericUpDown when used within the kryptonDataGridView columns
- Change log entry will be provided when KDGV is fully completed

![compile-results](https://github.com/user-attachments/assets/d311b32f-229a-47db-b1a6-2c8051da8036)
.