### PR TITLE
2037-V85-KryptonDataGridView-Sync-V85-and-V95-with-V100

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
@@ -27,8 +27,8 @@ namespace Krypton.Toolkit
     public class KryptonDataGridView : DataGridView
     {
         #region Type Declaractions
-        private class ColumnHeaderCache : Dictionary<int, bool> { }
-        private class RowHeaderCache : Dictionary<int, Rectangle> { }
+        private class ColumnHeaderCache : Dictionary<int, bool>;
+        private class RowHeaderCache : Dictionary<int, Rectangle>;
         #endregion
 
         #region Classes
@@ -110,9 +110,9 @@ namespace Krypton.Toolkit
         // States and redirector
 
         // Cached values for determining cell style overrides
-        private Font _columnFont;
-        private Font _rowFont;
-        private Font _dataCellFont;
+        private Font? _columnFont;
+        private Font? _rowFont;
+        private Font? _dataCellFont;
         private Padding _columnPadding;
         private Padding _rowPadding;
         private Padding _dataCellPadding;
@@ -138,7 +138,7 @@ namespace Krypton.Toolkit
         private bool _hideOuterBorders;
         private string _toolTipText;
         private byte _oldLocation;
-        private DataGridViewCell _oldCell;
+        private DataGridViewCell? _oldCell;
         private KryptonContextMenu? _kryptonContextMenu;
 
         //Seb
@@ -217,7 +217,7 @@ namespace Krypton.Toolkit
                 SystemEvents.UserPreferenceChanged -= OnUserPreferenceChanged;
 
                 // Dispose of view manager related resources
-                ViewManager.Dispose();
+                ViewManager?.Dispose();
             }
 
             base.Dispose(disposing);
@@ -231,8 +231,7 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public new Color BackgroundColor
-        {
+        public new Color BackgroundColor {
             get => base.BackgroundColor;
             set => base.BackgroundColor = value;
         }
@@ -256,7 +255,7 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public new DataGridViewCellBorderStyle CellBorderStyle
+        public new DataGridViewCellBorderStyle CellBorderStyle 
         {
             get => base.CellBorderStyle;
             set => base.CellBorderStyle = value;
@@ -268,7 +267,7 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public new DataGridViewHeaderBorderStyle ColumnHeadersBorderStyle
+        public new DataGridViewHeaderBorderStyle ColumnHeadersBorderStyle 
         {
             get => base.ColumnHeadersBorderStyle;
             set => base.ColumnHeadersBorderStyle = value;
@@ -280,7 +279,7 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public new DataGridViewCellStyle ColumnHeadersDefaultCellStyle
+        public new DataGridViewCellStyle ColumnHeadersDefaultCellStyle 
         {
             get => base.ColumnHeadersDefaultCellStyle;
             set => base.ColumnHeadersDefaultCellStyle = value;
@@ -292,7 +291,7 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public new DataGridViewCellStyle DefaultCellStyle
+        public new DataGridViewCellStyle DefaultCellStyle 
         {
             get => base.DefaultCellStyle;
             set => base.DefaultCellStyle = value;
@@ -304,7 +303,7 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public new bool EnableHeadersVisualStyles
+        public new bool EnableHeadersVisualStyles 
         {
             get => base.EnableHeadersVisualStyles;
             set => base.EnableHeadersVisualStyles = value;
@@ -316,7 +315,7 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public new Color GridColor
+        public new Color GridColor 
         {
             get => base.GridColor;
             set => base.GridColor = value;
@@ -328,7 +327,7 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public new DataGridViewHeaderBorderStyle RowHeadersBorderStyle
+        public new DataGridViewHeaderBorderStyle RowHeadersBorderStyle 
         {
             get => base.RowHeadersBorderStyle;
             set => base.RowHeadersBorderStyle = value;
@@ -340,7 +339,7 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public new DataGridViewCellStyle RowHeadersDefaultCellStyle
+        public new DataGridViewCellStyle RowHeadersDefaultCellStyle 
         {
             get => base.RowHeadersDefaultCellStyle;
             set => base.RowHeadersDefaultCellStyle = value;
@@ -349,16 +348,17 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Indicates if tool tips are Displayed when the mouse hovers over the cell.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public new bool ShowCellToolTips { get; set; }
 
         #endregion
 
         #region Public
-        [Browsable( true )]
-        [Category( @"Behavior" )]
-        [Description( @"When true the KryptonDataGridView will, upon connecting a data source, convert WinForms column types to Krypton column types, when false the standard WinForms column types." )]
-        [DefaultValue( true )]
-        public bool AutoGenerateKryptonColumns
+        [Browsable(true)]
+        [Category(@"Behavior")]
+        [Description(@"When true the KryptonDataGridView will, upon connecting a data source, convert WinForms column types to Krypton column types, when false the standard WinForms column types.")]
+        [DefaultValue(true)]
+        public bool AutoGenerateKryptonColumns 
         {
             get; set;
         } = true;
@@ -368,7 +368,7 @@ namespace Krypton.Toolkit
         [Category(@"Behavior")]
         [Description(@"Consider using KryptonContextMenu within the behaviors section.\nThe Winforms shortcut menu to show when the user right-clicks the page.\nNote: The ContextMenu will be rendered.")]
         [DefaultValue(null)]
-        public override ContextMenuStrip? ContextMenuStrip
+        public override ContextMenuStrip? ContextMenuStrip 
         {
             [DebuggerStepThrough]
             get => base.ContextMenuStrip;
@@ -401,7 +401,7 @@ namespace Krypton.Toolkit
         [Category(@"Behavior")]
         [Description(@"The KryptonContextMenu to show when the user right-clicks the Control.")]
         [DefaultValue(null)]
-        public virtual KryptonContextMenu? KryptonContextMenu
+        public virtual KryptonContextMenu? KryptonContextMenu 
         {
             get => _kryptonContextMenu;
 
@@ -432,7 +432,7 @@ namespace Krypton.Toolkit
         [Category(@"Visuals")]
         [Description(@"Determine if the outer borders of the grid cells are drawn.")]
         [DefaultValue(false)]
-        public bool HideOuterBorders
+        public bool HideOuterBorders 
         {
             get => _hideOuterBorders;
 
@@ -451,7 +451,8 @@ namespace Krypton.Toolkit
         /// </summary>
         [Category(@"Visuals")]
         [Description(@"Palette applied to drawing.")]
-        public PaletteMode PaletteMode
+        [DefaultValue(PaletteMode.Global)]
+        public PaletteMode PaletteMode 
         {
             [DebuggerStepThrough]
             get => _paletteMode;
@@ -499,7 +500,7 @@ namespace Krypton.Toolkit
         [Category(@"Visuals")]
         [Description(@"Custom palette applied to drawing.")]
         [DefaultValue(null)]
-        public PaletteBase? Palette
+        public PaletteBase? Palette 
         {
             [DebuggerStepThrough]
             get => _localPalette;
@@ -530,6 +531,7 @@ namespace Krypton.Toolkit
                         // No longer using a standard palette
                         _localPalette = value;
                         _paletteMode = PaletteMode.Custom;
+                        SetPalette(_localPalette);
                     }
 
                     // If real change has occurred
@@ -556,7 +558,7 @@ namespace Krypton.Toolkit
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public IRenderer? Renderer
+        public IRenderer? Renderer 
         {
             [DebuggerStepThrough]
             get;
@@ -652,7 +654,7 @@ namespace Krypton.Toolkit
                                                   int columnIndex,
                                                   out IPaletteBack paletteBack,
                                                   out IPaletteBorder paletteBorder,
-                                                  out IPaletteContent? paletteContent)
+                                                  out IPaletteContent paletteContent)
         {
             PaletteState retState;
 
@@ -814,7 +816,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public Point CellOver
+        public Point CellOver 
         {
             get => _cellOver;
             set => _cellOver = value;
@@ -825,7 +827,7 @@ namespace Krypton.Toolkit
         /// Highlight search strings in the DataGridView 
         /// </summary>
         /// <param name="s">The string to search.</param>
-        public void HighlightSearch(string s) => HighlightSearch(s, new List<int>());
+        public void HighlightSearch(string s) => HighlightSearch(s, []);
 
         /// <summary>
         /// Highlight search strings in the DataGridView 
@@ -860,8 +862,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the ViewManager instance.
         /// </summary>
-        protected ViewManager ViewManager
-        {
+        protected ViewManager? ViewManager {
             [DebuggerStepThrough]
             get;
             set;
@@ -870,8 +871,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets access to the need paint delegate.
         /// </summary>
-        protected NeedPaintHandler NeedPaintDelegate
-        {
+        protected NeedPaintHandler NeedPaintDelegate {
             [DebuggerStepThrough]
             get;
             private set;
@@ -882,7 +882,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
-        protected void OnNeedResyncPaint(object sender, NeedLayoutEventArgs e)
+        protected void OnNeedResyncPaint(object? sender, NeedLayoutEventArgs e)
         {
             // Ensure the current cell style values are in sync with the new 
             // palette setting and any state overrides that are defined
@@ -944,8 +944,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets a value indicating if transparent paint is needed
         /// </summary>
-        protected bool NeedTransparentPaint
-        {
+        protected bool NeedTransparentPaint {
             get
             {
                 // Do we need to evaluate the need for a tranparent paint
@@ -972,8 +971,10 @@ namespace Krypton.Toolkit
             // Update the redirector with latest palette
             Redirector.Target = _palette;
 
+            SyncCellStylesWithPalette();
+
             // A new palette source means we need to layout and redraw
-            OnNeedPaint(Palette, new NeedLayoutEventArgs(true));
+            OnNeedPaint(_palette, new NeedLayoutEventArgs(true));
 
             PaletteChanged?.Invoke(this, e);
         }
@@ -984,7 +985,7 @@ namespace Krypton.Toolkit
         /// <returns>True if paint required; otherwise false.</returns>
         protected virtual bool EvalTransparentPaint() =>
             // Do we have a manager to use for asking about painting?
-            ViewManager != null && ViewManager.EvalTransparentPaint(Renderer);
+            ViewManager != null && ViewManager.EvalTransparentPaint(Renderer!);
 
         /// <summary>
         /// Work out if this control needs to use Invoke to force a repaint.
@@ -1002,7 +1003,7 @@ namespace Krypton.Toolkit
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An EventArgs containing event data.</param>
         /// <exception cref="ArgumentNullException"></exception>
-        protected virtual void OnButtonSpecChanged(object sender, [DisallowNull] EventArgs e)
+        protected virtual void OnButtonSpecChanged(object? sender, [DisallowNull] EventArgs e)
         {
             Debug.Assert(e != null);
 
@@ -1013,6 +1014,7 @@ namespace Krypton.Toolkit
             }
         }
         #endregion
+
 
         #region Protected Override
         /// <inheritdoc/>
@@ -1052,7 +1054,7 @@ namespace Krypton.Toolkit
         protected override void OnCellMouseMove(DataGridViewCellMouseEventArgs e)
         {
             // Cache mouse location before calling base class
-            DataGridViewCell cell = GetCellInternal(e.ColumnIndex, e.RowIndex);
+            DataGridViewCell? cell = GetCellInternal(e.ColumnIndex, e.RowIndex);
 
             var oldLocation = CurrentMouseLocation(cell);
             if ((cell is DataGridViewRowHeaderCell) && (_oldCell == cell))
@@ -1173,6 +1175,10 @@ namespace Krypton.Toolkit
         /// <param name="e">A DataGridViewCellPaintingEventArgs that contains the event data.</param>
         protected override void OnCellPainting(DataGridViewCellPaintingEventArgs e)
         {
+            if (e is null)
+            {
+                throw new ArgumentNullException(nameof(e));
+            }
 
             // Get the palette and state values for this cell
             PaletteState state = GetCellTriple(e.State,
@@ -1180,12 +1186,12 @@ namespace Krypton.Toolkit
                                                e.ColumnIndex,
                                                out IPaletteBack paletteBack,
                                                out IPaletteBorder paletteBorder,
-                                               out IPaletteContent? paletteContent);
+                                               out IPaletteContent paletteContent);
 
             try
             {
                 // If the font we get from the base palette is a system font that is invalid this will throw exception
-                var hContent = _contentInherit.GetContentShortTextFont(state).Height;
+                var hContent = _contentInherit.GetContentShortTextFont(state)!.Height;
             }
             catch
             {
@@ -1197,18 +1203,18 @@ namespace Krypton.Toolkit
 
             // Use an offscreen bitmap to draw onto before blitting it to the screen
             var tempCellBounds = e.CellBounds with { X = 0, Y = 0 };
-            using (var tempBitmap = new Bitmap(e.CellBounds.Width, e.CellBounds.Height, e.Graphics))
+            using (var tempBitmap = new Bitmap(e.CellBounds.Width, e.CellBounds.Height, e.Graphics!))
             {
                 using (Graphics tempG = Graphics.FromImage(tempBitmap))
                 {
-                    using (var renderContext = new RenderContext(this, tempG, tempCellBounds, Renderer))
+                    using (var renderContext = new RenderContext(this, tempG, tempCellBounds, Renderer!))
                     {
                         // Force the border to have a specified maximum border edge
                         _borderForced.SetInherit(paletteBorder);
                         _borderForced.MaxBorderEdges = GetCellMaxBorderEdges(e.CellBounds, e.ColumnIndex, e.RowIndex);
 
                         // Get the padding used to decide how to draw the background
-                        Padding borderPadding = Renderer.RenderStandardBorder.GetBorderRawPadding(_borderForced, state, VisualOrientation.Top);
+                        Padding borderPadding = Renderer!.RenderStandardBorder.GetBorderRawPadding(_borderForced, state, VisualOrientation.Top);
 
                         // Get the border path used to limit drawing of the background
                         GraphicsPath borderPath = Renderer.RenderStandardBorder.GetBackPath(renderContext, tempCellBounds, _borderForced, VisualOrientation.Top, state);
@@ -1217,8 +1223,8 @@ namespace Krypton.Toolkit
                         Rectangle tempCellBackBounds = CommonHelper.ApplyPadding(VisualOrientation.Top, tempCellBounds, borderPadding);
 
                         // Update the back interceptor class
-                        _backInherit.SetInherit(paletteBack, e.CellStyle);
-
+                        _backInherit.SetInherit(paletteBack, e.CellStyle!);
+                        using var gh = new GraphicsHint(renderContext.Graphics, _borderForced.GetBorderGraphicsHint(PaletteState.Normal));
                         IDisposable? unused = Renderer.RenderStandardBack.DrawBack(renderContext, tempCellBackBounds, borderPath, _backInherit, VisualOrientation.Top, state, null);
 
                         // We never save the memento for reuse later
@@ -1227,6 +1233,7 @@ namespace Krypton.Toolkit
                         Renderer.RenderStandardBorder.DrawBorder(renderContext, tempCellBounds, _borderForced, VisualOrientation.Top, state);
 
                         // Must remember to release resources!
+                        gh.Dispose();
                         borderPath.Dispose();
 
                         switch (e)
@@ -1258,8 +1265,12 @@ namespace Krypton.Toolkit
                                                 ? 5
                                                 : width), tempCellBounds.Y + 3, spec.Icon.Width, spec.Icon.Height);
                                         renderContext.Graphics.DrawImage(spec.Icon, iconBounds);
-                                        tempCellBounds = tempCellBounds with { X = tempCellBounds.X +
-                                            (spec.Alignment == IconSpec.IconAlignment.Left ? iconWidth : 0), Width = width };
+                                        tempCellBounds = tempCellBounds with
+                                        {
+                                            X = tempCellBounds.X +
+                                            (spec.Alignment == IconSpec.IconAlignment.Left ? iconWidth : 0),
+                                            Width = width
+                                        };
                                     }
                                 }
 
@@ -1268,7 +1279,7 @@ namespace Krypton.Toolkit
                             // If this is a row header cell
                             case { RowIndex: >= 0, ColumnIndex: -1 }:
                             {
-                                // By default there is no glyph needed for the row
+                                // By default, there is no glyph needed for the row
                                 var glyph = GridRowGlyph.None;
 
                                 // Find the correct glyph that should be drawn
@@ -1321,9 +1332,9 @@ namespace Krypton.Toolkit
                                     Rectangle beforeCellBounds = tempCellBounds;
                                     tempCellBounds = Renderer.RenderGlyph.DrawGridErrorGlyph(renderContext, tempCellBounds, state, rtl);
 
-                                        // Calculate the icon rectangle
-                                        var iconBounds = new Rectangle(tempCellBounds.Right + 1, tempCellBounds.Top,
-                                        beforeCellBounds.Width - tempCellBounds.Width, tempCellBounds.Height);
+                                    // Calculate the icon rectangle
+                                    var iconBounds = new Rectangle(tempCellBounds.Right + 1, tempCellBounds.Top,
+                                    beforeCellBounds.Width - tempCellBounds.Width, tempCellBounds.Height);
 
                                     // Cache the icon area
                                     if (_rowCache.ContainsKey(e.RowIndex))
@@ -1367,8 +1378,12 @@ namespace Krypton.Toolkit
                                                 ? 5
                                                 : width), tempCellBounds.Y + 3, spec.Icon.Width, spec.Icon.Height);
                                         renderContext.Graphics.DrawImage(spec.Icon, iconBounds);
-                                        tempCellBounds = tempCellBounds with { X = tempCellBounds.X +
-                                            (spec.Alignment == IconSpec.IconAlignment.Left ? iconWidth : 0), Width = width };
+                                        tempCellBounds = tempCellBounds with
+                                        {
+                                            X = tempCellBounds.X +
+                                            (spec.Alignment == IconSpec.IconAlignment.Left ? iconWidth : 0),
+                                            Width = width
+                                        };
                                     }
                                 }
 
@@ -1390,11 +1405,14 @@ namespace Krypton.Toolkit
                             if (e is { ColumnIndex: >= 0, RowIndex: >= 0 })
                             {
                                 // Blit the image onto the screen
-                                e.Graphics.DrawImage(tempBitmap, e.CellBounds.Location);
+                                e.Graphics?.DrawImage(tempBitmap, e.CellBounds.Location);
 
                                 //Seb Search highlight 
                                 //Empty _restrictColumnsSearch means highlight everywhere
-                                if (!string.IsNullOrEmpty(_searchString) && (_restrictColumnsSearch.Count == 0 || (_restrictColumnsSearch.Count != 0 && _restrictColumnsSearch.Contains(e.ColumnIndex))) && e.FormattedValue.GetType().Name != nameof(Bitmap))
+                                if (!string.IsNullOrEmpty(_searchString)
+                                    && (_restrictColumnsSearch.Count == 0 || (_restrictColumnsSearch.Count != 0
+                                    && _restrictColumnsSearch.Contains(e.ColumnIndex)))
+                                    && e.FormattedValue!.GetType().Name != nameof(Bitmap))
                                 {
                                     var val = (string)e.FormattedValue;
                                     var sindx = val.ToLower().IndexOf(_searchString.ToLower());
@@ -1409,8 +1427,8 @@ namespace Krypton.Toolkit
 
                                         var sBefore = val.Substring(0, sindx);
                                         var sWord = val.Substring(sindx, _searchString.Length);
-                                        Size s1 = TextRenderer.MeasureText(e.Graphics, sBefore, e.CellStyle.Font, e.CellBounds.Size);
-                                        Size s2 = TextRenderer.MeasureText(e.Graphics, sWord, e.CellStyle.Font, e.CellBounds.Size);
+                                        Size s1 = TextRenderer.MeasureText(e.Graphics!, sBefore, e.CellStyle!.Font, e.CellBounds.Size);
+                                        Size s2 = TextRenderer.MeasureText(e.Graphics!, sWord, e.CellStyle.Font, e.CellBounds.Size);
 
                                         if (s1.Width > 5)
                                         {
@@ -1441,7 +1459,7 @@ namespace Krypton.Toolkit
                                                 ? new SolidBrush(Color.DarkGoldenrod)
                                                 : new SolidBrush(Color.Yellow);
 
-                                        e.Graphics.FillRectangle(hl_brush, hl_rect);
+                                        e.Graphics!.FillRectangle(hl_brush, hl_rect);
 
                                         hl_brush.Dispose();
                                         sindx = val.ToLower().IndexOf(_searchString.ToLower(), sCount++);
@@ -1453,7 +1471,7 @@ namespace Krypton.Toolkit
                             else
                             {
                                 // Update the content interceptor class
-                                _contentInherit.SetInherit(paletteContent, e.CellStyle);
+                                _contentInherit.SetInherit(paletteContent!, e.CellStyle!);
 
                                 // Is there any text to be Displayed?
                                 if (e.FormattedValue != null)
@@ -1495,19 +1513,19 @@ namespace Krypton.Toolkit
                                 }
 
                                 // Blit the image onto the screen
-                                e.Graphics.DrawImage(tempBitmap, e.CellBounds.Location);
+                                e.Graphics?.DrawImage(tempBitmap, e.CellBounds.Location);
                             }
                         }
                         else
                         {
                             // Blit the image onto the screen
-                            e.Graphics.DrawImage(tempBitmap, e.CellBounds.Location);
+                            e.Graphics?.DrawImage(tempBitmap, e.CellBounds.Location);
                         }
                     }
                 }
             }
 
-            if ((e.PaintParts & DataGridViewPaintParts.Focus) == DataGridViewPaintParts.Focus)
+            if (e != null && (e.PaintParts & DataGridViewPaintParts.Focus) == DataGridViewPaintParts.Focus)
             {
                 // Only consider drawing the focus rectangle if the control has focus wants to show the cues
                 if (ShowFocusCues && Focused)
@@ -1529,14 +1547,14 @@ namespace Krypton.Toolkit
                                 focusCellBounds.X++;
                             }
 
-                            ControlPaint.DrawFocusRectangle(e.Graphics, focusCellBounds, Color.Empty, paletteContent.GetContentShortTextColor1(state));
+                            ControlPaint.DrawFocusRectangle(e.Graphics!, focusCellBounds, Color.Empty, paletteContent!.GetContentShortTextColor1(state));
                         }
                     }
                 }
             }
 
             // Prevent base class from doing the standard drawing
-            e.Handled = true;
+            e!.Handled = true;
 
             base.OnCellPainting(e);
         }
@@ -1571,7 +1589,7 @@ namespace Krypton.Toolkit
                         PaintTransparentBackground(graphics, clipBounds);
 
                         // Use the view manager to paint the view panel that fills the entire areas as the background
-                        using var context = new RenderContext(this, graphics, clipBounds, Renderer);
+                        using var context = new RenderContext(this, graphics, clipBounds, Renderer!);
                         ViewManager.Paint(context);
                     }
 
@@ -1616,8 +1634,8 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Internal
-        internal PaletteRedirect Redirector
-        {
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        internal PaletteRedirect Redirector {
             [DebuggerStepThrough]
             get;
             private set;
@@ -1636,7 +1654,7 @@ namespace Krypton.Toolkit
             SyncCellStylesWithPalette();
         }
 
-        internal bool RightToLeftInternal
+        internal bool RightToLeftInternal 
         {
             get
             {
@@ -1645,18 +1663,19 @@ namespace Krypton.Toolkit
                 {
                     // Cache access to the internal get property 'RightToLeftInternal'
                     _piRTL = typeof(DataGridView).GetProperty(nameof(RightToLeftInternal), BindingFlags.Instance |
-                                                                                     BindingFlags.NonPublic |
-                                                                                     BindingFlags.GetField);
+                        BindingFlags.NonPublic |
+                        BindingFlags.GetField)!;
 
                 }
 
                 // Grab the internal calculated value of the right to left setting
-                return (bool)_piRTL.GetValue(this, null);
+                return (bool)_piRTL.GetValue(this, null)!;
             }
         }
         #endregion
 
         #region Implementation
+
         /// <summary>
         /// Handles the auto generation of Krypton columns<br/>
         /// </summary>
@@ -1674,16 +1693,20 @@ namespace Krypton.Toolkit
                 changeService?.OnComponentChanging(this, null);
             }
 
-            for (int i = 0; i < ColumnCount; i++)
+            for (int i = 0 ; i < ColumnCount ; i++)
             {
                 currentColumn = Columns[i];
 
+                /* 
+                 * Auto generated columns are always of type System.Windows.Forms.DataGridViewTextBoxColumn.
+                 * Only columns that are of type DataGridViewTextBoxColumn and have the DataPropertyName set will be converted to krypton Columns.
+                 */
                 if (currentColumn is DataGridViewTextBoxColumn && currentColumn.DataPropertyName.Length > 0)
                 {
                     index = currentColumn.Index;
 
                     var newColumn = this.DesignMode
-                        ? designerHost?.CreateComponent(typeof(KryptonDataGridViewTextBoxColumn)) as KryptonDataGridViewTextBoxColumn
+                        ? designerHost?.CreateComponent(typeof(KryptonDataGridViewTextBoxColumn)) as KryptonDataGridViewTextBoxColumn 
                         : new KryptonDataGridViewTextBoxColumn();
 
                     newColumn!.Name = currentColumn.Name;
@@ -1702,7 +1725,7 @@ namespace Krypton.Toolkit
                     index = currentColumn.Index;
 
                     var newColumn = this.DesignMode
-                        ? designerHost?.CreateComponent(typeof(KryptonDataGridViewCheckBoxColumn)) as KryptonDataGridViewCheckBoxColumn
+                        ? designerHost?.CreateComponent(typeof(KryptonDataGridViewCheckBoxColumn)) as KryptonDataGridViewCheckBoxColumn 
                         : new KryptonDataGridViewCheckBoxColumn();
 
                     newColumn!.Name = currentColumn.Name;
@@ -1734,10 +1757,11 @@ namespace Krypton.Toolkit
             _evalTransparent = true;
             _lastLayoutSize = Size.Empty;
 
-            // Set the palette to the defaults as specified by the manager
+            // Set the palette to the defaults as specified by the PaletteMode property
             _localPalette = null;
-            SetPalette(KryptonManager.CurrentGlobalPalette);
+            // start off with global mode as default
             _paletteMode = PaletteMode.Global;
+            SetPalette(KryptonManager.GetPaletteForMode(_paletteMode));
 
             // Create constant target for resolving palette delegates
             Redirector = new PaletteRedirect(_palette);
@@ -2175,7 +2199,7 @@ namespace Krypton.Toolkit
         }
 
         private byte UpdateLocationForRowErrors(DataGridViewCellMouseEventArgs e,
-                                                DataGridViewCell cell,
+                                                DataGridViewCell? cell,
                                                 byte location)
         {
             // If over the main area of a row header cell...
@@ -2237,6 +2261,7 @@ namespace Krypton.Toolkit
 
             // Should never happen!
             Debug.Assert(false);
+            DebugTools.NotImplemented(textH.ToString(), string.Empty);
             return DataGridViewContentAlignment.MiddleLeft;
         }
 
@@ -2310,7 +2335,7 @@ namespace Krypton.Toolkit
                         _layoutDirty = false;
 
                         // Ask the view to perform a layout
-                        ViewManager.Layout(Renderer);
+                        ViewManager.Layout(Renderer!);
 
                     } while (_layoutDirty && (max-- > 0));
 
@@ -2320,7 +2345,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void CellDataAreaMouseEnterInternal(DataGridViewCell cell)
+        private void CellDataAreaMouseEnterInternal(DataGridViewCell? cell)
         {
             Point currentCellAddress = CurrentCellAddress;
 
@@ -2328,11 +2353,11 @@ namespace Krypton.Toolkit
             {
                 // Are we allowed to show a tooltip?
                 if (ShowCellToolTips &&
-                    ((currentCellAddress.X == -1) || (currentCellAddress.X != cell.ColumnIndex) ||
+                    ((currentCellAddress.X == -1) || (currentCellAddress.X != cell!.ColumnIndex) ||
                     (currentCellAddress.Y != cell.RowIndex) || (EditingControl == null)))
                 {
                     // Grab the correct tooltip text for the cell
-                    _toolTipText = GetToolTipText(cell, cell.RowIndex);
+                    _toolTipText = GetToolTipText(cell, cell!.RowIndex);
 
                     // No explicit text provided?
                     if (string.IsNullOrEmpty(_toolTipText))
@@ -2344,12 +2369,12 @@ namespace Krypton.Toolkit
                             if ((cell.RowIndex != -1) && (cell.OwningColumn != null))
                             {
                                 if ((cell.OwningColumn.Width < GetCellPreferredWidth(cell)) ||
-                                    (cell.OwningRow.Height < GetCellPreferredHeight(cell)))
+                                    (cell.OwningRow!.Height < GetCellPreferredHeight(cell)))
                                 {
                                     var editedValue = cell.GetEditedFormattedValue(cell.RowIndex, DataGridViewDataErrorContexts.Display) as string;
                                     if (!string.IsNullOrEmpty(editedValue))
                                     {
-                                        _toolTipText = TruncateToolTipText(editedValue);
+                                        _toolTipText = TruncateToolTipText(editedValue ?? string.Empty);
                                     }
                                 }
                             }
@@ -2363,7 +2388,7 @@ namespace Krypton.Toolkit
                                         var editedValue = cell.GetEditedFormattedValue(cell.RowIndex, DataGridViewDataErrorContexts.Display) as string;
                                         if (!string.IsNullOrEmpty(editedValue))
                                         {
-                                            _toolTipText = TruncateToolTipText(editedValue);
+                                            _toolTipText = TruncateToolTipText(editedValue ?? string.Empty);
                                         }
                                     }
                                     catch
@@ -2389,10 +2414,10 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void CellErrorAreaMouseEnterInternal(DataGridViewCell cell)
+        private void CellErrorAreaMouseEnterInternal(DataGridViewCell? cell)
         {
             // Grab the correct error text for the cell
-            _toolTipText = GetErrorText(cell, cell.RowIndex);
+            _toolTipText = GetErrorText(cell, cell!.RowIndex);
 
             // Restart the timer for showing the error tooltip
             if (_showTimer != null)
@@ -2414,17 +2439,17 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnVisualPopupToolTipDisposed(object sender, EventArgs e)
+        private void OnVisualPopupToolTipDisposed(object? sender, EventArgs e)
         {
             // Unhook events from the specific instance that generated event
-            var popupToolTip = (VisualPopupToolTip)sender;
+            var popupToolTip = sender as VisualPopupToolTip ?? throw new ArgumentNullException(nameof(sender));
             popupToolTip.Disposed -= OnVisualPopupToolTipDisposed;
 
             // Not showing a popup page any more
             _visualPopupToolTip = null;
         }
 
-        private void OnTimerTick(object sender, EventArgs e)
+        private void OnTimerTick(object? sender, EventArgs e)
         {
             // Only need a one tick timer
             if (_showTimer != null)
@@ -2442,7 +2467,7 @@ namespace Krypton.Toolkit
                     // Create the actual tooltip popup object
                     _visualPopupToolTip = new VisualPopupToolTip(Redirector,
                                                                  new ToolTipContent(_toolTipText),
-                                                                 Renderer,
+                                                                 Renderer!,
                                                                  PaletteBackStyle.ControlToolTip,
                                                                  PaletteBorderStyle.ControlToolTip,
                                                                  PaletteContentStyle.LabelToolTip,
@@ -2456,7 +2481,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private DataGridViewCell GetCellInternal(int column, int row)
+        private DataGridViewCell? GetCellInternal(int column, int row)
         {
             // Only need to cache reflection info the first time around
             if (_miGCI == null)
@@ -2464,13 +2489,13 @@ namespace Krypton.Toolkit
                 // Cache access to the internal method 'GetCellInternal'
                 _miGCI = typeof(DataGridView).GetMethod(nameof(GetCellInternal), BindingFlags.Instance |
                                                                            BindingFlags.NonPublic |
-                                                                           BindingFlags.GetField);
+                                                                           BindingFlags.GetField)!;
             }
 
-            return (DataGridViewCell)_miGCI.Invoke(this, new object[] { column, row });
+            return _miGCI.Invoke(this, [column, row]) as DataGridViewCell;
         }
 
-        private string GetToolTipText(DataGridViewCell cell, int row)
+        private string GetToolTipText(DataGridViewCell? cell, int row)
         {
             // Only need to cache reflection info the first time around
             if (_miGTTT == null)
@@ -2478,12 +2503,12 @@ namespace Krypton.Toolkit
                 // Cache access to the internal get property 'GetToolTipText'
                 _miGTTT = typeof(DataGridViewCell).GetMethod(nameof(GetToolTipText), BindingFlags.Instance |
                                                                                BindingFlags.NonPublic |
-                                                                               BindingFlags.GetField);
+                                                                               BindingFlags.GetField)!;
             }
 
             try
             {
-                return (string)_miGTTT.Invoke(cell, new object[] { row });
+                return _miGTTT.Invoke(cell, [row]) as string ?? string.Empty;
             }
             catch
             {
@@ -2491,7 +2516,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private string GetErrorText(DataGridViewCell cell, int row)
+        private string GetErrorText(DataGridViewCell? cell, int row)
         {
             // Only need to cache reflection info the first time around
             if (_miGET == null)
@@ -2499,12 +2524,12 @@ namespace Krypton.Toolkit
                 // Cache access to the internal get property 'GetErrorText'
                 _miGET = typeof(DataGridViewCell).GetMethod(nameof(GetErrorText), BindingFlags.Instance |
                                                                             BindingFlags.NonPublic |
-                                                                            BindingFlags.GetField);
+                                                                            BindingFlags.GetField)!;
             }
 
             try
             {
-                return (string)_miGET.Invoke(cell, new object[] { row });
+                return _miGET.Invoke(cell, [row]) as string ?? string.Empty;
             }
             catch
             {
@@ -2512,7 +2537,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private byte CurrentMouseLocation(DataGridViewCell cell)
+        private byte CurrentMouseLocation(DataGridViewCell? cell)
         {
             // Only need to cache reflection info the first time around
             if (_piCML == null)
@@ -2520,39 +2545,49 @@ namespace Krypton.Toolkit
                 // Cache access to the internal get property 'CurrentMouseLocation'
                 _piCML = typeof(DataGridViewCell).GetProperty(nameof(CurrentMouseLocation), BindingFlags.Instance |
                                                                                       BindingFlags.NonPublic |
-                                                                                      BindingFlags.GetField);
+                                                                                      BindingFlags.GetField)!;
             }
 
             // Grab the internal calculated value of the right to left setting
-            return (byte)_piCML.GetValue(cell, null);
+            return (byte)_piCML.GetValue(cell, null)!;
         }
 
-        private int GetCellPreferredWidth(DataGridViewCell cell)
+        private int GetCellPreferredWidth([DisallowNull] DataGridViewCell? cell)
         {
+            if (cell is null)
+            {
+                throw new ArgumentNullException(nameof(cell));
+            }
+
             // Only need to cache reflection info the first time around
             if (_miGPW == null)
             {
                 // Cache access to the internal method 'GetPreferredWidth' of cells
                 _miGPW = typeof(DataGridViewCell).GetMethod(@"GetPreferredWidth", BindingFlags.Instance |
                                                                                  BindingFlags.NonPublic |
-                                                                                 BindingFlags.GetField);
+                                                                                 BindingFlags.GetField)!;
             }
 
-            return (int)_miGPW.Invoke(cell, new object[] { cell.RowIndex, cell.OwningRow.Height });
+            return (int)_miGPW.Invoke(cell, [cell.RowIndex!, cell.OwningRow!.Height!])!;
         }
 
-        private int GetCellPreferredHeight(DataGridViewCell cell)
+        private int GetCellPreferredHeight(DataGridViewCell? cell)
         {
+            if (cell is null)
+            {
+                throw new ArgumentNullException(nameof(cell));
+            }
+
             // Only need to cache reflection info the first time around
             if (_miGPH == null)
             {
                 // Cache access to the internal method 'GetPreferredHeight' of cells
                 _miGPH = typeof(DataGridViewCell).GetMethod(@"GetPreferredHeight", BindingFlags.Instance |
                                                                                   BindingFlags.NonPublic |
-                                                                                  BindingFlags.GetField);
+                                                                                  BindingFlags.GetField)!;
             }
 
-            return (int)_miGPH.Invoke(cell, new object[] { cell.RowIndex, cell.OwningColumn.Width });
+            return (int)_miGPH.Invoke(cell, [cell.RowIndex, cell.OwningColumn!.Width])!;
         }
 
         private string DismissBaseToolTips()
@@ -2563,10 +2598,10 @@ namespace Krypton.Toolkit
                 // Cache access to the internal get property 'ActivateToolTip'
                 _miATT = typeof(DataGridView).GetMethod(@"ActivateToolTip", BindingFlags.Instance |
                                                                            BindingFlags.NonPublic |
-                                                                           BindingFlags.GetField);
+                                                                           BindingFlags.GetField)!;
             }
 
-            return (string)_miATT.Invoke(this, new object[] { false, string.Empty, -1, -1 });
+            return _miATT.Invoke(this, [false, string.Empty, -1, -1]) as string ?? string.Empty;
         }
 
         private string TruncateToolTipText(string toolTipText)
@@ -2595,7 +2630,7 @@ namespace Krypton.Toolkit
                 _palette = palette;
 
                 // Get the renderer associated with the palette
-                Renderer = _palette.GetRenderer();
+                Renderer = _palette?.GetRenderer();
 
                 // Hook to new palette events
                 if (_palette != null)
@@ -2625,11 +2660,11 @@ namespace Krypton.Toolkit
                     _miPTB = typeof(Control).GetMethod(nameof(PaintTransparentBackground),
                                                        BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.InvokeMethod,
                                                        null, CallingConventions.HasThis,
-                                                       new[] { typeof(PaintEventArgs), typeof(Rectangle), typeof(Region) },
-                                                       null);
+                                                       [typeof(PaintEventArgs), typeof(Rectangle), typeof(Region)],
+                                                       null)!;
                 }
 
-                _miPTB.Invoke(this, new object[] { new PaintEventArgs(g, clipRect), ClientRectangle, null });
+                _miPTB.Invoke(this, [new PaintEventArgs(g, clipRect), ClientRectangle, null!]);
             }
         }
 
@@ -2658,7 +2693,7 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnGlobalPaletteChanged(object sender, EventArgs e)
+        private void OnGlobalPaletteChanged(object? sender, EventArgs e)
         {
             // We only care if we are using the global palette
             if (PaletteMode == PaletteMode.Global)
@@ -2670,18 +2705,18 @@ namespace Krypton.Toolkit
                 SyncCellStylesWithPalette();
 
                 // A new palette source means we need to layout and redraw
-                OnNeedPaint(Palette, new NeedLayoutEventArgs(true));
+                OnNeedPaint(Palette!, new NeedLayoutEventArgs(true));
             }
         }
 
