### PR TITLE
2047-MDI-children-do-respond-to-LayoutMdi-calls

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,7 +3,8 @@
 =======
 
 ## 2025-11-xx - Build 2511 - November 2025
-* Resolved [#2037](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2037) `KryptonDataGridView` Several bug fixes and improvements to the `KryptonDataGridView` and its components have been made. See this ticket for a complete overview.
+* Resolved [#2047](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2047), `KryptonForm` based MDI child windows do not respond to LayoutMDI calls
+* Resolved [#2037](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2037), `KryptonDataGridView` Several bug fixes and improvements to the `KryptonDataGridView` and its components have been made. See this ticket for a complete overview.
 * Reverted [#2027](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2027), Reverting `KryptonOutlookGrid` back to Extended Toolkit for another inspection.
 * Resolved [#2023](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2023), `KryptonDataGridView` IconSpecs do not get a repaint when changed at run-time.
 * Resolved [#2018](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2018), Corrects `KryptonDataGridView` palette switching difficulties.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
@@ -1010,7 +1010,9 @@ namespace Krypton.Toolkit
         {
             var processed = false;
 
-            if (_themedApp)
+            // We do not process the message if on an MDI child, because doing so prevents the 
+            // LayoutMdi call on the parent from working and cascading/tiling the children
+            if (_themedApp && MdiParent is null)
             {
                 switch (m.Msg)
                 {


### PR DESCRIPTION
[Issue 2047-MDI-children-do-respond-to-LayoutMdi-calls](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2047)
- Behaviour restored.
- And the change log

![compile-results](https://github.com/user-attachments/assets/e4374921-24db-4a19-8df8-26e676e03a4d)
