### PR TITLE
2260-V85-BreadCrumb-designer-has-no-cancel-button

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2025-06-23 - Build 2506 (Patch 7) - June 2025
+* Resolved [#2260](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2260), `KryptonBreadCrumb` Items designer lacks the cancel button.
 * Resolved [#2049](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2049), BlurValues do not work as expected
 * Implemented [#1190](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1190), Enables Windows 11 snap layouts.
 * Resolved [#2235](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2235), `OSUtilities` corrects Windows 10 & 11 detection.

--- a/Source/Krypton Components/Krypton.Toolkit/Designers/Editors/KryptonBreadCrumbItemsEditor.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Designers/Editors/KryptonBreadCrumbItemsEditor.cs
@@ -231,12 +231,13 @@ namespace Krypton.Toolkit
             private readonly KryptonBreadCrumbItemsEditor _editor;
             private DictItemBase _beforeItems;
             private readonly Button buttonOK;
+            private readonly Button buttonCancel;
             private readonly TreeView treeView1;
             private readonly Button buttonMoveUp;
             private readonly Button buttonMoveDown;
             private readonly Button buttonAddItem;
             private readonly Button buttonDelete;
-            private readonly /*PropertyGrid*/ KryptonPropertyGrid propertyGrid1;
+            private readonly PropertyGrid propertyGrid1;
             private readonly Label label1;
             private readonly Label label2;
             private readonly Button buttonAddChild;
@@ -252,12 +253,13 @@ namespace Krypton.Toolkit
                 _editor = editor;
 
                 buttonOK = new Button();
+                buttonCancel = new Button();
                 treeView1 = new TreeView();
                 buttonMoveUp = new Button();
                 buttonMoveDown = new Button();
                 buttonAddItem = new Button();
                 buttonDelete = new Button();
-                propertyGrid1 = new /*PropertyGrid()*/ KryptonPropertyGrid();
+                propertyGrid1 = new PropertyGrid();
                 label1 = new Label();
                 label2 = new Label();
                 buttonAddChild = new Button();
@@ -270,16 +272,26 @@ namespace Krypton.Toolkit
                 buttonOK.Location = new Point(547, 382);
                 buttonOK.Name = nameof(buttonOK);
                 buttonOK.Size = new Size(75, 23);
-                buttonOK.TabIndex = 8;
+                buttonOK.TabIndex = 9;
                 buttonOK.Text = "OK";
                 buttonOK.UseVisualStyleBackColor = true;
                 buttonOK.Click += buttonOK_Click;
                 // 
+                // buttonCancel
+                // 
+                buttonCancel.Anchor = AnchorStyles.Bottom | AnchorStyles.Left;
+                buttonCancel.DialogResult = DialogResult.Cancel;
+                buttonCancel.Location = new Point(12, 382);
+                buttonCancel.Name = nameof(buttonCancel);
+                buttonCancel.Size = new Size(75, 23);
+                buttonCancel.TabIndex = 8;
+                buttonCancel.Text = "Cancel";
+                buttonCancel.UseVisualStyleBackColor = true;
+                buttonCancel.Click += buttonCancel_Click;
+                // 
                 // treeView1
                 // 
-                treeView1.Anchor = AnchorStyles.Top | AnchorStyles.Bottom
-                                    | AnchorStyles.Left
-                                   | AnchorStyles.Right;
+                treeView1.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
                 treeView1.Location = new Point(12, 32);
                 treeView1.Name = nameof(treeView1);
                 treeView1.Size = new Size(254, 339);
@@ -340,7 +352,7 @@ namespace Krypton.Toolkit
                 buttonDelete.Location = new Point(272, 190);
                 buttonDelete.Name = nameof(buttonDelete);
                 buttonDelete.Size = new Size(95, 28);
-                buttonDelete.TabIndex = 5;
+                buttonDelete.TabIndex = 6;
                 buttonDelete.Text = "Delete Item";
                 buttonDelete.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
                 buttonDelete.TextImageRelation = TextImageRelation.ImageBeforeText;
@@ -349,8 +361,7 @@ namespace Krypton.Toolkit
                 // 
                 // propertyGrid1
                 // 
-                propertyGrid1.Anchor = AnchorStyles.Top | AnchorStyles.Bottom
-                                       | AnchorStyles.Right;
+                propertyGrid1.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Right;
                 propertyGrid1.HelpVisible = false;
                 propertyGrid1.Location = new Point(373, 32);
                 propertyGrid1.Name = nameof(propertyGrid1);
@@ -365,7 +376,7 @@ namespace Krypton.Toolkit
                 label1.Location = new Point(370, 13);
                 label1.Name = nameof(label1);
                 label1.Size = new Size(81, 13);
-                label1.TabIndex = 6;
+                label1.TabStop = false;
                 label1.Text = "Item Properties";
                 // 
                 // label2
@@ -374,7 +385,7 @@ namespace Krypton.Toolkit
                 label2.Location = new Point(12, 13);
                 label2.Name = nameof(label2);
                 label2.Size = new Size(142, 13);
-                label2.TabIndex = 0;
+                label2.TabStop = false;
                 label2.Text = "BreadCrumbItems Collection";
                 // 
                 // buttonAddChild
@@ -385,7 +396,7 @@ namespace Krypton.Toolkit
                 buttonAddChild.Location = new Point(272, 146);
                 buttonAddChild.Name = nameof(buttonAddChild);
                 buttonAddChild.Size = new Size(95, 28);
-                buttonAddChild.TabIndex = 9;
+                buttonAddChild.TabIndex = 5;
                 buttonAddChild.Text = "Add Child";
                 buttonAddChild.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
                 buttonAddChild.TextImageRelation = TextImageRelation.ImageBeforeText;
@@ -395,6 +406,7 @@ namespace Krypton.Toolkit
                 // KryptonBreadCrumbCollectionForm
                 // 
                 AcceptButton = buttonOK;
+                CancelButton = buttonCancel;
                 AutoScaleDimensions = new SizeF(6F, 13F);
                 AutoScaleMode = AutoScaleMode.Font;
                 ClientSize = new Size(634, 414);
@@ -408,9 +420,10 @@ namespace Krypton.Toolkit
                 Controls.Add(buttonMoveDown);
                 Controls.Add(buttonMoveUp);
                 Controls.Add(treeView1);
+                Controls.Add(buttonCancel);
                 Controls.Add(buttonOK);
                 Font = new Font(@"Tahoma", 8.25F, FontStyle.Regular, GraphicsUnit.Point, 0);
-                MinimumSize = new Size(501, 296);
+                MinimumSize = new Size(634, 414);
                 Name = "KryptonBreadCrumbCollectionForm";
                 StartPosition = FormStartPosition.CenterScreen;
                 Text = "BreadCrumbItem Collection Editor";
@@ -457,6 +470,12 @@ namespace Krypton.Toolkit
             #endregion
 
             #region Implementation
+            private void buttonCancel_Click(object? sender, EventArgs e)
+            {
+                treeView1.Nodes.Clear();
+                this.Close();
+            }
+
             private void buttonOK_Click(object sender, EventArgs e)
             {
                 // Create an array with all the root items


### PR DESCRIPTION
[Issue 2260-BreadCrumb-designer-has-no-cancel-button](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2260)
- Add the cancel button
- And the changelog

![compile-results](https://github.com/user-attachments/assets/409ca5e8-92ca-4563-8f51-2c13c264940b)
