### PR TITLE
2235-V100-OSUtilities-does-not-detect-win10-11-on-dotnet-lower-than-5.0

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 ==== 
 
 ## 2025-11-xx - Build 2511 (V10 - alpha) - November 2025
+* Resolved [#2235](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2235), `OSUtilities` corrects Windows 10 & 11 detection.
 * Resolved [#2095](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2095), `KryptonRibbon` `StateNormal` & `StateCommon` do not write changes to `RibbonFileAppTab` to the designer source.
 * Implemented [#1009](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1009), Powered by Krypton Toolkit button
 * Resolved [#2101](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2101), `KryptonContextMenu` items editor doesn't have a cancel button.

--- a/Source/Krypton Components/Krypton.Toolkit/General/PlatformInvoke.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/PlatformInvoke.cs
@@ -3444,7 +3444,7 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
         #endregion
 
         #region nt.dll
-        [DllImport("ntdll.dll", SetLastError = true)]
+        [DllImport(Libraries.NtDll, SetLastError = true)]
         internal static extern int RtlGetVersion(ref PI.OSVERSIONINFOEX lpVersionInformation);
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/General/PlatformInvoke.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/PlatformInvoke.cs
@@ -3441,9 +3441,11 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
             }
         }
 
+        #endregion
+
+        #region nt.dll
         [DllImport("ntdll.dll", SetLastError = true)]
         internal static extern int RtlGetVersion(ref PI.OSVERSIONINFOEX lpVersionInformation);
-
         #endregion
 
         #region Static Gdi32

--- a/Source/Krypton Components/Krypton.Toolkit/General/PlatformInvoke.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/PlatformInvoke.cs
@@ -3441,6 +3441,9 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
             }
         }
 
+        [DllImport("ntdll.dll", SetLastError = true)]
+        internal static extern int RtlGetVersion(ref PI.OSVERSIONINFOEX lpVersionInformation);
+
         #endregion
 
         #region Static Gdi32
@@ -4591,6 +4594,28 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
         {
             public int X;
             public int Y;
+        }
+
+        /// <summary>
+        /// Contains operating system version information. The information includes major and minor version numbers, a build number, a platform identifier, 
+        /// and information about product suites and the latest Service Pack installed on the system. 
+        /// This structure is used with the RtlGetVersion, GetVersionEx and VerifyVersionInfo functions.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+        internal struct OSVERSIONINFOEX
+        {
+            public uint dwOSVersionInfoSize;
+            public uint dwMajorVersion;
+            public uint dwMinorVersion;
+            public uint dwBuildNumber;
+            public uint dwPlatformId;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+            public string szCSDVersion;
+            public ushort wServicePackMajor;
+            public ushort wServicePackMinor;
+            public ushort wSuiteMask;
+            public byte wProductType;
+            public byte wReserved;
         }
 
         #region For Acrylic

--- a/Source/Krypton Components/Krypton.Toolkit/Utilities/OSUtilities.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Utilities/OSUtilities.cs
@@ -33,16 +33,31 @@ namespace Krypton.Toolkit
 
         /// <summary>Gets a value indicating whether the client version is Windows 10.</summary>
         /// <value><c>true</c> if the client version is Windows 10; otherwise, <c>false</c>.</value>
-        public static bool IsWindowsTen => Environment.OSVersion.Version is { Major: 10, Build: <= 19045 };
+        public static bool IsWindowsTen => RtlGetVersion() is { dwMajorVersion: 10, dwBuildNumber: <= 19045 };
 
         /// <summary>Gets a value indicating whether the client version is Windows 11.</summary>
         /// <value><c>true</c> if the client version is Windows 11; otherwise, <c>false</c>.</value>
-        public static bool IsAtLeastWindowsEleven => Environment.OSVersion.Version is { Major: >= 10, Build: > 19045 };
+        public static bool IsAtLeastWindowsEleven => RtlGetVersion() is { dwMajorVersion: >= 10, dwBuildNumber: > 19045 };
 
         /// <summary>Gets a value indicating whether the client is a 64 bit operating system.</summary>
         /// <value><c>true</c> if the client is a 64 bit operating system; otherwise, <c>false</c>.</value>
         public static bool Is64BitOperatingSystem => Environment.Is64BitOperatingSystem;
 
+        /// <summary>
+        /// Use is internal to this class only.
+        /// </summary>
+        /// <returns>PI.OSVERSIONINFOEX structure</returns>
+        private static PI.OSVERSIONINFOEX RtlGetVersion()
+        {
+            PI.OSVERSIONINFOEX osvi = new()
+            {
+                dwOSVersionInfoSize = (uint)Marshal.SizeOf(typeof(PI.OSVERSIONINFOEX))
+            };
+
+            PI.RtlGetVersion(ref osvi);
+
+            return osvi;
+        }
         #endregion
     }
 }


### PR DESCRIPTION
[Issue 2235-OSUtilities-does-not-detect-win10-11-on-dotnet-lower-than-5.0](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2235)
- Adds Pinvoke for Windows API RtlGetVersion()
- And the changelog

![compile-results](https://github.com/user-attachments/assets/c4180eb1-f82a-4c82-b2b1-604b73039ffe)
