### PR TITLE
2164-V95-KryptonDataGridView-does-not-apply-the-properties

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -7,6 +7,7 @@
 * Resolved [#2165](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2165), `KryptonPropertyGrid` lacks the `PropertyValueChanged` event handler
 * Resolved [#2137](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2137), NuGet version `90.25.2.55` should be `95.25.xx.xxx`
 * Resolved [#2035](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2035), Removes the designer attributes from all `KrpytonDataGridView` Columns. Using the default WinForms Column Designers
+* Resolved [#2164](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2164), Adjusted `.Width` and adds `.HeaderCell.Alignment`, `.DefaultCellStyle.Alignment`, `.Visible`, `.AutoSizeMode` and `.DefaultCellStyle.Format` in `ReplaceDefaultColumsWithKryptonColumns`.
 
 =======
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -1715,7 +1715,11 @@ namespace Krypton.Toolkit
                     newColumn.DataPropertyName = currentColumn.DataPropertyName;
                     newColumn.HeaderText = currentColumn.HeaderText;
                     newColumn.Width = currentColumn.Width;
-                    newColumn.AutoSizeMode = DataGridViewAutoSizeColumnMode.DisplayedCells;
+                    newColumn.AutoSizeMode = currentColumn.AutoSizeMode;
+                    newColumn.DefaultCellStyle.Format = currentColumn.DefaultCellStyle.Format;
+                    newColumn.DefaultCellStyle.Alignment = currentColumn.DefaultCellStyle.Alignment;
+                    newColumn.Visible = currentColumn.Visible;
+                    newColumn.HeaderCell.Style.Alignment= currentColumn.HeaderCell.Style.Alignment;
 
                     Columns.RemoveAt(index);
                     Columns.Insert(index, newColumn);
@@ -1734,7 +1738,11 @@ namespace Krypton.Toolkit
                     newColumn.DataPropertyName = currentColumn.DataPropertyName;
                     newColumn.HeaderText = currentColumn.HeaderText;
                     newColumn.Width = currentColumn.Width;
-                    newColumn.AutoSizeMode = DataGridViewAutoSizeColumnMode.DisplayedCells;
+                    newColumn.AutoSizeMode = currentColumn.AutoSizeMode;
+                    newColumn.DefaultCellStyle.Format = currentColumn.DefaultCellStyle.Format;
+                    newColumn.DefaultCellStyle.Alignment = currentColumn.DefaultCellStyle.Alignment;
+                    newColumn.Visible = currentColumn.Visible;
+                    newColumn.HeaderCell.Style.Alignment= currentColumn.HeaderCell.Style.Alignment;
 
                     Columns.RemoveAt(index);
                     Columns.Insert(index, newColumn);


### PR DESCRIPTION
Resolved [[Bug]: KryptonDataGridView does not apply the properties: .Width, .DefaultCellStyle.Alignment, .AutoSizeMode and .DefaultCellStyle.Format](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2164) #2164 V95

Adjusted .Width and adds .HeaderCell.Alignment, .DefaultCellStyle.Alignment, .Visible, .AutoSizeMode and .DefaultCellStyle.Format in ReplaceDefaultColumsWithKryptonColumns.

![image](https://github.com/user-attachments/assets/1f6f0379-983e-49a9-8463-c99a684a6de2)


@giduac 