### PR TITLE
1623-V100-establish-a-single-point-where-a-KryptonCustomPalette-is-assigned

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2025-11-xx - Build 2511 - November 2025
+* Implemented [#1623](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1623), Settings custom themes only available through ThemeManager from V110 onward. Adds Obsolete warnings so the move can be prepared from V100.
 * Resolved [#2053](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2053), `KryptonRichTextBox` Designer Issues
 * Resolved [#2047](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2047), `KryptonForm` based MDI child windows do not respond to LayoutMDI calls
 * Resolved [#2037](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2037), `KryptonDataGridView` Several bug fixes and improvements to the `KryptonDataGridView` and its components have been made. See this ticket for a complete overview.

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupThemeComboBox.cs
@@ -65,6 +65,7 @@ namespace Krypton.Ribbon
         [Description(@"The custom assigned palette mode.")]
         [DefaultValue(null)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        [Obsolete("Deprecated and will be removed in V110. Set a global custom palette through 'ThemeManager.ApplyTheme(...)'.")]
         public KryptonCustomPaletteBase? KryptonCustomPalette 
         {
             get => _kryptonCustomPalette;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
@@ -2140,7 +2140,7 @@ namespace Krypton.Toolkit
         /// Import palette settings from the specified xml file.
         /// </summary>
         /// <param name="filename">Filename to load.</param>
-        /// <param name="silent">Silent mode provides no user interface feedback.</param>
+        /// <param name="silent">True, silent mode provides user interface feedback from the palette import process. No messages when false.</param>
         /// <returns>Full path of imported filename; otherwise empty string.</returns>
         /// <exception>Thrown if failure to import</exception>
         public string Import(string filename, bool silent)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeComboBox.cs
@@ -53,6 +53,7 @@ namespace Krypton.Toolkit
         [Description(@"The custom assigned palette mode.")]
         [DefaultValue(null)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        [Obsolete("Deprecated and will be removed in V110. Set a global custom palette through 'ThemeManager.ApplyTheme(...)'.")]
         public KryptonCustomPaletteBase? KryptonCustomPalette 
         {
             get => _kryptonCustomPalette;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeListBox.cs
@@ -53,6 +53,7 @@ namespace Krypton.Toolkit
         [Description(@"The custom assigned palette mode.")]
         [DefaultValue(null)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        [Obsolete("Deprecated and will be removed in V110. Set a global custom palette through 'ThemeManager.ApplyTheme(...)'.")]
         public KryptonCustomPaletteBase? KryptonCustomPalette 
         {
             get => _kryptonCustomPalette;

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/ThemeManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/ThemeManager.cs
@@ -17,10 +17,8 @@ namespace Krypton.Toolkit
     /// </summary>
     public class ThemeManager
     {
-        #region Instance Fields
-
-        
-
+        #region Private static fields
+        private const string _msgBoxCaption = "ThemeManager";
         #endregion
 
         #region Properties
@@ -54,6 +52,42 @@ namespace Krypton.Toolkit
         /// <param name="themeName">Valid name of the theme.</param>
         /// <param name="manager">The manager.</param>
         public static void ApplyTheme(string themeName, KryptonManager manager) => ApplyGlobalTheme(manager, GetThemeManagerMode(themeName));
+
+        /// <summary>
+        /// Applies the theme using the theme's name.
+        /// </summary>
+        /// <param name="palette">Reference to a KryptonCustomPaletteBase object</param>
+        /// <param name="manager">The manager.</param>
+        public static void ApplyTheme(KryptonCustomPaletteBase palette, KryptonManager manager)
+        {
+            manager.GlobalCustomPalette = palette;
+            manager.GlobalPaletteMode = PaletteMode.Custom;
+        }
+
+        /// <summary>
+        /// Applies the theme using the theme's name.
+        /// </summary>
+        /// <param name="themeFile">Valid path including filename to the theme file. The file must exist an be compatible, otherwise the import will fail.</param>
+        /// <param name="silent">True if the operation should suppress messages from the palette import process, otherwise false.</param>
+        /// <param name="manager">The manager.</param>
+        public static void ApplyTheme(string themeFile, bool silent, KryptonManager manager)
+        {
+            if (themeFile.Length > 0 && File.Exists(themeFile))
+            {
+                KryptonCustomPaletteBase palette = new();
+                palette.Import(themeFile, silent);
+            }
+            else
+            {
+                KryptonMessageBox.Show(
+                    $"The parameter 'themeFile' points to a file that does not exist.\n" + 
+                    $"filename: {themeFile}\n\n" +
+                    $"ApplyTheme aborted.",
+                    _msgBoxCaption,
+                    buttons: KryptonMessageBoxButtons.OK,
+                    icon: KryptonMessageBoxIcon.Exclamation);
+            }
+        }
 
         /// <summary>
         /// Sets the theme.
@@ -104,6 +138,7 @@ namespace Krypton.Toolkit
         /// <param name="manager">The manager.</param>
         /// <param name="themeFile">A custom theme file.</param>
         /// <param name="silent">if set to <c>true</c> [silent].</param>
+        [Obsolete("Deprecated and will be removed in V110. Set a global custom palette through 'ThemeManager.ApplyTheme(...)'.")]
         public static void LoadCustomTheme(KryptonCustomPaletteBase palette, KryptonManager manager, string themeFile = "", bool silent = false)
         {
             try


### PR DESCRIPTION
[Issue 1623-establish-a-single-point-where-a-KryptonCustomPalette-is-assigned](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1623)
- Theme selectors updated with obsolete entries
- ThemeManager updated with ApplyTheme methods
- ThemeManager.LoadCustomTheme replaced by a new ApplyTheme method.
- And the change log

![compile-results](https://github.com/user-attachments/assets/e5e0f9a7-fca9-443e-a462-a31f68161589)
