### PR TITLE
2164-V85LTS-KryptonDataGridView-does-not-apply-the-properties

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -5,6 +5,7 @@
 ## 2025-04-21 - Build 2504 (Patch 6) - April 2025
 * Resolved [#2138](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2138), NuGet License type is not being detected in projects that use `PackageLicenseExpression`
 * Resolved [#2165](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2165), `KryptonPropertyGrid` lacks the `PropertyValueChanged` event handler
+* Resolved [#2164](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2164), Adjusted `.Width` and adds `.HeaderCell.Alignment`, `.DefaultCellStyle.Alignment`, `.Visible`, `.AutoSizeMode` and `.DefaultCellStyle.Format` in `ReplaceDefaultColumsWithKryptonColumns`.
 
 =======
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -1713,7 +1713,11 @@ namespace Krypton.Toolkit
                     newColumn.DataPropertyName = currentColumn.DataPropertyName;
                     newColumn.HeaderText = currentColumn.HeaderText;
                     newColumn.Width = currentColumn.Width;
-                    newColumn.AutoSizeMode = DataGridViewAutoSizeColumnMode.DisplayedCells;
+                    newColumn.AutoSizeMode = currentColumn.AutoSizeMode;
+                    newColumn.DefaultCellStyle.Format = currentColumn.DefaultCellStyle.Format;
+                    newColumn.DefaultCellStyle.Alignment = currentColumn.DefaultCellStyle.Alignment;
+                    newColumn.Visible = currentColumn.Visible;
+                    newColumn.HeaderCell.Style.Alignment= currentColumn.HeaderCell.Style.Alignment;
 
                     Columns.RemoveAt(index);
                     Columns.Insert(index, newColumn);
@@ -1732,7 +1736,11 @@ namespace Krypton.Toolkit
                     newColumn.DataPropertyName = currentColumn.DataPropertyName;
                     newColumn.HeaderText = currentColumn.HeaderText;
                     newColumn.Width = currentColumn.Width;
-                    newColumn.AutoSizeMode = DataGridViewAutoSizeColumnMode.DisplayedCells;
+                    newColumn.AutoSizeMode = currentColumn.AutoSizeMode;
+                    newColumn.DefaultCellStyle.Format = currentColumn.DefaultCellStyle.Format;
+                    newColumn.DefaultCellStyle.Alignment = currentColumn.DefaultCellStyle.Alignment;
+                    newColumn.Visible = currentColumn.Visible;
+                    newColumn.HeaderCell.Style.Alignment= currentColumn.HeaderCell.Style.Alignment;
 
                     Columns.RemoveAt(index);
                     Columns.Insert(index, newColumn);


### PR DESCRIPTION
Resolved [[Bug]: KryptonDataGridView does not apply the properties: .Width, .DefaultCellStyle.Alignment, .AutoSizeMode and .DefaultCellStyle.Format](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2164) #2164 V85 LTS

Adjusted .Width and adds .HeaderCell.Alignment, .DefaultCellStyle.Alignment, .Visible, .AutoSizeMode and .DefaultCellStyle.Format in ReplaceDefaultColumsWithKryptonColumns.

![image](https://github.com/user-attachments/assets/83232482-1c82-44d1-b310-eacebb2c74c9)

@giduac 