### PR TITLE
1190-V85-Add-Windows-11-snap-layouts

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,8 @@
 =======
 
 ## 2025-04-21 - Build 2504 (Patch 6) - April 2025
+* Implemented [#1190](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1190), Enables Windows 11 snap layouts.
+* Resolved [#2235](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2235), `OSUtilities` corrects Windows 10 & 11 detection.
 * Resolved [#2101](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2101), `KryptonContextMenu` items editor doesn't have a cancel button.
 * Resolved [#2209](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2209), `KryptonDropButton` does process shortcutkey
 * Implemented [#2164](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2164), `KryptonDataGridView.ColumnCount` when set, now converts basic columns to `KryptonDataGridViewTextBoxColumns` when Autogeneration is enabled.
@@ -108,7 +110,6 @@
 =======
 
 ## 2023-11-17 - Build 2311 (Patch 1) - November 2023
-* Resolved [#2235](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2235), `OSUtilities` corrects Windows 10 & 11 detection.
 * Resolved issue where an assertion is made when using `KryptonThemeComboBox` or `KryptonRibbonGroupThemeComboBox`
 * Resolved issue where `Sparkle` themes would crash when using certain `ButtonSpecs`
 * Resolved [#1174](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1174), Unable to adjust height of `KryptonForm` when `KryptonRibbon` is added

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -1070,6 +1070,12 @@ namespace Krypton.Toolkit
                     // Get the mouse controller for this button
                     ViewBase? viewBase = ViewManager?.Root?.ViewFromPoint(pt);
                     IMouseController? controller = viewBase?.FindMouseController();
+                    
+                    // Display snap layouts on Windows 11
+                    if (OSUtilities.IsWindowsEleven && _buttonManager.GetButtonRectangle(ButtonSpecMax).Contains(pt))
+                    {
+                        return new IntPtr(PI.HT.MAXBUTTON);
+                    }
 
                     // Ensure the button shows as 'normal' state when mouse not over and pressed
                     if (controller is ButtonController buttonController)


### PR DESCRIPTION
[Issue 1190-Add-Windows-11-snap-layouts](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1190)
- Adds snap layouts for Windows 11
- And the changelog

![compile-results](https://github.com/user-attachments/assets/e3e6130b-396a-4d64-96ba-2336a20be535)
