### PR TITLE
1832-V100-KryptonComboBox-does-not-respect-padding

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2025-11-xx - Build 2511 - November 2025
+* Resolved [#1832](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1832), `KryptonComboBox` now will always vertically center the inner ComboBox. The `IntegralHeight` property now is true by default.
 * Implemented [#1116](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1116), Toggle switch/button
 * Implemented [#667](https://github.com/Krypton-Suite/Standard-Toolkit/issues/667), Adds the AutoSize property and functionality to `KryptonNumericUpDown` and `KryptonDomainUpDown`
 * Obsolete [#2022](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2022), Remove obsolete method `ThemeManager.SetTheme()`. Use `ThemeManager.ApplyTheme(...)` instead.


### PR DESCRIPTION
[Issue 1832-KryptonComboBox-does-not-respect-padding](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1832)
- KCombobox now always centers the inner combo vertically.
- And the change log.

![compile-results](https://github.com/user-attachments/assets/3bc5a46a-d0d5-4197-976d-182f4ad8962e)