-        private void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e) => OnNeedResyncPaint(Palette, new NeedLayoutEventArgs(true));
+        private void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e) => OnNeedResyncPaint(Palette!, new NeedLayoutEventArgs(true));
 
-        private void OnSyncPropertyChanged(object sender, EventArgs e) =>
+        private void OnSyncPropertyChanged(object? sender, EventArgs e) =>
             // Ensure the current cell style values are in sync with the new palette 
             // setting and any state overrides that are defined.
             SyncCellStylesWithPalette();
 
-        private void OnSyncBackPropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void OnSyncBackPropertyChanged(object? sender, PropertyChangedEventArgs e)
         {
             // Only interested in the first color from the background palettes
             if (e.PropertyName == "Color1")
@@ -2693,14 +2728,17 @@ namespace Krypton.Toolkit
         }
         #endregion
 
-        #region menus
-        private void OnContextMenuStripOpening(object sender, CancelEventArgs e)
+        #region Menus
+        private void OnContextMenuStripOpening(object? sender, CancelEventArgs e)
         {
             // Get the actual strip instance
-            ContextMenuStrip cms = base.ContextMenuStrip;
+            ContextMenuStrip? cms = base.ContextMenuStrip;
 
             // Make sure it has the correct renderer
-            cms.Renderer = CreateToolStripRenderer();
+            if (cms != null)
+            {
+                cms.Renderer = CreateToolStripRenderer();
+            }
         }
 
         /// <summary>
@@ -2708,15 +2746,15 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [EditorBrowsable(EditorBrowsableState.Advanced)]
-        public ToolStripRenderer CreateToolStripRenderer() => Renderer.RenderToolStrip(GetResolvedPalette());
+        public ToolStripRenderer CreateToolStripRenderer() => Renderer?.RenderToolStrip(GetResolvedPalette()!)!;
 
-        private void OnKryptonContextMenuDisposed(object sender, EventArgs e) =>
+        private void OnKryptonContextMenuDisposed(object? sender, EventArgs e) =>
             // When the current krypton context menu is disposed, we should remove 
             // it to prevent it being used again, as that would just throw an exception 
             // because it has been disposed.
             KryptonContextMenu = null;
 
-        private void OnContextMenuClosed(object sender, ToolStripDropDownClosedEventArgs e) => ContextMenuClosed();
+        private void OnContextMenuClosed(object? sender, ToolStripDropDownClosedEventArgs e) => ContextMenuClosed();
 
         /// <summary>
         /// Called when a context menu has just been closed.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewButtonCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewButtonCell.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
