### PR TITLE
2235-V85-OSUtilities-does-not-detect-win10-11-on-dotnet-lower-than-5.0

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2025-08-25 - Build 2508 (Patch 8) - August 2025
+* Resolved [#2235](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2235), `OSUtilities` Adds OsVersionInfo to the properties.
 * Resolved [#2264](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2264), Implementation of style: `PaletteBackStyle.Control`, `PaletteContentStyle.LabelAlternateControl` and `PaletteContentStyle.LabelAlternatePanel` in all themes.
 
 =======

--- a/Source/Krypton Components/Krypton.Toolkit/Utilities/OSUtilities.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Utilities/OSUtilities.cs
@@ -5,18 +5,24 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
 
-namespace Krypton.Toolkit
+namespace Krypton.Toolkit;
+
+/// <summary>Gets access to specific information about the client operating system.</summary>
+public class OSUtilities
 {
-    /// <summary>Gets access to specific information about the client operating system.</summary>
-    public class OSUtilities
+    #region Classes
+    /// <summary>
+    /// Version data obtained via the RtlGetVersion API call.
+    /// </summary>
+    public class OsVersionInfoData
     {
-        #region Static Identity
-        static OSUtilities()
+        // Call refresh before first use / after instantiation.
+        public void Refresh()
         {
             PI.OSVERSIONINFOEX osvi = new()
             {
@@ -24,42 +30,86 @@ namespace Krypton.Toolkit
             };
             PI.RtlGetVersion(ref osvi);
 
-            // evaluate and initialize once at startup
-            IsWindowsSeven = Environment.OSVersion.Version is { Major: 6, Minor: 1 };
-            IsWindowsEight = Environment.OSVersion.Version is { Major: 6, Minor: 2 };
-            IsWindowsEightPointOne = Environment.OSVersion.Version is { Major: 6, Minor: 3 };
-            IsWindowsTen = osvi is { dwMajorVersion: 10, dwBuildNumber: <= 19045 };
-            IsWindowsEleven = osvi is { dwMajorVersion: >= 10, dwBuildNumber: > 19045 };
-            Is64BitOperatingSystem = Environment.Is64BitOperatingSystem;
+            MajorVersion = ((int)osvi.dwMajorVersion);
+            MinorVersion = ((int)osvi.dwMinorVersion);
+            BuildNumber = ((int)osvi.dwBuildNumber);
+            PlatformId = ((int)osvi.dwPlatformId);
+            CSDVersion = osvi.szCSDVersion;
+            ServicePackMajor = ((short)osvi.wServicePackMajor);
+            ServicePackMinor = ((short)osvi.wServicePackMinor);
+            SuiteMask = ((short)osvi.wSuiteMask);
+            ProductType = osvi.wProductType;
         }
-        #endregion
 
-        #region Implementation
-        // Note: Update these, once a new public upgrade becomes GA
-
-        /// <summary>Gets a value indicating whether the client version is Windows 7.</summary>
-        /// <value><c>true</c> if the client version is Windows 7; otherwise, <c>false</c>.</value>
-        public static bool IsWindowsSeven { get; }
-
-        /// <summary>Gets a value indicating whether the client version is Windows 8.</summary>
-        /// <value><c>true</c> if the client version is Windows 8; otherwise, <c>false</c>.</value>
-        public static bool IsWindowsEight { get; }
-
-        /// <summary>Gets a value indicating whether the client version is Windows 8.1.</summary>
-        /// <value><c>true</c> if the client version is Windows 8.1; otherwise, <c>false</c>.</value>
-        public static bool IsWindowsEightPointOne { get; }
-
-        /// <summary>Gets a value indicating whether the client version is Windows 10.</summary>
-        /// <value><c>true</c> if the client version is Windows 10; otherwise, <c>false</c>.</value>
-        public static bool IsWindowsTen { get; }
-
-        /// <summary>Gets a value indicating whether the client version is Windows 11.</summary>
-        /// <value><c>true</c> if the client version is Windows 11; otherwise, <c>false</c>.</value>
-        public static bool IsWindowsEleven { get; }
-
-        /// <summary>Gets a value indicating whether the client is a 64 bit operating system.</summary>
-        /// <value><c>true</c> if the client is a 64 bit operating system; otherwise, <c>false</c>.</value>
-        public static bool Is64BitOperatingSystem { get; }
-        #endregion
+        public int MajorVersion { get; private set; }
+        public int MinorVersion { get; private set; }
+        public int BuildNumber { get; private set; }
+        public int PlatformId { get; private set; }
+        public string CSDVersion { get; private set; }
+        public short ServicePackMajor { get; private set; }
+        public short ServicePackMinor { get; private set; }
+        public short SuiteMask { get; private set; }
+        public byte ProductType { get; private set; }
     }
+    #endregion
+
+    #region Static Identity
+    static OSUtilities()
+    {
+        Refresh();
+    }
+    #endregion
+
+    #region Implementation
+    // Note: Update these, once a new public upgrade becomes GA
+
+    /// <summary>Gets a value indicating whether the client version is Windows 7.</summary>
+    /// <value><c>true</c> if the client version is Windows 7; otherwise, <c>false</c>.</value>
+    public static bool IsWindowsSeven { get; private set; }
+
+    /// <summary>Gets a value indicating whether the client version is Windows 8.</summary>
+    /// <value><c>true</c> if the client version is Windows 8; otherwise, <c>false</c>.</value>
+    public static bool IsWindowsEight { get; private set; }
+
+    /// <summary>Gets a value indicating whether the client version is Windows 8.1.</summary>
+    /// <value><c>true</c> if the client version is Windows 8.1; otherwise, <c>false</c>.</value>
+    public static bool IsWindowsEightPointOne { get; private set; }
+
+    /// <summary>Gets a value indicating whether the client version is Windows 10.</summary>
+    /// <value><c>true</c> if the client version is Windows 10; otherwise, <c>false</c>.</value>
+    public static bool IsWindowsTen { get; private set; }
+
+    /// <summary>Gets a value indicating whether the client version is Windows 11.</summary>
+    /// <value><c>true</c> if the client version is Windows 11; otherwise, <c>false</c>.</value>
+    public static bool IsWindowsEleven { get; private set; }
+
+    /// <summary>Gets a value indicating whether the client version is Windows 11.</summary>
+    /// <value><c>true</c> if the client version is Windows 11; otherwise, <c>false</c>.</value>
+    public static bool IsAtLeastWindowsEleven { get; private set; }
+
+    /// <summary>Gets a value indicating whether the client is a 64 bit operating system.</summary>
+    /// <value><c>true</c> if the client is a 64 bit operating system; otherwise, <c>false</c>.</value>
+    public static bool Is64BitOperatingSystem { get; private set; }
+
+    /// <summary>OSVersionInfo data obtained from the Windows Api call RtlGetVersion.</summary>
+    public static OsVersionInfoData OsVersionInfo { get; private set; }
+
+    /// <summary> Rereads the version info. </summary>
+    public static void Refresh()
+    {
+        // First update OsVersionEx data
+        OsVersionInfo ??= new OsVersionInfoData();
+        OsVersionInfo.Refresh();
+
+        // Set the properties
+        IsWindowsSeven = Environment.OSVersion.Version is { Major: 6, Minor: 1 };
+        IsWindowsEight = Environment.OSVersion.Version is { Major: 6, Minor: 2 };
+        IsWindowsEightPointOne = Environment.OSVersion.Version is { Major: 6, Minor: 3 };
+        IsWindowsTen = OsVersionInfo is { MajorVersion: 10, BuildNumber: <= 19045 }; // needs an update when the next release comes out.
+        IsWindowsEleven = OsVersionInfo is { MajorVersion: 10, BuildNumber: > 19045 }; // needs an update when the next release comes out.
+        IsAtLeastWindowsEleven = OsVersionInfo is { MajorVersion: >= 10, BuildNumber: > 19045 };
+        Is64BitOperatingSystem = Environment.Is64BitOperatingSystem;
+    }
+
+    #endregion
 }


### PR DESCRIPTION
[Issue 2235-OSUtilities-does-not-detect-win10-11-on-dotnet-lower-than-5.0](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2235)
- Adds OsVersionInfo to the properties.
- And the change log

![compile-results](https://github.com/user-attachments/assets/7bf1a5ce-9724-4ab7-98be-86ce8f4665e2)
