### PR TITLE
2022-V100-remove-obsolete-method-SetTheme-from-ThemeManager

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2025-11-xx - Build 2511 - November 2025
+* Obsolete [#2022](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2022), Remove obsolete method `ThemeManager.SetTheme()`. Use `ThemeManager.ApplyTheme(...)` instead.
 * Implemented [#1623](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1623), Settings custom themes only available through ThemeManager from V110 onward. Adds Obsolete warnings so the move can be prepared from V100.
 * Resolved [#2053](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2053), `KryptonRichTextBox` Designer Issues
 * Resolved [#2047](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2047), `KryptonForm` based MDI child windows do not respond to LayoutMDI calls

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/ThemeManager.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/ThemeManager.cs
@@ -90,23 +90,13 @@ namespace Krypton.Toolkit
             {
                 KryptonMessageBox.Show(
                     $"The parameter 'themeFile' points to a file that does not exist.\n" + 
-                    $"filename: {themeFile}\n\n" +
+                    $"Filename: {themeFile}\n\n" +
                     $"ApplyTheme aborted.",
                     _msgBoxCaption,
                     buttons: KryptonMessageBoxButtons.OK,
                     icon: KryptonMessageBoxIcon.Exclamation);
             }
         }
-
-        /// <summary>
-        /// Sets the theme.
-        /// </summary>
-        /// <param name="themeName">Name of the theme.</param>
-        /// <param name="manager">The manager.</param>
-        [Obsolete("Deprecated and will be removed in V100. Replace this with calls to ApplyTheme( . . . )")]
-        public static void SetTheme(string themeName, KryptonManager manager) =>
-            //TODO V100 Remove SetTheme method
-            ApplyGlobalTheme(manager, GetThemeManagerMode(themeName));
 
         /// <summary>
         /// Applies the global theme.


### PR DESCRIPTION
[Issue 2022-remove-obsolete-method-SetTheme-from-ThemeManager](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2022)
- Remove obsolete method ThemeManager.SetTheme
- And the change log

![compile-results](https://github.com/user-attachments/assets/01d6cdbf-7ed9-46bf-ae65-18087baca2de)