@@ -48,12 +48,11 @@ namespace Krypton.Toolkit
         public override object Clone()
         {
             var dataGridViewCell = base.Clone() as KryptonDataGridViewButtonCell;
-            if (dataGridViewCell != null)
-            {
-                dataGridViewCell._styleSet = _styleSet;
-                dataGridViewCell._shortTextValue = _shortTextValue;
-                dataGridViewCell._buttonStyle = _buttonStyle;
-            }
+
+            dataGridViewCell._styleSet = _styleSet;
+            dataGridViewCell._shortTextValue = _shortTextValue;
+            dataGridViewCell._buttonStyle = _buttonStyle;
+
             return dataGridViewCell;
         }
 
@@ -70,7 +69,7 @@ namespace Krypton.Toolkit
             {
                 _buttonStyle = value;
                 _styleSet = true;
-                DataGridView.InvalidateCell(this);
+                DataGridView?.InvalidateCell(this);
             }
         }
         #endregion
@@ -104,13 +103,13 @@ namespace Krypton.Toolkit
         {
             try
             {
-                var kDGV = (KryptonDataGridView)DataGridView;
+                var kDGV = DataGridView as KryptonDataGridView;
 
                 // Create the view elements and palette structure
-                CreateViewAndPalettes(kDGV);
+                CreateViewAndPalettes(kDGV!);
 
                 // Is this cell the currently active cell
-                var currentCell = (rowIndex == DataGridView.CurrentCellAddress.Y) &&
+                var currentCell = (rowIndex == DataGridView!.CurrentCellAddress.Y) &&
                                   (ColumnIndex == DataGridView.CurrentCellAddress.X);
 
                 // Is this cell the same as the one with the mouse inside it
@@ -141,21 +140,21 @@ namespace Krypton.Toolkit
                 }
 
                 // Update the display text
-                if ((kDGV.Columns[ColumnIndex] is KryptonDataGridViewButtonColumn { UseColumnTextForButtonValue: true } col) && !kDGV.Rows[rowIndex].IsNewRow)
+                if ((kDGV!.Columns[ColumnIndex] is KryptonDataGridViewButtonColumn { UseColumnTextForButtonValue: true } col) && !kDGV.Rows[rowIndex].IsNewRow)
                 {
-                    _shortTextValue.ShortText = col.Text;
+                    _shortTextValue!.ShortText = col.Text;
                 }
                 else if (!string.IsNullOrEmpty(FormattedValue?.ToString()))
                 {
-                    _shortTextValue.ShortText = FormattedValue.ToString();
+                    _shortTextValue!.ShortText = FormattedValue!.ToString();
                 }
                 else
                 {
-                    _shortTextValue.ShortText = string.Empty;
+                    _shortTextValue!.ShortText = string.Empty;
                 }
 
                 // Position the button element inside the available cell area
-                using var layoutContext = new ViewLayoutContext(kDGV, kDGV.Renderer);
+                using var layoutContext = new ViewLayoutContext(kDGV, kDGV.Renderer!);
                 // Define the available area for layout
                 layoutContext.DisplayRectangle = new Rectangle(0, 0, int.MaxValue, int.MaxValue);
 
@@ -190,23 +189,23 @@ namespace Krypton.Toolkit
         /// <param name="advancedBorderStyle">A DataGridViewAdvancedBorderStyle that contains border styles for the cell that is being painted.</param>
         /// <param name="paintParts">A bitwise combination of the DataGridViewPaintParts values that specifies which parts of the cell need to be painted.</param>
         protected override void Paint(Graphics graphics,
-            Rectangle clipBounds,
-            Rectangle cellBounds,
-            int rowIndex,
-            DataGridViewElementStates cellState,
-            object value,
-            object formattedValue,
-            string errorText,
-            DataGridViewCellStyle cellStyle,
-            DataGridViewAdvancedBorderStyle advancedBorderStyle,
-            DataGridViewPaintParts paintParts)
+                                      Rectangle clipBounds,
+                                      Rectangle cellBounds,
+                                      int rowIndex,
+                                      DataGridViewElementStates cellState,
+                                      object? value,
+                                      object? formattedValue,
+                                      string? errorText,
+                                      DataGridViewCellStyle cellStyle,
+                                      DataGridViewAdvancedBorderStyle advancedBorderStyle,
+                                      DataGridViewPaintParts paintParts)
         {
             if (DataGridView is KryptonDataGridView kDgv)
             {
                 // Should we draw the content foreground?
                 if ((paintParts & DataGridViewPaintParts.ContentForeground) == DataGridViewPaintParts.ContentForeground)
                 {
-                    using var renderContext = new RenderContext(kDgv, graphics, cellBounds, kDgv.Renderer);
+                    using var renderContext = new RenderContext(kDgv, graphics, cellBounds, kDgv.Renderer!);
                     // Create the view elements and palette structure
                     CreateViewAndPalettes(kDgv);
 
@@ -250,15 +249,15 @@ namespace Krypton.Toolkit
                             UseColumnTextForButtonValue: true
                         } col) && !kDgv.Rows[rowIndex].IsNewRow)
                     {
-                        _shortTextValue.ShortText = col.Text;
+                        _shortTextValue!.ShortText = col.Text;
                     }
                     else if (!string.IsNullOrEmpty(FormattedValue?.ToString()))
                     {
-                        _shortTextValue.ShortText = FormattedValue.ToString();
+                        _shortTextValue!.ShortText = FormattedValue!.ToString();
                     }
                     else
                     {
-                        _shortTextValue.ShortText = string.Empty;
+                        _shortTextValue!.ShortText = string.Empty;
                     }
 
                     // Prevent button overlapping the bottom/right border
@@ -279,7 +278,7 @@ namespace Krypton.Toolkit
                     cellBounds.Height -= cellStyle.Padding.Vertical;
 
                     // Position the button element inside the available cell area
-                    using (var layoutContext = new ViewLayoutContext(kDgv, kDgv.Renderer))
+                    using (var layoutContext = new ViewLayoutContext(kDgv, kDgv.Renderer!))
                     {
                         // Define the available area for layout
                         layoutContext.DisplayRectangle = cellBounds;
@@ -352,13 +351,10 @@ namespace Krypton.Toolkit
                     _piButtonState = typeof(DataGridViewButtonCell).GetProperty(nameof(ButtonState), BindingFlags.Instance |
                                                                                                BindingFlags.NonPublic |
                                                                                                BindingFlags.GetField);
-
                 }
 
                 // Grab the internal property implemented by base class
-                return _piButtonState != null
-                    ? (ButtonState)(_piButtonState.GetValue(this, null) ?? ButtonState.Normal)
-                    : ButtonState.Normal;
+                return _piButtonState != null ? (ButtonState)(_piButtonState.GetValue(this, null) ?? ButtonState.Normal) : ButtonState.Normal;
             }
         }
 
@@ -373,7 +369,6 @@ namespace Krypton.Toolkit
                     _fiMouseInContentBounds = typeof(DataGridViewButtonCell).GetField(@"mouseInContentBounds", BindingFlags.Static |
                                                                                                               BindingFlags.NonPublic |
                                                                                                               BindingFlags.GetField);
-
                     if (_fiMouseInContentBounds == null)
                     {
                         // https://github.com/dotnet/winforms/commit/27e010d21c78457113f5be67eeea842499ab5f74#diff-bb5ad249080118c559367691ad27b9a93f8d5324b814f65113ff2e4bd15c9b39
@@ -400,7 +395,6 @@ namespace Krypton.Toolkit
                     _piMouseEnteredCellAddress = typeof(DataGridView).GetProperty(@"MouseEnteredCellAddress", BindingFlags.Instance |
                                                                                                              BindingFlags.NonPublic |
                                                                                                              BindingFlags.GetField);
-
                 }
 
                 // Grab the internal property implemented by base class

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewButtonColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewButtonColumn.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
@@ -19,7 +19,7 @@ namespace Krypton.Toolkit
     public class KryptonDataGridViewButtonColumn : KryptonDataGridViewIconColumn
     {
         #region Static Fields
-        private MethodInfo _miColumnCommonChange;
+        private MethodInfo? _miColumnCommonChange;
         private PropertyInfo _piUseColumnTextForButtonValueInternal;
         #endregion
 
@@ -67,6 +67,7 @@ namespace Krypton.Toolkit
             // Create a new instance
             var clone = base.Clone() as KryptonDataGridViewButtonColumn;
             clone.Text = Text;
+
             return clone;
         }
         #endregion
@@ -77,9 +78,19 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        [DisallowNull]
-        public override DataGridViewCell CellTemplate
+        public override DataGridViewCell? CellTemplate
         {
+            /*
+             Text from the base property, shows that it can be null
+             //
+             // Summary:
+             //     Gets or sets the template used to create new cells.
+             //
+             // Returns:
+             //     A System.Windows.Forms.DataGridViewCell that all other cells in the column are
+             //     modeled after. The default is null.
+            */
+ 
             get => base.CellTemplate;
 
             set
@@ -98,12 +109,16 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(true)]
         [Category(@"Appearance")]
+        [AllowNull]
         public override DataGridViewCellStyle DefaultCellStyle
         {
+            // Data type made non-nullable again to keep it inline with the underlying virtual base method 
+            // Added [AllowNull] attribute since the base can take null as a value
+
             get => base.DefaultCellStyle;
             set => base.DefaultCellStyle = value;
         }
-        
+
         /// <summary>
         /// Gets or sets the default text Displayed on the button cell.
         /// </summary>
