### PR TITLE
2235-V100-OSUtilities-does-not-detect-win10-11-on-dotnet-lower-than-5.0

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Utilities/OSUtilities.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Utilities/OSUtilities.cs
@@ -15,47 +15,10 @@ namespace Krypton.Toolkit;
 /// <summary>Gets access to specific information about the client operating system.</summary>
 public class OSUtilities
 {
-    #region Classes
-    /// <summary>
-    /// Version data obtained via the RtlGetVersion API call.
-    /// </summary>
-    public class OsVersionInfoData
-    {
-        // Call refresh before first use / after instantiation.
-        public void Refresh()
-        {
-            PI.OSVERSIONINFOEX osvi = new()
-            {
-                dwOSVersionInfoSize = (uint)Marshal.SizeOf<PI.OSVERSIONINFOEX>()
-            };
-            PI.RtlGetVersion(ref osvi);
-
-            MajorVersion = ((int)osvi.dwMajorVersion);
-            MinorVersion = ((int)osvi.dwMinorVersion);
-            BuildNumber = ((int)osvi.dwBuildNumber);
-            PlatformId = ((int)osvi.dwPlatformId);
-            CSDVersion = osvi.szCSDVersion;
-            ServicePackMajor = ((short)osvi.wServicePackMajor);
-            ServicePackMinor = ((short)osvi.wServicePackMinor);
-            SuiteMask = ((short)osvi.wSuiteMask);
-            ProductType = osvi.wProductType;
-        }
-
-        public int MajorVersion { get; private set; }
-        public int MinorVersion { get; private set; }
-        public int BuildNumber { get; private set; }
-        public int PlatformId { get; private set; }
-        public string CSDVersion { get; private set; }
-        public short ServicePackMajor { get; private set; }
-        public short ServicePackMinor { get; private set; }
-        public short SuiteMask { get; private set; }
-        public byte ProductType { get; private set; }
-    }
-    #endregion
-
     #region Static Identity
     static OSUtilities()
     {
+        OsVersionInfo = new OsVersionInfo();
         Refresh();
     }
     #endregion
@@ -92,24 +55,59 @@ public class OSUtilities
     public static bool Is64BitOperatingSystem { get; private set; }
 
     /// <summary>OSVersionInfo data obtained from the Windows Api call RtlGetVersion.</summary>
-    public static OsVersionInfoData OsVersionInfo { get; private set; }
+    public static OsVersionInfo OsVersionInfo { get; private set; }
 
     /// <summary> Rereads the version info. </summary>
     public static void Refresh()
     {
         // First update OsVersionEx data
-        OsVersionInfo ??= new OsVersionInfoData();
         OsVersionInfo.Refresh();
 
         // Set the properties
         IsWindowsSeven = Environment.OSVersion.Version is { Major: 6, Minor: 1 };
         IsWindowsEight = Environment.OSVersion.Version is { Major: 6, Minor: 2 };
         IsWindowsEightPointOne = Environment.OSVersion.Version is { Major: 6, Minor: 3 };
-        IsWindowsTen = OsVersionInfo is { MajorVersion: 10, BuildNumber: <= 19045 }; // needs an update when the next release comes out.
+        IsWindowsTen = OsVersionInfo is { MajorVersion: 10, BuildNumber: <= 19045 }; 
         IsWindowsEleven = OsVersionInfo is { MajorVersion: 10, BuildNumber: > 19045 }; // needs an update when the next release comes out.
-        IsAtLeastWindowsEleven = OsVersionInfo is { MajorVersion: >= 10, BuildNumber: > 19045 };
+        IsAtLeastWindowsEleven = OsVersionInfo is { MajorVersion: >= 10, BuildNumber: > 19045 }; // needs an update when the next release comes out.
         Is64BitOperatingSystem = Environment.Is64BitOperatingSystem;
     }
-
     #endregion
+}
+
+/// <summary>
+/// Version data obtained via the RtlGetVersion API call.<br/>
+/// Used by static class OSUtilities
+/// </summary>
+public class OsVersionInfo
+{
+    // Call refresh before first use / after instantiation.
+    public void Refresh()
+    {
+        PI.OSVERSIONINFOEX osvi = new()
+        {
+            dwOSVersionInfoSize = (uint)Marshal.SizeOf<PI.OSVERSIONINFOEX>()
+        };
+        PI.RtlGetVersion(ref osvi);
+
+        MajorVersion = ((int)osvi.dwMajorVersion);
+        MinorVersion = ((int)osvi.dwMinorVersion);
+        BuildNumber = ((int)osvi.dwBuildNumber);
+        PlatformId = ((int)osvi.dwPlatformId);
+        CSDVersion = osvi.szCSDVersion;
+        ServicePackMajor = ((short)osvi.wServicePackMajor);
+        ServicePackMinor = ((short)osvi.wServicePackMinor);
+        SuiteMask = ((short)osvi.wSuiteMask);
+        ProductType = osvi.wProductType;
+    }
+
+    public int MajorVersion { get; private set; }
+    public int MinorVersion { get; private set; }
+    public int BuildNumber { get; private set; }
+    public int PlatformId { get; private set; }
+    public string CSDVersion { get; private set; }
+    public short ServicePackMajor { get; private set; }
+    public short ServicePackMinor { get; private set; }
+    public short SuiteMask { get; private set; }
+    public byte ProductType { get; private set; }
 }

--- a/Source/Krypton Components/TestForm/PanelForm.Designer.cs
+++ b/Source/Krypton Components/TestForm/PanelForm.Designer.cs
@@ -54,6 +54,7 @@
             this.kryptonButton1.TabIndex = 0;
             this.kryptonButton1.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton1.Values.Text = "kryptonButton1";
