### PR TITLE
1190-V95-Add-Windows-11-snap-layouts

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2025-0#-## - Build 250# (Patch #) - #### 2025
+* Implemented [#1190](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1190), Enables Windows 11 snap layouts.
 * Resolved [#2235](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2235), `OSUtilities` corrects Windows 10 & 11 detection.
 * Resolved [#2101](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2101), `KryptonContextMenu` items editor doesn't have a cancel button.
 * Resolved [#2213](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2213), `KryptonToolStrip` & `KryptonStatusBar` controls text unreadable on Microsoft 365 White theme.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -1063,6 +1063,12 @@ namespace Krypton.Toolkit
                 ViewBase? viewBase = ViewManager?.Root.ViewFromPoint(pt);
                 IMouseController? controller = viewBase?.FindMouseController();
 
+                // Display snap layouts on Windows 11
+                if (OSUtilities.IsAtLeastWindowsEleven && _buttonManager.GetButtonRectangle(ButtonSpecMax).Contains(pt))
+                {
+                    return new IntPtr(PI.HT.MAXBUTTON);
+                }
+
                 // Ensure the button shows as 'normal' state when mouse not over and pressed
                 if (controller is ButtonController buttonController)
                 {


### PR DESCRIPTION
[Issue 1190-Add-Windows-11-snap-layouts](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1190)
- Adds snap layouts for Windows 11
- And the changelog

![compile-results](https://github.com/user-attachments/assets/a3bb9c1e-3847-41b9-b8eb-7a9b95b32851)
