### PR TITLE
2095-V100-StateCommon-StateNormal-RibbonFileAppTab-changes-not-writte…

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 ==== 
 
 ## 2025-11-xx - Build 2511 (V10 - alpha) - November 2025
+* Resolved [#2095](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2095), `KryptonRibbon` `StateNormal` & `StateCommon` do not write changes to `RibbonFileAppTab` to the designer source.
 * Implemented [#1009](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1009), Powered by Krypton Toolkit button
 * Resolved [#2101](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2101), `KryptonContextMenu` items editor doesn't have a cancel button.
 * Resolved [#2213](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2213), `KryptonToolStrip` & `KryptonStatusBar` controls text unreadable on Microsoft 365 White theme.

--- a/Source/Krypton Components/Krypton.Ribbon/Palette/PaletteRibbonNormal.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Palette/PaletteRibbonNormal.cs
@@ -51,11 +51,12 @@ namespace Krypton.Ribbon
         /// </summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public override bool IsDefault => base.IsDefault &&
-                                            RibbonGroupCheckBoxText.IsDefault &&
-                                            RibbonGroupButtonText.IsDefault &&
-                                            RibbonGroupLabelText.IsDefault &&
-                                            RibbonGroupRadioButtonText.IsDefault;
+        public override bool IsDefault => base.IsDefault
+            && RibbonFileAppTab.IsDefault
+            && RibbonGroupCheckBoxText.IsDefault
+            && RibbonGroupButtonText.IsDefault
+            && RibbonGroupLabelText.IsDefault
+            && RibbonGroupRadioButtonText.IsDefault;
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Ribbon/Palette/PaletteRibbonRedirect.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Palette/PaletteRibbonRedirect.cs
@@ -207,31 +207,32 @@ namespace Krypton.Ribbon
         /// </summary>
         [Browsable(false)]
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-        public override bool IsDefault => RibbonAppButton.IsDefault &&
-                                            RibbonAppMenuOuter.IsDefault &&
-                                            RibbonAppMenuInner.IsDefault &&
-                                            RibbonAppMenuDocs.IsDefault &&
-                                            RibbonAppMenuDocsTitle.IsDefault &&
-                                            RibbonAppMenuDocsEntry.IsDefault &&
-                                            RibbonGeneral.IsDefault &&
-                                            RibbonGroupBackArea.IsDefault &&
-                                            RibbonGroupCheckBoxText.IsDefault &&
-                                            RibbonGroupNormalBorder.IsDefault &&
-                                            RibbonGroupNormalTitle.IsDefault &&
-                                            RibbonGroupButtonText.IsDefault &&
-                                            RibbonGroupCollapsedBorder.IsDefault &&
-                                            RibbonGroupCollapsedBack.IsDefault &&
-                                            RibbonGroupCollapsedFrameBorder.IsDefault &&
-                                            RibbonGroupCollapsedFrameBack.IsDefault &&
-                                            RibbonGroupCollapsedText.IsDefault &&
-                                            RibbonGroupRadioButtonText.IsDefault &&
-                                            RibbonGroupLabelText.IsDefault &&
-                                            RibbonImages.IsDefault &&
-                                            RibbonTab.IsDefault &&
-                                            RibbonQATFullbar.IsDefault &&
-                                            RibbonQATMinibarActive.IsDefault &&
-                                            RibbonQATMinibarInactive.IsDefault &&
-                                            RibbonQATOverflow.IsDefault;
+        public override bool IsDefault => RibbonAppButton.IsDefault
+            && RibbonFileAppTab.IsDefault
+            && RibbonAppMenuOuter.IsDefault
+            && RibbonAppMenuInner.IsDefault
+            && RibbonAppMenuDocs.IsDefault
+            && RibbonAppMenuDocsTitle.IsDefault
+            && RibbonAppMenuDocsEntry.IsDefault
+            && RibbonGeneral.IsDefault
+            && RibbonGroupBackArea.IsDefault
+            && RibbonGroupCheckBoxText.IsDefault
+            && RibbonGroupNormalBorder.IsDefault
+            && RibbonGroupNormalTitle.IsDefault
+            && RibbonGroupButtonText.IsDefault
+            && RibbonGroupCollapsedBorder.IsDefault
+            && RibbonGroupCollapsedBack.IsDefault
+            && RibbonGroupCollapsedFrameBorder.IsDefault
+            && RibbonGroupCollapsedFrameBack.IsDefault
+            && RibbonGroupCollapsedText.IsDefault
+            && RibbonGroupRadioButtonText.IsDefault
+            && RibbonGroupLabelText.IsDefault
+            && RibbonImages.IsDefault
+            && RibbonTab.IsDefault
+            && RibbonQATFullbar.IsDefault
+            && RibbonQATMinibarActive.IsDefault
+            && RibbonQATMinibarInactive.IsDefault
+            && RibbonQATOverflow.IsDefault;
 
         #endregion
 


### PR DESCRIPTION
[Issue 2095-StateCommon-StateNormal-RibbonFileAppTab-changes-not-written-to-the-designer-source](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2095)
- IsDefault properties corrected
- And the changelog

![compile-results](https://github.com/user-attachments/assets/15fe9c40-c2ef-4a3a-9259-461e568f08f7)
