### PR TITLE
2235-V100-OSUtilities-does-not-detect-win10-11-on-dotnet-lower-than-5.0

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Utilities/OSUtilities.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Utilities/OSUtilities.cs
@@ -15,6 +15,13 @@ namespace Krypton.Toolkit
     /// <summary>Gets access to specific information about the client operating system.</summary>
     public class OSUtilities
     {
+        #region Private static vars
+        // cache the result of RtlGetVersion
+        private static bool? _isWindowsTen = null;
+        // cache the result of RtlGetVersion
+        private static bool? _isAtLeastWindowsEleven = null;
+        #endregion
+
         #region Implementation
 
         // Note: Update these, once a new public upgrade becomes GA
@@ -33,11 +40,11 @@ namespace Krypton.Toolkit
 
         /// <summary>Gets a value indicating whether the client version is Windows 10.</summary>
         /// <value><c>true</c> if the client version is Windows 10; otherwise, <c>false</c>.</value>
-        public static bool IsWindowsTen => RtlGetVersion() is { dwMajorVersion: 10, dwBuildNumber: <= 19045 };
+        public static bool IsWindowsTen => _isWindowsTen ??= RtlGetVersion() is { dwMajorVersion: 10, dwBuildNumber: <= 19045 };
 
         /// <summary>Gets a value indicating whether the client version is Windows 11.</summary>
         /// <value><c>true</c> if the client version is Windows 11; otherwise, <c>false</c>.</value>
-        public static bool IsAtLeastWindowsEleven => RtlGetVersion() is { dwMajorVersion: >= 10, dwBuildNumber: > 19045 };
+        public static bool IsAtLeastWindowsEleven => _isAtLeastWindowsEleven ??= RtlGetVersion() is { dwMajorVersion: >= 10, dwBuildNumber: > 19045 };
 
         /// <summary>Gets a value indicating whether the client is a 64 bit operating system.</summary>
         /// <value><c>true</c> if the client is a 64 bit operating system; otherwise, <c>false</c>.</value>

--- a/Source/Krypton Components/TestForm/Main.cs
+++ b/Source/Krypton Components/TestForm/Main.cs
@@ -388,7 +388,7 @@ namespace TestForm
             }
             catch (Exception ex)
             {
-                KryptonExceptionDialog.Show(ex);
+                //KryptonExceptionDialog.Show(ex);
             }
         }
 


### PR DESCRIPTION
[Issue 2235-OSUtilities-does-not-detect-win10-11-on-dotnet-lower-than-5.0](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2235)
- Update PR 2236
- Cache the result of RtlGetVersion()