### PR TITLE
Resolves #2164 for V100

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2025-11-xx - Build 2511 - November 2025
+* Resolved [#2164](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2164), Adjusted `.Width` and adds `.HeaderCell.Alignment`, `.DefaultCellStyle.Alignment`, `.Visible`, `.AutoSizeMode` and `.DefaultCellStyle.Format` in `ReplaceDefaultColumsWithKryptonColumns`.
 * Resolved [#2138](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2138), NuGet License type is not being detected in projects that use `PackageLicenseExpression`
 * Resolved [#2165](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2165), `KryptonPropertyGrid` lacks the `PropertyValueChanged` event handler
 * Implemented [#2145](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2145), Support the new `slnx` format

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -1716,8 +1716,13 @@ namespace Krypton.Toolkit
                         newColumn.DataPropertyName = currentColumn.DataPropertyName;
                         newColumn.HeaderText = currentColumn.HeaderText;
                         newColumn.Width = currentColumn.Width;
-                        newColumn.AutoSizeMode = DataGridViewAutoSizeColumnMode.DisplayedCells;
-
+                        //newColumn.AutoSizeMode = DataGridViewAutoSizeColumnMode.DisplayedCells;
+                        newColumn.DefaultCellStyle.Format = currentColumn.DefaultCellStyle.Format;
+                        newColumn.DefaultCellStyle.Alignment = currentColumn.DefaultCellStyle.Alignment;
+                        newColumn.AutoSizeMode = currentColumn.AutoSizeMode;
+                        newColumn.Visible = currentColumn.Visible;
+                        newColumn.HeaderCell.Style.Alignment= currentColumn.HeaderCell.Style.Alignment;
+                        
                         Columns.RemoveAt(index);
                         Columns.Insert(index, newColumn);
 
@@ -1733,7 +1738,12 @@ namespace Krypton.Toolkit
                         newColumn.DataPropertyName = currentColumn.DataPropertyName;
                         newColumn.HeaderText = currentColumn.HeaderText;
                         newColumn.Width = currentColumn.Width;
-                        newColumn.AutoSizeMode = DataGridViewAutoSizeColumnMode.DisplayedCells;
+                        //newColumn.AutoSizeMode = DataGridViewAutoSizeColumnMode.DisplayedCells;
+                        newColumn.DefaultCellStyle.Format = currentColumn.DefaultCellStyle.Format;
+                        newColumn.DefaultCellStyle.Alignment = currentColumn.DefaultCellStyle.Alignment;
+                        newColumn.AutoSizeMode = currentColumn.AutoSizeMode;
+                        newColumn.Visible = currentColumn.Visible;
+                        newColumn.HeaderCell.Style.Alignment= currentColumn.HeaderCell.Style.Alignment;
 
                         Columns.RemoveAt(index);
                         Columns.Insert(index, newColumn);
@@ -1751,7 +1761,12 @@ namespace Krypton.Toolkit
                         newColumn.HeaderText = currentColumn.HeaderText;
                         newColumn.Width = currentColumn.Width;
                         newColumn.ImageLayout = (currentColumn as DataGridViewImageColumn)!.ImageLayout;
-                        newColumn.AutoSizeMode = DataGridViewAutoSizeColumnMode.DisplayedCells;
+                        //newColumn.AutoSizeMode = DataGridViewAutoSizeColumnMode.DisplayedCells;
+                        newColumn.DefaultCellStyle.Format = currentColumn.DefaultCellStyle.Format;
+                        newColumn.DefaultCellStyle.Alignment = currentColumn.DefaultCellStyle.Alignment;
+                        newColumn.AutoSizeMode = currentColumn.AutoSizeMode;
+                        newColumn.Visible = currentColumn.Visible;
+                        newColumn.HeaderCell.Style.Alignment= currentColumn.HeaderCell.Style.Alignment;
 
                         Columns.RemoveAt(index);
                         Columns.Insert(index, newColumn);


### PR DESCRIPTION
Resolved [[Bug]: KryptonDataGridView does not apply the properties: .Width, .DefaultCellStyle.Alignment, .AutoSizeMode and .DefaultCellStyle.Format](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2164) #2164  for V100

Adjusted `.Width` and adds `.HeaderCell.Alignment`, `.DefaultCellStyle.Alignment`, `.Visible`, `.AutoSizeMode` and `.DefaultCellStyle.Format` in `ReplaceDefaultColumsWithKryptonColumns`.
![image](https://github.com/user-attachments/assets/466901b6-c4b9-462a-8ec1-4ea4966862b6)
