### PR TITLE
2209-V100-KryptonDropButton-does-process-shortcutkey

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 ==== 
 
 ## 2025-11-xx - Build 2511 (V10 - alpha) - November 2025
+* Resolved [#2209](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2209), `KryptonDropButton` does process shortcutkey
 * Resolved [#2180](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2180), `KryptonTextBox` does not store the TabStop property in the designer source when needed.
 * Resolved [#2166](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2166), [Bug]: Form with Krypton Ribbon, when maximized, cuts off the right, left and bottom edges.
 * Resolved [#2112](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2112), MdiContainer and KForm

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDropButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDropButton.cs
@@ -673,7 +673,7 @@ namespace Krypton.Toolkit
                 // Does the button primary text contain the mnemonic?
                 if (IsMnemonic(charCode, Values.Text))
                 {
-                    if (!Splitter)
+                    if (Splitter)
                     {
                         PerformDropDown();
                     }


### PR DESCRIPTION
[Issue 2209-KryptonDropButton-does-process-shortcutkey](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2209)
- Enable shortcutkey
- And the change log

![compile-results](https://github.com/user-attachments/assets/a8fad00c-4e78-4edd-8199-6c81f1db682b)
