### PR TITLE
2200-V100-Krypton-Docking-KryptonAutoHiddenSlidePanel-PreFilterMessag…

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 ==== 
 
 ## 2025-11-xx - Build 2511 (V10 - alpha) - November 2025
+* Resolved [#2200](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2200), `KryptonAutoHiddenSlidePanel.PreFilterMessage` will now use the ActiveFormTracker.
 * Implemented [#2251](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2251), Implements the `ActiveFormTracker` static class and integrates the tracker into the `KryptonForm`.
 * Resolved [#2260](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2260), `KryptonBreadCrumb` Items designer lacks the cancel button.
 * Implemented [#1263](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1263), Is it possible to create custom pre-processor directives

--- a/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonAutoHiddenSlidePanel.cs
+++ b/Source/Krypton Components/Krypton.Docking/Control Docking/KryptonAutoHiddenSlidePanel.cs
@@ -505,95 +505,99 @@ public class KryptonAutoHiddenSlidePanel : KryptonPanel,
     /// <returns>true to filter out; false otherwise.</returns>
     public bool PreFilterMessage(ref Message msg)
     {
-        Form? parentForm = FindForm();
-        Form? parentMdi = (parentForm?.MdiParent);
-
-        // Only interested in snooping messages if....
-        //    The Form we are inside is the active form                             AND
-        //    If an MDI Child Form then we must be the active MDI Child Form        AND
-        //    We are not in the hidden state                                        AND
-        //    We have an associated auto hidden group control that is not disposed  AND
-        //    We are not disposed
-        if ((parentForm != null)
-            && ((parentForm == Form.ActiveForm)
-                || ((parentMdi != null)
-                    && (parentMdi.ActiveMdiChild == parentForm)
-                )
-            )
-            && parentForm.ContainsFocus
-            && (_state != DockingAutoHiddenShowState.Hidden)
-            && _group is { IsDisposed: false } && !IsDisposed
-           )
+        // The form this component is situated on
+        // This can also be a mdi child form
+        if (FindForm() is Form parentForm)
         {
-            switch (msg.Msg)
+            bool isActiveForm =
+                // The parent form is active and is not a mdi container
+                (ActiveFormTracker.IsActiveForm(parentForm) && !parentForm.IsMdiContainer)
+                // parentFrom has a mdi parent that is set and active, parentForm is the active mdi child
+                || (ActiveFormTracker.IsActiveForm(parentForm.MdiParent) && ActiveFormTracker.IsActiveMdiChild(parentForm));
+
+            // Only interested in snooping messages if....
+            //    The Form we are inside is the active form                             AND
+            //    If an MDI Child Form then we must be the active MDI Child Form        AND
+            //    We are not in the hidden state                                        AND
+            //    We have an associated auto hidden group control that is not disposed  AND
+            //    We are not disposed
+            if (isActiveForm
+                && parentForm.ContainsFocus
+                && _state != DockingAutoHiddenShowState.Hidden
+                && _group is { IsDisposed: false }
+                && !IsDisposed)
+
             {
-                case PI.WM_.KEYDOWN:
-                    // Pressing escape removes the auto hidden window
-                    if ((int)msg.WParam == PI.VK_ESCAPE)
-                    {
-                        MakeHidden();
-                        return true;
-                    }
-                    break;
-
-                case PI.WM_.MOUSELEAVE:
-                    // If the mouse is leaving a control then we start the dismiss timer so that a mouse move is required
-                    // to cancel the mouse move and prevent the actual dismissal occurring. The exception to this is if the
-                    // slide out dockspace has the focus, in which case we do nothing.
-                    if (!_dismissRunning && !DockspaceControl.ContainsFocus)
-                    {
-                        _dismissTimer.Stop();
-                        _dismissTimer.Start();
-                        _dismissRunning = true;
-                    }
-                    break;
-
-                case PI.WM_.MOUSEMOVE:
-                    // Convert the mouse position into a screen location
-                    Point screenPt = CommonHelper.ClientMouseMessageToScreenPt(msg);
-
-                    // Is the mouse over ourselves or over the associated auto hidden group
-                    if (RectangleToScreen(ClientRectangle).Contains(screenPt)
-                        || _group.RectangleToScreen(_group.ClientRectangle).Contains(screenPt)
-                       )
-                    {
-                        // We do not dismiss while the mouse is over ourselves
-                        if (_dismissRunning)
+                switch (msg.Msg)
+                {
+                    case PI.WM_.KEYDOWN:
+                        // Pressing escape removes the auto hidden window
+                        if ((int)msg.WParam == PI.VK_ESCAPE)
                         {
-                            _dismissTimer.Stop();
-                            _dismissRunning = false;
+                            MakeHidden();
+                            return true;
                         }
-                    }
-                    else
-                    {
-                        // When mouse not over a relevant area we need to start the dismiss process 
-                        // unless the slide out dockspace has the focus, in which case we do nothing.
+                        break;
+
+                    case PI.WM_.MOUSELEAVE:
+                        // If the mouse is leaving a control then we start the dismiss timer so that a mouse move is required
+                        // to cancel the mouse move and prevent the actual dismissal occurring. The exception to this is if the
+                        // slide out dockspace has the focus, in which case we do nothing.
                         if (!_dismissRunning && !DockspaceControl.ContainsFocus)
                         {
                             _dismissTimer.Stop();
                             _dismissTimer.Start();
                             _dismissRunning = true;
                         }
-                    }
+                        break;
 
-                    // If first message for this window then need to track to get the mouse leave
-                    if (_mouseTrackWindow != msg.HWnd)
-                    {
-                        _mouseTrackWindow = msg.HWnd;
+                    case PI.WM_.MOUSEMOVE:
+                        // Convert the mouse position into a screen location
+                        Point screenPt = CommonHelper.ClientMouseMessageToScreenPt(msg);
 
-                        // This structure needs to know its own size in bytes
-                        var tme = new PI.TRACKMOUSEEVENTS
+                        // Is the mouse over ourselves or over the associated auto hidden group
+                        if (RectangleToScreen(ClientRectangle).Contains(screenPt)
+                            || _group.RectangleToScreen(_group.ClientRectangle).Contains(screenPt)
+                           )
                         {
-                            cbSize = (uint)Marshal.SizeOf(typeof(PI.TRACKMOUSEEVENTS)),
-                            dwHoverTime = 100,
-                            dwFlags = PI.TME_LEAVE,
-                            hWnd = Handle
-                        };
+                            // We do not dismiss while the mouse is over ourselves
+                            if (_dismissRunning)
+                            {
+                                _dismissTimer.Stop();
+                                _dismissRunning = false;
+                            }
+                        }
+                        else
+                        {
+                            // When mouse not over a relevant area we need to start the dismiss process 
+                            // unless the slide out dockspace has the focus, in which case we do nothing.
+                            if (!_dismissRunning && !DockspaceControl.ContainsFocus)
+                            {
+                                _dismissTimer.Stop();
+                                _dismissTimer.Start();
+                                _dismissRunning = true;
+                            }
+                        }
 
-                        // Call Win32 API to start tracking
-                        PI.TrackMouseEvent(ref tme);
-                    }
-                    break;
+                        // If first message for this window then need to track to get the mouse leave
+                        if (_mouseTrackWindow != msg.HWnd)
+                        {
+                            _mouseTrackWindow = msg.HWnd;
+
+                            // This structure needs to know its own size in bytes
+                            var tme = new PI.TRACKMOUSEEVENTS
+                            {
+                                cbSize = (uint)Marshal.SizeOf(typeof(PI.TRACKMOUSEEVENTS)),
+                                dwHoverTime = 100,
+                                dwFlags = PI.TME_LEAVE,
+                                hWnd = Handle
+                            };
+
+                            // Call Win32 API to start tracking
+                            PI.TrackMouseEvent(ref tme);
+                        }
+                        break;
+                }
             }
         }
 


### PR DESCRIPTION
[Issue 2200-Krypton-Docking-KryptonAutoHiddenSlidePanel-PreFilterMessage-Excessive-Polling](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2200)
- Updates method PreFilterMessage to use the ActiveFormTracker
- And the changelog

![compile-results](https://github.com/user-attachments/assets/332d07a1-7958-4346-a040-242ab8b22bbe)

