### PR TITLE
2235-V85-OSUtilities-does-not-detect-win10-11-on-dotnet-lower-than-5.0

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -108,6 +108,7 @@
 =======
 
 ## 2023-11-17 - Build 2311 (Patch 1) - November 2023
+* Resolved [#2235](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2235), `OSUtilities` corrects Windows 10 & 11 detection.
 * Resolved issue where an assertion is made when using `KryptonThemeComboBox` or `KryptonRibbonGroupThemeComboBox`
 * Resolved issue where `Sparkle` themes would crash when using certain `ButtonSpecs`
 * Resolved [#1174](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1174), Unable to adjust height of `KryptonForm` when `KryptonRibbon` is added

--- a/Source/Krypton Components/Krypton.Toolkit/General/PlatformInvoke.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/PlatformInvoke.cs
@@ -3599,6 +3599,11 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
 
         #endregion
 
+        #region nt.dll
+        [DllImport(Libraries.NtDll, SetLastError = true)]
+        internal static extern int RtlGetVersion(ref PI.OSVERSIONINFOEX lpVersionInformation);
+        #endregion
+
         #region dwmapi
 
         public class Dwm
@@ -4559,6 +4564,28 @@ BS_ICON or BS_BITMAP set? 	BM_SETIMAGE called? 	Result
             public RECT rcMaximizeButton;
             public RECT rcHelpButton;
             public RECT rcCloseButton;
+        }
+
+        /// <summary>
+        /// Contains operating system version information. The information includes major and minor version numbers, a build number, a platform identifier, 
+        /// and information about product suites and the latest Service Pack installed on the system. 
+        /// This structure is used with the RtlGetVersion, GetVersionEx and VerifyVersionInfo functions.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+        internal struct OSVERSIONINFOEX
+        {
+            public uint dwOSVersionInfoSize;
+            public uint dwMajorVersion;
+            public uint dwMinorVersion;
+            public uint dwBuildNumber;
+            public uint dwPlatformId;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+            public string szCSDVersion;
+            public ushort wServicePackMajor;
+            public ushort wServicePackMinor;
+            public ushort wSuiteMask;
+            public byte wProductType;
+            public byte wReserved;
         }
         #endregion
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Utilities/OSUtilities.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Utilities/OSUtilities.cs
@@ -43,16 +43,31 @@ namespace Krypton.Toolkit
 
         /// <summary>Gets a value indicating whether the client version is Windows 10.</summary>
         /// <value><c>true</c> if the client version is Windows 10; otherwise, <c>false</c>.</value>
-        public static bool IsWindowsTen => Environment.OSVersion.Version is { Major: >= 10, Build: <= 19045 };
+        public static bool IsWindowsTen => RtlGetVersion() is { dwMajorVersion: 10, dwBuildNumber: <= 19045 };
 
         /// <summary>Gets a value indicating whether the client version is Windows 11.</summary>
         /// <value><c>true</c> if the client version is Windows 11; otherwise, <c>false</c>.</value>
-        public static bool IsWindowsEleven => Environment.OSVersion.Version is { Major: >= 10, Build: <= 22621 };
+        public static bool IsWindowsEleven => RtlGetVersion() is { dwMajorVersion: >= 10, dwBuildNumber: > 19045 };
 
         /// <summary>Gets a value indicating whether the client is a 64 bit operating system.</summary>
         /// <value><c>true</c> if the client is a 64 bit operating system; otherwise, <c>false</c>.</value>
         public static bool Is64BitOperatingSystem => Environment.Is64BitOperatingSystem;
 
+        /// <summary>
+        /// Use is internal to this class only.
+        /// </summary>
+        /// <returns>PI.OSVERSIONINFOEX structure</returns>
+        private static PI.OSVERSIONINFOEX RtlGetVersion()
+        {
+            PI.OSVERSIONINFOEX osvi = new()
+            {
+                dwOSVersionInfoSize = (uint)Marshal.SizeOf(typeof(PI.OSVERSIONINFOEX))
+            };
+
+            PI.RtlGetVersion(ref osvi);
+
+            return osvi;
+        }
         #endregion
     }
 }


### PR DESCRIPTION
[Issue 2235-OSUtilities-does-not-detect-win10-11-on-dotnet-lower-than-5.0](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2235)
- Adds Pinvoke for Windows API RtlGetVersion()
- And the changelog

![compile-results](https://github.com/user-attachments/assets/8b83a56f-cf4f-4ebc-8442-36fc97eaf737)
