### PR TITLE
2164-V95-KryptonDataGridView-does-not-apply-the-properties

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2025-04-25 - Build 2504 (Patch 6) - April 2025
+* Implemented [#2164](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2164), `KryptonDataGridView.ColumnCount` when set, now converts basic columns to `KryptonDataGridViewTextBoxColumns` when Autogeneration is enabled.
 * Resolved [#868](https://github.com/Krypton-Suite/Standard-Toolkit/issues/868), `KryptonForm` Does not route `WM_HELP` request
 * Resolved [#2138](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2138), NuGet License type is not being detected in projects that use `PackageLicenseExpression`
 * Resolved [#2165](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2165), `KryptonPropertyGrid` lacks the `PropertyValueChanged` event handler

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -226,6 +226,36 @@ namespace Krypton.Toolkit
 
         #region Public New
         /// <summary>
+        /// Gets or sets the number of columns displayed in the KryptonDataGridView.
+        /// </summary>
+        /// <returns>The number of columns displayed in the KryptonDataGridView.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">The specified value when setting this property is less than 0.</exception>
+        /// <exception cref="System.InvalidOperationException">When setting this property, the System.Windows.Forms.DataGridView.DataSource property has been set.</exception>
+        [Browsable(false)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [DefaultValue(0)]
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public new int ColumnCount 
+        {
+            // base.ColumnCount is a non virtual property.
+            get => base.ColumnCount;
+
+            set
+            {
+                // Let the base do its work
+                base.ColumnCount = value;
+
+                // If there is a count and AutoGenerate is enabled convert them to Krypton columns
+                if (base.ColumnCount > 0
+                    && AutoGenerateColumns
+                    && AutoGenerateKryptonColumns)
+                {
+                    ReplaceDefaultColumsWithKryptonColumns(true);
+                }
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the background color of the DataGridView.
         /// </summary>
         [Browsable(false)]
@@ -1681,7 +1711,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Handles the auto generation of Krypton columns<br/>
         /// </summary>
-        private void ReplaceDefaultColumsWithKryptonColumns()
+        private void ReplaceDefaultColumsWithKryptonColumns(bool convertOnEmptyDataPropertyName = false)
         {
             DataGridViewColumn currentColumn;
             int index;
@@ -1700,54 +1730,56 @@ namespace Krypton.Toolkit
                 currentColumn = Columns[i];
 
                 /* 
-                 * Auto generated columns are always of type System.Windows.Forms.DataGridViewTextBoxColumn.
-                 * Only columns that are of type DataGridViewTextBoxColumn and have the DataPropertyName set will be converted to krypton Columns.
+                 * Auto generated columns are always of DataGridViewTextBoxColumn, DataGridViewCheckBoxBoxColumn or DataGridViewImageColumn
                  */
-                if (currentColumn is DataGridViewTextBoxColumn && currentColumn.DataPropertyName.Length > 0)
+                if (currentColumn.DataPropertyName.Length > 0 || convertOnEmptyDataPropertyName)
                 {
-                    index = currentColumn.Index;
+                    if (currentColumn is DataGridViewTextBoxColumn)
+                    {
+                        index = currentColumn.Index;
 
-                    var newColumn = this.DesignMode
-                        ? designerHost?.CreateComponent(typeof(KryptonDataGridViewTextBoxColumn)) as KryptonDataGridViewTextBoxColumn 
-                        : new KryptonDataGridViewTextBoxColumn();
+                        var newColumn = this.DesignMode
+                            ? designerHost?.CreateComponent(typeof(KryptonDataGridViewTextBoxColumn)) as KryptonDataGridViewTextBoxColumn
+                            : new KryptonDataGridViewTextBoxColumn();
 
-                    newColumn!.Name = currentColumn.Name;
-                    newColumn.DataPropertyName = currentColumn.DataPropertyName;
-                    newColumn.HeaderText = currentColumn.HeaderText;
-                    newColumn.Width = currentColumn.Width;
-                    newColumn.AutoSizeMode = currentColumn.AutoSizeMode;
-                    newColumn.DefaultCellStyle.Format = currentColumn.DefaultCellStyle.Format;
-                    newColumn.DefaultCellStyle.Alignment = currentColumn.DefaultCellStyle.Alignment;
-                    newColumn.Visible = currentColumn.Visible;
-                    newColumn.HeaderCell.Style.Alignment= currentColumn.HeaderCell.Style.Alignment;
+                        newColumn!.Name = currentColumn.Name;
+                        newColumn.DataPropertyName = currentColumn.DataPropertyName;
+                        newColumn.HeaderText = currentColumn.HeaderText;
+                        newColumn.Width = currentColumn.Width;
+                        newColumn.AutoSizeMode = currentColumn.AutoSizeMode;
+                        newColumn.DefaultCellStyle.Format = currentColumn.DefaultCellStyle.Format;
+                        newColumn.DefaultCellStyle.Alignment = currentColumn.DefaultCellStyle.Alignment;
+                        newColumn.Visible = currentColumn.Visible;
+                        newColumn.HeaderCell.Style.Alignment = currentColumn.HeaderCell.Style.Alignment;
 
-                    Columns.RemoveAt(index);
-                    Columns.Insert(index, newColumn);
+                        Columns.RemoveAt(index);
+                        Columns.Insert(index, newColumn);
 
-                    designerHost?.DestroyComponent(currentColumn);
-                }
-                else if (currentColumn is DataGridViewCheckBoxColumn && currentColumn.DataPropertyName.Length > 0)
-                {
-                    index = currentColumn.Index;
+                        designerHost?.DestroyComponent(currentColumn);
+                    }
+                    else if (currentColumn is DataGridViewCheckBoxColumn)
+                    {
+                        index = currentColumn.Index;
 
-                    var newColumn = this.DesignMode
-                        ? designerHost?.CreateComponent(typeof(KryptonDataGridViewCheckBoxColumn)) as KryptonDataGridViewCheckBoxColumn 
-                        : new KryptonDataGridViewCheckBoxColumn();
+                        var newColumn = this.DesignMode
+                            ? designerHost?.CreateComponent(typeof(KryptonDataGridViewCheckBoxColumn)) as KryptonDataGridViewCheckBoxColumn
+                            : new KryptonDataGridViewCheckBoxColumn();
 
-                    newColumn!.Name = currentColumn.Name;
-                    newColumn.DataPropertyName = currentColumn.DataPropertyName;
-                    newColumn.HeaderText = currentColumn.HeaderText;
-                    newColumn.Width = currentColumn.Width;
-                    newColumn.AutoSizeMode = currentColumn.AutoSizeMode;
-                    newColumn.DefaultCellStyle.Format = currentColumn.DefaultCellStyle.Format;
-                    newColumn.DefaultCellStyle.Alignment = currentColumn.DefaultCellStyle.Alignment;
-                    newColumn.Visible = currentColumn.Visible;
-                    newColumn.HeaderCell.Style.Alignment= currentColumn.HeaderCell.Style.Alignment;
+                        newColumn!.Name = currentColumn.Name;
+                        newColumn.DataPropertyName = currentColumn.DataPropertyName;
+                        newColumn.HeaderText = currentColumn.HeaderText;
+                        newColumn.Width = currentColumn.Width;
+                        newColumn.AutoSizeMode = currentColumn.AutoSizeMode;
+                        newColumn.DefaultCellStyle.Format = currentColumn.DefaultCellStyle.Format;
+                        newColumn.DefaultCellStyle.Alignment = currentColumn.DefaultCellStyle.Alignment;
+                        newColumn.Visible = currentColumn.Visible;
+                        newColumn.HeaderCell.Style.Alignment = currentColumn.HeaderCell.Style.Alignment;
 
-                    Columns.RemoveAt(index);
-                    Columns.Insert(index, newColumn);
+                        Columns.RemoveAt(index);
+                        Columns.Insert(index, newColumn);
 
-                    designerHost?.DestroyComponent(currentColumn);
+                        designerHost?.DestroyComponent(currentColumn);
+                    }
                 }
             }
 


### PR DESCRIPTION
[Issue 2164-V95-KryptonDataGridView-does-not-apply-the-properties](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2164)
- When ColumnCount is set and auto generation enbled columns will be converted tot KryptonDataGridViewTextBoxColumns
- And the change log.

![compile-results](https://github.com/user-attachments/assets/f6feef9d-fed3-4126-b106-3a7c7e9fd16b)
