### PR TITLE
2277 v85 added colors to the  scheme office colors

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2025-08-25 - Build 2508 (Patch 8) - August 2025
+* Resolved [#2277](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2277), Added colors in the `Color[] _schemeOfficeColors`.
 * Resolved [#2235](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2235), `OSUtilities` Adds OsVersionInfo to the properties.
 * Resolved [#2264](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2264), Implementation of style: `PaletteBackStyle.Control`, `PaletteContentStyle.LabelAlternateControl` and `PaletteContentStyle.LabelAlternatePanel` in all themes.
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365DarkGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365DarkGray.cs
@@ -332,7 +332,6 @@ namespace Krypton.Toolkit
             Color.FromArgb(240, 241, 242), // RibbonGalleryBackTracking
             Color.FromArgb(195, 200, 209), // RibbonGalleryBack1
             Color.FromArgb(217, 220, 224), // RibbonGalleryBack2
-            Color.Empty, // RibbonTabTracking1
             Color.Empty, // RibbonTabTracking3
             Color.Empty, // RibbonTabTracking4
             Color.Empty, // RibbonGroupBorder3

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365DarkGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365DarkGray.cs
@@ -332,10 +332,13 @@ namespace Krypton.Toolkit
             Color.FromArgb(240, 241, 242), // RibbonGalleryBackTracking
             Color.FromArgb(195, 200, 209), // RibbonGalleryBack1
             Color.FromArgb(217, 220, 224), // RibbonGalleryBack2
+            Color.Empty, // RibbonTabTracking1
             Color.Empty, // RibbonTabTracking3
             Color.Empty, // RibbonTabTracking4
             Color.Empty, // RibbonGroupBorder3
             Color.Empty, // RibbonGroupBorder4
+            Color.Empty, // RibbonGroupBorder5
+            Color.Empty, // RibbonGroupTitleText
             Color.Empty, // RibbonDropArrowLight
             Color.Empty, // RibbonDropArrowDark
             Color.FromArgb(237, 242, 248), // HeaderDockInactiveBack1

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Non Official Themes/PaletteOffice2010DarkGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Non Official Themes/PaletteOffice2010DarkGray.cs
@@ -272,7 +272,6 @@ namespace Krypton.Toolkit
             Color.FromArgb(240, 241, 242), // RibbonGalleryBackTracking
             Color.FromArgb(195, 200, 209), // RibbonGalleryBack1
             Color.FromArgb(217, 220, 224), // RibbonGalleryBack2
-            Color.Empty, // RibbonTabTracking1
             Color.Empty, // RibbonTabTracking3
             Color.Empty, // RibbonTabTracking4
             Color.Empty, // RibbonGroupBorder3

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Non Official Themes/PaletteOffice2010DarkGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Non Official Themes/PaletteOffice2010DarkGray.cs
@@ -272,10 +272,13 @@ namespace Krypton.Toolkit
             Color.FromArgb(240, 241, 242), // RibbonGalleryBackTracking
             Color.FromArgb(195, 200, 209), // RibbonGalleryBack1
             Color.FromArgb(217, 220, 224), // RibbonGalleryBack2
+            Color.Empty, // RibbonTabTracking1
             Color.Empty, // RibbonTabTracking3
             Color.Empty, // RibbonTabTracking4
             Color.Empty, // RibbonGroupBorder3
             Color.Empty, // RibbonGroupBorder4
+            Color.Empty, // RibbonGroupBorder5
+            Color.Empty, // RibbonGroupTitleText
             Color.Empty, // RibbonDropArrowLight
             Color.Empty, // RibbonDropArrowDark
             Color.FromArgb(237, 242, 248), // HeaderDockInactiveBack1

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013DarkGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013DarkGray.cs
@@ -275,7 +275,6 @@ namespace Krypton.Toolkit
             Color.FromArgb(240, 241, 242), // RibbonGalleryBackTracking
             Color.FromArgb(195, 200, 209), // RibbonGalleryBack1
             Color.FromArgb(217, 220, 224), // RibbonGalleryBack2
-            Color.Empty, // RibbonTabTracking1
             Color.Empty, // RibbonTabTracking3
             Color.Empty, // RibbonTabTracking4
             Color.Empty, // RibbonGroupBorder3

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013DarkGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013DarkGray.cs
@@ -275,10 +275,13 @@ namespace Krypton.Toolkit
             Color.FromArgb(240, 241, 242), // RibbonGalleryBackTracking
             Color.FromArgb(195, 200, 209), // RibbonGalleryBack1
             Color.FromArgb(217, 220, 224), // RibbonGalleryBack2
+            Color.Empty, // RibbonTabTracking1
             Color.Empty, // RibbonTabTracking3
             Color.Empty, // RibbonTabTracking4
             Color.Empty, // RibbonGroupBorder3
             Color.Empty, // RibbonGroupBorder4
+            Color.Empty, // RibbonGroupBorder5
+            Color.Empty, // RibbonGroupTitleText
             Color.Empty, // RibbonDropArrowLight
             Color.Empty, // RibbonDropArrowDark
             Color.FromArgb(237, 242, 248), // HeaderDockInactiveBack1

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013LightGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013LightGray.cs
@@ -275,7 +275,6 @@ namespace Krypton.Toolkit
             Color.FromArgb(240, 241, 242), // RibbonGalleryBackTracking
             Color.FromArgb(195, 200, 209), // RibbonGalleryBack1
             Color.FromArgb(217, 220, 224), // RibbonGalleryBack2
-            Color.Empty, // RibbonTabTracking1
             Color.Empty, // RibbonTabTracking3
             Color.Empty, // RibbonTabTracking4
             Color.Empty, // RibbonGroupBorder3

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013LightGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013LightGray.cs
@@ -275,10 +275,13 @@ namespace Krypton.Toolkit
             Color.FromArgb(240, 241, 242), // RibbonGalleryBackTracking
             Color.FromArgb(195, 200, 209), // RibbonGalleryBack1
             Color.FromArgb(217, 220, 224), // RibbonGalleryBack2
+            Color.Empty, // RibbonTabTracking1
             Color.Empty, // RibbonTabTracking3
             Color.Empty, // RibbonTabTracking4
             Color.Empty, // RibbonGroupBorder3
             Color.Empty, // RibbonGroupBorder4
+            Color.Empty, // RibbonGroupBorder5
+            Color.Empty, // RibbonGroupTitleText
             Color.Empty, // RibbonDropArrowLight
             Color.Empty, // RibbonDropArrowDark
             Color.FromArgb(237, 242, 248), // HeaderDockInactiveBack1


### PR DESCRIPTION

Resolve [[Bug]: Error in 'GroupBackStyle = Control - ToolTip' of KGroupBox (System.IndexOutRangeException) #2277](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2277)

Added colors in the `Color[] _schemeOfficeColors` of the themes:
Office 2010 - Dark Gray, 
Office 2013 - Dark Gray, 
Office 2013 - Light Gray and 
Microsoft 365 - Dark Gray.

![image](https://github.com/user-attachments/assets/05b6ee4e-e3e4-4f10-b1c9-2a8ce2e103ab)
