### PR TITLE
2213-V100-KryptonToolstrip-controls-text-unreadable-on-MS-365-White

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 ==== 
 
 ## 2025-11-xx - Build 2511 (V10 - alpha) - November 2025
+* Resolved [#2213](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2213), `KryptonToolStrip` & `KryptonStatusBar` controls text unreadable on Microsoft 365 White theme.
 * Resolved [#2209](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2209), `KryptonDropButton` does process shortcutkey
 * Resolved [#2180](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2180), `KryptonTextBox` does not store the TabStop property in the designer source when needed.
 * Resolved [#2166](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2166), [Bug]: Form with Krypton Ribbon, when maximized, cuts off the right, left and bottom edges.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365White.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365White.cs
@@ -144,96 +144,96 @@ namespace Krypton.Toolkit
 
         private static readonly Color[] _schemeOfficeColors =
         [
-            Color.FromArgb(59, 59, 59), // TextLabelControl
-            Color.FromArgb(59, 59, 59), // TextButtonNormal
-            Color.Black, // TextButtonChecked
-            Color.FromArgb(170, 170, 170), // ButtonNormalBorder1 -n
-            Color.FromArgb(170, 170, 170), // ButtonNormalDefaultBorder -n
-            Color.FromArgb(253, 253, 253), // ButtonNormalBack1 -n
-            Color.FromArgb(253, 253, 253), // ButtonNormalBack2 -n
-            Color.FromArgb(235, 235, 235), // ButtonNormalDefaultBack1
-            Color.FromArgb(195, 195, 195), // ButtonNormalDefaultBack2
-            Color.FromArgb(207, 212, 218), // ButtonNormalNavigatorBack1
-            Color.FromArgb(207, 212, 218), // ButtonNormalNavigatorBack2
-            Color.White, // PanelClient -n
-            Color.FromArgb(207, 212, 218), // PanelAlternative
-            Color.FromArgb(213, 213, 213), // ControlBorder -n
-            Color.FromArgb(250, 253, 255), // SeparatorHighBorder1
-            Color.FromArgb(227, 232, 237), // SeparatorHighBorder2
-            Color.FromArgb(255, 255, 255), // HeaderPrimaryBack1 -n
-            Color.FromArgb(255, 255, 255), // HeaderPrimaryBack2 -n
-            Color.FromArgb(255, 255, 255), // HeaderSecondaryBack1
-            Color.FromArgb(255, 255, 255), // HeaderSecondaryBack2-n
-            Color.FromArgb(59, 59, 59), // HeaderText
-            Color.FromArgb(255, 255, 255), // StatusStripText
-            Color.FromArgb(236, 199, 87), // ButtonBorder
-            Color.FromArgb(247, 250, 252), // SeparatorLight
-            Color.FromArgb(119, 123, 127), // SeparatorDark
-            Color.FromArgb(191, 191, 191), // GripLight
-            Color.FromArgb(191, 191, 191), // GripDark
-            Color.FromArgb(227, 230, 232), // ToolStripBack
-            Color.FromArgb(0, 114, 198), // StatusStripLight
-            Color.FromArgb(0, 114, 198), // StatusStripDark
-            Color.White, // ImageMargin
-            Color.FromArgb(255, 255, 255), // ToolStripBegin
-            Color.FromArgb(255, 255, 255), // ToolStripMiddle
-            Color.FromArgb(255, 255, 255), // ToolStripEnd
-            Color.FromArgb(147, 154, 163), // OverflowBegin
-            Color.FromArgb(147, 154, 163), // OverflowMiddle
-            Color.FromArgb(147, 154, 163), // OverflowEnd
-            Color.FromArgb(147, 154, 163), // ToolStripBorder
-            Color.FromArgb(0, 114, 198), // FormBorderActive -n
-            Color.FromArgb(134, 139, 145), // FormBorderInactive
-            Color.FromArgb(228, 230, 232), // FormBorderActiveLight
-            Color.FromArgb(255, 255, 255), // FormBorderActiveDark
-            Color.FromArgb(248, 247, 247), // FormBorderInactiveLight
-            Color.FromArgb(248, 247, 247), // FormBorderInactiveDark
-            Color.FromArgb(101, 109, 117), // FormBorderHeaderActive
-            Color.FromArgb(134, 139, 145), // FormBorderHeaderInactive
-            Color.FromArgb(235, 237, 240), // FormBorderHeaderActive1
-            Color.FromArgb(228, 230, 232), // FormBorderHeaderActive2
-            Color.FromArgb(248, 247, 247), // FormBorderHeaderInctive1
-            Color.FromArgb(248, 247, 247), // FormBorderHeaderInctive2
-            Color.FromArgb(59, 59, 59),    // FormHeaderShortActive
-            Color.FromArgb(138, 138, 138), // FormHeaderShortInactive
-            Color.FromArgb(59, 59, 59),    // FormHeaderLongActive
-            Color.FromArgb(138, 138, 138), // FormHeaderLongInactive
-            Color.FromArgb(166, 172, 179), // FormButtonBorderTrack
-            Color.FromArgb(255, 255, 255), // FormButtonBack1Track
-            Color.FromArgb(228, 228, 229), // FormButtonBack2Track
-            Color.FromArgb(166, 172, 179), // FormButtonBorderPressed
-            Color.FromArgb(223, 228, 235), // FormButtonBack1Pressed
-            Color.FromArgb(188, 193, 200), // FormButtonBack2Pressed
-            Color.Black, // TextButtonFormNormal
-            Color.Black, // TextButtonFormTracking
-            Color.Black, // TextButtonFormPressed
-            Color.Blue, // LinkNotVisitedOverrideControl
-            Color.Purple, // LinkVisitedOverrideControl
-            Color.Red, // LinkPressedOverrideControl
-            Color.Blue, // LinkNotVisitedOverridePanel
-            Color.Purple, // LinkVisitedOverridePanel
-            Color.Red, // LinkPressedOverridePanel
-            Color.FromArgb(59, 59, 59), // TextLabelPanel
-            Color.FromArgb(102, 102, 102), // RibbonTabTextNormal -n
-            Color.FromArgb(0, 114, 198), // RibbonTabTextChecked -n
-            Color.FromArgb(182, 186, 191), // RibbonTabSelected1
-            Color.White, // RibbonTabSelected2
-            Color.White, // RibbonTabSelected3
-            Color.White, // RibbonTabSelected4
-            Color.White, // RibbonTabSelected5
-            Color.FromArgb(177, 181, 186), // RibbonTabTracking1
-            Color.FromArgb(248, 249, 249), // RibbonTabTracking2
-            Color.FromArgb(182, 186, 191), // RibbonTabHighlight1
-            Color.White, // RibbonTabHighlight2
-            Color.White, // RibbonTabHighlight3
-            Color.White, // RibbonTabHighlight4
-            Color.White, // RibbonTabHighlight5
-            Color.FromArgb(182, 186, 191), // RibbonTabSeparatorColor
-            Color.FromArgb(212, 212, 212), // RibbonGroupsArea1 -n
-            Color.FromArgb(212, 212, 212), // RibbonGroupsArea2 -n
-            Color.White, // RibbonGroupsArea3 -n
-            Color.White, // RibbonGroupsArea4 -n
-            Color.White, // RibbonGroupsArea5 -n
+            Color.FromArgb(59, 59, 59),     // TextLabelControl
+            Color.FromArgb(59, 59, 59),     // TextButtonNormal
+            Color.Black,                    // TextButtonChecked
+            Color.FromArgb(170, 170, 170),  // ButtonNormalBorder1 -n
+            Color.FromArgb(170, 170, 170),  // ButtonNormalDefaultBorder -n
+            Color.FromArgb(253, 253, 253),  // ButtonNormalBack1 -n
+            Color.FromArgb(253, 253, 253),  // ButtonNormalBack2 -n
+            Color.FromArgb(235, 235, 235),  // ButtonNormalDefaultBack1
+            Color.FromArgb(195, 195, 195),  // ButtonNormalDefaultBack2
+            Color.FromArgb(207, 212, 218),  // ButtonNormalNavigatorBack1
+            Color.FromArgb(207, 212, 218),  // ButtonNormalNavigatorBack2
+            Color.White,                    // PanelClient -n
+            Color.FromArgb(207, 212, 218),  // PanelAlternative
+            Color.FromArgb(213, 213, 213),  // ControlBorder -n
+            Color.FromArgb(250, 253, 255),  // SeparatorHighBorder1
+            Color.FromArgb(227, 232, 237),  // SeparatorHighBorder2
+            Color.FromArgb(255, 255, 255),  // HeaderPrimaryBack1 -n
+            Color.FromArgb(255, 255, 255),  // HeaderPrimaryBack2 -n
+            Color.FromArgb(255, 255, 255),  // HeaderSecondaryBack1
+            Color.FromArgb(255, 255, 255),  // HeaderSecondaryBack2-n
+            Color.FromArgb(59, 59, 59),     // HeaderText
+            Color.FromArgb(59, 59, 59),     // StatusStripText & ToolStrip Control text
+            Color.FromArgb(236, 199, 87),   // ButtonBorder
+            Color.FromArgb(247, 250, 252),  // SeparatorLight
+            Color.FromArgb(119, 123, 127),  // SeparatorDark
+            Color.FromArgb(191, 191, 191),  // GripLight
+            Color.FromArgb(191, 191, 191),  // GripDark
+            Color.FromArgb(227, 230, 232),  // ToolStripBack
+            Color.FromArgb(202, 204, 206),  // StatusStripLight
+            Color.FromArgb(202, 204, 206),  // StatusStripDark
+            Color.White,                    // ImageMargin
+            Color.FromArgb(202, 204, 206),  // ToolStripBegin
+            Color.FromArgb(202, 204, 206),  // ToolStripMiddle
+            Color.FromArgb(202, 204, 206),  // ToolStripEnd
+            Color.FromArgb(147, 154, 163),  // OverflowBegin
+            Color.FromArgb(147, 154, 163),  // OverflowMiddle
+            Color.FromArgb(147, 154, 163),  // OverflowEnd
+            Color.FromArgb(147, 154, 163),  // ToolStripBorder
+            Color.FromArgb(0, 114, 198),    // FormBorderActive -n
+            Color.FromArgb(134, 139, 145),  // FormBorderInactive
+            Color.FromArgb(228, 230, 232),  // FormBorderActiveLight
+            Color.FromArgb(255, 255, 255),  // FormBorderActiveDark
+            Color.FromArgb(248, 247, 247),  // FormBorderInactiveLight
+            Color.FromArgb(248, 247, 247),  // FormBorderInactiveDark
+            Color.FromArgb(101, 109, 117),  // FormBorderHeaderActive
+            Color.FromArgb(134, 139, 145),  // FormBorderHeaderInactive
+            Color.FromArgb(235, 237, 240),  // FormBorderHeaderActive1
+            Color.FromArgb(228, 230, 232),  // FormBorderHeaderActive2
+            Color.FromArgb(248, 247, 247),  // FormBorderHeaderInctive1
+            Color.FromArgb(248, 247, 247),  // FormBorderHeaderInctive2
+            Color.FromArgb(59, 59, 59),     // FormHeaderShortActive
+            Color.FromArgb(138, 138, 138),  // FormHeaderShortInactive
+            Color.FromArgb(59, 59, 59),     // FormHeaderLongActive
+            Color.FromArgb(138, 138, 138),  // FormHeaderLongInactive
+            Color.FromArgb(166, 172, 179),  // FormButtonBorderTrack
+            Color.FromArgb(255, 255, 255),  // FormButtonBack1Track
+            Color.FromArgb(228, 228, 229),  // FormButtonBack2Track
+            Color.FromArgb(166, 172, 179),  // FormButtonBorderPressed
+            Color.FromArgb(223, 228, 235),  // FormButtonBack1Pressed
+            Color.FromArgb(188, 193, 200),  // FormButtonBack2Pressed
+            Color.Black,                    // TextButtonFormNormal
+            Color.Black,                    // TextButtonFormTracking
+            Color.Black,                    // TextButtonFormPressed
+            Color.Blue,                     // LinkNotVisitedOverrideControl
+            Color.Purple,                   // LinkVisitedOverrideControl
+            Color.Red,                      // LinkPressedOverrideControl
+            Color.Blue,                     // LinkNotVisitedOverridePanel
+            Color.Purple,                   // LinkVisitedOverridePanel
+            Color.Red,                      // LinkPressedOverridePanel
+            Color.FromArgb(59, 59, 59),     // TextLabelPanel
+            Color.FromArgb(102, 102, 102),  // RibbonTabTextNormal -n
+            Color.FromArgb(0, 114, 198),    // RibbonTabTextChecked -n
+            Color.FromArgb(182, 186, 191),  // RibbonTabSelected1
+            Color.White,                    // RibbonTabSelected2
+            Color.White,                    // RibbonTabSelected3
+            Color.White,                    // RibbonTabSelected4
+            Color.White,                    // RibbonTabSelected5
+            Color.FromArgb(177, 181, 186),  // RibbonTabTracking1
+            Color.FromArgb(248, 249, 249),  // RibbonTabTracking2
+            Color.FromArgb(182, 186, 191),  // RibbonTabHighlight1
+            Color.White,                    // RibbonTabHighlight2
+            Color.White,                    // RibbonTabHighlight3
+            Color.White,                    // RibbonTabHighlight4
+            Color.White,                    // RibbonTabHighlight5
+            Color.FromArgb(182, 186, 191),  // RibbonTabSeparatorColor
+            Color.FromArgb(212, 212, 212),  // RibbonGroupsArea1 -n
+            Color.FromArgb(212, 212, 212),  // RibbonGroupsArea2 -n
+            Color.White,                    // RibbonGroupsArea3 -n
+            Color.White,                    // RibbonGroupsArea4 -n
+            Color.White,                    // RibbonGroupsArea5 -n
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder1 -n
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder2 -n
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupTitle1
@@ -242,12 +242,12 @@ namespace Krypton.Toolkit
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorderContext2
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupTitleContext1
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupTitleContext2
-            Color.FromArgb(148, 149, 152), // RibbonGroupDialogDark
-            Color.FromArgb(180, 182, 183), // RibbonGroupDialogLight
+            Color.FromArgb(148, 149, 152),  // RibbonGroupDialogDark
+            Color.FromArgb(180, 182, 183),  // RibbonGroupDialogLight
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupTitleTracking1
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupTitleTracking2
-            Color.FromArgb(207, 212, 218), // RibbonMinimizeBarDark
-            Color.FromArgb(255, 255, 255), // RibbonMinimizeBarLight
+            Color.FromArgb(207, 212, 218),  // RibbonMinimizeBarDark
+            Color.FromArgb(255, 255, 255),  // RibbonMinimizeBarLight
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupCollapsedBorder1
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupCollapsedBorder2
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupCollapsedBorder3
@@ -261,115 +261,116 @@ namespace Krypton.Toolkit
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupCollapsedBorderT3
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupCollapsedBorderT4
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupCollapsedBackT1
-            Color.FromArgb(242, 244, 247), // RibbonGroupCollapsedBackT2
-            Color.FromArgb(238, 241, 245), // RibbonGroupCollapsedBackT3
-            Color.FromArgb(234, 235, 235), // RibbonGroupCollapsedBackT4
-            Color.FromArgb(208, 212, 217), // RibbonGroupFrameBorder1
-            Color.FromArgb(208, 212, 217), // RibbonGroupFrameBorder2
-            Color.FromArgb(254, 254, 254), // RibbonGroupFrameInside1
-            Color.FromArgb(254, 254, 254), // RibbonGroupFrameInside2
+            Color.FromArgb(242, 244, 247),  // RibbonGroupCollapsedBackT2
+            Color.FromArgb(238, 241, 245),  // RibbonGroupCollapsedBackT3
+            Color.FromArgb(234, 235, 235),  // RibbonGroupCollapsedBackT4
+            Color.FromArgb(208, 212, 217),  // RibbonGroupFrameBorder1
+            Color.FromArgb(208, 212, 217),  // RibbonGroupFrameBorder2
+            Color.FromArgb(254, 254, 254),  // RibbonGroupFrameInside1
+            Color.FromArgb(254, 254, 254),  // RibbonGroupFrameInside2
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupFrameInside3
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupFrameInside4
-            Color.FromArgb(59, 59, 59), // RibbonGroupCollapsedText
-            Color.FromArgb(179, 185, 195), // AlternatePressedBack1
-            Color.FromArgb(216, 224, 224), // AlternatePressedBack2
-            Color.FromArgb(125, 125, 125), // AlternatePressedBorder1
-            Color.FromArgb(186, 186, 186), // AlternatePressedBorder2
-            Color.FromArgb(157, 166, 174), // FormButtonBack1Checked
-            Color.FromArgb(222, 230, 242), // FormButtonBack2Checked
-            Color.FromArgb(149, 154, 160), // FormButtonBorderCheck
-            Color.FromArgb(147, 156, 164), // FormButtonBack1CheckTrack
-            Color.FromArgb(237, 245, 250), // FormButtonBack2CheckTrack
-            Color.FromArgb(180, 180, 180), // RibbonQATMini1
-            Color.FromArgb(210, 215, 221), // RibbonQATMini2
-            Color.FromArgb(195, 200, 206), // RibbonQATMini3
-            Color.FromArgb(10, Color.White), // RibbonQATMini4
-            Color.FromArgb(32, Color.White), // RibbonQATMini5
-            Color.FromArgb(200, 200, 200), // RibbonQATMini1I
-            Color.FromArgb(233, 234, 238), // RibbonQATMini2I
-            Color.FromArgb(223, 224, 228), // RibbonQATMini3I
-            Color.FromArgb(10, Color.White), // RibbonQATMini4I
-            Color.FromArgb(32, Color.White), // RibbonQATMini5I
-            Color.FromArgb(223, 227, 234), // RibbonQATFullbar1
-            Color.FromArgb(213, 217, 222), // RibbonQATFullbar2
-            Color.FromArgb(135, 140, 146), // RibbonQATFullbar3
-            Color.FromArgb(90, 90, 90), // RibbonQATButtonDark
-            Color.FromArgb(210, 212, 215), // RibbonQATButtonLight
-            Color.FromArgb(233, 237, 241), // RibbonQATOverflow1
-            Color.FromArgb(138, 144, 150), // RibbonQATOverflow2
-            Color.FromArgb(191, 195, 199), // RibbonGroupSeparatorDark
-            Color.FromArgb(255, 255, 255), // RibbonGroupSeparatorLight
-            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1
-            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2
-            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1
-            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2
-            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor
-            Color.White, // GridListNormal1
-            Color.White, // GridListNormal2
-            Color.FromArgb(203, 207, 212), // GridListPressed1
-            Color.White, // GridListPressed2
-            Color.FromArgb(186, 189, 194), // GridListSelected
-            Color.FromArgb(238, 241, 247), // GridSheetColNormal1
-            Color.FromArgb(218, 222, 227), // GridSheetColNormal2
-            Color.FromArgb(255, 223, 107), // GridSheetColPressed1
-            Color.FromArgb(255, 252, 230), // GridSheetColPressed2
-            Color.FromArgb(255, 211, 89), // GridSheetColSelected1
-            Color.FromArgb(255, 239, 113), // GridSheetColSelected2
-            Color.FromArgb(223, 227, 232), // GridSheetRowNormal
-            Color.FromArgb(255, 223, 107), // GridSheetRowPressed
-            Color.FromArgb(245, 210, 87), // GridSheetRowSelected
-            Color.FromArgb(218, 220, 221), // GridDataCellBorder
-            Color.FromArgb(183, 219, 255), // GridDataCellSelected
-            Color.Black, // InputControlTextNormal
-            Color.FromArgb(168, 168, 168), // InputControlTextDisabled
-            Color.FromArgb(212, 214, 217), // InputControlBorderNormal
-            Color.FromArgb(187, 187, 187), // InputControlBorderDisabled
-            Color.FromArgb(255, 255, 255), // InputControlBackNormal
-            Color.FromArgb(240, 240, 240), // InputControlBackDisabled
-            Color.FromArgb(247, 247, 247), // InputControlBackInactive
-            Color.Black, // InputDropDownNormal1
-            Color.Transparent, // InputDropDownNormal2
-            Color.FromArgb(172, 168, 153), // InputDropDownDisabled1
-            Color.Transparent, // InputDropDownDisabled2
-            Color.FromArgb(240, 242, 245), // ContextMenuHeadingBack
-            Color.FromArgb(59, 59, 59), // ContextMenuHeadingText
-            Color.White, // ContextMenuImageColumn
-            Color.FromArgb(224, 227, 231), // AppButtonBack1
-            Color.FromArgb(224, 227, 231), // AppButtonBack2
-            Color.FromArgb(135, 140, 146), // AppButtonBorder
-            Color.FromArgb(224, 227, 231), // AppButtonOuter1
-            Color.FromArgb(224, 227, 231), // AppButtonOuter2
-            Color.FromArgb(224, 227, 231), // AppButtonOuter3
+            Color.FromArgb(59, 59, 59),     // RibbonGroupCollapsedText
+            Color.FromArgb(179, 185, 195),  // AlternatePressedBack1
+            Color.FromArgb(216, 224, 224),  // AlternatePressedBack2
+            Color.FromArgb(125, 125, 125),  // AlternatePressedBorder1
+            Color.FromArgb(186, 186, 186),  // AlternatePressedBorder2
+            Color.FromArgb(157, 166, 174),  // FormButtonBack1Checked
+            Color.FromArgb(222, 230, 242),  // FormButtonBack2Checked
+            Color.FromArgb(149, 154, 160),  // FormButtonBorderCheck
+            Color.FromArgb(147, 156, 164),  // FormButtonBack1CheckTrack
+            Color.FromArgb(237, 245, 250),  // FormButtonBack2CheckTrack
+            Color.FromArgb(180, 180, 180),  // RibbonQATMini1
+            Color.FromArgb(210, 215, 221),  // RibbonQATMini2
+            Color.FromArgb(195, 200, 206),  // RibbonQATMini3
+            Color.FromArgb(10, Color.White),// RibbonQATMini4
+            Color.FromArgb(32, Color.White),// RibbonQATMini5
+            Color.FromArgb(200, 200, 200),  // RibbonQATMini1I
+            Color.FromArgb(233, 234, 238),  // RibbonQATMini2I
+            Color.FromArgb(223, 224, 228),  // RibbonQATMini3I
+            Color.FromArgb(10, Color.White),// RibbonQATMini4I
+            Color.FromArgb(32, Color.White),// RibbonQATMini5I
+            Color.FromArgb(223, 227, 234),  // RibbonQATFullbar1
+            Color.FromArgb(213, 217, 222),  // RibbonQATFullbar2
+            Color.FromArgb(135, 140, 146),  // RibbonQATFullbar3
+            Color.FromArgb(90, 90, 90),     // RibbonQATButtonDark
+            Color.FromArgb(210, 212, 215),  // RibbonQATButtonLight
+            Color.FromArgb(233, 237, 241),  // RibbonQATOverflow1
+            Color.FromArgb(138, 144, 150),  // RibbonQATOverflow2
+            Color.FromArgb(191, 195, 199),  // RibbonGroupSeparatorDark
+            Color.FromArgb(255, 255, 255),  // RibbonGroupSeparatorLight
+            Color.FromArgb(231, 234, 238),  // ButtonClusterButtonBack1
+            Color.FromArgb(241, 243, 243),  // ButtonClusterButtonBack2
+            Color.FromArgb(197, 198, 199),  // ButtonClusterButtonBorder1
+            Color.FromArgb(157, 158, 159),  // ButtonClusterButtonBorder2
+            Color.FromArgb(238, 238, 244),  // NavigatorMiniBackColor
+            Color.White,                    // GridListNormal1
+            Color.White,                    // GridListNormal2
+            Color.FromArgb(203, 207, 212),  // GridListPressed1
+            Color.White,                    // GridListPressed2
+            Color.FromArgb(186, 189, 194),  // GridListSelected
+            Color.FromArgb(238, 241, 247),  // GridSheetColNormal1
+            Color.FromArgb(218, 222, 227),  // GridSheetColNormal2
+            Color.FromArgb(255, 223, 107),  // GridSheetColPressed1
+            Color.FromArgb(255, 252, 230),  // GridSheetColPressed2
+            Color.FromArgb(255, 211, 89),   // GridSheetColSelected1
+            Color.FromArgb(255, 239, 113),  // GridSheetColSelected2
+            Color.FromArgb(223, 227, 232),  // GridSheetRowNormal
+            Color.FromArgb(255, 223, 107),  // GridSheetRowPressed
+            Color.FromArgb(245, 210, 87),   // GridSheetRowSelected
+            Color.FromArgb(218, 220, 221),  // GridDataCellBorder
+            Color.FromArgb(183, 219, 255),  // GridDataCellSelected
+            Color.Black,                    // InputControlTextNormal
+            Color.FromArgb(168, 168, 168),  // InputControlTextDisabled
+            Color.FromArgb(212, 214, 217),  // InputControlBorderNormal
+            Color.FromArgb(187, 187, 187),  // InputControlBorderDisabled
+            Color.FromArgb(255, 255, 255),  // InputControlBackNormal
+            Color.FromArgb(240, 240, 240),  // InputControlBackDisabled
+            Color.FromArgb(247, 247, 247),  // InputControlBackInactive
+            Color.Black,                    // InputDropDownNormal1
+            Color.Transparent,              // InputDropDownNormal2
+            Color.FromArgb(172, 168, 153),  // InputDropDownDisabled1
+            Color.Transparent,              // InputDropDownDisabled2
+            Color.FromArgb(240, 242, 245),  // ContextMenuHeadingBack
+            Color.FromArgb(59, 59, 59),     // ContextMenuHeadingText
+            Color.White,                    // ContextMenuImageColumn
+            Color.FromArgb(224, 227, 231),  // AppButtonBack1
+            Color.FromArgb(224, 227, 231),  // AppButtonBack2
+            Color.FromArgb(135, 140, 146),  // AppButtonBorder
+            Color.FromArgb(224, 227, 231),  // AppButtonOuter1
+            Color.FromArgb(224, 227, 231),  // AppButtonOuter2
+            Color.FromArgb(224, 227, 231),  // AppButtonOuter3
             GlobalStaticValues.EMPTY_COLOR, // AppButtonInner1
-            Color.FromArgb(135, 140, 146), // AppButtonInner2
-            Color.White, // AppButtonMenuDocs
-            Color.Black, // AppButtonMenuDocsText
-            Color.FromArgb(250, 253, 255), // SeparatorHighInternalBorder1
-            Color.FromArgb(227, 232, 237), // SeparatorHighInternalBorder2
-            Color.FromArgb(198, 202, 205), // RibbonGalleryBorder
-            Color.FromArgb(255, 255, 255), // RibbonGalleryBackNormal
-            Color.FromArgb(255, 255, 255), // RibbonGalleryBackTracking
-            Color.FromArgb(250, 250, 250), // RibbonGalleryBack1
-            Color.FromArgb(228, 231, 235), // RibbonGalleryBack2                        //Color.FromArgb(177, 181, 186), // RibbonTabTracking1
-            Color.FromArgb(229, 231, 235), // RibbonTabTracking3
-            Color.FromArgb(231, 233, 235), // RibbonTabTracking4
-            Color.FromArgb(176, 182, 188), // RibbonGroupBorder3
-            Color.FromArgb(246, 247, 248), // RibbonGroupBorder4
-            Color.FromArgb(249, 250, 250), // RibbonGroupBorder5
-            Color.FromArgb(102, 109, 124), // RibbonGroupTitleText
-            Color.FromArgb(151, 156, 163), // RibbonDropArrowLight
-            Color.FromArgb(39, 49, 60), // RibbonDropArrowDark
-            Color.FromArgb(237, 242, 248), // HeaderDockInactiveBack1
-            Color.FromArgb(207, 213, 220), // HeaderDockInactiveBack2
-            Color.FromArgb(161, 169, 179), // ButtonNavigatorBorder
-            Color.Black, // ButtonNavigatorText
-            Color.FromArgb(207, 213, 220), // ButtonNavigatorTrack1
-            Color.FromArgb(232, 234, 238), // ButtonNavigatorTrack2
-            Color.FromArgb(191, 196, 202), // ButtonNavigatorPressed1
-            Color.FromArgb(225, 226, 230), // ButtonNavigatorPressed2
-            Color.FromArgb(222, 227, 234), // ButtonNavigatorChecked1
-            Color.FromArgb(206, 214, 221), // ButtonNavigatorChecked2
-            Color.FromArgb(221, 221, 221) // ToolTipBottom
+            Color.FromArgb(135, 140, 146),  // AppButtonInner2
+            Color.White,                    // AppButtonMenuDocs
+            Color.Black,                    // AppButtonMenuDocsText
+            Color.FromArgb(250, 253, 255),  // SeparatorHighInternalBorder1
+            Color.FromArgb(227, 232, 237),  // SeparatorHighInternalBorder2
+            Color.FromArgb(198, 202, 205),  // RibbonGalleryBorder
+            Color.FromArgb(255, 255, 255),  // RibbonGalleryBackNormal
+            Color.FromArgb(255, 255, 255),  // RibbonGalleryBackTracking
+            Color.FromArgb(250, 250, 250),  // RibbonGalleryBack1
+            Color.FromArgb(228, 231, 235),  // RibbonGalleryBack2 
+            //Color.FromArgb(177, 181, 186), // RibbonTabTracking1
+            Color.FromArgb(229, 231, 235),  // RibbonTabTracking3
+            Color.FromArgb(231, 233, 235),  // RibbonTabTracking4
+            Color.FromArgb(176, 182, 188),  // RibbonGroupBorder3
+            Color.FromArgb(246, 247, 248),  // RibbonGroupBorder4
+            Color.FromArgb(249, 250, 250),  // RibbonGroupBorder5
+            Color.FromArgb(102, 109, 124),  // RibbonGroupTitleText
+            Color.FromArgb(151, 156, 163),  // RibbonDropArrowLight
+            Color.FromArgb(39, 49, 60),     // RibbonDropArrowDark
+            Color.FromArgb(237, 242, 248),  // HeaderDockInactiveBack1
+            Color.FromArgb(207, 213, 220),  // HeaderDockInactiveBack2
+            Color.FromArgb(161, 169, 179),  // ButtonNavigatorBorder
+            Color.Black,                    // ButtonNavigatorText
+            Color.FromArgb(207, 213, 220),  // ButtonNavigatorTrack1
+            Color.FromArgb(232, 234, 238),  // ButtonNavigatorTrack2
+            Color.FromArgb(191, 196, 202),  // ButtonNavigatorPressed1
+            Color.FromArgb(225, 226, 230),  // ButtonNavigatorPressed2
+            Color.FromArgb(222, 227, 234),  // ButtonNavigatorChecked1
+            Color.FromArgb(206, 214, 221),  // ButtonNavigatorChecked2
+            Color.FromArgb(221, 221, 221)   // ToolTipBottom
         ];
 
         #endregion


### PR DESCRIPTION
[Issue 2213-KryptonToolstrip-controls-text-unreadable-on-MS-365-White](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2213)
- Colours corrected
- And the change log

![compile-results](https://github.com/user-attachments/assets/47f66a30-8d80-432e-8573-ee9f66d72ea3)

