### PR TITLE
2101-V85-KryptonContextMenu-designer-lacks-cancel-button

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 ## 2025-04-21 - Build 2504 (Patch 6) - April 2025
+* Resolved [#2101](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2101), `KryptonContextMenu` items editor doesn't have a cancel button.
 * Resolved [#2209](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2209), `KryptonDropButton` does process shortcutkey
 * Implemented [#2164](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2164), `KryptonDataGridView.ColumnCount` when set, now converts basic columns to `KryptonDataGridViewTextBoxColumns` when Autogeneration is enabled.
 * Resolved [#2138](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2138), NuGet License type is not being detected in projects that use `PackageLicenseExpression`

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/UX/KryptonContextMenuCollectionForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/UX/KryptonContextMenuCollectionForm.cs
@@ -189,6 +189,7 @@ namespace Krypton.Toolkit
             private DictItemBase _beforeItems;
             private readonly KryptonContextMenuCollectionEditor _editor;
             private Button _buttonOk;
+            private Button _buttonCancel;
             private TreeView _treeView;
             private Label _label1;
             private Label _label2;
@@ -234,6 +235,7 @@ namespace Krypton.Toolkit
             {
                 components = new Container();
                 _buttonOk = new Button();
+                _buttonCancel = new();
                 _treeView = new TreeView();
                 _imageList = new ImageList(components);
                 _label1 = new Label();
@@ -272,11 +274,21 @@ namespace Krypton.Toolkit
                 _buttonOk.UseVisualStyleBackColor = true;
                 _buttonOk.Click += buttonOK_Click;
                 // 
+                // buttonCancel
+                // 
+                _buttonCancel.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
+                _buttonCancel.DialogResult = DialogResult.Cancel;
+                _buttonCancel.Location = new Point(10, 675);
+                _buttonCancel.Name = nameof(_buttonCancel);
+                _buttonCancel.Size = new Size(75, 33);
+                _buttonCancel.TabIndex = 17;
+                _buttonCancel.Text = @"Cancel";
+                _buttonCancel.UseVisualStyleBackColor = true;
+                _buttonCancel.Click += buttonCancel_Click;
+                // 
                 // treeView
                 // 
-                _treeView.Anchor = AnchorStyles.Top | AnchorStyles.Bottom
-                                   | AnchorStyles.Left
-                                  | AnchorStyles.Right;
+                _treeView.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
                 _treeView.HideSelection = false;
                 _treeView.ImageIndex = 0;
                 _treeView.ImageList = _imageList;
@@ -588,6 +600,7 @@ namespace Krypton.Toolkit
                 _tableLayoutPanel1.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
                 _tableLayoutPanel1.Controls.Add(_label1, 0, 0);
                 _tableLayoutPanel1.Controls.Add(_buttonOk, 2, 2);
+                _tableLayoutPanel1.Controls.Add(_buttonCancel, 0, 2);
                 _tableLayoutPanel1.Controls.Add(_label2, 2, 0);
                 _tableLayoutPanel1.Controls.Add(_treeView, 0, 1);
                 _tableLayoutPanel1.Controls.Add(_propertyGrid1, 2, 1);
@@ -628,6 +641,7 @@ namespace Krypton.Toolkit
                 // KryptonContextMenuCollectionForm
                 // 
                 AcceptButton = _buttonOk;
+                CancelButton = _buttonCancel;
                 AutoScaleMode = AutoScaleMode.None;
                 ClientSize = new Size(816, 724);
                 ControlBox = false;
@@ -688,6 +702,11 @@ namespace Krypton.Toolkit
             private void KryptonContextMenuEditorForm_Load(object sender, EventArgs e) =>
                 // Set allowed categories into the property grid filter
                 _propertyGrid1.BrowsableAttributes = new AttributeCollection(new KryptonPersistAttribute());
+
+            private void buttonCancel_Click(object? sender, EventArgs e)
+            {
+                _treeView.Nodes.Clear();
+            }
 
             private void buttonOK_Click(object sender, EventArgs e)
             {


### PR DESCRIPTION
[Issue 2101-KryptonContextMenu-designer-lacks-cancel-button](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2101)
- Adds the cancel button
- And the change log

![compile-results](https://github.com/user-attachments/assets/969d3fc0-71ff-43ad-b0bc-bcaacf06a153)