@@ -153,13 +168,13 @@ namespace Krypton.Toolkit
         public bool UseColumnTextForButtonValue
         {
             get =>
-                ((KryptonDataGridViewButtonCell)CellTemplate)?.UseColumnTextForButtonValue ?? throw new InvalidOperationException(@"KryptonDataGridViewButtonColumn cell template required");
+                (CellTemplate as KryptonDataGridViewButtonCell)?.UseColumnTextForButtonValue ?? throw new InvalidOperationException(@"KryptonDataGridViewButtonColumn cell template required");
 
             set
             {
                 if (UseColumnTextForButtonValue != value)
                 {
-                    SetUseColumnTextForButtonValueInternal(CellTemplate, value);
+                    SetUseColumnTextForButtonValueInternal(CellTemplate!, value);
                     if (DataGridView != null)
                     {
                         DataGridViewRowCollection rows = DataGridView.Rows;
@@ -186,13 +201,14 @@ namespace Krypton.Toolkit
         public ButtonStyle ButtonStyle
         {
             get =>
-                ((KryptonDataGridViewButtonCell)CellTemplate)?.ButtonStyle ?? throw new InvalidOperationException(@"KryptonDataGridViewButtonColumn cell template required");
+                (CellTemplate as KryptonDataGridViewButtonCell)?.ButtonStyle ?? throw new InvalidOperationException(@"KryptonDataGridViewButtonColumn cell template required");
 
             set
             {
                 if (ButtonStyle != value)
                 {
-                    ((KryptonDataGridViewButtonCell)CellTemplate).ButtonStyleInternal = value;
+                    (CellTemplate as KryptonDataGridViewButtonCell)!.ButtonStyleInternal = value;
+
                     if (DataGridView != null)
                     {
                         DataGridViewRowCollection rows = DataGridView.Rows;
@@ -219,14 +235,21 @@ namespace Krypton.Toolkit
                 return false;
             }
 
-            DataGridViewCellStyle defaultCellStyle = DefaultCellStyle;
-            return !defaultCellStyle.BackColor.IsEmpty || !defaultCellStyle.ForeColor.IsEmpty ||
-!defaultCellStyle.SelectionBackColor.IsEmpty || !defaultCellStyle.SelectionForeColor.IsEmpty ||
-                 defaultCellStyle.Font != null || !defaultCellStyle.IsNullValueDefault ||
-!defaultCellStyle.IsDataSourceNullValueDefault || !string.IsNullOrEmpty(defaultCellStyle.Format) ||
-!defaultCellStyle.FormatProvider.Equals(CultureInfo.CurrentCulture) || defaultCellStyle.Alignment != DataGridViewContentAlignment.MiddleCenter ||
-                 defaultCellStyle.WrapMode != DataGridViewTriState.NotSet || defaultCellStyle.Tag != null
-|| !defaultCellStyle.Padding.Equals(Padding.Empty);
+            DataGridViewCellStyle defaultCellStyle = DefaultCellStyle!;
+
+            return !defaultCellStyle.BackColor.IsEmpty 
+                || !defaultCellStyle.ForeColor.IsEmpty 
+                || !defaultCellStyle.SelectionBackColor.IsEmpty 
+                || !defaultCellStyle.SelectionForeColor.IsEmpty 
+                || defaultCellStyle.Font != null 
+                || !defaultCellStyle.IsNullValueDefault 
+                || !defaultCellStyle.IsDataSourceNullValueDefault 
+                || !string.IsNullOrEmpty(defaultCellStyle.Format) 
+                || !defaultCellStyle.FormatProvider.Equals(CultureInfo.CurrentCulture) 
+                || defaultCellStyle.Alignment != DataGridViewContentAlignment.MiddleCenter 
+                || defaultCellStyle.WrapMode != DataGridViewTriState.NotSet 
+                || defaultCellStyle.Tag != null
+                || !defaultCellStyle.Padding.Equals(Padding.Empty);
         }
 
         private void ColumnCommonChange(int columnIndex)
@@ -241,7 +264,7 @@ namespace Krypton.Toolkit
 
             }
 
-            _miColumnCommonChange.Invoke(DataGridView, new object[] { columnIndex });
+            _miColumnCommonChange?.Invoke(DataGridView, [columnIndex]);
         }
 
         private void SetUseColumnTextForButtonValueInternal(object instance, bool value)
@@ -252,11 +275,11 @@ namespace Krypton.Toolkit
                 // Cache access to the internal property sette 'UseColumnTextForButtonValueInternal'
                 _piUseColumnTextForButtonValueInternal = typeof(DataGridViewButtonCell).GetProperty(@"UseColumnTextForButtonValueInternal", BindingFlags.Instance |
                                                                                                                                            BindingFlags.NonPublic |
-                                                                                                                                           BindingFlags.SetProperty);
+                                                                                                                                           BindingFlags.SetProperty)!;
 
             }
 
-            _piUseColumnTextForButtonValueInternal.SetValue(instance, value, null);
+            _piUseColumnTextForButtonValueInternal?.SetValue(instance, value, null);
         }
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewCheckBoxCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewCheckBoxCell.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
@@ -75,10 +75,10 @@ namespace Krypton.Toolkit
         {
             try
             {
-                var kDGV = (KryptonDataGridView)DataGridView;
+                var kDGV = DataGridView as KryptonDataGridView;
 
                 // Is this cell the currently active cell
-                var currentCell = (rowIndex == DataGridView.CurrentCellAddress.Y) &&
+                var currentCell = (rowIndex == DataGridView!.CurrentCellAddress.Y) &&
                                   (ColumnIndex == DataGridView.CurrentCellAddress.X);
 
                 // Is this cell the same as the one with the mouse inside it
@@ -91,8 +91,8 @@ namespace Krypton.Toolkit
                 var pressed = currentCell && ((ButtonStateInternal & ButtonState.Pushed) == ButtonState.Pushed);
 
                 // Find out the requested size of the check box drawing
-                using var viewContent = new ViewLayoutContext(kDGV, kDGV.Renderer);
-                Size checkBoxSize = kDGV.Renderer.RenderGlyph.GetCheckBoxPreferredSize(viewContent,
+                using var viewContent = new ViewLayoutContext(kDGV!, kDGV!.Renderer!);
+                Size checkBoxSize = kDGV.Renderer!.RenderGlyph.GetCheckBoxPreferredSize(viewContent,
                     kDGV.Redirector,
                     kDGV.Enabled,
                     CheckState.Unchecked,
@@ -131,9 +131,9 @@ namespace Krypton.Toolkit
             Rectangle cellBounds,
             int rowIndex,
             DataGridViewElementStates cellState,
-            object value,
-            object formattedValue,
-            string errorText,
+            object? value,
+            object? formattedValue,
+            string? errorText,
             DataGridViewCellStyle cellStyle,
             DataGridViewAdvancedBorderStyle advancedBorderStyle,
             DataGridViewPaintParts paintParts)
@@ -171,13 +171,13 @@ namespace Krypton.Toolkit
                     var tracking = mouseCell && MouseInContentBoundsInternal;
                     var pressed = currentCell && ((ButtonStateInternal & ButtonState.Pushed) == ButtonState.Pushed);
 
-                    using var renderContext = new RenderContext(kDgv, graphics, cellBounds, kDgv.Renderer);
+                    using var renderContext = new RenderContext(kDgv, graphics, cellBounds, kDgv.Renderer!);
                     Size checkBoxSize;
 
                     // Find out the requested size of the check box drawing
-                    using (var viewContent = new ViewLayoutContext(kDgv, kDgv.Renderer))
+                    using (var viewContent = new ViewLayoutContext(kDgv, kDgv.Renderer!))
                     {
-                        checkBoxSize = renderContext.Renderer.RenderGlyph.GetCheckBoxPreferredSize(viewContent, 
+                        checkBoxSize = renderContext.Renderer!.RenderGlyph.GetCheckBoxPreferredSize(viewContent, 
                             kDgv.Redirector,
                             kDgv.Enabled && !base.ReadOnly,
                             checkState,
@@ -265,7 +265,7 @@ namespace Krypton.Toolkit
                 }
 
                 // Grab the internal property implemented by base class
-                return _piButtonState != null ? (ButtonState)_piButtonState.GetValue(this, null) : ButtonState.Normal;
+                return _piButtonState != null ? (ButtonState)_piButtonState!.GetValue(this, null)! : ButtonState.Normal;
             }
         }
 
@@ -280,7 +280,6 @@ namespace Krypton.Toolkit
                     _fiMouseInContentBounds = typeof(DataGridViewCheckBoxCell).GetField(@"mouseInContentBounds", BindingFlags.Static |
                                                                                                                 BindingFlags.NonPublic |
                                                                                                                 BindingFlags.GetField);
-
                     if (_fiMouseInContentBounds == null)
                     {
                         // https://github.com/dotnet/winforms/commit/7ab46c6e6ae1c39143a7638d694fb6e130ab4edc#diff-2684515ec95bea4ec16a0bf7c9e6ff09dc33d31aafabd2c35f016994c800fc84
@@ -292,7 +291,7 @@ namespace Krypton.Toolkit
                 }
 
                 // Grab the internal property implemented by base class
-                return (bool)_fiMouseInContentBounds.GetValue(this);
+                return (bool)_fiMouseInContentBounds!.GetValue(this)!;
             }
         }
 
@@ -312,7 +311,7 @@ namespace Krypton.Toolkit
 
                 // Grab the internal property implemented by base class
                 // ReSharper disable RedundantBaseQualifier
-                return (Point)_piMouseEnteredCellAddress.GetValue(base.DataGridView, null);
+                return (Point)_piMouseEnteredCellAddress!.GetValue(base.DataGridView, null)!;
                 // ReSharper restore RedundantBaseQualifier
             }
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewCheckBoxColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewCheckBoxColumn.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
@@ -77,7 +77,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public override DataGridViewCell CellTemplate
+        public override DataGridViewCell? CellTemplate
         {
             get => base.CellTemplate;
 
@@ -98,7 +98,7 @@ namespace Krypton.Toolkit
         [Category(@"Data")]
         [DefaultValue(@"")]
         [TypeConverter(typeof(StringConverter))]
-        public object FalseValue
+        public object? FalseValue
         {
             get =>
                 CheckBoxCellTemplate == null
@@ -108,7 +108,8 @@ namespace Krypton.Toolkit
             {
                 if (FalseValue != value)
                 {
-                    CheckBoxCellTemplate.FalseValue = value;
+                    CheckBoxCellTemplate!.FalseValue = value;
+
                     if (DataGridView != null)
                     {
                         DataGridViewRowCollection rows = DataGridView.Rows;
@@ -133,7 +134,7 @@ namespace Krypton.Toolkit
         [Category(@"Data")]
         [DefaultValue(@"")]
         [TypeConverter(typeof(StringConverter))]
-        public object IndeterminateValue
+        public object? IndeterminateValue
         {
             get =>
                 CheckBoxCellTemplate == null
@@ -143,7 +144,7 @@ namespace Krypton.Toolkit
             {
                 if (IndeterminateValue != value)
                 {
-                    CheckBoxCellTemplate.IndeterminateValue = value;
+                    CheckBoxCellTemplate!.IndeterminateValue = value;
                     if (DataGridView != null)
                     {
                         DataGridViewRowCollection rows = DataGridView.Rows;
@@ -168,7 +169,7 @@ namespace Krypton.Toolkit
         [Category(@"Data")]
         [DefaultValue(@"")]
         [TypeConverter(typeof(StringConverter))]
-        public object TrueValue
+        public object? TrueValue
         {
             get =>
                 CheckBoxCellTemplate == null
@@ -178,7 +179,7 @@ namespace Krypton.Toolkit
             {
                 if (TrueValue != value)
                 {
-                    CheckBoxCellTemplate.TrueValue = value;
+                    CheckBoxCellTemplate!.TrueValue = value;
                     if (DataGridView != null)
                     {
                         DataGridViewRowCollection rows = DataGridView.Rows;
@@ -210,7 +211,7 @@ namespace Krypton.Toolkit
             {
                 if (ThreeState != value)
                 {
-                    CheckBoxCellTemplate.ThreeState = value;
+                    CheckBoxCellTemplate!.ThreeState = value;
                     if (DataGridView != null)
                     {
                         DataGridViewRowCollection rows = DataGridView.Rows;
@@ -243,7 +244,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Private
-        private KryptonDataGridViewCheckBoxCell? CheckBoxCellTemplate => (KryptonDataGridViewCheckBoxCell)CellTemplate;
+        private KryptonDataGridViewCheckBoxCell? CheckBoxCellTemplate => CellTemplate as KryptonDataGridViewCheckBoxCell;
 
         private bool ShouldSerializeCellTemplate()
         {
@@ -268,7 +269,17 @@ namespace Krypton.Toolkit
                 // ReSharper restore RedundantBaseQualifier
 
                 DataGridViewCellStyle defaultCellStyle = DefaultCellStyle;
-                if (defaultCellStyle.BackColor.IsEmpty && defaultCellStyle.ForeColor.IsEmpty && defaultCellStyle.SelectionBackColor.IsEmpty && defaultCellStyle.SelectionForeColor.IsEmpty && (defaultCellStyle.Font == null) && defaultCellStyle.NullValue.Equals(indeterminate) && defaultCellStyle.IsDataSourceNullValueDefault && string.IsNullOrEmpty(defaultCellStyle.Format) && defaultCellStyle.FormatProvider.Equals(CultureInfo.CurrentCulture) && (defaultCellStyle.Alignment == DataGridViewContentAlignment.MiddleCenter) && defaultCellStyle is { WrapMode: DataGridViewTriState.NotSet, Tag: null })
+                if (defaultCellStyle.BackColor.IsEmpty 
+                    && defaultCellStyle.ForeColor.IsEmpty 
+                    && defaultCellStyle.SelectionBackColor.IsEmpty 
+                    && defaultCellStyle.SelectionForeColor.IsEmpty 
+                    && (defaultCellStyle.Font is null) 
+                    && defaultCellStyle.NullValue!.Equals(indeterminate) 
+                    && defaultCellStyle.IsDataSourceNullValueDefault 
+                    && string.IsNullOrEmpty(defaultCellStyle.Format) 
+                    && defaultCellStyle.FormatProvider.Equals(CultureInfo.CurrentCulture) 
+                    && (defaultCellStyle.Alignment == DataGridViewContentAlignment.MiddleCenter) 
+                    && defaultCellStyle is { WrapMode: DataGridViewTriState.NotSet, Tag: null })
                 {
                     return !defaultCellStyle.Padding.Equals(Padding.Empty);
                 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxCell.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
@@ -20,8 +20,10 @@ namespace Krypton.Toolkit
     public class KryptonDataGridViewComboBoxCell : DataGridViewTextBoxCell
     {
         #region Static Fields
+        [ThreadStatic]
         private static readonly Type _defaultEditType = typeof(KryptonDataGridViewComboBoxEditingControl);
         private static readonly Type _defaultValueType = typeof(string);
+        private static readonly Size _sizeLarge = new Size(10000, 10000);
         #endregion
 
         #region Instance Fields
@@ -88,26 +90,24 @@ namespace Krypton.Toolkit
         public override object Clone()
         {
             var dataGridViewCell = base.Clone() as KryptonDataGridViewComboBoxCell;
-            if (dataGridViewCell != null)
-            {
-                dataGridViewCell.DropDownStyle = DropDownStyle;
-                dataGridViewCell.DropDownHeight = DropDownHeight;
-                dataGridViewCell.DropDownWidth = DropDownWidth;
-                dataGridViewCell.MaxDropDownItems = MaxDropDownItems;
-                dataGridViewCell.AutoCompleteMode = AutoCompleteMode;
-                dataGridViewCell.AutoCompleteSource = AutoCompleteSource;
-                dataGridViewCell.DisplayMember = DisplayMember;
-                dataGridViewCell.ValueMember = ValueMember;
-                dataGridViewCell.DataSource = DataSource;
-            }
-            return dataGridViewCell;
+
+            dataGridViewCell.DropDownStyle = DropDownStyle;
+            dataGridViewCell.DropDownHeight = DropDownHeight;
+            dataGridViewCell.DropDownWidth = DropDownWidth;
+            dataGridViewCell.MaxDropDownItems = MaxDropDownItems;
+            dataGridViewCell.AutoCompleteMode = AutoCompleteMode;
+            dataGridViewCell.AutoCompleteSource = AutoCompleteSource;
+            dataGridViewCell.DisplayMember = DisplayMember;
+            dataGridViewCell.ValueMember = ValueMember;
+            dataGridViewCell.DataSource = DataSource;
+
+            return dataGridViewCell!;
         }
         /// <summary>
         /// The DropDownStyle property replicates the one from the KryptonComboBox control
         /// </summary>
         [DefaultValue(0)]
-        public ComboBoxStyle DropDownStyle
-        {
+        public ComboBoxStyle DropDownStyle {
             get => _dropDownStyle;
 
             set
@@ -129,8 +129,7 @@ namespace Krypton.Toolkit
         /// The MaxDropDownItems property replicates the one from the KryptonComboBox control
         /// </summary>
         [DefaultValue(8)]
-        public int MaxDropDownItems
-        {
+        public int MaxDropDownItems {
             get => _maxDropDownItems;
 
             set
@@ -147,8 +146,7 @@ namespace Krypton.Toolkit
         /// The DropDownHeight property replicates the one from the KryptonComboBox control
         /// </summary>
         [DefaultValue(200)]
-        public int DropDownHeight
-        {
+        public int DropDownHeight {
             get => _dropDownHeight;
 
             set
@@ -165,8 +163,7 @@ namespace Krypton.Toolkit
         /// The DropDownWidth property replicates the one from the KryptonComboBox control
         /// </summary>
         [DefaultValue(121)]
-        public int DropDownWidth
-        {
+        public int DropDownWidth {
             get => _dropDownWidth;
 
             set
@@ -183,8 +180,7 @@ namespace Krypton.Toolkit
         /// The AutoCompleteMode property replicates the one from the KryptonComboBox control
         /// </summary>
         [DefaultValue(AutoCompleteMode.None)]
-        public AutoCompleteMode AutoCompleteMode
-        {
+        public AutoCompleteMode AutoCompleteMode {
             get => _autoCompleteMode;
 
             set
@@ -201,8 +197,7 @@ namespace Krypton.Toolkit
         /// The AutoCompleteSource property replicates the one from the KryptonComboBox control
         /// </summary>
         [DefaultValue(AutoCompleteSource.None)]
-        public AutoCompleteSource AutoCompleteSource
-        {
+        public AutoCompleteSource AutoCompleteSource {
             get => _autoCompleteSource;
 
             set
@@ -219,8 +214,7 @@ namespace Krypton.Toolkit
         /// The DisplayMember property replicates the one from the KryptonComboBox control
         /// </summary>
         [DefaultValue(@"")]
-        public string DisplayMember
-        {
+        public string DisplayMember {
             get => _displayMember;
 
             set
@@ -237,8 +231,7 @@ namespace Krypton.Toolkit
         /// The ValueMember property replicates the one from the KryptonComboBox control
         /// </summary>
         [DefaultValue(@"")]
-        public string ValueMember
-        {
+        public string ValueMember {
             get => _valueMember;
 
             set
@@ -259,8 +252,7 @@ namespace Krypton.Toolkit
         [AttributeProvider(typeof(IListSource))]
         [RefreshProperties(RefreshProperties.Repaint)]
         [DefaultValue(null)]
-        public object? DataSource
-        {
+        public object? DataSource {
             get => _dataSource;
             set
             {
@@ -278,10 +270,11 @@ namespace Krypton.Toolkit
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public override void DetachEditingControl()
         {
-            DataGridView dataGridView = DataGridView;
-            if (dataGridView?.EditingControl == null)
+            DataGridView? dataGridView = DataGridView;
+            switch (dataGridView?.EditingControl)
             {
-                throw new InvalidOperationException(@"Cell is detached or its grid has no editing control.");
+                case null:
+                    throw new InvalidOperationException(@"Cell is detached or its grid has no editing control.");
             }
 
             if (dataGridView.EditingControl is KryptonComboBox comboBox)
@@ -293,6 +286,7 @@ namespace Krypton.Toolkit
             {
                 _selectedItemText = string.Empty;
             }
+
 
             base.DetachEditingControl();
         }
@@ -362,6 +356,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Protected
+
         ///<inheritdoc/>
         protected override void Paint(Graphics graphics, Rectangle clipBounds, Rectangle cellBounds, int rowIndex, DataGridViewElementStates cellState, object? value,
             object? formattedValue, string? errorText, DataGridViewCellStyle cellStyle, DataGridViewAdvancedBorderStyle advancedBorderStyle, DataGridViewPaintParts paintParts)
@@ -410,13 +405,19 @@ namespace Krypton.Toolkit
 
                 // Draw the drop down button, only if no ErrorText has been set.
                 // If the ErrorText is set, only the error icon is shown. Otherwise both are painted on the same spot.
+                string text;
                 if (ErrorText.Length == 0)
                 {
                     graphics.DrawImage(image, new Point(pos, textArea.Top));
+                    text = _selectedItemText;
+                }
+                else
+                {
+                    text = ErrorText;
                 }
 
                 // Cell display text
-                TextRenderer.DrawText(graphics, _selectedItemText, cellStyle.Font, textArea, cellStyle.ForeColor,
+                TextRenderer.DrawText(graphics, text, cellStyle.Font, textArea, cellStyle.ForeColor,
                     KryptonDataGridViewUtilities.ComputeTextFormatFlagsForCellStyleAlignment(righToLeft, cellStyle.Alignment, cellStyle.WrapMode));
             }
         }
@@ -427,17 +428,8 @@ namespace Krypton.Toolkit
         /// </summary>
         protected override Rectangle GetErrorIconBounds(Graphics graphics, DataGridViewCellStyle cellStyle, int rowIndex)
         {
-            const int BUTTONS_WIDTH = 16;
-
             Rectangle errorIconBounds = base.GetErrorIconBounds(graphics, cellStyle, rowIndex);
-            if (DataGridView.RightToLeft == RightToLeft.Yes)
-            {
-                errorIconBounds.X = errorIconBounds.Left + BUTTONS_WIDTH;
-            }
-            else
-            {
-                errorIconBounds.X = errorIconBounds.Left - BUTTONS_WIDTH;
-            }
+            errorIconBounds.X = errorIconBounds.Left;
 
             return errorIconBounds;
         }
@@ -447,26 +439,15 @@ namespace Krypton.Toolkit
         /// </summary>
         protected override Size GetPreferredSize(Graphics graphics, DataGridViewCellStyle cellStyle, int rowIndex, Size constraintSize)
         {
-            if (DataGridView == null)
-            {
-                return new Size(-1, -1);
-            }
-
-            Size preferredSize = base.GetPreferredSize(graphics, cellStyle, rowIndex, constraintSize);
-            if (constraintSize.Width == 0)
-            {
-                const int BUTTONS_WIDTH = 16; // Account for the width of the up/down buttons.
-                const int BUTTON_MARGIN = 8;  // Account for some blank pixels between the text and buttons.
-                preferredSize.Width += BUTTONS_WIDTH + BUTTON_MARGIN;
-            }
-
-            return preferredSize;
+            return DataGridView == null
+                ? new Size(-1, -1)
+                : base.GetPreferredSize(graphics, cellStyle, rowIndex, constraintSize);
         }
         #endregion
 
         #region Private
 
-        private KryptonDataGridViewComboBoxEditingControl EditingComboBox => DataGridView.EditingControl as KryptonDataGridViewComboBoxEditingControl;
+        private KryptonDataGridViewComboBoxEditingControl? EditingComboBox => DataGridView!.EditingControl as KryptonDataGridViewComboBoxEditingControl;
 
         private void OnCommonChange()
         {
@@ -484,10 +465,9 @@ namespace Krypton.Toolkit
         }
 
         private bool OwnsEditingComboBox(int rowIndex) =>
-            rowIndex != -1 
-            && DataGridView is { EditingControl: KryptonDataGridViewComboBoxEditingControl control } 
+            rowIndex != -1
+            && DataGridView is { EditingControl: KryptonDataGridViewComboBoxEditingControl control }
             && (rowIndex == ((IDataGridViewEditingControl)control).EditingControlRowIndex);
-
         #endregion
 
         #region Internal
@@ -496,7 +476,7 @@ namespace Krypton.Toolkit
             _dropDownStyle = value;
             if (OwnsEditingComboBox(rowIndex))
             {
-                EditingComboBox.DropDownStyle = value;
+                EditingComboBox!.DropDownStyle = value;
             }
         }
 
@@ -505,7 +485,7 @@ namespace Krypton.Toolkit
             _maxDropDownItems = value;
             if (OwnsEditingComboBox(rowIndex))
             {
-                EditingComboBox.MaxDropDownItems = value;
+                EditingComboBox!.MaxDropDownItems = value;
             }
         }
 
@@ -514,7 +494,7 @@ namespace Krypton.Toolkit
             _dropDownHeight = value;
             if (OwnsEditingComboBox(rowIndex))
             {
-                EditingComboBox.DropDownHeight = value;
+                EditingComboBox!.DropDownHeight = value;
             }
         }
 
@@ -523,7 +503,7 @@ namespace Krypton.Toolkit
             _dropDownWidth = value;
             if (OwnsEditingComboBox(rowIndex))
             {
-                EditingComboBox.DropDownWidth = value;
+                EditingComboBox!.DropDownWidth = value;
             }
         }
 
@@ -532,7 +512,7 @@ namespace Krypton.Toolkit
             _autoCompleteMode = value;
             if (OwnsEditingComboBox(rowIndex))
             {
-                EditingComboBox.AutoCompleteMode = value;
+                EditingComboBox!.AutoCompleteMode = value;
             }
         }
 
@@ -541,7 +521,7 @@ namespace Krypton.Toolkit
             _autoCompleteSource = value;
             if (OwnsEditingComboBox(rowIndex))
             {
-                EditingComboBox.AutoCompleteSource = value;
+                EditingComboBox!.AutoCompleteSource = value;
             }
         }
 
@@ -550,7 +530,7 @@ namespace Krypton.Toolkit
             _displayMember = value;
             if (OwnsEditingComboBox(rowIndex))
             {
-                EditingComboBox.DisplayMember = value;
+                EditingComboBox!.DisplayMember = value;
             }
         }
 
@@ -559,16 +539,19 @@ namespace Krypton.Toolkit
             _valueMember = value;
             if (OwnsEditingComboBox(rowIndex))
             {
-                EditingComboBox.ValueMember = value;
+                EditingComboBox!.ValueMember = value;
             }
         }
 
-        internal void SetDataSource(int rowIndex, object value)
+        internal void SetDataSource(int rowIndex, object? value)
         {
+            // Force a reread of the cell value and paint when the datasource changes
+            ResetInitialSelectedItemText();
+
             _dataSource = value;
             if (OwnsEditingComboBox(rowIndex))
             {
-                EditingComboBox.DataSource = value;
+                EditingComboBox!.DataSource = value;
             }
         }
 
@@ -576,9 +559,10 @@ namespace Krypton.Toolkit
         /// Type casted version of OwningColumn
         /// </summary>
         internal KryptonDataGridViewComboBoxColumn? KryptonOwningColumn => OwningColumn as KryptonDataGridViewComboBoxColumn;
+        #endregion
 
         /// <summary>
-        /// Resets the inital selected item text.
+        /// Resets the initial selected item text.
         /// </summary>
         internal void ResetInitialSelectedItemText()
         {
@@ -681,7 +665,6 @@ namespace Krypton.Toolkit
 
             return result;
         }
-        #endregion
     }
 }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewComboBoxColumn.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
@@ -17,15 +17,10 @@ namespace Krypton.Toolkit
     /// <summary>
     /// Hosts a collection of KryptonDataGridViewComboBoxCell cells.
     /// </summary>
-    [Designer(typeof(KryptonComboBoxColumnDesigner))]
+    //[Designer(typeof(KryptonComboBoxColumnDesigner))]
     [ToolboxBitmap(typeof(KryptonDataGridViewComboBoxColumn), "ToolboxBitmaps.KryptonComboBox.bmp")]
-    public class KryptonDataGridViewComboBoxColumn : KryptonDataGridViewIconColumn
+    public partial class KryptonDataGridViewComboBoxColumn : KryptonDataGridViewIconColumn
     {
-        #region Fields
-        // Cell indicator image instance
-        private KryptonDataGridViewCellIndicatorImage _kryptonDataGridViewCellIndicatorImage;
-        #endregion
-
         #region Identity
         /// <summary>
         /// Initialize a new instance of the KryptonDataGridViewComboBoxColumn class.
@@ -33,8 +28,8 @@ namespace Krypton.Toolkit
         public KryptonDataGridViewComboBoxColumn()
             : base(new KryptonDataGridViewComboBoxCell())
         {
-            Items = new List<object>();
-            AutoCompleteCustomSource = new AutoCompleteStringCollection();
+            Items = [];
+            AutoCompleteCustomSource = [];
             _kryptonDataGridViewCellIndicatorImage = new();
         }
 
@@ -44,6 +39,7 @@ namespace Krypton.Toolkit
             _kryptonDataGridViewCellIndicatorImage.DataGridView = DataGridView as KryptonDataGridView;
             base.OnDataGridViewChanged();
         }
+
         /// <summary>
         /// Returns a standard compact string representation of the column.
         /// </summary>
@@ -89,8 +85,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public override DataGridViewCell CellTemplate
-        {
+        public override DataGridViewCell? CellTemplate {
             get => base.CellTemplate;
 
             set
@@ -125,8 +120,7 @@ namespace Krypton.Toolkit
         [Description(@"Controls the appearance and functionality of the KryptonComboBox.")]
         [DefaultValue(ComboBoxStyle.DropDown)]
         [RefreshProperties(RefreshProperties.Repaint)]
-        public ComboBoxStyle DropDownStyle
-        {
+        public ComboBoxStyle DropDownStyle {
             get =>
                 ComboBoxCellTemplate?.DropDownStyle ?? throw new InvalidOperationException(@"Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
 
@@ -167,8 +161,7 @@ namespace Krypton.Toolkit
         [Description(@"The maximum number of entries to display in the drop-down list.")]
         [Localizable(true)]
         [DefaultValue(8)]
-        public int MaxDropDownItems
-        {
+        public int MaxDropDownItems {
             get =>
                 ComboBoxCellTemplate?.MaxDropDownItems ?? throw new InvalidOperationException(@"Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
 
@@ -210,8 +203,7 @@ namespace Krypton.Toolkit
         [EditorBrowsable(EditorBrowsableState.Always)]
         [DefaultValue(200)]
         [Browsable(true)]
-        public int DropDownHeight
-        {
+        public int DropDownHeight {
             get =>
                 ComboBoxCellTemplate?.DropDownHeight ?? throw new InvalidOperationException(@"Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
 
@@ -252,8 +244,8 @@ namespace Krypton.Toolkit
         [Description(@"The width, in pixels, of the drop-down box in a KryptonComboBox.")]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Browsable(true)]
-        public int DropDownWidth
-        {
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public int DropDownWidth {
             get =>
                 ComboBoxCellTemplate?.DropDownWidth ?? throw new InvalidOperationException(@"Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
 
@@ -307,8 +299,7 @@ namespace Krypton.Toolkit
         [DefaultValue(AutoCompleteMode.None)]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Browsable(true)]
-        public AutoCompleteMode AutoCompleteMode
-        {
+        public AutoCompleteMode AutoCompleteMode {
             get =>
                 ComboBoxCellTemplate?.AutoCompleteMode ?? throw new InvalidOperationException(@"Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
 
@@ -349,8 +340,7 @@ namespace Krypton.Toolkit
         [DefaultValue(AutoCompleteSource.None)]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Browsable(true)]
-        public AutoCompleteSource AutoCompleteSource
-        {
+        public AutoCompleteSource AutoCompleteSource {
             get =>
                 ComboBoxCellTemplate?.AutoCompleteSource ?? throw new InvalidOperationException(@"Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.");
 
@@ -392,8 +382,7 @@ namespace Krypton.Toolkit
         [TypeConverter(@"System.Windows.Forms.Design.DataMemberFieldConverter")]
         [Editor(@"System.Windows.Forms.Design.DataMemberFieldEditor", typeof(UITypeEditor))]
         [DefaultValue(@"")]
-        public string DisplayMember
-        {
+        public string DisplayMember {
             get =>
                 ComboBoxCellTemplate == null
                     ? throw new InvalidOperationException(@"Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
@@ -438,8 +427,7 @@ namespace Krypton.Toolkit
         [TypeConverter(@"System.Windows.Forms.Design.DataMemberFieldConverter")]
         [Editor(@"System.Windows.Forms.Design.DataMemberFieldEditor", typeof(UITypeEditor))]
         [DefaultValue(@"")]
-        public string ValueMember
-        {
+        public string ValueMember {
             get =>
                 ComboBoxCellTemplate == null
                     ? throw new InvalidOperationException(@"Operation cannot be completed because this DataGridViewColumn does not have a CellTemplate.")
@@ -482,8 +470,8 @@ namespace Krypton.Toolkit
         [Description(@"Indicates the Datasource for the items in this control.")]
         [TypeConverter(@"System.Windows.Forms.Design.DataSourceConverter")]
         [Editor(@"System.Windows.Forms.Design.DataSourceListEditor", typeof(UITypeEditor))]
-        public object? DataSource
-        {
+        [DefaultValue(null)]
+        public object? DataSource {
 
             get =>
                 ComboBoxCellTemplate == null
@@ -522,7 +510,10 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Small utility function that returns the template cell as a KryptonDataGridViewComboBoxCell
         /// </summary>
-        private KryptonDataGridViewComboBoxCell? ComboBoxCellTemplate => (KryptonDataGridViewComboBoxCell)CellTemplate;
+        private KryptonDataGridViewComboBoxCell? ComboBoxCellTemplate => CellTemplate as KryptonDataGridViewComboBoxCell;
+        // Cell indicator image instance
+        private KryptonDataGridViewCellIndicatorImage _kryptonDataGridViewCellIndicatorImage;
+
         #endregion
 
         #region Internal
@@ -532,5 +523,6 @@ namespace Krypton.Toolkit
         /// </summary>
         internal Image? CellIndicatorImage => _kryptonDataGridViewCellIndicatorImage.Image;
         #endregion Internal
+
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDateTimePickerColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDateTimePickerColumn.cs
@@ -15,17 +15,16 @@ namespace Krypton.Toolkit
     /// <summary>
     /// Hosts a collection of KryptonDataGridViewDateTimePickerCell cells.
     /// </summary>
-    [Designer(typeof(KryptonDateTimePickerColumnDesigner))]
+    //[Designer(typeof(KryptonDateTimePickerColumnDesigner))]
     [ToolboxBitmap(typeof(KryptonDataGridViewDateTimePickerColumn), "ToolboxBitmaps.KryptonDateTimePicker.bmp")]
     public class KryptonDataGridViewDateTimePickerColumn : KryptonDataGridViewIconColumn
     {
         #region Instance Fields
+
         private readonly DateTimeList _annualDates;
         private readonly DateTimeList _monthlyDates;
         private readonly DateTimeList _dates;
-       // Cell indicator image instance
-        private readonly KryptonDataGridViewCellIndicatorImage _kryptonDataGridViewCellIndicatorImage;
-         #endregion
+        #endregion
 
         #region Identity
         /// <summary>
@@ -896,6 +895,8 @@ namespace Krypton.Toolkit
         /// Small utility function that returns the template cell as a KryptonDataGridViewDateTimePickerCell
         /// </summary>
         private KryptonDataGridViewDateTimePickerCell? DateTimePickerCellTemplate => CellTemplate as KryptonDataGridViewDateTimePickerCell;
+        // Cell indicator image instance
+        private KryptonDataGridViewCellIndicatorImage _kryptonDataGridViewCellIndicatorImage;
         #endregion
 
         #region Internal

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownCell.cs
@@ -101,7 +101,6 @@ namespace Krypton.Toolkit
 
                 domainUpDown.Text = initialFormattedValue as string ?? string.Empty;
             }
-            Debug.Print("InitializeEditingControl 5");
         }
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownColumn.cs
@@ -15,7 +15,7 @@ namespace Krypton.Toolkit
     /// <summary>
     /// Hosts a collection of KryptonDataGridViewDomainUpDownCell cells.
     /// </summary>
-    [Designer(typeof(KryptonDomainUpDownColumnDesigner))]
+    //[Designer(typeof(KryptonDomainUpDownColumnDesigner))]
     [ToolboxBitmap(typeof(KryptonDataGridViewDomainUpDownColumn), "ToolboxBitmaps.KryptonDomainUpDown.bmp")]
     public class KryptonDataGridViewDomainUpDownColumn : KryptonDataGridViewIconColumn
     {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownEditingControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewDomainUpDownEditingControl.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
@@ -17,10 +17,10 @@ namespace Krypton.Toolkit
     /// </summary>
     [ToolboxItem(false)]
     public class KryptonDataGridViewDomainUpDownEditingControl : KryptonDomainUpDown,
-        IDataGridViewEditingControl
+        IDataGridViewEditingControl, IKryptonDataGridViewEditingControl
     {
         #region Instance Fields
-        private DataGridView _dataGridView;
+        private DataGridView? _dataGridView;
         private bool _valueChanged;
 
         #endregion
@@ -42,29 +42,51 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Property which caches the grid that uses this editing control
         /// </summary>
-        public virtual DataGridView EditingControlDataGridView
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public virtual DataGridView? EditingControlDataGridView
         {
             get => _dataGridView;
-            set => _dataGridView = value;
+            set
+            {
+                // (un)subscribing must be performed before _dataGridView is updated.
+                KryptonDataGridViewUtilities.OnKryptonDataGridViewEditingControlDataGridViewChanged(_dataGridView, value, OnKryptonDataGridViewPaletteModeChanged);
+
+                _dataGridView = value;
+
+                // Trigger a manual palette check
+                KryptonDataGridViewUtilities.OnKryptonDataGridViewPaletteModeChanged(_dataGridView, this);
+            }
+
         }
 
         /// <summary>
         /// Property which represents the current formatted value of the editing control
+        /// <para>Allows null as input, but null will saved as an empty string.</para>
         /// </summary>
-        public virtual object EditingControlFormattedValue
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [AllowNull]
+        public virtual object EditingControlFormattedValue 
         {
+            // [AllowNull] removes warning CS8767, but allows for null input, which is undesired.
+            // The Text property is a non-nullable string and therefore null input
+            // will be converted to String.Empty.
+
             get => GetEditingControlFormattedValue(DataGridViewDataErrorContexts.Formatting);
-            set => Text = (string)value;
+            set => Text = value is string str && str is not null
+                ? str
+                : string.Empty;
         }
 
         /// <summary>
         /// Property which represents the row in which the editing control resides
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual int EditingControlRowIndex { get; set; }
 
         /// <summary>
         /// Property which indicates whether the value of the editing control has changed or not
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual bool EditingControlValueChanged
         {
             get => _valueChanged;
@@ -80,6 +102,12 @@ namespace Krypton.Toolkit
         /// Property which indicates whether the editing control needs to be repositioned when its value changes.
         /// </summary>
         public virtual bool RepositionEditingControlOnValueChange => false;
+
+        /// <inheritdoc/>
+        public void OnKryptonDataGridViewPaletteModeChanged(object? sender, EventArgs e)
+        {
+            KryptonDataGridViewUtilities.OnKryptonDataGridViewPaletteModeChanged(sender, this);
+        }
 
         /// <summary>
         /// Method called by the grid before the editing control is shown so it can adapt to the provided cell style.
@@ -220,7 +248,7 @@ namespace Krypton.Toolkit
             if (!_valueChanged)
             {
                 _valueChanged = true;
-                _dataGridView.NotifyCurrentCellDirty(true);
+                _dataGridView?.NotifyCurrentCellDirty(true);
             }
         }
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewLinkCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewLinkCell.cs
@@ -5,11 +5,12 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
 
+// ReSharper disable InconsistentNaming
 namespace Krypton.Toolkit
 {
     /// <summary>
@@ -80,7 +81,7 @@ namespace Krypton.Toolkit
                 {
                     _labelStyle = value;
                     _labelStyleDefined = true;
-                    DataGridView.InvalidateCell(this);
+                    DataGridView!.InvalidateCell(this);
                 }
             }
         }
@@ -115,7 +116,7 @@ namespace Krypton.Toolkit
         {
             try
             {
-                var kDGV = (KryptonDataGridView)DataGridView;
+                var kDGV = DataGridView as KryptonDataGridView;
 
                 // Ensure the view classes are created and hooked up
                 CreateViewAndPalettes(kDGV);
@@ -126,16 +127,16 @@ namespace Krypton.Toolkit
                 // Update the display text
                 if ((rowIndex >= 0) && !string.IsNullOrEmpty(FormattedValue?.ToString()))
                 {
-                    _shortTextValue.ShortText = FormattedValue.ToString();
+                    _shortTextValue.ShortText = FormattedValue!.ToString();
                 }
                 else
                 {
-                    if ((kDGV.Columns[ColumnIndex] is KryptonDataGridViewButtonColumn
+                    if ((kDGV?.Columns[ColumnIndex] is KryptonDataGridViewButtonColumn
                         {
                             UseColumnTextForButtonValue: true
                         } col) && !kDGV.Rows[rowIndex].IsNewRow)
                     {
-                        _shortTextValue.ShortText = col.Text;
+                        _shortTextValue.ShortText = col.Text!;
                     }
                     else
                     {
@@ -144,7 +145,7 @@ namespace Krypton.Toolkit
                 }
 
                 // Position the button element inside the available cell area
-                using var layoutContext = new ViewLayoutContext(kDGV, kDGV.Renderer);
+                using var layoutContext = new ViewLayoutContext(kDGV!, kDGV?.Renderer!);
                 // Define the available area for layout
                 layoutContext.DisplayRectangle = new Rectangle(0, 0, int.MaxValue, int.MaxValue);
 
@@ -179,23 +180,23 @@ namespace Krypton.Toolkit
         /// <param name="advancedBorderStyle">A DataGridViewAdvancedBorderStyle that contains border styles for the cell that is being painted.</param>
         /// <param name="paintParts">A bitwise combination of the DataGridViewPaintParts values that specifies which parts of the cell need to be painted.</param>
         protected override void Paint(Graphics graphics,
-            Rectangle clipBounds,
-            Rectangle cellBounds,
-            int rowIndex,
-            DataGridViewElementStates cellState,
-            object value,
-            object? formattedValue,
-            string errorText,
-            DataGridViewCellStyle cellStyle,
-            DataGridViewAdvancedBorderStyle advancedBorderStyle,
-            DataGridViewPaintParts paintParts)
+                                      Rectangle clipBounds,
+                                      Rectangle cellBounds,
+                                      int rowIndex,
+                                      DataGridViewElementStates cellState,
+                                      object? value,
+                                      object? formattedValue,
+                                      string? errorText,
+                                      DataGridViewCellStyle cellStyle,
+                                      DataGridViewAdvancedBorderStyle advancedBorderStyle,
+                                      DataGridViewPaintParts paintParts)
         {
             if (DataGridView is KryptonDataGridView kDgv)
             {
                 // Should we draw the content foreground?
                 if ((paintParts & DataGridViewPaintParts.ContentForeground) == DataGridViewPaintParts.ContentForeground)
                 {
-                    using var renderContext = new RenderContext(kDgv, graphics, cellBounds, kDgv.Renderer);
+                    using var renderContext = new RenderContext(kDgv, graphics, cellBounds, kDgv.Renderer!);
                     // Cache the starting cell bounds
                     Rectangle startBounds = cellBounds;
 
@@ -206,9 +207,9 @@ namespace Krypton.Toolkit
                     SetElementStateAndPalette();
 
                     // Update the display text
-                    if (!string.IsNullOrEmpty(formattedValue?.ToString()))
+                    if (!string.IsNullOrEmpty(formattedValue?.ToString())!)
                     {
-                        _shortTextValue.ShortText = formattedValue.ToString();
+                        _shortTextValue.ShortText = formattedValue!.ToString();
                     }
                     else
                     {
@@ -217,7 +218,7 @@ namespace Krypton.Toolkit
                                 UseColumnTextForButtonValue: true
                             } col) && !kDgv.Rows[rowIndex].IsNewRow)
                         {
-                            _shortTextValue.ShortText = col.Text;
+                            _shortTextValue.ShortText = col.Text!;
                         }
                         else
                         {
@@ -243,7 +244,7 @@ namespace Krypton.Toolkit
                     cellBounds.Height -= cellStyle.Padding.Vertical;
 
                     // Position the button element inside the available cell area
-                    using (var layoutContext = new ViewLayoutContext(kDgv, kDgv.Renderer))
+                    using (var layoutContext = new ViewLayoutContext(kDgv, kDgv.Renderer!))
                     {
                         // Define the available area for calculating layout
                         layoutContext.DisplayRectangle = cellBounds;
@@ -333,13 +334,13 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Private
-        private void CreateViewAndPalettes(KryptonDataGridView kDGV)
+        private void CreateViewAndPalettes(KryptonDataGridView? kDGV)
         {
             // Create the view element when first needed
-            if (_viewLabel == null)
+            if (_viewLabel is null)
             {
                 // Create helper object to get all values from the DGV redirector
-                _palette = new PaletteContentToPalette(kDGV.Redirector, PaletteContentStyle.LabelNormalPanel);
+                _palette = new PaletteContentToPalette(kDGV!.Redirector, PaletteContentStyle.LabelNormalPanel);
                 _inheritBehavior = new LinkLabelBehaviorInherit(_palette, KryptonLinkBehavior.AlwaysUnderline);
                 _overrideVisited = new PaletteContentInheritOverride(_palette, _inheritBehavior, PaletteState.LinkNotVisitedOverride, true);
                 _overridePressed = new PaletteContentInheritOverride(_palette, _overrideVisited, PaletteState.LinkPressedOverride, false);
@@ -354,7 +355,7 @@ namespace Krypton.Toolkit
 
         private void SetElementStateAndPalette()
         {
-            LinkState linkState = LinkStateInternal;
+            LinkState? linkState = LinkStateInternal;
 
             // Has the item been visited
             _overrideVisited.OverrideState = LinkVisited ? PaletteState.LinkVisitedOverride : PaletteState.LinkNotVisitedOverride;
@@ -378,22 +379,21 @@ namespace Krypton.Toolkit
             _palette.ContentStyle = CommonHelper.ContentStyleFromLabelStyle(_labelStyle);
         }
 
-        private LinkState LinkStateInternal
+        private LinkState? LinkStateInternal
         {
             get
             {
                 // Only need to cache reflection info the first time around
-                if (_piLinkState == null)
+                if (_piLinkState is null)
                 {
                     // Cache access to the internal get property 'LinkState'
                     _piLinkState = typeof(DataGridViewLinkCell).GetProperty(nameof(LinkState), BindingFlags.Instance |
-                                                                                         BindingFlags.NonPublic |
-                                                                                         BindingFlags.GetField);
-
+                                                                                               BindingFlags.NonPublic |
+                                                                                               BindingFlags.GetField)!;
                 }
 
                 // Grab the internal property implemented by base class
-                return (LinkState)_piLinkState.GetValue(this, null);
+                return (LinkState?)_piLinkState!.GetValue(this, null);
             }
         }
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewLinkColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewLinkColumn.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
@@ -65,6 +65,7 @@ namespace Krypton.Toolkit
             var clone = base.Clone() as KryptonDataGridViewLinkColumn;
             clone.Text = Text;
             clone.LabelStyle = LabelStyle;
+
             return clone;
         }
         #endregion
@@ -75,18 +76,18 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public override DataGridViewCell CellTemplate
+        public override DataGridViewCell? CellTemplate
         {
             get => base.CellTemplate;
 
             set
             {
-                if ((value != null) && value is not KryptonDataGridViewLinkCell)
+                if ((value is not null) && value is not KryptonDataGridViewLinkCell)
                 {
                     throw new InvalidCastException("Can only assign a object of type KryptonDataGridViewLinkCell");
                 }
 
-                base.CellTemplate = value;
+                base.CellTemplate = value as KryptonDataGridViewLinkCell;
             }
         }
 
@@ -144,7 +145,7 @@ namespace Krypton.Toolkit
                 if (_labelStyle != value)
                 {
                     _labelStyle = value;
-                    ((KryptonDataGridViewLinkCell)CellTemplate).LabelStyleInternal = value;
+                    ((KryptonDataGridViewLinkCell)CellTemplate!).LabelStyleInternal = value;
                     // ReSharper disable RedundantBaseQualifier
                     if (base.DataGridView != null)
                     // ReSharper restore RedundantBaseQualifier
@@ -172,12 +173,12 @@ namespace Krypton.Toolkit
         public LinkBehavior LinkBehavior
         {
             get =>
-                ((KryptonDataGridViewLinkCell)CellTemplate)?.LinkBehavior ?? throw new InvalidOperationException("KryptonDataGridViewLinkCell cell template required");
+                ((KryptonDataGridViewLinkCell)CellTemplate!)?.LinkBehavior ?? throw new InvalidOperationException("KryptonDataGridViewLinkCell cell template required");
             set
             {
                 if (!LinkBehavior.Equals(value))
                 {
-                    ((KryptonDataGridViewLinkCell)CellTemplate).LinkBehaviorInternal = value;
+                    ((KryptonDataGridViewLinkCell)CellTemplate!).LinkBehaviorInternal = value;
                     // ReSharper disable RedundantBaseQualifier
                     if (base.DataGridView != null)
                     // ReSharper restore RedundantBaseQualifier
@@ -205,12 +206,12 @@ namespace Krypton.Toolkit
         public bool TrackVisitedState
         {
             get =>
-                ((KryptonDataGridViewLinkCell)CellTemplate)?.TrackVisitedState ?? throw new InvalidOperationException("KryptonDataGridViewLinkCell cell template required");
+                ((KryptonDataGridViewLinkCell)CellTemplate!)?.TrackVisitedState ?? throw new InvalidOperationException("KryptonDataGridViewLinkCell cell template required");
             set
             {
                 if (TrackVisitedState != value)
                 {
-                    TrackVisitedStateInternal(CellTemplate, value);
+                    TrackVisitedStateInternal(CellTemplate!, value);
                     if (DataGridView != null)
                     {
                         DataGridViewRowCollection rows = DataGridView.Rows;
@@ -236,13 +237,13 @@ namespace Krypton.Toolkit
         public bool UseColumnTextForLinkValue
         {
             get =>
-                ((KryptonDataGridViewLinkCell)CellTemplate)?.UseColumnTextForLinkValue ?? throw new InvalidOperationException("KryptonDataGridViewLinkCell cell template required");
+                ((KryptonDataGridViewLinkCell)CellTemplate!)?.UseColumnTextForLinkValue ?? throw new InvalidOperationException("KryptonDataGridViewLinkCell cell template required");
 
             set
             {
                 if (UseColumnTextForLinkValue != value)
                 {
-                    SetUseColumnTextForLinkValueInternal(CellTemplate, value);
+                    SetUseColumnTextForLinkValueInternal(CellTemplate!, value);
                     if (DataGridView != null)
                     {
                         DataGridViewRowCollection rows = DataGridView.Rows;
@@ -265,27 +266,27 @@ namespace Krypton.Toolkit
         private void ColumnCommonChange(int columnIndex)
         {
             // Only need to cache reflection info the first time around
-            if (_miColumnCommonChange == null)
+            if (_miColumnCommonChange is null)
             {
                 // Cache access to the internal method 'OnColumnCommonChange'
                 _miColumnCommonChange = typeof(DataGridView).GetMethod("OnColumnCommonChange", BindingFlags.Instance |
                                                                                                BindingFlags.NonPublic |
-                                                                                               BindingFlags.GetField);
+                                                                                               BindingFlags.GetField)!;
 
             }
 
-            _miColumnCommonChange.Invoke(DataGridView, new object[] { columnIndex });
+            _miColumnCommonChange.Invoke(DataGridView, [columnIndex]);
         }
 
         private void SetUseColumnTextForLinkValueInternal(object instance, bool value)
         {
             // Only need to cache reflection info the first time around
-            if (_piUseColumnTextForLinkValueInternal == null)
+            if (_piUseColumnTextForLinkValueInternal is null)
             {
                 // Cache access to the internal property sette 'UseColumnTextForLinkValueInternal'
                 _piUseColumnTextForLinkValueInternal = typeof(DataGridViewLinkCell).GetProperty(@"UseColumnTextForLinkValueInternal", BindingFlags.Instance |
-                                                                                                                                     BindingFlags.NonPublic |
-                                                                                                                                     BindingFlags.SetProperty);
+                                                                                                                                      BindingFlags.NonPublic |
+                                                                                                                                      BindingFlags.SetProperty)!;
 
             }
 
@@ -295,12 +296,12 @@ namespace Krypton.Toolkit
         private void TrackVisitedStateInternal(object instance, bool value)
         {
             // Only need to cache reflection info the first time around
-            if (_piTrackVisitedStateInternal == null)
+            if (_piTrackVisitedStateInternal is null)
             {
                 // Cache access to the internal property sette 'TrackVisitedStateInternal'
                 _piTrackVisitedStateInternal = typeof(DataGridViewLinkCell).GetProperty(nameof(TrackVisitedStateInternal), BindingFlags.Instance |
-                                                                                                                     BindingFlags.NonPublic |
-                                                                                                                     BindingFlags.SetProperty);
+                                                                                                                           BindingFlags.NonPublic |
+                                                                                                                           BindingFlags.SetProperty)!;
 
             }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewMaskedTextBoxCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewMaskedTextBoxCell.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
@@ -414,7 +414,7 @@ namespace Krypton.Toolkit
                 dataGridViewCell.TextMaskFormat = TextMaskFormat;
                 dataGridViewCell.UseSystemPasswordChar = UseSystemPasswordChar;
             }
-            return dataGridViewCell;
+            return dataGridViewCell!;
         }
 
         /// <summary>
@@ -424,7 +424,7 @@ namespace Krypton.Toolkit
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public override void DetachEditingControl()
         {
-            DataGridView dataGridView = DataGridView;
+            DataGridView? dataGridView = DataGridView;
             if (dataGridView?.EditingControl == null)
             {
                 throw new InvalidOperationException("Cell is detached or its grid has no editing control.");
@@ -450,12 +450,12 @@ namespace Krypton.Toolkit
         /// set according to the cell properties.
         /// </summary>
         public override void InitializeEditingControl(int rowIndex,
-            object initialFormattedValue,
+            object? initialFormattedValue,
             DataGridViewCellStyle dataGridViewCellStyle)
         {
             base.InitializeEditingControl(rowIndex, initialFormattedValue, dataGridViewCellStyle);
 
-            if (DataGridView.EditingControl is KryptonMaskedTextBox maskedTextBox)
+            if (DataGridView!.EditingControl is KryptonMaskedTextBox maskedTextBox)
             {
                 maskedTextBox.PromptChar = PromptChar;
                 maskedTextBox.AllowPromptAsInput = AllowPromptAsInput;
@@ -473,7 +473,7 @@ namespace Krypton.Toolkit
                 maskedTextBox.SkipLiterals = SkipLiterals;
                 maskedTextBox.TextMaskFormat = TextMaskFormat;
                 maskedTextBox.UseSystemPasswordChar = UseSystemPasswordChar;
-                maskedTextBox.Text = initialFormattedValue is string initialFormattedValueStr ? initialFormattedValueStr : string.Empty;
+                maskedTextBox.Text = initialFormattedValue as string ?? string.Empty;
             }
         }
 
@@ -496,7 +496,7 @@ namespace Krypton.Toolkit
                 isFirstDisplayedColumn, isFirstDisplayedRow);
 
             editingControlBounds = GetAdjustedEditingControlBounds(editingControlBounds, cellStyle);
-            DataGridView.EditingControl.Location = new Point(editingControlBounds.X, editingControlBounds.Y);
+            DataGridView!.EditingControl!.Location = new Point(editingControlBounds.X, editingControlBounds.Y);
             DataGridView.EditingControl.Size = new Size(editingControlBounds.Width, editingControlBounds.Height);
         }
         #endregion
@@ -508,17 +508,8 @@ namespace Krypton.Toolkit
         /// </summary>
         protected override Rectangle GetErrorIconBounds(Graphics graphics, DataGridViewCellStyle cellStyle, int rowIndex)
         {
-            const int BUTTONS_WIDTH = 16;
-
             Rectangle errorIconBounds = base.GetErrorIconBounds(graphics, cellStyle, rowIndex);
-            if (DataGridView.RightToLeft == RightToLeft.Yes)
-            {
-                errorIconBounds.X = errorIconBounds.Left + BUTTONS_WIDTH;
-            }
-            else
-            {
-                errorIconBounds.X = errorIconBounds.Left - BUTTONS_WIDTH;
-            }
+            errorIconBounds.X = errorIconBounds.Left;
 
             return errorIconBounds;
         }
@@ -528,27 +519,16 @@ namespace Krypton.Toolkit
         /// </summary>
         protected override Size GetPreferredSize(Graphics graphics, DataGridViewCellStyle cellStyle, int rowIndex, Size constraintSize)
         {
-            if (DataGridView == null)
-            {
-                return new Size(-1, -1);
-            }
-
-            Size preferredSize = base.GetPreferredSize(graphics, cellStyle, rowIndex, constraintSize);
-            if (constraintSize.Width == 0)
-            {
-                const int BUTTONS_WIDTH = 16; // Account for the width of the up/down buttons.
-                const int BUTTON_MARGIN = 8;  // Account for some blank pixels between the text and buttons.
-                preferredSize.Width += BUTTONS_WIDTH + BUTTON_MARGIN;
-            }
-
-            return preferredSize;
+            return DataGridView == null
+                ? new Size(-1, -1) 
+                : base.GetPreferredSize(graphics, cellStyle, rowIndex, constraintSize);
         }
 
         #endregion
 
         #region Private
 
-        private KryptonDataGridViewMaskedTextBoxEditingControl EditingMaskedTextBox => DataGridView.EditingControl as KryptonDataGridViewMaskedTextBoxEditingControl;
+        private KryptonDataGridViewMaskedTextBoxEditingControl? EditingMaskedTextBox => DataGridView!.EditingControl as KryptonDataGridViewMaskedTextBoxEditingControl;
 
         private Rectangle GetAdjustedEditingControlBounds(Rectangle editingControlBounds,
             DataGridViewCellStyle cellStyle)
@@ -591,8 +571,8 @@ namespace Krypton.Toolkit
         }
 
         private bool OwnsEditingMaskedTextBox(int rowIndex) =>
-            rowIndex != -1 
-            && DataGridView is { EditingControl: KryptonDataGridViewMaskedTextBoxEditingControl control } 
+            rowIndex != -1
+            && DataGridView is { EditingControl: KryptonDataGridViewMaskedTextBoxEditingControl control }
             && (rowIndex == ((IDataGridViewEditingControl)control).EditingControlRowIndex);
 
         private static bool PartPainted(DataGridViewPaintParts paintParts, DataGridViewPaintParts paintPart) => (paintParts & paintPart) != 0;
@@ -605,7 +585,7 @@ namespace Krypton.Toolkit
             _promptChar = value;
             if (OwnsEditingMaskedTextBox(rowIndex))
             {
-                EditingMaskedTextBox.PromptChar = value;
+                EditingMaskedTextBox!.PromptChar = value;
             }
         }
 
@@ -614,7 +594,7 @@ namespace Krypton.Toolkit
             _allowPromptAsInput = value;
             if (OwnsEditingMaskedTextBox(rowIndex))
             {
-                EditingMaskedTextBox.AllowPromptAsInput = value;
+                EditingMaskedTextBox!.AllowPromptAsInput = value;
             }
         }
 
@@ -623,7 +603,7 @@ namespace Krypton.Toolkit
             _asciiOnly = value;
             if (OwnsEditingMaskedTextBox(rowIndex))
             {
-                EditingMaskedTextBox.AsciiOnly = value;
+                EditingMaskedTextBox!.AsciiOnly = value;
             }
         }
 
@@ -632,7 +612,7 @@ namespace Krypton.Toolkit
             _beepOnError = value;
             if (OwnsEditingMaskedTextBox(rowIndex))
             {
-                EditingMaskedTextBox.BeepOnError = value;
+                EditingMaskedTextBox!.BeepOnError = value;
             }
         }
 
@@ -641,7 +621,7 @@ namespace Krypton.Toolkit
             _cutCopyMaskFormat = value;
             if (OwnsEditingMaskedTextBox(rowIndex))
             {
-                EditingMaskedTextBox.CutCopyMaskFormat = value;
+                EditingMaskedTextBox!.CutCopyMaskFormat = value;
             }
         }
 
@@ -650,7 +630,7 @@ namespace Krypton.Toolkit
             _hidePromptOnLeave = value;
             if (OwnsEditingMaskedTextBox(rowIndex))
             {
-                EditingMaskedTextBox.HidePromptOnLeave = value;
+                EditingMaskedTextBox!.HidePromptOnLeave = value;
             }
         }
 
@@ -659,7 +639,7 @@ namespace Krypton.Toolkit
             _hideSelection = value;
             if (OwnsEditingMaskedTextBox(rowIndex))
             {
-                EditingMaskedTextBox.HideSelection = value;
+                EditingMaskedTextBox!.HideSelection = value;
             }
         }
 
@@ -668,7 +648,7 @@ namespace Krypton.Toolkit
             _insertKeyMode = value;
             if (OwnsEditingMaskedTextBox(rowIndex))
             {
-                EditingMaskedTextBox.InsertKeyMode = value;
+                EditingMaskedTextBox!.InsertKeyMode = value;
             }
         }
 
@@ -677,7 +657,7 @@ namespace Krypton.Toolkit
             _mask = value;
             if (OwnsEditingMaskedTextBox(rowIndex))
             {
-                EditingMaskedTextBox.Mask = value;
+                EditingMaskedTextBox!.Mask = value;
             }
         }
 
@@ -686,7 +666,7 @@ namespace Krypton.Toolkit
             _passwordChar = value;
             if (OwnsEditingMaskedTextBox(rowIndex))
             {
-                EditingMaskedTextBox.PasswordChar = value;
+                EditingMaskedTextBox!.PasswordChar = value;
             }
         }
 
@@ -695,7 +675,7 @@ namespace Krypton.Toolkit
             _rejectInputOnFirstFailure = value;
             if (OwnsEditingMaskedTextBox(rowIndex))
             {
-                EditingMaskedTextBox.RejectInputOnFirstFailure = value;
+                EditingMaskedTextBox!.RejectInputOnFirstFailure = value;
             }
         }
 
@@ -704,7 +684,7 @@ namespace Krypton.Toolkit
             _resetOnPrompt = value;
             if (OwnsEditingMaskedTextBox(rowIndex))
             {
-                EditingMaskedTextBox.ResetOnPrompt = value;
+                EditingMaskedTextBox!.ResetOnPrompt = value;
             }
         }
 
@@ -713,7 +693,7 @@ namespace Krypton.Toolkit
             _resetOnSpace = value;
             if (OwnsEditingMaskedTextBox(rowIndex))
             {
-                EditingMaskedTextBox.ResetOnSpace = value;
+                EditingMaskedTextBox!.ResetOnSpace = value;
             }
         }
 
@@ -722,7 +702,7 @@ namespace Krypton.Toolkit
             _skipLiterals = value;
             if (OwnsEditingMaskedTextBox(rowIndex))
             {
-                EditingMaskedTextBox.SkipLiterals = value;
+                EditingMaskedTextBox!.SkipLiterals = value;
             }
         }
 
@@ -731,7 +711,7 @@ namespace Krypton.Toolkit
             _textMaskFormat = value;
             if (OwnsEditingMaskedTextBox(rowIndex))
             {
-                EditingMaskedTextBox.TextMaskFormat = value;
+                EditingMaskedTextBox!.TextMaskFormat = value;
             }
         }
 
@@ -740,7 +720,7 @@ namespace Krypton.Toolkit
             _useSystemPasswordChar = value;
             if (OwnsEditingMaskedTextBox(rowIndex))
             {
-                EditingMaskedTextBox.UseSystemPasswordChar = value;
+                EditingMaskedTextBox!.UseSystemPasswordChar = value;
             }
         }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewMaskedTextBoxColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewMaskedTextBoxColumn.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
@@ -15,7 +15,7 @@ namespace Krypton.Toolkit
     /// <summary>
     /// Hosts a collection of KryptonDataGridViewMaskedTextBoxCell cells.
     /// </summary>
-    [Designer(typeof(KryptonMaskedTextBoxColumnDesigner))]
+    //[Designer(typeof(KryptonMaskedTextBoxColumnDesigner))]
     [ToolboxBitmap(typeof(KryptonDataGridViewMaskedTextBoxColumn), "ToolboxBitmaps.KryptonMaskedTextBox.bmp")]
     public class KryptonDataGridViewMaskedTextBoxColumn : KryptonDataGridViewIconColumn
     {
@@ -63,7 +63,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public override DataGridViewCell CellTemplate
+        public override DataGridViewCell? CellTemplate
         {
             get => base.CellTemplate;
             set
@@ -724,7 +724,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Small utility function that returns the template cell as a KryptonDataGridViewMaskedTextBoxCell
         /// </summary>
-        private KryptonDataGridViewMaskedTextBoxCell? MaskedTextBoxCellTemplate => (KryptonDataGridViewMaskedTextBoxCell)CellTemplate;
+        private KryptonDataGridViewMaskedTextBoxCell? MaskedTextBoxCellTemplate => CellTemplate as KryptonDataGridViewMaskedTextBoxCell;
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewMaskedTextBoxEditingControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewMaskedTextBoxEditingControl.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
@@ -17,10 +17,10 @@ namespace Krypton.Toolkit
     /// </summary>
     [ToolboxItem(false)]
     public class KryptonDataGridViewMaskedTextBoxEditingControl : KryptonMaskedTextBox,
-        IDataGridViewEditingControl
+        IDataGridViewEditingControl, IKryptonDataGridViewEditingControl
     {
         #region Instance Fields
-        private DataGridView _dataGridView;
+        private DataGridView? _dataGridView;
         private bool _valueChanged;
 
         #endregion
@@ -42,29 +42,51 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Property which caches the grid that uses this editing control
         /// </summary>
-        public virtual DataGridView EditingControlDataGridView
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public virtual DataGridView? EditingControlDataGridView
         {
             get => _dataGridView;
-            set => _dataGridView = value;
+            set
+            {
+                // (un)subscribing must be performed before _dataGridView is updated.
+                KryptonDataGridViewUtilities.OnKryptonDataGridViewEditingControlDataGridViewChanged(_dataGridView, value, OnKryptonDataGridViewPaletteModeChanged);
+
+                _dataGridView = value;
+
+                // Trigger a manual palette check
+                KryptonDataGridViewUtilities.OnKryptonDataGridViewPaletteModeChanged(_dataGridView, this);
+            }
+
         }
 
         /// <summary>
         /// Property which represents the current formatted value of the editing control
+        /// <para>Allows null as input, but null will saved as an empty string.</para>
         /// </summary>
-        public virtual object EditingControlFormattedValue
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [AllowNull]
+        public virtual object EditingControlFormattedValue 
         {
+            // [AllowNull] removes warning CS8767, but allows for null input, which is undesired.
+            // The Text property is a non-nullable string and therefore null input
+            // will be converted to String.Empty.
+
             get => GetEditingControlFormattedValue(DataGridViewDataErrorContexts.Formatting);
-            set => Text = (string)value;
+            set => Text = value is string str && str is not null
+                ? str
+                : string.Empty;
         }
 
         /// <summary>
         /// Property which represents the row in which the editing control resides
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual int EditingControlRowIndex { get; set; }
 
         /// <summary>
         /// Property which indicates whether the value of the editing control has changed or not
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual bool EditingControlValueChanged
         {
             get => _valueChanged;
@@ -80,6 +102,12 @@ namespace Krypton.Toolkit
         /// Property which indicates whether the editing control needs to be repositioned when its value changes.
         /// </summary>
         public virtual bool RepositionEditingControlOnValueChange => false;
+
+        /// <inheritdoc/>
+        public void OnKryptonDataGridViewPaletteModeChanged(object? sender, EventArgs e)
+        {
+            KryptonDataGridViewUtilities.OnKryptonDataGridViewPaletteModeChanged(sender, this);
+        }
 
         /// <summary>
         /// Method called by the grid before the editing control is shown so it can adapt to the provided cell style.
@@ -220,7 +248,7 @@ namespace Krypton.Toolkit
             if (!_valueChanged)
             {
                 _valueChanged = true;
-                _dataGridView.NotifyCurrentCellDirty(true);
+                _dataGridView?.NotifyCurrentCellDirty(true);
             }
         }
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewNumericUpDownColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewNumericUpDownColumn.cs
@@ -15,7 +15,7 @@ namespace Krypton.Toolkit
     /// <summary>
     /// Hosts a collection of KryptonDataGridViewNumericUpDownCell cells.
     /// </summary>
-    [Designer(typeof(KryptonNumericUpDownColumnDesigner))]
+    //[Designer(typeof(KryptonNumericUpDownColumnDesigner))]
     [ToolboxBitmap(typeof(KryptonDataGridViewNumericUpDownColumn), "ToolboxBitmaps.KryptonNumericUpDown.bmp")]
     public class KryptonDataGridViewNumericUpDownColumn : KryptonDataGridViewIconColumn
     {

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewNumericUpDownEditingControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewNumericUpDownEditingControl.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
@@ -17,10 +17,10 @@ namespace Krypton.Toolkit
     /// </summary>
     [ToolboxItem(false)]
     public class KryptonDataGridViewNumericUpDownEditingControl : KryptonNumericUpDown,
-        IDataGridViewEditingControl
+        IDataGridViewEditingControl, IKryptonDataGridViewEditingControl
     {
         #region Instance Fields
-        private DataGridView _dataGridView;
+        private DataGridView? _dataGridView;
         private bool _valueChanged;
 
         #endregion
@@ -42,29 +42,51 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Property which caches the grid that uses this editing control
         /// </summary>
-        public virtual DataGridView EditingControlDataGridView
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public virtual DataGridView? EditingControlDataGridView
         {
             get => _dataGridView;
-            set => _dataGridView = value;
+            set
+            {
+                // (un)subscribing must be performed before _dataGridView is updated.
+                KryptonDataGridViewUtilities.OnKryptonDataGridViewEditingControlDataGridViewChanged(_dataGridView, value, OnKryptonDataGridViewPaletteModeChanged);
+
+                _dataGridView = value;
+
+                // Trigger a manual palette check
+                KryptonDataGridViewUtilities.OnKryptonDataGridViewPaletteModeChanged(_dataGridView, this);
+            }
+
         }
 
         /// <summary>
         /// Property which represents the current formatted value of the editing control
+        /// <para>Allows null as input, but null will saved as an empty string.</para>
         /// </summary>
-        public virtual object EditingControlFormattedValue
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [AllowNull]
+        public virtual object EditingControlFormattedValue 
         {
+            // [AllowNull] removes warning CS8767, but allows for null input, which is undesired.
+            // The Text property is a non-nullable string and therefore null input
+            // will be converted to String.Empty.
+
             get => GetEditingControlFormattedValue(DataGridViewDataErrorContexts.Formatting);
-            set => Text = (string)value;
+            set => Text = value is string str && str is not null
+                ? str
+                : string.Empty;
         }
 
         /// <summary>
         /// Property which represents the row in which the editing control resides
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual int EditingControlRowIndex { get; set; }
 
         /// <summary>
         /// Property which indicates whether the value of the editing control has changed or not
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual bool EditingControlValueChanged
         {
             get => _valueChanged;
@@ -80,6 +102,12 @@ namespace Krypton.Toolkit
         /// Property which indicates whether the editing control needs to be repositioned when its value changes.
         /// </summary>
         public virtual bool RepositionEditingControlOnValueChange => false;
+
+        /// <inheritdoc/>
+        public void OnKryptonDataGridViewPaletteModeChanged(object? sender, EventArgs e)
+        {
+            KryptonDataGridViewUtilities.OnKryptonDataGridViewPaletteModeChanged(sender, this);
+        }
 
         /// <summary>
         /// Method called by the grid before the editing control is shown so it can adapt to the provided cell style.
@@ -285,7 +313,7 @@ namespace Krypton.Toolkit
             if (!_valueChanged)
             {
                 _valueChanged = true;
-                _dataGridView.NotifyCurrentCellDirty(true);
+                _dataGridView?.NotifyCurrentCellDirty(true);
             }
         }
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxCell.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxCell.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
@@ -76,11 +76,11 @@ namespace Krypton.Toolkit
         /// <returns></returns>
         public override object Clone()
         {
-            var cloned = base.Clone() as KryptonDataGridViewTextBoxCell;
-
+            var cloned = (KryptonDataGridViewTextBoxCell)base.Clone();
+ 
             cloned.Multiline = Multiline;
             cloned.MultilineStringEditor = MultilineStringEditor;
-
+            
             return cloned;
         }
 
@@ -116,7 +116,7 @@ namespace Krypton.Toolkit
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         public override void DetachEditingControl()
         {
-            DataGridView dataGridView = DataGridView;
+            DataGridView? dataGridView = DataGridView;
             if (dataGridView?.EditingControl == null)
             {
                 throw new InvalidOperationException("Cell is detached or its grid has no editing control.");
@@ -142,19 +142,19 @@ namespace Krypton.Toolkit
         /// set according to the cell properties.
         /// </summary>
         public override void InitializeEditingControl(int rowIndex,
-            object initialFormattedValue,
+            object? initialFormattedValue,
             DataGridViewCellStyle dataGridViewCellStyle)
         {
             base.InitializeEditingControl(rowIndex, initialFormattedValue, dataGridViewCellStyle);
 
-            if (DataGridView.EditingControl is KryptonTextBox textBox)
+            if (DataGridView!.EditingControl is KryptonTextBox textBox)
             {
-                textBox.Text = initialFormattedValue is not string initialFormattedValueStr ? string.Empty : initialFormattedValueStr;
+                textBox.Text = initialFormattedValue as string ?? string.Empty;
 
                 DataGridViewTriState wrapMode = Style.WrapMode;
                 if (wrapMode == DataGridViewTriState.NotSet)
                 {
-                    wrapMode = OwningColumn.DefaultCellStyle.WrapMode;
+                    wrapMode = OwningColumn!.DefaultCellStyle.WrapMode;
                 }
 
                 textBox.WordWrap = textBox.Multiline = wrapMode == DataGridViewTriState.True;
@@ -195,7 +195,7 @@ namespace Krypton.Toolkit
                 isFirstDisplayedColumn, isFirstDisplayedRow);
 
             editingControlBounds = GetAdjustedEditingControlBounds(editingControlBounds, cellStyle);
-            DataGridView.EditingControl.Location = new Point(editingControlBounds.X, editingControlBounds.Y);
+            DataGridView!.EditingControl!.Location = new Point(editingControlBounds.X, editingControlBounds.Y);
             DataGridView.EditingControl.Size = new Size(editingControlBounds.Width, editingControlBounds.Height);
         }
         #endregion
@@ -208,17 +208,8 @@ namespace Krypton.Toolkit
         /// </summary>
         protected override Rectangle GetErrorIconBounds(Graphics graphics, DataGridViewCellStyle cellStyle, int rowIndex)
         {
-            const int BUTTONS_WIDTH = 16;
-
             Rectangle errorIconBounds = base.GetErrorIconBounds(graphics, cellStyle, rowIndex);
-            if (DataGridView.RightToLeft == RightToLeft.Yes)
-            {
-                errorIconBounds.X = errorIconBounds.Left + BUTTONS_WIDTH;
-            }
-            else
-            {
-                errorIconBounds.X = errorIconBounds.Left - BUTTONS_WIDTH;
-            }
+            errorIconBounds.X = errorIconBounds.Left;
 
             return errorIconBounds;
         }
@@ -228,33 +219,22 @@ namespace Krypton.Toolkit
         /// </summary>
         protected override Size GetPreferredSize(Graphics graphics, DataGridViewCellStyle cellStyle, int rowIndex, Size constraintSize)
         {
-            if (DataGridView == null)
-            {
-                return new Size(-1, -1);
-            }
-
-            Size preferredSize = base.GetPreferredSize(graphics, cellStyle, rowIndex, constraintSize);
-
-            if (constraintSize.Width == 0)
-            {
-                const int BUTTONS_WIDTH = 16; // Account for the width of the up/down buttons.
-                const int BUTTON_MARGIN = 8;  // Account for some blank pixels between the text and buttons.
-                preferredSize.Width += BUTTONS_WIDTH + BUTTON_MARGIN;
-            }
-            return preferredSize;
+            return DataGridView == null 
+                ? new Size(-1, -1) 
+                : base.GetPreferredSize(graphics, cellStyle, rowIndex, constraintSize);
         }
 
         #endregion
 
         #region Private
 
-        private KryptonDataGridViewTextBoxEditingControl EditingTextBox => DataGridView.EditingControl as KryptonDataGridViewTextBoxEditingControl;
+        private KryptonDataGridViewTextBoxEditingControl? EditingTextBox => DataGridView!.EditingControl as KryptonDataGridViewTextBoxEditingControl;
 
         private Rectangle GetAdjustedEditingControlBounds(Rectangle editingControlBounds,
             DataGridViewCellStyle cellStyle)
         {
             // Adjust the vertical location of the editing control:
-            var preferredHeight = DataGridView.EditingControl.GetPreferredSize(new Size(editingControlBounds.Width, 10000)).Height;
+            var preferredHeight = DataGridView!.EditingControl!.GetPreferredSize(new Size(editingControlBounds.Width, 10000)).Height;
             if (preferredHeight < editingControlBounds.Height)
             {
                 switch (cellStyle.Alignment)
@@ -305,7 +285,7 @@ namespace Krypton.Toolkit
             _multiline = value;
             if (OwnsEditingTextBox(rowIndex))
             {
-                EditingTextBox.Multiline = value;
+                EditingTextBox!.Multiline = value;
             }
         }
 
@@ -314,7 +294,7 @@ namespace Krypton.Toolkit
             _multilineStringEditor = value;
             if (OwnsEditingTextBox(rowIndex))
             {
-                EditingTextBox.MultilineStringEditor = value;
+                EditingTextBox!.MultilineStringEditor = value;
             }
         }
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxColumn.cs
@@ -1,11 +1,11 @@
-﻿#region BSD License
+﻿    #region BSD License
 /*
  * 
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
@@ -18,7 +18,7 @@ namespace Krypton.Toolkit
     /// <summary>
     /// Hosts a collection of KryptonDataGridViewTextBoxCell cells.
     /// </summary>
-    [Designer(typeof(KryptonTextBoxColumnDesigner))]
+    //[Designer(typeof(KryptonTextBoxColumnDesigner))]
     [ToolboxBitmap(typeof(KryptonDataGridViewTextBoxColumn), "ToolboxBitmaps.KryptonTextBox.bmp")]
     public class KryptonDataGridViewTextBoxColumn : KryptonDataGridViewIconColumn
     {
@@ -57,6 +57,7 @@ namespace Krypton.Toolkit
 
             cloned.Multiline = Multiline;
             cloned.MultilineStringEditor = MultilineStringEditor;
+
             return cloned;
         }
 
@@ -90,8 +91,9 @@ namespace Krypton.Toolkit
             {
                 if (MaxInputLength != value)
                 {
-                    TextBoxCellTemplate.MaxInputLength = value;
-                    if (DataGridView != null)
+                    TextBoxCellTemplate!.MaxInputLength = value;
+
+                    if (DataGridView is not null)
                     {
                         DataGridViewRowCollection rows = DataGridView.Rows;
                         var count = rows.Count;
@@ -122,18 +124,20 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public override DataGridViewCell CellTemplate
+        public override DataGridViewCell? CellTemplate
         {
+            // base.CellTemplate can be null for getter and setter
+
             get => base.CellTemplate;
 
             set
             {
-                if ((value != null) && value is not KryptonDataGridViewTextBoxCell)
+                if ((value is not null) && value is not KryptonDataGridViewTextBoxCell)
                 {
                     throw new InvalidCastException("Can only assign a object of type KryptonDataGridViewTextBoxCell");
                 }
 
-                base.CellTemplate = value;
+                base.CellTemplate = (KryptonDataGridViewTextBoxCell)value!;
             }
         }
 
@@ -143,18 +147,26 @@ namespace Krypton.Toolkit
         [Browsable(true)]
         [Category(@"Appearance")]
         [Description(@"DataGridView Column DefaultCell Style\r\nIf you set wrap mode, then this will ensure the DataRows are set to display the wrapped text!")]
+        [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
         public override DataGridViewCellStyle DefaultCellStyle
         {
+            // base.DefaultCellStyle will take a null value and handle it.
+            // [NotNull] if the base getter encounters a null value it will always return a DefaultCellStyle
+
             get => base.DefaultCellStyle;
 
             set
             {
                 base.DefaultCellStyle = value;
-                if ((value.WrapMode != DataGridViewTriState.True)
+
+                if (value is null
+                    || value.WrapMode != DataGridViewTriState.True
                     || DataGridView == null)
                 {
                     return;
                 }
+
                 // https://stackoverflow.com/questions/16514352/multiple-lines-in-a-datagridview-cell/16514393
                 switch (DataGridView.AutoSizeRowsMode)
                 {
@@ -252,7 +264,7 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Private
-        private KryptonDataGridViewTextBoxCell? TextBoxCellTemplate => (KryptonDataGridViewTextBoxCell)CellTemplate;
+        private KryptonDataGridViewTextBoxCell? TextBoxCellTemplate => CellTemplate as KryptonDataGridViewTextBoxCell;
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxEditingControl.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewTextBoxEditingControl.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
@@ -17,7 +17,7 @@ namespace Krypton.Toolkit
     /// </summary>
     [ToolboxItem(false)]
     public class KryptonDataGridViewTextBoxEditingControl : KryptonTextBox,
-        IDataGridViewEditingControl
+        IDataGridViewEditingControl, IKryptonDataGridViewEditingControl
     {
         #region Instance Fields
         private DataGridView? _dataGridView;
@@ -42,29 +42,52 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Property which caches the grid that uses this editing control
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual DataGridView? EditingControlDataGridView
         {
             get => _dataGridView;
-            set => _dataGridView = value;
+            set
+            {
+                // (un)subscribing must be performed before _dataGridView is updated.
+                KryptonDataGridViewUtilities.OnKryptonDataGridViewEditingControlDataGridViewChanged(_dataGridView, value, OnKryptonDataGridViewPaletteModeChanged);
+
+                _dataGridView = value;
+
+                // Trigger a manual palette check
+                KryptonDataGridViewUtilities.OnKryptonDataGridViewPaletteModeChanged(_dataGridView, this);
+
+            }
+
         }
 
         /// <summary>
         /// Property which represents the current formatted value of the editing control
+        /// <para>Allows null as input, but null will saved as an empty string.</para>
         /// </summary>
-        public virtual object EditingControlFormattedValue
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [AllowNull]
+        public virtual object EditingControlFormattedValue 
         {
+            // [AllowNull] removes warning CS8767, but allows for null input, which is undesired.
+            // The Text property is a non-nullable string and therefore null input
+            // will be converted to String.Empty.
+
             get => GetEditingControlFormattedValue(DataGridViewDataErrorContexts.Formatting);
-            set => Text = (string)value;
+            set => Text = value is string str && str is not null
+                ? str
+                : string.Empty;
         }
 
         /// <summary>
         /// Property which represents the row in which the editing control resides
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual int EditingControlRowIndex { get; set; }
 
         /// <summary>
         /// Property which indicates whether the value of the editing control has changed or not
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public virtual bool EditingControlValueChanged
         {
             get => _valueChanged;
@@ -80,6 +103,12 @@ namespace Krypton.Toolkit
         /// Property which indicates whether the editing control needs to be repositioned when its value changes.
         /// </summary>
         public virtual bool RepositionEditingControlOnValueChange => false;
+
+        /// <inheritdoc/>
+        public void OnKryptonDataGridViewPaletteModeChanged(object? sender, EventArgs e)
+        {
+            KryptonDataGridViewUtilities.OnKryptonDataGridViewPaletteModeChanged(sender, this);
+        }
 
         /// <summary>
         /// Method called by the grid before the editing control is shown so it can adapt to the provided cell style.
@@ -193,7 +222,7 @@ namespace Krypton.Toolkit
             base.OnTextChanged(e);
 
             //if (Focused)
-                NotifyDataGridViewOfValueChange();
+            NotifyDataGridViewOfValueChange();
         }
 
         /// <summary>
@@ -218,7 +247,7 @@ namespace Krypton.Toolkit
             if (!_valueChanged)
             {
                 _valueChanged = true;
-                _dataGridView.NotifyCurrentCellDirty(true);
+                _dataGridView?.NotifyCurrentCellDirty(true);
             }
         }
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewUtilities.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewUtilities.cs
@@ -8,6 +8,17 @@
 
 namespace Krypton.Toolkit
 {
+    #region Interfaces
+    public interface IKryptonDataGridViewEditingControl
+    {
+        /// <summary>
+        /// Connect this method to KryptonDataGridView.PaletteChanged
+        /// </summary>
+        /// <param name="sender">KryptonDataGridView instance that performed a local theme change.</param>
+        /// <param name="e">Not used.</param>
+        void OnKryptonDataGridViewPaletteModeChanged(object sender, EventArgs e);
+    }
+    #endregion
 
     internal class KryptonDataGridViewUtilities
     {
@@ -70,7 +81,49 @@ namespace Krypton.Toolkit
             return  tff | (wrapMode == DataGridViewTriState.False
                 ? TextFormatFlags.SingleLine
                 : TextFormatFlags.WordBreak);
+        }
 
+        /// <summary>
+        /// Used by the KrypronDataGridViewEditingControl classes to (un)subscribe to the KrypronDataGridView.PaletteChanged event.
+        /// </summary>
+        /// <param name="currentDataGridView">The current DataGridView instance.</param>
+        /// <param name="newDataGridView">THe new DataGridView instance.</param>
+        /// <param name="eventHandler">Eventhandler to (un)subscribe from/to.</param>
+        internal static void OnKryptonDataGridViewEditingControlDataGridViewChanged(DataGridView? currentDataGridView, DataGridView? newDataGridView, EventHandler eventHandler)
+        {
+            if (currentDataGridView != newDataGridView)
+            {
+                if (currentDataGridView is KryptonDataGridView dataGridView1)
+                {
+                    dataGridView1.PaletteChanged -= eventHandler;
+                }
+
+                if (newDataGridView is KryptonDataGridView dataGridView2)
+                {
+                    dataGridView2.PaletteChanged += eventHandler;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Used by the KrypronDataGridViewEditingControl classes to change the control's local palette to that of the KrypronDataGridView
+        /// </summary>
+        /// <param name="sender">KryptonDataGridView reference.</param>
+        /// <param name="visualControlBase">The control that will be assigned the palette values.</param>
+        internal static void OnKryptonDataGridViewPaletteModeChanged(object? sender, VisualControlBase visualControlBase)
+        {
+            if (sender is KryptonDataGridView dataGridView)
+            {
+                if (visualControlBase.Palette != dataGridView.Palette)
+                {
+                    visualControlBase.Palette = dataGridView.Palette as KryptonCustomPaletteBase;
+                }
+
+                if (visualControlBase.PaletteMode != dataGridView.PaletteMode)
+                {
+                    visualControlBase.PaletteMode = dataGridView.PaletteMode;
+                }
+            }
         }
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
@@ -67,6 +67,7 @@ namespace Krypton.Toolkit
             /// <summary>
             /// Gets and sets if the mouse is currently over the combo box.
             /// </summary>
+            [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
             public bool MouseOver
             {
                 get => _mouseOver;
@@ -174,6 +175,7 @@ namespace Krypton.Toolkit
             /// <summary>
             /// Gets or sets a value indicating whether a value has been entered by the user.
             /// </summary>
+            [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
             protected internal bool InternalUserEdit
             {
                 get => UserEdit;
@@ -632,7 +634,7 @@ namespace Krypton.Toolkit
                 _viewButton.ElementState = ButtonElementState(upRect);
                 _viewButton.Layout(layoutContext);
                 _viewButton.Render(renderContext);
-                renderContext.Renderer.RenderGlyph.DrawInputControlNumericUpGlyph(renderContext, _viewButton.ClientRectangle, _palette.PaletteContent, _viewButton.ElementState);
+                renderContext.Renderer!.RenderGlyph.DrawInputControlNumericUpGlyph(renderContext, _viewButton.ClientRectangle, _palette.PaletteContent, _viewButton.ElementState);
 
                 // Down button
                 layoutContext.DisplayRectangle = downRect;
@@ -707,7 +709,6 @@ namespace Krypton.Toolkit
         private bool _mouseOver;
         private bool _alwaysActive;
         private bool _trackingMouseEnter;
-        private float _cornerRoundingRadius;
         private int _cachedHeight;
         #endregion
 
@@ -849,10 +850,10 @@ namespace Krypton.Toolkit
 
             // Create button specification collection manager
             _buttonManager = new ButtonSpecManagerLayout(this, Redirector, ButtonSpecs, null,
-                                                         new[] { _drawDockerInner },
-                                                         new IPaletteMetric[] { StateCommon },
-                                                         new[] { PaletteMetricInt.HeaderButtonEdgeInsetInputControl },
-                                                         new[] { PaletteMetricPadding.HeaderButtonPaddingInputControl },
+                [_drawDockerInner],
+                [StateCommon],
+                [PaletteMetricInt.HeaderButtonEdgeInsetInputControl],
+                [PaletteMetricPadding.HeaderButtonPaddingInputControl],
                                                          CreateToolStripRenderer,
                                                          NeedPaintDelegate);
 
@@ -864,9 +865,6 @@ namespace Krypton.Toolkit
 
             // Add text box to the controls collection
             ((KryptonReadOnlyControls)Controls).AddInternal(_domainUpDown);
-
-            // Set `CornerRoundingRadius' to 'GlobalStaticValues.PRIMARY_CORNER_ROUNDING_VALUE' (-1)
-            _cornerRoundingRadius = GlobalStaticValues.PRIMARY_CORNER_ROUNDING_VALUE;
         }
 
         /// <summary>
@@ -892,21 +890,10 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Public
-        /// <summary>Gets or sets the corner rounding radius.</summary>
-        /// <value>The corner rounding radius.</value>
-        [Category(@"Visuals")]
-        [Description(@"Gets or sets the corner rounding radius.")]
-        [DefaultValue(GlobalStaticValues.PRIMARY_CORNER_ROUNDING_VALUE)]
-        public float CornerRoundingRadius
-        {
-            get => _cornerRoundingRadius;
-
-            set => SetCornerRoundingRadius(value);
-        }
-
         /// <summary>
         /// Gets and sets if the control is in the tab chain.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public new bool TabStop
         {
             get => DomainUpDown.TabStop;
@@ -942,6 +929,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color BackColor
         {
             get => base.BackColor;
@@ -955,6 +943,7 @@ namespace Krypton.Toolkit
         [Bindable(false)]
         [AmbientValue(null)]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Font Font
         {
             get => base.Font;
@@ -966,6 +955,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color ForeColor
         {
             get => base.ForeColor;
@@ -995,6 +985,7 @@ namespace Krypton.Toolkit
         /// Gets or sets the text for the control.
         /// </summary>
         [AllowNull]
+        [DesignerSerializationVisibility( DesignerSerializationVisibility.Visible)]
         public override string Text
         {
             get => DomainUpDown.Text;
@@ -1004,6 +995,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the associated context menu strip.
         /// </summary>
+        [DesignerSerializationVisibility( DesignerSerializationVisibility.Visible)]
         public override ContextMenuStrip? ContextMenuStrip
         {
             get => base.ContextMenuStrip;
@@ -1557,7 +1549,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
-        protected override void OnPaletteNeedPaint(object sender, NeedLayoutEventArgs e)
+        protected override void OnPaletteNeedPaint(object? sender, NeedLayoutEventArgs e)
         {
             InvalidateChildren();
             base.OnPaletteChanged(e);
@@ -1724,10 +1716,10 @@ namespace Krypton.Toolkit
                 IPaletteTriple triple = GetTripleState();
                 PaletteState state = _drawDockerOuter.State;
                 _domainUpDown.BackColor = triple.PaletteBack.GetBackColor1(state);
-                _domainUpDown.ForeColor = triple.PaletteContent.GetContentShortTextColor1(state);
+                _domainUpDown.ForeColor = triple.PaletteContent!.GetContentShortTextColor1(state);
 
                 // Only set the font if the domain up down has been created
-                Font font = triple.PaletteContent.GetContentShortTextFont(state);
+                Font? font = triple.PaletteContent.GetContentShortTextFont(state);
                 if ((_domainUpDown.Handle != IntPtr.Zero) && !_domainUpDown.Font.Equals(font))
                 {
                     _domainUpDown.Font = font;
@@ -1801,7 +1793,11 @@ namespace Krypton.Toolkit
         private void InvalidateChildren()
         {
             DomainUpDown.Invalidate();
-            PI.RedrawWindow(Handle, IntPtr.Zero, IntPtr.Zero, 0x85);
+
+            if (!IsDisposed && !Disposing)
+            {
+                PI.RedrawWindow(Handle, IntPtr.Zero, IntPtr.Zero, 0x85);
+            }
         }
 
         private void SubclassEditControl()
@@ -1865,13 +1861,13 @@ namespace Krypton.Toolkit
         {
             // Get the correct palette settings to use
             IPaletteTriple tripleState = GetTripleState();
-            _drawDockerOuter.SetPalettes(tripleState.PaletteBack, tripleState.PaletteBorder);
+            _drawDockerOuter.SetPalettes(tripleState.PaletteBack, tripleState.PaletteBorder!);
 
             // Update enabled state
             _drawDockerOuter.Enabled = Enabled;
 
             // Find the new state of the main view element
-            PaletteState state = IsActive ? PaletteState.Tracking : PaletteState.Normal;
+            PaletteState state = Enabled ? (IsActive ? PaletteState.Tracking : PaletteState.Normal) : PaletteState.Disabled;
 
             _drawDockerOuter.ElementState = state;
         }
@@ -1890,13 +1886,13 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnDomainUpDownTextChanged(object sender, EventArgs e) => OnTextChanged(e);
+        private void OnDomainUpDownTextChanged(object? sender, EventArgs e) => OnTextChanged(e);
 
-        private void OnDomainUpDownScroll(object sender, ScrollEventArgs e) => OnScroll(e);
+        private void OnDomainUpDownScroll(object? sender, ScrollEventArgs e) => OnScroll(e);
 
-        private void OnDomainUpDownSelectedItemChanged(object sender, EventArgs e) => OnSelectedItemChanged(e);
+        private void OnDomainUpDownSelectedItemChanged(object? sender, EventArgs e) => OnSelectedItemChanged(e);
 
-        private void OnDomainUpDownGotFocus(object sender, EventArgs e)
+        private void OnDomainUpDownGotFocus(object? sender, EventArgs e)
         {
             UpdateStateAndPalettes();
             PerformNeedPaint(true);
@@ -1904,7 +1900,7 @@ namespace Krypton.Toolkit
             base.OnGotFocus(e);
         }
 
-        private void OnDomainUpDownLostFocus(object sender, EventArgs e)
+        private void OnDomainUpDownLostFocus(object? sender, EventArgs e)
         {
             UpdateStateAndPalettes();
             PerformNeedPaint(true);
@@ -1914,19 +1910,19 @@ namespace Krypton.Toolkit
             // ReSharper restore RedundantBaseQualifier
         }
 
-        private void OnDomainUpDownKeyPress(object sender, KeyPressEventArgs e) => OnKeyPress(e);
+        private void OnDomainUpDownKeyPress(object? sender, KeyPressEventArgs e) => OnKeyPress(e);
 
-        private void OnDomainUpDownKeyUp(object sender, KeyEventArgs e) => OnKeyUp(e);
+        private void OnDomainUpDownKeyUp(object? sender, KeyEventArgs e) => OnKeyUp(e);
 
-        private void OnDomainUpDownKeyDown(object sender, KeyEventArgs e) => OnKeyDown(e);
+        private void OnDomainUpDownKeyDown(object? sender, KeyEventArgs e) => OnKeyDown(e);
 
-        private void OnDomainUpDownPreviewKeyDown(object sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
+        private void OnDomainUpDownPreviewKeyDown(object? sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
 
-        private void OnDomainUpDownValidated(object sender, EventArgs e) => OnValidated(e);
+        private void OnDomainUpDownValidated(object? sender, EventArgs e) => OnValidated(e);
 
-        private void OnDomainUpDownValidating(object sender, CancelEventArgs e) => OnValidating(e);
+        private void OnDomainUpDownValidating(object? sender, CancelEventArgs e) => OnValidating(e);
 
-        private void OnShowToolTip(object sender, ToolTipEventArgs e)
+        private void OnShowToolTip(object? sender, ToolTipEventArgs e)
         {
             if (!IsDisposed && !Disposing)
             {
@@ -1993,21 +1989,21 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnCancelToolTip(object sender, EventArgs e) =>
+        private void OnCancelToolTip(object? sender, EventArgs e) =>
             // Remove any currently showing tooltip
             _visualPopupToolTip?.Dispose();
 
-        private void OnVisualPopupToolTipDisposed(object sender, EventArgs e)
+        private void OnVisualPopupToolTipDisposed(object? sender, EventArgs e)
         {
             // Unhook events from the specific instance that generated event
-            var popupToolTip = (VisualPopupToolTip)sender;
+            var popupToolTip = sender as VisualPopupToolTip ?? throw new ArgumentNullException(nameof(sender));
             popupToolTip.Disposed -= OnVisualPopupToolTipDisposed;
 
             // Not showing a popup page any more
             _visualPopupToolTip = null;
         }
 
-        private void OnDomainUpDownMouseChange(object sender, EventArgs e)
+        private void OnDomainUpDownMouseChange(object? sender, EventArgs e)
         {
             // Find new tracking mouse change state
             var tracking = _domainUpDown.MouseOver ||
@@ -2033,14 +2029,6 @@ namespace Krypton.Toolkit
                 }
             }
         }
-
-        private void SetCornerRoundingRadius(float? radius)
-        {
-            _cornerRoundingRadius = radius ?? GlobalStaticValues.PRIMARY_CORNER_ROUNDING_VALUE;
-
-            StateCommon.Border.Rounding = _cornerRoundingRadius;
-        }
-
         #endregion
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonNumericUpDown.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
@@ -74,6 +74,7 @@ namespace Krypton.Toolkit
             /// <summary>
             /// Gets and sets if the mouse is currently over the combo box.
             /// </summary>
+            [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
             public bool MouseOver
             {
                 get => _mouseOver;
@@ -180,6 +181,7 @@ namespace Krypton.Toolkit
             /// <summary>
             /// Gets or sets a value indicating whether a value has been entered by the user.
             /// </summary>
+            [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
             protected internal bool InternalUserEdit
             {
                 get => UserEdit;
@@ -655,7 +657,7 @@ namespace Krypton.Toolkit
                 _viewButton.ElementState = ButtonElementState(upRect);
                 _viewButton.Layout(layoutContext);
                 _viewButton.Render(renderContext);
-                renderContext.Renderer.RenderGlyph.DrawInputControlNumericUpGlyph(renderContext, _viewButton.ClientRectangle, _palette.PaletteContent, _viewButton.ElementState);
+                renderContext.Renderer!.RenderGlyph.DrawInputControlNumericUpGlyph(renderContext, _viewButton.ClientRectangle, _palette.PaletteContent, _viewButton.ElementState);
 
                 // Down button
                 layoutContext.DisplayRectangle = downRect;
@@ -719,22 +721,20 @@ namespace Krypton.Toolkit
         #region Instance Fields
 
         private VisualPopupToolTip? _visualPopupToolTip;
-        private readonly ButtonSpecManagerLayout _buttonManager;
+        private readonly ButtonSpecManagerLayout? _buttonManager;
         private readonly ViewLayoutDocker _drawDockerInner;
         private readonly ViewDrawDocker _drawDockerOuter;
         private readonly ViewLayoutFill _layoutFill;
         private readonly InternalNumericUpDown _numericUpDown;
         private InputControlStyle _inputControlStyle;
         private ButtonStyle _upDownButtonStyle;
-        private SubclassEdit _subclassEdit;
+        private SubclassEdit? _subclassEdit;
         private SubclassButtons? _subclassButtons;
         private bool? _fixedActive;
         private bool _forcedLayout;
         private bool _mouseOver;
         private bool _alwaysActive;
         private bool _trackingMouseEnter;
-        private float _cornerRoundingRadius;
-
         #endregion
 
         #region Events
@@ -873,10 +873,10 @@ namespace Krypton.Toolkit
 
             // Create button specification collection manager
             _buttonManager = new ButtonSpecManagerLayout(this, Redirector, ButtonSpecs, null,
-                                                         new[] { _drawDockerInner },
-                                                         new IPaletteMetric[] { StateCommon },
-                                                         new[] { PaletteMetricInt.HeaderButtonEdgeInsetInputControl },
-                                                         new[] { PaletteMetricPadding.HeaderButtonPaddingInputControl },
+                [_drawDockerInner],
+                [StateCommon],
+                [PaletteMetricInt.HeaderButtonEdgeInsetInputControl],
+                [PaletteMetricPadding.HeaderButtonPaddingInputControl],
                                                          CreateToolStripRenderer,
                                                          NeedPaintDelegate);
 
@@ -888,8 +888,6 @@ namespace Krypton.Toolkit
 
             // Add text box to the controls collection
             ((KryptonReadOnlyControls)Controls).AddInternal(_numericUpDown);
-
-            _cornerRoundingRadius = GlobalStaticValues.PRIMARY_CORNER_ROUNDING_VALUE;
         }
 
         /// <summary>
@@ -904,7 +902,7 @@ namespace Krypton.Toolkit
                 OnCancelToolTip(this, EventArgs.Empty);
 
                 // Remember to pull down the manager instance
-                _buttonManager.Destruct();
+                _buttonManager?.Destruct();
 
                 // Tell the buttons class to cleanup resources
                 _subclassButtons?.Dispose();
@@ -915,22 +913,10 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Public
-
-        /// <summary>Gets or sets the corner rounding radius.</summary>
-        /// <value>The corner rounding radius.</value>
-        [Category(@"Visuals")]
-        [Description(@"Gets or sets the corner rounding radius.")]
-        [DefaultValue(GlobalStaticValues.PRIMARY_CORNER_ROUNDING_VALUE)]
-        public float CornerRoundingRadius
-        {
-            get => _cornerRoundingRadius;
-
-            set => SetCornerRoundingRadius(value);
-        }
-
         /// <summary>
         /// Gets and sets if the control is in the tab chain.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public new bool TabStop
         {
             get => _numericUpDown.TabStop;
@@ -951,7 +937,7 @@ namespace Krypton.Toolkit
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [EditorBrowsable(EditorBrowsableState.Always)]
         [Browsable(false)]
-        public NumericUpDown? NumericUpDown => _numericUpDown;
+        public NumericUpDown NumericUpDown => _numericUpDown;
 
         /// <summary>
         /// Gets access to the contained input control.
@@ -972,6 +958,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color BackColor
         {
             get => base.BackColor;
@@ -985,10 +972,11 @@ namespace Krypton.Toolkit
         [Bindable(false)]
         [AmbientValue(null)]
         [AllowNull]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Font Font
         {
             get => base.Font;
-            set => base.Font = value;
+            set => base.Font = value!;
         }
 
         /// <summary>
@@ -996,6 +984,7 @@ namespace Krypton.Toolkit
         /// </summary>
         [Browsable(false)]
         [Bindable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public override Color ForeColor
         {
             get => base.ForeColor;
@@ -1033,6 +1022,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets the associated context menu strip.
         /// </summary>
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public override ContextMenuStrip? ContextMenuStrip
         {
             get => base.ContextMenuStrip;
@@ -1102,11 +1092,11 @@ namespace Krypton.Toolkit
         [DefaultValue(true)]
         public bool UseMnemonic
         {
-            get => _buttonManager.UseMnemonic;
+            get => _buttonManager!.UseMnemonic;
 
             set
             {
-                if (_buttonManager.UseMnemonic != value)
+                if (_buttonManager!.UseMnemonic != value)
                 {
                     _buttonManager.UseMnemonic = value;
                     PerformNeedPaint(true);
@@ -1400,7 +1390,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="start">The position of the first character in the current text selection within the text box.</param>
         /// <param name="length">The number of characters to select.</param>
-        public void Select(int start, int length) => _numericUpDown.Select(start, length);
+        public void Select(int start, int length) => _numericUpDown?.Select(start, length);
 
         /// <summary>
         /// Sets the fixed state of the control.
@@ -1440,12 +1430,12 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Displays the previous item in the collection.
         /// </summary>
-        public void UpButton() => NumericUpDown.UpButton();
+        public void UpButton() => NumericUpDown?.UpButton();
 
         /// <summary>
         /// Displays the next item in the collection.
         /// </summary>
-        public void DownButton() => NumericUpDown.DownButton();
+        public void DownButton() => NumericUpDown?.DownButton();
 
         /// <summary>
         /// Get the preferred size of the control based on a proposed size.
@@ -1550,9 +1540,9 @@ namespace Krypton.Toolkit
         /// <param name="pt">Mouse location.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Browsable(false)]
-        public Component DesignerComponentFromPoint(Point pt) =>
+        public Component? DesignerComponentFromPoint(Point pt) =>
             // Ignore call as view builder is already destructed
-            IsDisposed ? null : ViewManager.ComponentFromPoint(pt);
+            IsDisposed ? null : ViewManager?.ComponentFromPoint(pt);
 
         // Ask the current view for a decision
         /// <summary>
@@ -1661,7 +1651,7 @@ namespace Krypton.Toolkit
             _drawDockerOuter.Enabled = Enabled;
 
             // Update state to reflect change in enabled state
-            _buttonManager.RefreshButtons();
+            _buttonManager?.RefreshButtons();
 
             PerformNeedPaint(true);
 
@@ -1684,7 +1674,7 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="sender">Source of notification.</param>
         /// <param name="e">An NeedLayoutEventArgs containing event data.</param>
-        protected override void OnPaletteNeedPaint(object sender, NeedLayoutEventArgs e)
+        protected override void OnPaletteNeedPaint(object? sender, NeedLayoutEventArgs e)
         {
             InvalidateChildren();
             base.OnPaletteChanged(e);
@@ -1750,7 +1740,7 @@ namespace Krypton.Toolkit
                 if (IsHandleCreated || _forcedLayout || (DesignMode && (_numericUpDown != null)))
                 {
                     Rectangle fillRect = _layoutFill.FillRect;
-                    _numericUpDown.SetBounds(fillRect.X, fillRect.Y, fillRect.Width, fillRect.Height);
+                    _numericUpDown?.SetBounds(fillRect.X, fillRect.Y, fillRect.Width, fillRect.Height);
                 }
             }
         }
@@ -1786,7 +1776,7 @@ namespace Krypton.Toolkit
         protected override void OnGotFocus(EventArgs e)
         {
             base.OnGotFocus(e);
-            _numericUpDown.Focus();
+            _numericUpDown?.Focus();
         }
 
         /// <summary>
@@ -1848,13 +1838,13 @@ namespace Krypton.Toolkit
                 IPaletteTriple triple = GetTripleState();
                 PaletteState state = _drawDockerOuter.State;
                 _numericUpDown.BackColor = triple.PaletteBack.GetBackColor1(state);
-                _numericUpDown.ForeColor = triple.PaletteContent.GetContentShortTextColor1(state);
+                _numericUpDown.ForeColor = triple.PaletteContent!.GetContentShortTextColor1(state);
 
                 // Only set the font if the numeric up down has been created
-                Font font = triple.PaletteContent.GetContentShortTextFont(state);
+                Font? font = triple.PaletteContent.GetContentShortTextFont(state);
                 if ((_numericUpDown.Handle != IntPtr.Zero) && !_numericUpDown.Font.Equals(font))
                 {
-                    _numericUpDown.Font = font;
+                    _numericUpDown.Font = font!;
                 }
             }
 
@@ -1932,7 +1922,11 @@ namespace Krypton.Toolkit
             if (NumericUpDown != null)
             {
                 NumericUpDown.Invalidate();
-                PI.RedrawWindow(Handle, IntPtr.Zero, IntPtr.Zero, 0x85);
+
+                if (!IsDisposed && !Disposing)
+                {
+                    PI.RedrawWindow(Handle, IntPtr.Zero, IntPtr.Zero, 0x85);
+                }
             }
         }
 
@@ -1999,13 +1993,13 @@ namespace Krypton.Toolkit
         {
             // Get the correct palette settings to use
             IPaletteTriple tripleState = GetTripleState();
-            _drawDockerOuter.SetPalettes(tripleState.PaletteBack, tripleState.PaletteBorder);
+            _drawDockerOuter.SetPalettes(tripleState.PaletteBack, tripleState.PaletteBorder!);
 
             // Update enabled state
             _drawDockerOuter.Enabled = Enabled;
 
             // Find the new state of the main view element
-            PaletteState state = IsActive ? PaletteState.Tracking : PaletteState.Normal;
+            PaletteState state = Enabled ? (IsActive ? PaletteState.Tracking : PaletteState.Normal) : PaletteState.Disabled;
 
             _drawDockerOuter.ElementState = state;
         }
@@ -2024,11 +2018,11 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnNumericUpDownTextChanged(object sender, EventArgs e) => OnTextChanged(e);
+        private void OnNumericUpDownTextChanged(object? sender, EventArgs e) => OnTextChanged(e);
 
-        private void OnNumericUpDownValueChanged(object sender, EventArgs e) => OnValueChanged(e);
+        private void OnNumericUpDownValueChanged(object? sender, EventArgs e) => OnValueChanged(e);
 
-        private void OnNumericUpDownGotFocus(object sender, EventArgs e)
+        private void OnNumericUpDownGotFocus(object? sender, EventArgs e)
         {
             UpdateStateAndPalettes();
             PerformNeedPaint(true);
@@ -2038,7 +2032,7 @@ namespace Krypton.Toolkit
             // ReSharper restore RedundantBaseQualifier
         }
 
-        private void OnNumericUpDownLostFocus(object sender, EventArgs e)
+        private void OnNumericUpDownLostFocus(object? sender, EventArgs e)
         {
             UpdateStateAndPalettes();
             PerformNeedPaint(true);
@@ -2048,19 +2042,19 @@ namespace Krypton.Toolkit
             // ReSharper restore RedundantBaseQualifier
         }
 
-        private void OnNumericUpDownKeyPress(object sender, KeyPressEventArgs e) => OnKeyPress(e);
+        private void OnNumericUpDownKeyPress(object? sender, KeyPressEventArgs e) => OnKeyPress(e);
 
-        private void OnNumericUpDownKeyUp(object sender, KeyEventArgs e) => OnKeyUp(e);
+        private void OnNumericUpDownKeyUp(object? sender, KeyEventArgs e) => OnKeyUp(e);
 
-        private void OnNumericUpDownKeyDown(object sender, KeyEventArgs e) => OnKeyDown(e);
+        private void OnNumericUpDownKeyDown(object? sender, KeyEventArgs e) => OnKeyDown(e);
 
-        private void OnNumericUpDownPreviewKeyDown(object sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
+        private void OnNumericUpDownPreviewKeyDown(object? sender, PreviewKeyDownEventArgs e) => OnPreviewKeyDown(e);
 
-        private void OnNumericUpDownValidated(object sender, EventArgs e) => OnValidated(e);
+        private void OnNumericUpDownValidated(object? sender, EventArgs e) => OnValidated(e);
 
-        private void OnNumericUpDownValidating(object sender, CancelEventArgs e) => OnValidating(e);
+        private void OnNumericUpDownValidating(object? sender, CancelEventArgs e) => OnValidating(e);
 
-        private void OnShowToolTip(object sender, ToolTipEventArgs e)
+        private void OnShowToolTip(object? sender, ToolTipEventArgs e)
         {
             if (!IsDisposed && !Disposing)
             {
@@ -2080,7 +2074,7 @@ namespace Krypton.Toolkit
                     var shadow = true;
 
                     // Find the button spec associated with the tooltip request
-                    ButtonSpec? buttonSpec = _buttonManager.ButtonSpecFromView(e.Target);
+                    ButtonSpec? buttonSpec = _buttonManager?.ButtonSpecFromView(e.Target);
 
                     // If the tooltip is for a button spec
                     if (buttonSpec != null)
@@ -2127,21 +2121,21 @@ namespace Krypton.Toolkit
             }
         }
 
-        private void OnCancelToolTip(object sender, EventArgs e) =>
+        private void OnCancelToolTip(object? sender, EventArgs e) =>
             // Remove any currently showing tooltip
             _visualPopupToolTip?.Dispose();
 
-        private void OnVisualPopupToolTipDisposed(object sender, EventArgs e)
+        private void OnVisualPopupToolTipDisposed(object? sender, EventArgs e)
         {
             // Unhook events from the specific instance that generated event
-            var popupToolTip = (VisualPopupToolTip)sender;
+            var popupToolTip = sender as VisualPopupToolTip ?? throw new ArgumentNullException(nameof(sender));
             popupToolTip.Disposed -= OnVisualPopupToolTipDisposed;
 
-            // Not showing a popup page any more
+            // Not showing a popup page anymore
             _visualPopupToolTip = null;
         }
 
-        private void OnNumericUpDownMouseChange(object sender, EventArgs e)
+        private void OnNumericUpDownMouseChange(object? sender, EventArgs e)
         {
             // Find new tracking mouse change state
             var tracking = _numericUpDown.MouseOver ||
@@ -2167,14 +2161,6 @@ namespace Krypton.Toolkit
                 }
             }
         }
-
-        private void SetCornerRoundingRadius(float? radius)
-        {
-            _cornerRoundingRadius = radius ?? GlobalStaticValues.PRIMARY_CORNER_ROUNDING_VALUE;
-
-            StateCommon.Border.Rounding = _cornerRoundingRadius;
-        }
-
         #endregion
     }
 }


### PR DESCRIPTION
[Issue 2037-KryptonDataGridView-Sync-V85-and-V95-with-V100](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2037)
- Sync KryptonDataGridView and changed components with alpha branch
- Fixes a null reference exception for KDomainUpDown and KNumericUpDown when used within the kryptonDataGridView.

![compile-results](https://github.com/user-attachments/assets/03f21de8-8d92-44c5-b2b2-c81ae246f236)

