### PR TITLE
1832-V95-KryptonComboBox-does-not-respect-padding

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2025-02-25 - Build 2502 (Patch 5) - February 2025
+* Resolved [#1832](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1832), `KryptonComboBox` now will always vertically center the inner ComboBox. The `IntegralHeight` property now defaults to true.
 * Resolved [#2108](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2108), `KryptonPropertyGrid` needs to support 'resetting' of values
 * Resolved [#2047](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2047), `KryptonForm` based MDI child windows do not respond to LayoutMDI calls
 * Resolved [#2037](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2037) `KryptonDataGridView` Several bug fixes and improvements to the `KryptonDataGridView` and its components have been made. See this ticket for a complete overview.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -1119,6 +1119,7 @@ namespace Krypton.Toolkit
 
             // Create the internal combo box used for containing content
             _comboBox = new InternalComboBox(this);
+            _comboBox.IntegralHeight = true;
             _comboBox.DrawItem += OnComboBoxDrawItem;
             _comboBox.MeasureItem += OnComboBoxMeasureItem;
             _comboBox.TrackMouseEnter += OnComboBoxMouseChange;
@@ -2561,9 +2562,6 @@ namespace Krypton.Toolkit
             {
                 AttachEditControl();
 
-                // Update to match the new palette settings
-                Height = PreferredHeight;
-
                 // Let base class calculate fill rectangle
                 base.OnLayout(levent);
 
@@ -2571,19 +2569,20 @@ namespace Krypton.Toolkit
                 {
                     // Only use layout logic if control is fully initialized or if being forced
                     // to allow a relayout or if in design mode.
-                    if (_forcedLayout || (DesignMode && (_comboHolder != null)))
+                    if ((_forcedLayout || (DesignMode && (_comboHolder != null)))
+                        && _layoutFill.FillRect is { Height: > 0, Width: > 0 } fillRect
+                        && fillRect != _comboHolder.Bounds)
                     {
-                        // Only need to relayout if there is something that would be visible
-                        if (_layoutFill.FillRect is { Height: > 0, Width: > 0 })
-                        {
-                            // Only update the bounds if they have changed
-                            Rectangle fillRect = _layoutFill.FillRect;
-                            if (fillRect != _comboHolder.Bounds)
-                            {
-                                _comboHolder.SetBounds(fillRect.X, fillRect.Y, fillRect.Width, fillRect.Height);
-                                _comboBox.SetBounds(-(1 + _layoutPadding.Left), -(1 + _layoutPadding.Top), fillRect.Width + 2 + _layoutPadding.Right, fillRect.Height + 2 + _layoutPadding.Bottom);
-                            }
-                        }
+                        _comboHolder.SetBounds(fillRect.X, fillRect.Y, fillRect.Width, fillRect.Height);
+                        _comboBox.SetBounds(-(1 + _layoutPadding.Left), -1, fillRect.Width + 2 + _layoutPadding.Right, fillRect.Height);
+
+                        // Always center the combo vertically
+                        _comboBox.Top = fillRect.Height / 2 - _comboBox.Height / 2;
+
+                        // IntegralHeight does not always work as it should when set to true (possibly in this case).
+                        // Toggling it corrects the chopped off text and shows the item in full
+                        IntegralHeight = !IntegralHeight;
+                        IntegralHeight = !IntegralHeight;
                     }
                 }
                 catch


### PR DESCRIPTION
[Issue 1832-KryptonComboBox-does-not-respect-padding](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1832)
- KCombobox now always centers the inner combo vertically.
- And the change log.

![compile-results](https://github.com/user-attachments/assets/9a909b3c-7f7d-434d-b7b4-0610d0c5411b)
