### PR TITLE
2209-V85-KryptonDropButton-does-process-shortcutkey

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2025-04-21 - Build 2504 (Patch 6) - April 2025
+* Resolved [#2209](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2209), `KryptonDropButton` does process shortcutkey
 * Implemented [#2164](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2164), `KryptonDataGridView.ColumnCount` when set, now converts basic columns to `KryptonDataGridViewTextBoxColumns` when Autogeneration is enabled.
 * Resolved [#2138](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2138), NuGet License type is not being detected in projects that use `PackageLicenseExpression`
 * Resolved [#2165](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2165), `KryptonPropertyGrid` lacks the `PropertyValueChanged` event handler

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDropButton.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDropButton.cs
@@ -670,7 +670,7 @@ namespace Krypton.Toolkit
                 // Does the button primary text contain the mnemonic?
                 if (IsMnemonic(charCode, Values.Text))
                 {
-                    if (!Splitter)
+                    if (Splitter)
                     {
                         PerformDropDown();
                     }


### PR DESCRIPTION
[Issue 2209-KryptonDropButton-does-process-shortcutkey](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2209)
- Enable shortcutkey
- And the change log

![compile-results](https://github.com/user-attachments/assets/5116efd9-4b30-4626-8a62-c79e6aa0fd97)
