### PR TITLE
2162-V100-Embedded-Themes-KryptonCustomPaletteBase-clean-up

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCustomPaletteBase.cs
@@ -23,7 +23,6 @@ namespace Krypton.Toolkit
     [ToolboxItem(true)]
     [ToolboxBitmap(typeof(KryptonCustomPaletteBase), "ToolboxBitmaps.KryptonPalette.bmp")]
     [DefaultEvent(nameof(PalettePaint))]
-    //[DefaultProperty(nameof(BasePaletteMode))]
     [DesignerCategory(@"code")]
     [Designer(typeof(KryptonCustomPaletteBaseDesigner))]
     [Description(@"A customisable palette component.")]
@@ -40,7 +39,6 @@ namespace Krypton.Toolkit
         private IRenderer? _baseRenderer;
         private RendererMode _baseRenderMode;
         private PaletteBase? _basePalette;
-        //private PaletteMode _basePaletteMode;
         private readonly PaletteRedirect _redirector;
         private readonly NeedPaintHandler _needPaintDelegate;
 
@@ -56,7 +54,7 @@ namespace Krypton.Toolkit
             _needPaintDelegate = OnNeedPaint;
 
             // Set the default palette/palette mode
-            _basePalette = KryptonManager.GetPaletteForMode(PaletteMode.Microsoft365Blue);
+            _basePalette = KryptonManager.GetPaletteForMode(ThemeManager.DefaultGlobalPalette);
 
             // Set the default renderer
             _baseRenderer = null;
@@ -307,22 +305,6 @@ namespace Krypton.Toolkit
         public KryptonPaletteForms FormStyles { get; set; }
 
         private bool ShouldSerializeFormStyles() => !FormStyles.IsDefault;
-
-        #endregion
-
-        #region Font        
-        /*
-        /// <summary>
-        /// Gets access to defining the font and colour values for text.
-        /// </summary>
-        [KryptonPersist]
-        [Category(@"Visuals")]
-        [Description(@"Overrides the font and colour values for text.")]
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
-        public KryptonPaletteFont Font { get; set; }
-
-        //public bool ShouldSerializeFont() => !Font.IsDefault;
-        */
 
         #endregion
 
