### PR TITLE
2180-V95-KryptonTextBox-does-not-save-TabStop-to-the-designer-source

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2025-0#-## - Build 250# (Patch #) - #### 2025
+* Resolved [#2180](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2180), `KryptonTextBox` does not store the TabStop property in the designer source when needed.
 * Resolved [#2166](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2166), [Bug]: Form with Krypton Ribbon, when maximized, cuts off the right, left and bottom edges.
 
 # 2025-04-21 - Build 2504 (Patch 6) - April 2025

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
@@ -596,7 +596,7 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Gets and sets if the control is in the tab chain.
         /// </summary>
-        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
         public new bool TabStop
         {
             get => _textBox.TabStop;


### PR DESCRIPTION
[Issue 2180-KryptonTextBox-does-not-save-TabStop-to-the-designer-source](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2180)
- Restore TabStop behaviour
- And the change log

![compile-results](https://github.com/user-attachments/assets/f09da7b6-c9cb-443d-a9d1-54b5ab433234)
