### PR TITLE
2213-V95-KryptonToolstrip-controls-text-unreadable-on-MS-365-White

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2025-0#-## - Build 250# (Patch #) - #### 2025
+* Resolved [#2213](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2213), `KryptonToolStrip` & `KryptonStatusBar` controls text unreadable on Microsoft 365 White theme.
 * Resolved [#2209](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2209), `KryptonDropButton` does process shortcutkey
 * Resolved [#2180](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2180), `KryptonTextBox` does not store the TabStop property in the designer source when needed.
 * Resolved [#2166](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2166), [Bug]: Form with Krypton Ribbon, when maximized, cuts off the right, left and bottom edges.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365White.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365White.cs
@@ -165,19 +165,19 @@ namespace Krypton.Toolkit
             Color.FromArgb(255, 255, 255), // HeaderSecondaryBack1
             Color.FromArgb(255, 255, 255), // HeaderSecondaryBack2-n
             Color.FromArgb(59, 59, 59), // HeaderText
-            Color.FromArgb(255, 255, 255), // StatusStripText
+            Color.FromArgb(59, 59, 59), // StatusStripText & ToolStrip Control text
             Color.FromArgb(236, 199, 87), // ButtonBorder
             Color.FromArgb(247, 250, 252), // SeparatorLight
             Color.FromArgb(119, 123, 127), // SeparatorDark
             Color.FromArgb(191, 191, 191), // GripLight
             Color.FromArgb(191, 191, 191), // GripDark
             Color.FromArgb(227, 230, 232), // ToolStripBack
-            Color.FromArgb(0, 114, 198), // StatusStripLight
-            Color.FromArgb(0, 114, 198), // StatusStripDark
+            Color.FromArgb(202, 204, 206), // StatusStripLight
+            Color.FromArgb(202, 204, 206), // StatusStripDark
             Color.White, // ImageMargin
-            Color.FromArgb(255, 255, 255), // ToolStripBegin
-            Color.FromArgb(255, 255, 255), // ToolStripMiddle
-            Color.FromArgb(255, 255, 255), // ToolStripEnd
+            Color.FromArgb(202, 204, 206), // ToolStripBegin
+            Color.FromArgb(202, 204, 206), // ToolStripMiddle
+            Color.FromArgb(202, 204, 206), // ToolStripEnd
             Color.FromArgb(147, 154, 163), // OverflowBegin
             Color.FromArgb(147, 154, 163), // OverflowMiddle
             Color.FromArgb(147, 154, 163), // OverflowEnd


### PR DESCRIPTION
[Issue 2213-KryptonToolstrip-controls-text-unreadable-on-MS-365-White](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2213)
- Colours corrected
- And the change log

![compile-results](https://github.com/user-attachments/assets/1259c3c7-0cf3-489a-bfe4-41ed954b27ab)
