### PR TITLE
2235-V95-OSUtilities-does-not-detect-win10-11-on-dotnet-lower-than-5.0

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2025-0#-## - Build 250# (Patch #) - #### 2025
+* Resolved [#2235](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2235), `OSUtilities` corrects Windows 10 & 11 detection.
 * Resolved [#2101](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2101), `KryptonContextMenu` items editor doesn't have a cancel button.
 * Resolved [#2213](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2213), `KryptonToolStrip` & `KryptonStatusBar` controls text unreadable on Microsoft 365 White theme.
 * Resolved [#2209](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2209), `KryptonDropButton` does process shortcutkey

--- a/Source/Krypton Components/Krypton.Toolkit/General/PlatformInvoke.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/PlatformInvoke.cs
@@ -3604,6 +3604,11 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
 
         #endregion
 
+        #region nt.dll
+        [DllImport(Libraries.NtDll, SetLastError = true)]
+        internal static extern int RtlGetVersion(ref PI.OSVERSIONINFOEX lpVersionInformation);
+        #endregion
+
         #region dwmapi
 
         public class Dwm
@@ -4592,6 +4597,28 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
         {
             public int X;
             public int Y;
+        }
+
+        /// <summary>
+        /// Contains operating system version information. The information includes major and minor version numbers, a build number, a platform identifier, 
+        /// and information about product suites and the latest Service Pack installed on the system. 
+        /// This structure is used with the RtlGetVersion, GetVersionEx and VerifyVersionInfo functions.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+        internal struct OSVERSIONINFOEX
+        {
+            public uint dwOSVersionInfoSize;
+            public uint dwMajorVersion;
+            public uint dwMinorVersion;
+            public uint dwBuildNumber;
+            public uint dwPlatformId;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+            public string szCSDVersion;
+            public ushort wServicePackMajor;
+            public ushort wServicePackMinor;
+            public ushort wSuiteMask;
+            public byte wProductType;
+            public byte wReserved;
         }
 
         #region For Acrylic

--- a/Source/Krypton Components/Krypton.Toolkit/Utilities/OSUtilities.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Utilities/OSUtilities.cs
@@ -33,15 +33,31 @@ namespace Krypton.Toolkit
 
         /// <summary>Gets a value indicating whether the client version is Windows 10.</summary>
         /// <value><c>true</c> if the client version is Windows 10; otherwise, <c>false</c>.</value>
-        public static bool IsWindowsTen => Environment.OSVersion.Version is { Major: 10, Build: <= 19045 };
+        public static bool IsWindowsTen => RtlGetVersion() is { dwMajorVersion: 10, dwBuildNumber: <= 19045 };
 
         /// <summary>Gets a value indicating whether the client version is Windows 11.</summary>
         /// <value><c>true</c> if the client version is Windows 11; otherwise, <c>false</c>.</value>
-        public static bool IsAtLeastWindowsEleven => Environment.OSVersion.Version is { Major: >= 10, Build: > 19045 };
+        public static bool IsAtLeastWindowsEleven => RtlGetVersion() is { dwMajorVersion: >= 10, dwBuildNumber: > 19045 };
 
         /// <summary>Gets a value indicating whether the client is a 64 bit operating system.</summary>
         /// <value><c>true</c> if the client is a 64 bit operating system; otherwise, <c>false</c>.</value>
         public static bool Is64BitOperatingSystem => Environment.Is64BitOperatingSystem;
+
+        /// <summary>
+        /// Use is internal to this class only.
+        /// </summary>
+        /// <returns>PI.OSVERSIONINFOEX structure</returns>
+        private static PI.OSVERSIONINFOEX RtlGetVersion()
+        {
+            PI.OSVERSIONINFOEX osvi = new()
+            {
+                dwOSVersionInfoSize = (uint)Marshal.SizeOf(typeof(PI.OSVERSIONINFOEX))
+            };
+
+            PI.RtlGetVersion(ref osvi);
+
+            return osvi;
+        }
 
         #endregion
     }


### PR DESCRIPTION
[Issue 2235-OSUtilities-does-not-detect-win10-11-on-dotnet-lower-than-5.0](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2235)
- Adds Pinvoke for Windows API RtlGetVersion()
- And the changelog

![compile-results](https://github.com/user-attachments/assets/b288f4e2-62dd-40cb-9116-00d3fb63d925)