@@ -2678,11 +2660,10 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Should any of these global values be serialised
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         public bool IsDefault => !(ShouldSerializeCustomisedKryptonPaletteFilePath()
             || ShouldSerializePaletteName()
-            //|| ShouldSerializeBasePaletteMode()
             || ShouldSerializeBasePalette()
             || ShouldSerializeBaseRendererMode()
             || ShouldSerializeBaseRenderer()
@@ -2695,7 +2676,6 @@ namespace Krypton.Toolkit
         {
             ResetCustomisedKryptonPaletteFilePath();
             ResetPaletteName();
-            //ResetBasePaletteMode();
             ResetBasePalette();
             ResetBaseRendererMode();
             ResetBaseRenderer();
@@ -2723,70 +2703,6 @@ namespace Krypton.Toolkit
         private bool ShouldSerializePaletteName() => !string.IsNullOrWhiteSpace(PaletteName);
         private void ResetPaletteName() => PaletteName = string.Empty;
 
-        ///// <summary>
-        ///// Gets or sets the base palette used to inherit from.
-        ///// </summary>
-        //[KryptonPersist(false, false)]
-        //[Category(@"Visuals")]
-        //[Description(@"Base palette used to inherit from.")]
-        //[DefaultValue(PaletteMode.Microsoft365Blue)]
-        //public PaletteMode BasePaletteMode
-        //{
-        //    get => _basePaletteMode;
-
-        //    set
-        //    {
-        //        if (_basePaletteMode != value)
-        //        {
-        //            // Action depends on new value
-        //            switch (value)
-        //            {
-        //                case PaletteMode.Custom:
-        //                    // Do nothing, you must assign a palette to the 
-        //                    // 'BasePalette' property in order to get the custom mode
-        //                    break;
-        //                default:
-        //                    // Cache the original values
-        //                    PaletteMode tempMode = _basePaletteMode;
-        //                    PaletteBase? tempPalette = _basePalette;
-
-        //                    // Use the new value
-        //                    _basePaletteMode = value;
-        //                    _basePalette = KryptonManager.GetPaletteForMode(_basePaletteMode);
-
-        //                    // If the new value creates a circular reference
-        //                    if (HasCircularReference())
-        //                    {
-        //                        // Restore the original values
-        //                        _basePaletteMode = tempMode;
-        //                        _basePalette = tempPalette;
-
-        //                        throw new ArgumentOutOfRangeException(nameof(value), @"Cannot use palette that would create a circular reference");
-        //                    }
-        //                    else
-        //                    {
-        //                        // Restore the original base palette as 'SetPalette' will not 
-        //                        // work correctly unless it still has the old value in place
-        //                        _basePalette = tempPalette;
-        //                    }
-
-        //                    // Get a reference to the standard palette from its name
-        //                    SetPalette(KryptonManager.GetPaletteForMode(_basePaletteMode));
-
-        //                    // Fire events to indicate a change in palette values
-        //                    OnBasePaletteChanged(this, EventArgs.Empty);
-        //                    OnBaseRendererChanged(this, EventArgs.Empty);
-        //                    OnUseThemeFormChromeBorderWidthChanged(this, EventArgs.Empty);
-        //                    OnButtonSpecChanged(this, EventArgs.Empty);
-        //                    OnPalettePaint(this, new PaletteLayoutEventArgs(true, true));
-        //                    break;
-        //            }
-        //        }
-        //    }
-        //}
-        //private bool ShouldSerializeBasePaletteMode() => BasePaletteMode != PaletteMode.Microsoft365Blue;
-        //private void ResetBasePaletteMode() => BasePaletteMode = PaletteMode.Microsoft365Blue;
-
         /// <summary>
         /// Gets and sets the KryptonPalette used to inherit from.
         /// </summary>
@@ -2802,35 +2718,11 @@ namespace Krypton.Toolkit
                 // Only interested in changes of value
                 if (_basePalette != value)
                 {
-                    // Store the original values
-                    //PaletteMode tempMode = _basePaletteMode;
-                    var tempPalette = _basePalette;
-
-                    // Find the new palette mode based on the incoming value
-                    //_basePaletteMode = value == null ? PaletteMode.Microsoft365Blue : PaletteMode.Custom;
-                    _basePalette = value;
-
-                    // If the new value creates a circular reference
-                    //if (HasCircularReference())
-                    //{
-                    //    // Put back the original palette details
-                    //    //_basePaletteMode = tempMode;
-                    //    _basePalette = tempPalette;
-
-                    //    throw new ArgumentOutOfRangeException(nameof(value), @"Cannot use palette that would create a circular reference");
-                    //}
-                    //else
-                    {
-                        // Restore the original base palette as 'SetPalette' will not 
-                        // work correctly unless it still has the old value in place
-                        _basePalette = tempPalette;
-                    }
-
                     // If no custom palette is required
                     if (value == null)
                     {
                         // Get the appropriate palette for the global mode
-                        SetPalette(KryptonManager.GetPaletteForMode(PaletteMode.Microsoft365Blue/*_basePaletteMode*/));
+                        SetPalette(KryptonManager.GetPaletteForMode(ThemeManager.DefaultGlobalPalette));
                     }
                     else
                     {
@@ -3040,52 +2932,6 @@ namespace Krypton.Toolkit
                 base.OnButtonSpecChanged(this, e);
             }
         }
-        #endregion
-
-        #region Internal
-        //internal bool HasCircularReference()
-        //{
-        //    // Use a dictionary as a set to check for existence
-        //    var paletteSet = new Dictionary<PaletteBase, bool>();
-
-        //    // Start processing from ourself upwards
-        //    PaletteBase? palette = this;
-
-        //    // Keep searching until no more palettes found
-        //    while (palette != null)
-        //    {
-        //        // If the palette has already been encountered then it is a circular reference
-        //        if (paletteSet.ContainsKey(palette))
-        //        {
-        //            return true;
-        //        }
-        //        else
-        //        {
-        //            // Otherwise, add to the set
-        //            paletteSet.Add(palette, true);
-        //            // Cast to correct type
-
-        //            // If this is a KryptonPalette instance
-        //            if (palette is KryptonCustomPaletteBase owner)
-        //            {
-        //                // Get the next palette up in hierarchy
-        //                palette = owner.BasePaletteMode switch
-        //                {
-        //                    PaletteMode.Custom => owner.BasePalette,
-        //                    PaletteMode.Global => KryptonManager.InternalGlobalPalette,
-        //                    _ => null
-        //                };
-        //            }
-        //            else
-        //            {
-        //                palette = null;
-        //            }
-        //        }
-        //    }
-
-        //    // No circular reference encountered
-        //    return false;
-        //}
         #endregion
 
         #region Implementation Persistence, Used by threading
@@ -3867,7 +3713,6 @@ namespace Krypton.Toolkit
             [typeof(PaletteTextTrim)] = nameof(PaletteTextTrim),
             [typeof(PaletteColorStyle)] = nameof(PaletteColorStyle),
             [typeof(PaletteGraphicsHint)] = nameof(PaletteGraphicsHint),
-            [typeof(PaletteMode)] = nameof(PaletteMode),
             [typeof(PaletteButtonStyle)] = nameof(PaletteButtonStyle),
             [typeof(PaletteButtonOrientation)] = nameof(PaletteButtonOrientation),
             [typeof(PaletteRelativeEdgeAlign)] = nameof(PaletteRelativeEdgeAlign),

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteImagesIntegratedToolBar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Component/KryptonPaletteImagesIntegratedToolBar.cs
@@ -12,6 +12,7 @@ namespace Krypton.Toolkit
     /// <summary>Storage for palette integrated toolbar images.</summary>
     public class KryptonPaletteImagesIntegratedToolBar : Storage
     {
+
         #region Instance Fields
 
         private PaletteRedirect? _redirect;
@@ -492,6 +493,14 @@ namespace Krypton.Toolkit
             }
         }
 
+        #endregion
+
+        #region Public override
+        // Overrides ToString() since this normally displays the text "Modified" in the property grid.
+        public override string ToString()
+        {
+            return string.Empty;
+        }
         #endregion
     }
 }


### PR DESCRIPTION
[Issue 2162-V100-Embedded-Themes-KryptonCustomPaletteBase-clean-up](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2162)
- Clean up KryptonCustomPaletteBase class
- Add ToString override on KryptonPaletteImagesIntegratedToolBar for tidy display in the propertygrid 
- No changelog since this is part of embedded themes change

![compile-results](https://github.com/user-attachments/assets/2b2d2d06-0a51-417f-81a6-30195114ede3)