+            this.kryptonButton1.Click += new System.EventHandler(this.kryptonButton1_Click);
             // 
             // dataGridView1
             // 
@@ -70,7 +71,7 @@
             this.Column9,
             this.Column10,
             this.Column11});
-            this.dataGridView1.Location = new System.Drawing.Point(512, 150);
+            this.dataGridView1.Location = new System.Drawing.Point(106, 162);
             this.dataGridView1.Name = "dataGridView1";
             this.dataGridView1.Size = new System.Drawing.Size(240, 150);
             this.dataGridView1.TabIndex = 2;
@@ -144,7 +145,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1262, 636);
+            this.ClientSize = new System.Drawing.Size(1266, 624);
             this.Controls.Add(this.dataGridView1);
             this.Controls.Add(this.kryptonButton1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;

--- a/Source/Krypton Components/TestForm/PanelForm.cs
+++ b/Source/Krypton Components/TestForm/PanelForm.cs
@@ -6,4 +6,15 @@ public partial class PanelForm : KryptonForm
     {
         InitializeComponent();
     }
+
+    private void kryptonButton1_Click(object sender, EventArgs e)
+    {
+        MessageBox.Show(
+
+            $"IsWindowsEleven: {OSUtilities.IsWindowsEleven}" +
+            $"PlatformID: {OSUtilities.OsVersionInfo.PlatformId}"
+            );
+    }
+
+
 }

--- a/Source/Krypton Components/TestForm/StartScreen.Designer.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.Designer.cs
@@ -42,6 +42,7 @@ namespace TestForm
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(StartScreen));
             this.kryptonPanel1 = new Krypton.Toolkit.KryptonPanel();
+            this.kbtnBlurredForm = new Krypton.Toolkit.KryptonButton();
             this.kbtnSplashScreen = new Krypton.Toolkit.KryptonButton();
             this.kbtnControlStyles = new Krypton.Toolkit.KryptonButton();
             this.kbtnDateTime = new Krypton.Toolkit.KryptonButton();
@@ -75,7 +76,6 @@ namespace TestForm
             this.kbtnCommandLinkButtons = new Krypton.Toolkit.KryptonButton();
             this.kbtnBreadCrumb = new Krypton.Toolkit.KryptonButton();
             this.kryptonManager1 = new Krypton.Toolkit.KryptonManager(this.components);
-            this.kbtnBlurredForm = new Krypton.Toolkit.KryptonButton();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).BeginInit();
             this.kryptonPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonThemeComboBox1)).BeginInit();
@@ -119,8 +119,19 @@ namespace TestForm
             this.kryptonPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonPanel1.Location = new System.Drawing.Point(0, 0);
             this.kryptonPanel1.Name = "kryptonPanel1";
-            this.kryptonPanel1.Size = new System.Drawing.Size(366, 500);
+            this.kryptonPanel1.Size = new System.Drawing.Size(358, 476);
             this.kryptonPanel1.TabIndex = 0;
+            // 
+            // kbtnBlurredForm
+            // 
+            this.kbtnBlurredForm.Location = new System.Drawing.Point(13, 439);
+            this.kbtnBlurredForm.Margin = new System.Windows.Forms.Padding(2);
+            this.kbtnBlurredForm.Name = "kbtnBlurredForm";
+            this.kbtnBlurredForm.Size = new System.Drawing.Size(153, 20);
+            this.kbtnBlurredForm.TabIndex = 32;
+            this.kbtnBlurredForm.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnBlurredForm.Values.Text = "Blurred Form";
+            this.kbtnBlurredForm.Click += new System.EventHandler(this.kbtnBlurredForm_Click);
             // 
             // kbtnSplashScreen
             // 
@@ -476,24 +487,13 @@ namespace TestForm
             this.kryptonManager1.ToolkitStrings.MessageBoxStrings.LessDetails = "L&ess Details...";
             this.kryptonManager1.ToolkitStrings.MessageBoxStrings.MoreDetails = "&More Details...";
             // 
-            // kbtnBlurredForm
-            // 
-            this.kbtnBlurredForm.Location = new System.Drawing.Point(13, 439);
-            this.kbtnBlurredForm.Margin = new System.Windows.Forms.Padding(2);
-            this.kbtnBlurredForm.Name = "kbtnBlurredForm";
-            this.kbtnBlurredForm.Size = new System.Drawing.Size(153, 20);
-            this.kbtnBlurredForm.TabIndex = 32;
-            this.kbtnBlurredForm.Values.DropDownArrowColor = System.Drawing.Color.Empty;
-            this.kbtnBlurredForm.Values.Text = "Blurred Form";
-            this.kbtnBlurredForm.Click += new System.EventHandler(this.kbtnBlurredForm_Click);
-            // 
             // StartScreen
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
             this.CancelButton = this.kbtnExit;
-            this.ClientSize = new System.Drawing.Size(366, 500);
+            this.ClientSize = new System.Drawing.Size(358, 476);
             this.Controls.Add(this.kryptonPanel1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MaximizeBox = false;

--- a/Source/Krypton Components/TestForm/StartScreen.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.cs
@@ -180,7 +180,7 @@ public partial class StartScreen : KryptonForm
 
     private void btnColourTestimonials_Click(object sender, EventArgs e)
     {
-        new ColorTestimonials().Show();
+        new PanelForm().Show();
     }
 
     private void kbtnRibbonNavigatorWorkspace_Click(object sender, EventArgs e)


### PR DESCRIPTION
[Issue 2235-OSUtilities-does-not-detect-win10-11-on-dotnet-lower-than-5.0](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2235)
- Updates previous PR 2278
