### PR TITLE
1190-V100-Add-Windows-11-snap-layouts

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 ==== 
 
 ## 2025-11-xx - Build 2511 (V10 - alpha) - November 2025
+* Implemented [#1190](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1190), Enables Windows 11 snap layouts.
 * Resolved [#2235](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2235), `OSUtilities` corrects Windows 10 & 11 detection.
 * Resolved [#2095](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2095), `KryptonRibbon` `StateNormal` & `StateCommon` do not write changes to `RibbonFileAppTab` to the designer source.
 * Implemented [#1009](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1009), Powered by Krypton Toolkit button

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -1263,6 +1263,12 @@ namespace Krypton.Toolkit
                 ViewBase? viewBase = ViewManager?.Root.ViewFromPoint(pt);
                 IMouseController? controller = viewBase?.FindMouseController();
 
+                // Display snap layouts on Windows 11
+                if (OSUtilities.IsAtLeastWindowsEleven && _buttonManager.GetButtonRectangle(ButtonSpecMax).Contains(pt))
+                {
+                    return new IntPtr(PI.HT.MAXBUTTON);
+                }
+
                 // Ensure the button shows as 'normal' state when mouse not over and pressed
                 if (controller is ButtonController buttonController)
                 {


### PR DESCRIPTION
[Issue 1190-Add-Windows-11-snap-layouts](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1190)
- Adds snap layouts for Windows 11
- And the changelog

![compile-results](https://github.com/user-attachments/assets/b1a6fcf6-251f-4c2d-bdbc-375dc525b614)
