### PR TITLE
2209-V95-KryptonDropButton-does-process-shortcutkey

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2025-0#-## - Build 250# (Patch #) - #### 2025
+* Resolved [#2209](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2209), `KryptonDropButton` does process shortcutkey
 * Resolved [#2180](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2180), `KryptonTextBox` does not store the TabStop property in the designer source when needed.
 * Resolved [#2166](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2166), [Bug]: Form with Krypton Ribbon, when maximized, cuts off the right, left and bottom edges.
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDropButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDropButton.cs
@@ -677,7 +677,7 @@ namespace Krypton.Toolkit
                 // Does the button primary text contain the mnemonic?
                 if (IsMnemonic(charCode, Values.Text))
                 {
-                    if (!Splitter)
+                    if (Splitter)
                     {
                         PerformDropDown();
                     }


### PR DESCRIPTION
[Issue 2209-KryptonDropButton-does-process-shortcutkey](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2209)
- Enable shortcutkey
- And the change log

![compile-results](https://github.com/user-attachments/assets/b1851ee2-c57b-4191-a79d-eea663c625a1)
