### PR TITLE
(feat) Added PaletteViewer to TestForm's StartScreen

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Bases/PaletteMicrosoft365Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Bases/PaletteMicrosoft365Base.cs
@@ -27,7 +27,7 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
     private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
     private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
     private static readonly Padding _contentPaddingCalendar = new Padding(2);
-    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
+    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);
     private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
     private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
     private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Non Official Themes/PaletteMicrosoft365Blue.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Non Official Themes/PaletteMicrosoft365Blue.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
  *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *
  */
 #endregion
 
@@ -195,8 +195,8 @@ public class PaletteMicrosoft365Blue : PaletteMicrosoft365Base
         Color.FromArgb(162, 173, 185), // FormBorderHeaderInactive
         Color.FromArgb(193, 212, 236), // FormBorderHeaderActive1
         Color.FromArgb(187, 206, 230), // FormBorderHeaderActive2
-        Color.FromArgb(223, 235, 247), // FormBorderHeaderInctive1
-        Color.FromArgb(223, 235, 247), // FormBorderHeaderInctive2
+        Color.FromArgb(223, 235, 247), // FormBorderHeaderInactive1
+        Color.FromArgb(223, 235, 247), // FormBorderHeaderInactive2
         Color.FromArgb(30, 57, 91), // FormHeaderShortActive
         Color.FromArgb(106, 128, 168), // FormHeaderShortInactive
         Color.FromArgb(30, 57, 91), // FormHeaderLongActive
@@ -267,13 +267,14 @@ public class PaletteMicrosoft365Blue : PaletteMicrosoft365Base
         GlobalStaticValues.EMPTY_COLOR, // RibbonGroupCollapsedBackT2
         GlobalStaticValues.EMPTY_COLOR, // RibbonGroupCollapsedBackT3
         GlobalStaticValues.EMPTY_COLOR, // RibbonGroupCollapsedBackT4
-        Color.FromArgb(189, 203, 218), // RibbonGroupFrameBorder1
-        Color.FromArgb(184, 199, 216), // RibbonGroupFrameBorder2
-        Color.FromArgb(233, 241, 250), // RibbonGroupFrameInside1
-        Color.FromArgb(222, 233, 246), // RibbonGroupFrameInside2
+        Color.FromArgb(189, 203, 218),  // RibbonGroupFrameBorder1
+        Color.FromArgb(184, 199, 216),  // RibbonGroupFrameBorder2
+        Color.FromArgb(233, 241, 250),  // RibbonGroupFrameInside1
+        Color.FromArgb(222, 233, 246),  // RibbonGroupFrameInside2
         GlobalStaticValues.EMPTY_COLOR, // RibbonGroupFrameInside3
         GlobalStaticValues.EMPTY_COLOR, // RibbonGroupFrameInside4
-        Color.FromArgb(30, 57, 91), // RibbonGroupCollapsedText
+        Color.FromArgb(30, 57, 91),     // RibbonGroupCollapsedText
+        Color.FromArgb(30, 57, 91),     // RibbonGroupButtonText
         Color.FromArgb(118, 153, 200), // AlternatePressedBack1
         Color.FromArgb(184, 215, 253), // AlternatePressedBack2
         Color.FromArgb(135, 156, 175), // AlternatePressedBorder1
@@ -287,44 +288,38 @@ public class PaletteMicrosoft365Blue : PaletteMicrosoft365Base
         Color.FromArgb(219, 231, 247), // RibbonQATMini2
         Color.FromArgb(195, 213, 236), // RibbonQATMini3
         Color.FromArgb(128, Color.White), // RibbonQATMini4
-        Color.FromArgb(72, Color.White), // RibbonQATMini5                                                       
+        Color.FromArgb(72, Color.White), // RibbonQATMini5
         Color.FromArgb(153, 176, 206), // RibbonQATMini1I
         Color.FromArgb(226, 233, 241), // RibbonQATMini2I
         Color.FromArgb(198, 210, 226), // RibbonQATMini3I
         Color.FromArgb(128, Color.White), // RibbonQATMini4I
-        Color.FromArgb(72, Color.White), // RibbonQATMini5I                                                      
-        Color.FromArgb(213, 232, 254), // RibbonQATFullbar1                                                      
-        Color.FromArgb(205, 223, 245), // RibbonQATFullbar2                                                      
-        Color.FromArgb(114, 142, 173), // RibbonQATFullbar3                                                      
-        Color.FromArgb(90, 90, 90), // RibbonQATButtonDark                                                      
-        Color.FromArgb(207, 214, 224), // RibbonQATButtonLight                                                      
-        Color.FromArgb(222, 236, 252), // RibbonQATOverflow1                                                      
-        Color.FromArgb(123, 139, 156), // RibbonQATOverflow2                                                      
-        Color.FromArgb(145, 166,
-            194), // RibbonGroupSeparatorDark                                                      
-        Color.FromArgb(239, 245,
-            250), // RibbonGroupSeparatorLight                                                      
-        Color.FromArgb(192, 212,
-            241), // ButtonClusterButtonBack1                                                      
-        Color.FromArgb(200, 219,
-            238), // ButtonClusterButtonBack2                                                      
-        Color.FromArgb(155, 183,
-            224), // ButtonClusterButtonBorder1                                                      
-        Color.FromArgb(117, 150,
-            191), // ButtonClusterButtonBorder2                                                      
-        Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor                                                    
-        Color.FromArgb(244, 249, 255), // GridListNormal1                                                    
-        Color.FromArgb(218, 231, 245), // GridListNormal2                                                    
-        Color.FromArgb(198, 211, 225), // GridListPressed1                                                    
-        Color.FromArgb(244, 249, 255), // GridListPressed2                                                    
-        Color.FromArgb(160, 185, 230), // GridListSelected                                                    
-        Color.FromArgb(233, 246, 255), // GridSheetColNormal1                                                    
-        Color.FromArgb(213, 226, 240), // GridSheetColNormal2                                                    
-        Color.FromArgb(255, 223, 107), // GridSheetColPressed1                                                    
-        Color.FromArgb(255, 252, 230), // GridSheetColPressed2                                                    
+        Color.FromArgb(72, Color.White), // RibbonQATMini5I
+        Color.FromArgb(213, 232, 254), // RibbonQATFullbar1
+        Color.FromArgb(205, 223, 245), // RibbonQATFullbar2
+        Color.FromArgb(114, 142, 173), // RibbonQATFullbar3
+        Color.FromArgb(90,   90,  90), // RibbonQATButtonDark
+        Color.FromArgb(207, 214, 224), // RibbonQATButtonLight
+        Color.FromArgb(222, 236, 252), // RibbonQATOverflow1
+        Color.FromArgb(123, 139, 156), // RibbonQATOverflow2
+        Color.FromArgb(145, 166, 194), // RibbonGroupSeparatorDark
+        Color.FromArgb(239, 245, 250), // RibbonGroupSeparatorLight
+        Color.FromArgb(192, 212, 241), // ButtonClusterButtonBack1
+        Color.FromArgb(200, 219, 238), // ButtonClusterButtonBack2
+        Color.FromArgb(155, 183, 224), // ButtonClusterButtonBorder1
+        Color.FromArgb(117, 150, 191), // ButtonClusterButtonBorder2
+        Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor
+        Color.FromArgb(244, 249, 255), // GridListNormal1
+        Color.FromArgb(218, 231, 245), // GridListNormal2
+        Color.FromArgb(198, 211, 225), // GridListPressed1
+        Color.FromArgb(244, 249, 255), // GridListPressed2
+        Color.FromArgb(160, 185, 230), // GridListSelected
+        Color.FromArgb(233, 246, 255), // GridSheetColNormal1
+        Color.FromArgb(213, 226, 240), // GridSheetColNormal2
+        Color.FromArgb(255, 223, 107), // GridSheetColPressed1
+        Color.FromArgb(255, 252, 230), // GridSheetColPressed2
         Color.FromArgb(255, 211, 89), // GridSheetColSelected1
         Color.FromArgb(255, 239, 113), // GridSheetColSelected2
-        Color.FromArgb(218, 231, 245), // GridSheetRowNormal                                                   
+        Color.FromArgb(218, 231, 245), // GridSheetRowNormal
         Color.FromArgb(255, 223, 107), // GridSheetRowPressed
         Color.FromArgb(245, 210, 87), // GridSheetRowSelected
         Color.FromArgb(218, 220, 221), // GridDataCellBorder
@@ -351,7 +346,7 @@ public class PaletteMicrosoft365Blue : PaletteMicrosoft365Base
         Color.FromArgb(195, 212, 235), // AppButtonOuter3
         GlobalStaticValues.EMPTY_COLOR, // AppButtonInner1
         Color.FromArgb(114, 142, 173), // AppButtonInner2
-        Color.White, // AppButtonMenuDocs
+        Color.White, // AppButtonMenuDocsBack
         Color.Black, // AppButtonMenuDocsText
         Color.FromArgb(239, 245, 255), // SeparatorHighInternalBorder1
         Color.FromArgb(200, 217, 239), // SeparatorHighInternalBorder2
@@ -378,8 +373,7 @@ public class PaletteMicrosoft365Blue : PaletteMicrosoft365Base
         Color.FromArgb(198, 214, 231), // ButtonNavigatorPressed2
         Color.FromArgb(200, 219, 240), // ButtonNavigatorChecked1
         Color.FromArgb(177, 201, 228), // ButtonNavigatorChecked2
-        Color.FromArgb(201, 217,
-            239) // ToolTipBottom                                                                      
+        Color.FromArgb(201, 217, 239)  // ToolTipBottom
     ];
 
     #endregion
@@ -424,7 +418,7 @@ public class PaletteMicrosoft365Blue : PaletteMicrosoft365Base
     }
     #endregion
 
-    #region Images        
+    #region Images
     /// <summary>
     /// Gets an image indicating a sub-menu on a context menu item.
     /// </summary>
@@ -435,7 +429,7 @@ public class PaletteMicrosoft365Blue : PaletteMicrosoft365Base
 
     #endregion
 
-    #region ButtonSpec        
+    #region ButtonSpec
     /// <summary>
     /// Gets the image to display for the button.
     /// </summary>

--- a/Source/Krypton Components/TestForm/App.config
+++ b/Source/Krypton Components/TestForm/App.config
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <!-- Enable High-DPI auto-resizing for Windows Forms -->
+    <add key="EnableWindowsFormsHighDpiAutoResizing" value="true" />
+    <add key="DpiAwareness" value="PerMonitorV2" />
+  </appSettings>
+
+  <runtime>
+    <AppContextSwitchOverrides value="Switch.System.Windows.Forms.DontSupportReentrantFilterMessage=true" />
+  </runtime>
+
+  <System.Windows.Forms.ApplicationConfigurationSection>
+    <add key="DpiAwareness" value="PerMonitorV2" />
+    <add key="EnableWindowsFormsHighDpiAutoResizing" value="true" />
+  </System.Windows.Forms.ApplicationConfigurationSection>
+</configuration>

--- a/Source/Krypton Components/TestForm/Classes/Exporter.cs
+++ b/Source/Krypton Components/TestForm/Classes/Exporter.cs
@@ -1,0 +1,126 @@
+using System.Text;
+using System.Xml;
+using Newtonsoft.Json;
+
+namespace Classes
+{
+    internal static class Exporter
+    {
+        public static string ToCsv(DataGridView grid)
+        {
+            var sb = new StringBuilder();
+            sb.Append("\"Theme\"");
+            for (int r = 0; r < grid.Rows.Count; r++)
+            {
+                sb.Append(',').Append('"').Append(grid.Rows[r].Cells[0].Value?.ToString() ?? r.ToString()).Append('"');
+            }
+            sb.AppendLine();
+
+            for (int c = 3; c < grid.Columns.Count; c++)
+            {
+                var theme = GetPaletteName(grid.Columns[c]);
+                sb.Append('"').Append(theme.Replace("\"", "\"\"")).Append('"');
+                for (int r = 0; r < grid.Rows.Count; r++)
+                {
+                    sb.Append(',');
+                    var val = grid.Rows[r].Cells[c].Value?.ToString() ?? string.Empty;
+                    sb.Append('"').Append(val.Replace("\"", "\"\"")).Append('"');
+                }
+                sb.AppendLine();
+            }
+
+            return sb.ToString();
+        }
+
+        public static string ToJson(DataGridView grid)
+        {
+            var root = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, string>>();
+            for (int c = 3; c < grid.Columns.Count; c++)
+            {
+                var theme = GetPaletteName(grid.Columns[c]);
+                var dict = new System.Collections.Generic.Dictionary<string, string>();
+                for (int r = 0; r < grid.Rows.Count; r++)
+                {
+                    var idx = grid.Rows[r].Cells[0].Value?.ToString() ?? r.ToString();
+                    var val = grid.Rows[r].Cells[c].Value?.ToString() ?? string.Empty;
+                    dict[idx] = val;
+                }
+                root[theme] = dict;
+            }
+            return JsonConvert.SerializeObject(root);
+        }
+
+        public static void ToXml(DataGridView grid, string fileName)
+        {
+            using (var writer = XmlWriter.Create(fileName, new XmlWriterSettings { Indent = true }))
+            {
+                writer.WriteStartDocument();
+                writer.WriteStartElement("PaletteViewerExport");
+
+                for (int c = 3; c < grid.Columns.Count; c++)
+                {
+                    var theme = GetPaletteName(grid.Columns[c]);
+                    var safeTheme = XmlConvert.EncodeName(theme);
+                    writer.WriteStartElement(safeTheme);
+
+                    for (int r = 0; r < grid.Rows.Count; r++)
+                    {
+                        var idx = grid.Rows[r].Cells[0].Value?.ToString() ?? r.ToString();
+                        var val = grid.Rows[r].Cells[c].Value?.ToString() ?? string.Empty;
+
+                        writer.WriteStartElement("Color");
+                        writer.WriteAttributeString("index", idx);
+                        writer.WriteString(val);
+                        writer.WriteEndElement();
+                    }
+
+                    writer.WriteEndElement();
+                }
+
+                writer.WriteEndElement();
+                writer.WriteEndDocument();
+            }
+        }
+
+        private static string GetPaletteName(DataGridViewColumn col)
+        {
+            var full = col.Name ?? string.Empty;
+            int idx = full.LastIndexOf('.');
+            return idx >= 0 ? full.Substring(idx + 1) : full;
+        }
+
+        private static string CleanHeader(DataGridViewColumn col, int columnIndex)
+        {
+            string header = col.HeaderText;
+
+            // For palette columns (index >= 2) we need full theme name, but without any extra lines like "(baseline)" or warnings.
+            if (columnIndex >= 2)
+            {
+                // Split by line breaks inserted by BreakHeader / extra status lines
+                var parts = header.Split('\n');
+                var significant = new System.Collections.Generic.List<string>();
+                foreach (var p in parts)
+                {
+                    var part = p.Trim();
+                    if (string.IsNullOrEmpty(part))
+                        continue;
+
+                    // Skip status annotations
+                    if (part.StartsWith("(") || part.StartsWith("⚠"))
+                        break;
+
+                    significant.Add(part);
+                }
+
+                header = string.Join(" ", significant);
+            }
+            else
+            {
+                // For non-palette columns keep original behaviour (single-line, replace newlines with space)
+                header = header.Replace("\n", " ").Trim();
+            }
+
+            return header;
+        }
+    }
+}

--- a/Source/Krypton Components/TestForm/Classes/PaletteArrayIssues.cs
+++ b/Source/Krypton Components/TestForm/Classes/PaletteArrayIssues.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+
+namespace Classes
+{
+    /// <summary>
+    /// Holds the outcome of comparing a palette's _schemeOfficeColors array against the SchemeOfficeColors enum list.
+    /// </summary>
+    internal sealed class PaletteArrayIssues
+    {
+        public int MissingCount { get; set; }
+        public int UnlabelledCount { get; set; }
+        public int OutOfOrderCount { get; set; }
+        public int ExtraCount { get; set; }
+
+        public List<int> MissingIndices { get; } = new List<int>();
+        public List<int> UnlabelledIndices { get; } = new List<int>();
+        public List<int> OutOfOrderIndices { get; } = new List<int>();
+        public List<int> ExtraIndices { get; } = new List<int>();
+
+        /// <summary>
+        /// True when no discrepancies were found.
+        /// </summary>
+        public bool IsClean => MissingCount == 0 && UnlabelledCount == 0 && OutOfOrderCount == 0 && ExtraCount == 0;
+    }
+}

--- a/Source/Krypton Components/TestForm/Classes/ThemeArrayInspector.cs
+++ b/Source/Krypton Components/TestForm/Classes/ThemeArrayInspector.cs
@@ -1,0 +1,297 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Classes
+{
+    /// <summary>
+    /// Provides static helper methods for analysing palette source files and detecting
+    /// discrepancies between the _schemeOfficeColors array and the SchemeOfficeColors enum order.
+    /// Ported from the ThemeArrayEnumDiff console utility but adapted to return structured data
+    /// instead of writing to the console.
+    /// </summary>
+    internal static class ThemeArrayInspector
+    {
+        private const string EnumFileRelativePath = "Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Enumerations/PaletteEnumerations.cs";
+        private const string EnumName = "SchemeBaseColors";
+        // Some palette classes use alternate array identifiers (e.g. the Visual Studio themes).
+        // Maintain a list of acceptable array variable names to search for, in priority order.
+        private static readonly string[] TargetArrayNames =
+        [
+            "_schemeBaseColors",          // default for Office, Microsoft 365, etc.
+            "_schemeVisualStudioColors"    // used by Visual Studio 2010 *Variation themes
+        ];
+
+        private static IReadOnlyList<string> _cachedEnumNames;
+
+        // Menu special entries that may be ignored for certain outputs (kept for parity with original logic).
+        private static readonly HashSet<string> MenuNames = new HashSet<string>(new[]
+        {
+            "MenuItemText",
+            "MenuMarginGradientStart",
+            "MenuMarginGradientMiddle",
+            "MenuMarginGradientEnd",
+            "DisabledMenuItemText",
+            "MenuStripText"
+        }, StringComparer.Ordinal);
+
+        /// <summary>
+        /// Performs the discrepancy analysis for a palette type's source file.
+        /// </summary>
+        /// <param name="paletteType">Type of the runtime palette (e.g., PaletteOffice2010Blue).</param>
+        /// <param name="sourceRoot">Root folder that contains the Krypton Toolkit source tree.</param>
+        /// <returns>PaletteArrayIssues; returns null if file could not be located or parsed.</returns>
+        public static PaletteArrayIssues GetIssues(Type paletteType, string sourceRoot)
+        {
+            if (paletteType == null || string.IsNullOrWhiteSpace(sourceRoot))
+            {
+                return null;
+            }
+
+            if (!Directory.Exists(sourceRoot))
+            {
+                return null; // invalid path – silently ignore
+            }
+
+            EnsureEnumNamesCached(sourceRoot);
+
+            string fileName = paletteType.Name + ".cs";
+
+            // Search recursively for the palette file – constrained under Palette Builtin
+            string paletteDir = Path.Combine(sourceRoot, "Source");
+            if (!Directory.Exists(paletteDir))
+            {
+                // Fallback: search entire tree under provided root
+                paletteDir = sourceRoot;
+            }
+
+            string paletteBuiltinSegment = Path.Combine("Palette Builtin", string.Empty);
+            var matches = Directory.EnumerateFiles(paletteDir, fileName, SearchOption.AllDirectories)
+                .Where(f => f.IndexOf(paletteBuiltinSegment, StringComparison.OrdinalIgnoreCase) >= 0)
+                .ToList();
+
+            string palettePath = matches.FirstOrDefault();
+            if (palettePath == null)
+            {
+                return null; // file not found
+            }
+
+            List<string> arrayNames = null;
+
+            // Attempt extraction using each known array variable name until one yields results.
+            foreach (var arrayVar in TargetArrayNames)
+            {
+                try
+                {
+                    arrayNames = ExtractArrayComments(palettePath, arrayVar);
+                }
+                catch (IOException)
+                {
+                    return null; // I/O error while reading – abort
+                }
+
+                if (arrayNames != null && arrayNames.Count > 0)
+                {
+                    break; // success
+                }
+            }
+
+            // If still no entries, we cannot analyse this palette.
+            if (arrayNames == null || arrayNames.Count == 0)
+            {
+                return null;
+            }
+
+            var issues = Compare(_cachedEnumNames, arrayNames);
+            return issues;
+        }
+
+        private static void EnsureEnumNamesCached(string sourceRoot)
+        {
+            if (_cachedEnumNames != null) return;
+
+            string enumPath = Path.Combine(sourceRoot, EnumFileRelativePath.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(enumPath))
+            {
+                _cachedEnumNames = Array.Empty<string>();
+                return;
+            }
+
+            _cachedEnumNames = ExtractEnumNames(enumPath, EnumName);
+        }
+
+        private static PaletteArrayIssues Compare(IReadOnlyList<string> enumNames, List<string> arrayNames)
+        {
+            var result = new PaletteArrayIssues();
+
+            if (enumNames == null || enumNames.Count == 0)
+            {
+                return result; // nothing to compare against
+            }
+
+            // Build lookup for array names (first occurrence wins)
+            var arrayLookup = new Dictionary<string, int>(StringComparer.Ordinal);
+            for (int i = 0; i < arrayNames.Count; i++)
+            {
+                var name = arrayNames[i];
+                if (string.IsNullOrEmpty(name)) continue;
+                if (!arrayLookup.ContainsKey(name))
+                {
+                    arrayLookup[name] = i;
+                }
+            }
+
+            int? currentDelta = null;
+
+            for (int i = 0; i < enumNames.Count; i++)
+            {
+                var enumName = enumNames[i];
+                bool isMenu = MenuNames.Contains(enumName);
+
+                if (!arrayLookup.TryGetValue(enumName, out var arrIndex))
+                {
+                    bool unlabeledHere = i < arrayNames.Count && string.IsNullOrEmpty(arrayNames[i]);
+                    if (!isMenu)
+                    {
+                        if (unlabeledHere)
+                        {
+                            result.UnlabelledCount++;
+                            result.UnlabelledIndices.Add(i);
+                        }
+                        else
+                        {
+                            result.MissingCount++;
+                            result.MissingIndices.Add(i);
+                        }
+                    }
+                }
+                else if (arrIndex != i)
+                {
+                    int diff = arrIndex - i;
+                    if (currentDelta != diff && !isMenu)
+                    {
+                        result.OutOfOrderCount++;
+                        result.OutOfOrderIndices.Add(arrIndex);
+                        currentDelta = diff;
+                    }
+                }
+            }
+
+            // Extras – names in array not in enum
+            var extras = arrayLookup.Keys.Except(enumNames, StringComparer.Ordinal).ToList();
+            foreach (var extra in extras)
+            {
+                if (MenuNames.Contains(extra))
+                {
+                    continue;
+                }
+                result.ExtraCount++;
+                result.ExtraIndices.Add(arrayLookup[extra]);
+            }
+
+            return result;
+        }
+
+        #region Parsing helpers (ported)
+
+        private static List<string> ExtractEnumNames(string filePath, string enumName)
+        {
+            var lines = File.ReadAllLines(filePath);
+            var names = new List<string>();
+            bool inEnum = false;
+            foreach (var line in lines)
+            {
+                if (!inEnum)
+                {
+                    if (line.Contains($"enum {enumName}"))
+                        inEnum = true;
+                }
+                else
+                {
+                    if (line.Contains("}")) break;
+                    var match = Regex.Match(line, @"^\s*([A-Za-z0-9_]+)\s*(=\s*\d+)?\s*,?");
+                    if (match.Success)
+                    {
+                        names.Add(match.Groups[1].Value.Trim());
+                    }
+                }
+            }
+            return names;
+        }
+
+        private static List<string> ExtractArrayComments(string filePath, string arrayName)
+        {
+            var lines = File.ReadAllLines(filePath);
+            var names = new List<string>();
+            bool inArray = false;
+            foreach (var line in lines)
+            {
+                if (!inArray)
+                {
+                    if (line.Contains($"{arrayName} ="))
+                        inArray = true;
+                }
+                else
+                {
+                    // Skip lines that are completely commented out (e.g., //Color.FromArgb(...))
+                    var trimmed = line.TrimStart();
+                    if (trimmed.StartsWith("//", StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    if (line.Contains("];") || line.Contains("};")) break;
+
+                    int idx = line.LastIndexOf("//", StringComparison.Ordinal);
+                    if (idx >= 0)
+                    {
+                        var commentPart = line.Substring(idx + 2);
+                        var match = Regex.Match(commentPart, @"^\s*([A-Za-z0-9_]+)");
+                        if (match.Success)
+                        {
+                            names.Add(Normalize(match.Groups[1].Value.Trim()));
+                            continue;
+                        }
+                    }
+
+                    if (line.Contains(")") || line.Contains("EMPTY_COLOR"))
+                    {
+                        names.Add(string.Empty);
+                    }
+                }
+            }
+            return names;
+        }
+
+        private static string Normalize(string token)
+        {
+            if (string.IsNullOrWhiteSpace(token)) return token;
+
+            var aliases = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                {"ButtonNormalBorder1", "ButtonNormalBorder"},
+                {"ButtonNormalBorder2", "ButtonNormalDefaultBorder"},
+                {"ContextMenuHeading", "ContextMenuHeadingBack"},
+                {"AppButtonMenuDocs", "AppButtonMenuDocsBack"}
+            };
+
+            if (aliases.TryGetValue(token, out var mapped))
+            {
+                token = mapped;
+            }
+
+            token = token.Replace("Inctive", "Inactive");
+
+            if (token.Equals("Color", StringComparison.OrdinalIgnoreCase) ||
+                token.Equals("FromArgb", StringComparison.OrdinalIgnoreCase))
+            {
+                return string.Empty;
+            }
+
+            return token;
+        }
+
+        #endregion
+    }
+}

--- a/Source/Krypton Components/TestForm/Classes/WindowStateStore.cs
+++ b/Source/Krypton Components/TestForm/Classes/WindowStateStore.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+using Newtonsoft.Json;
+
+namespace TestForm
+{
+    public class WindowStateInfo
+    {
+        public int Left { get; set; }
+        public int Top { get; set; }
+        public int Width { get; set; }
+        public int Height { get; set; }
+        public System.Windows.Forms.FormWindowState State { get; set; }
+        public int SelectedTab { get; set; }
+        public int ContentSplitterDistance { get; set; }
+        public string LastWtsFolder { get; set; }
+        public string LastTheme { get; set; }
+        public string SourcePath { get; set; }
+    }
+
+    public class WindowStateStore
+    {
+        private readonly string _filePath;
+
+        public WindowStateStore()
+        {
+            var dir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "TestForm");
+            Directory.CreateDirectory(dir);
+            _filePath = Path.Combine(dir, "windowstate.json");
+        }
+
+        public WindowStateInfo Load()
+        {
+            if (!File.Exists(_filePath)) return null;
+            var json = File.ReadAllText(_filePath);
+            return JsonConvert.DeserializeObject<WindowStateInfo>(json);
+        }
+
+        public void Save(WindowStateInfo info)
+        {
+            var json = JsonConvert.SerializeObject(info, Formatting.Indented);
+            File.WriteAllText(_filePath, json);
+        }
+    }
+}

--- a/Source/Krypton Components/TestForm/PaletteViewer/PaletteViewerForm.Designer.cs
+++ b/Source/Krypton Components/TestForm/PaletteViewer/PaletteViewerForm.Designer.cs
@@ -1,0 +1,254 @@
+using System.Windows.Forms;
+
+namespace TestForm
+{
+    partial class PaletteViewerForm
+    {
+        private Krypton.Toolkit.KryptonDataGridView dataGridViewPalette;
+        private Krypton.Toolkit.KryptonButton buttonAddPalette;
+        private Krypton.Toolkit.KryptonButton buttonRemovePalette;
+        private Krypton.Toolkit.KryptonComboBox comboTheme;
+        private Krypton.Toolkit.KryptonPanel panelTop;
+        private System.Windows.Forms.StatusStrip statusStrip;
+        private System.Windows.Forms.ToolStripStatusLabel statusLabel;
+        private Krypton.Toolkit.KryptonButton buttonAddAll;
+        private Krypton.Toolkit.KryptonButton buttonCancel;
+        private Krypton.Toolkit.KryptonButton buttonClear;
+        private Krypton.Toolkit.KryptonComboBox comboSaveFormat;
+        private Krypton.Toolkit.KryptonButton buttonSave;
+        private Krypton.Toolkit.KryptonLabel labelSourceTitle;
+        private Krypton.Toolkit.KryptonTextBox textSourcePath;
+        private Krypton.Toolkit.KryptonButton buttonBrowseSource;
+
+        private void InitializeComponent()
+        {
+            this.dataGridViewPalette = new Krypton.Toolkit.KryptonDataGridView();
+            this.buttonAddPalette = new Krypton.Toolkit.KryptonButton();
+            this.buttonRemovePalette = new Krypton.Toolkit.KryptonButton();
+            this.comboTheme = new Krypton.Toolkit.KryptonComboBox();
+            this.panelTop = new Krypton.Toolkit.KryptonPanel();
+            this.buttonAddAll = new Krypton.Toolkit.KryptonButton();
+            this.buttonClear = new Krypton.Toolkit.KryptonButton();
+            this.comboSaveFormat = new Krypton.Toolkit.KryptonComboBox();
+            this.buttonSave = new Krypton.Toolkit.KryptonButton();
+            this.buttonCancel = new Krypton.Toolkit.KryptonButton();
+            this.statusStrip = new System.Windows.Forms.StatusStrip();
+            this.statusLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.labelSourceTitle = new Krypton.Toolkit.KryptonLabel();
+            this.textSourcePath = new Krypton.Toolkit.KryptonTextBox();
+            this.buttonBrowseSource = new Krypton.Toolkit.KryptonButton();
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewPalette)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.comboTheme)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.panelTop)).BeginInit();
+            this.panelTop.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.comboSaveFormat)).BeginInit();
+            this.statusStrip.SuspendLayout();
+            this.SuspendLayout();
+            //
+            // dataGridViewPalette
+            //
+            this.dataGridViewPalette.AllowUserToAddRows = false;
+            this.dataGridViewPalette.AllowUserToDeleteRows = false;
+            this.dataGridViewPalette.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.dataGridViewPalette.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.dataGridViewPalette.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.dataGridViewPalette.EditMode = System.Windows.Forms.DataGridViewEditMode.EditOnEnter;
+            this.dataGridViewPalette.Location = new System.Drawing.Point(0, 40);
+            this.dataGridViewPalette.MultiSelect = false;
+            this.dataGridViewPalette.Name = "dataGridViewPalette";
+            this.dataGridViewPalette.RowTemplate.Height = 30;
+            this.dataGridViewPalette.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.CellSelect;
+            this.dataGridViewPalette.Size = new System.Drawing.Size(1157, 564);
+            this.dataGridViewPalette.TabIndex = 0;
+            this.dataGridViewPalette.CellPainting += new System.Windows.Forms.DataGridViewCellPaintingEventHandler(this.DataGridViewPalette_CellPainting);
+            this.dataGridViewPalette.ColumnAdded += new System.Windows.Forms.DataGridViewColumnEventHandler(this.DataGridViewPalette_ColumnAdded);
+            this.dataGridViewPalette.ColumnHeaderMouseClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.DataGridViewPalette_ColumnHeaderMouseClick);
+            this.dataGridViewPalette.CurrentCellChanged += new System.EventHandler(this.DataGridViewPalette_CurrentCellChanged);
+            this.dataGridViewPalette.EditingControlShowing += new System.Windows.Forms.DataGridViewEditingControlShowingEventHandler(this.DataGridViewPalette_EditingControlShowing);
+            this.dataGridViewPalette.Scroll += new System.Windows.Forms.ScrollEventHandler(this.DataGridViewPalette_Scroll);
+            this.dataGridViewPalette.SelectionChanged += new System.EventHandler(this.DataGridViewPalette_SelectionChanged);
+            this.dataGridViewPalette.Paint += new System.Windows.Forms.PaintEventHandler(this.DataGridViewPalette_Paint);
+            //
+            // buttonAddPalette
+            //
+            this.buttonAddPalette.AutoSize = true;
+            this.buttonAddPalette.Location = new System.Drawing.Point(383, 8);
+            this.buttonAddPalette.Name = "buttonAddPalette";
+            this.buttonAddPalette.Size = new System.Drawing.Size(90, 26);
+            this.buttonAddPalette.TabIndex = 1;
+            this.buttonAddPalette.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.buttonAddPalette.Values.Text = "Add Palette";
+            this.buttonAddPalette.Click += new System.EventHandler(this.BtnAddPalette_Click);
+            //
+            // buttonRemovePalette
+            //
+            this.buttonRemovePalette.AutoSize = true;
+            this.buttonRemovePalette.Location = new System.Drawing.Point(479, 8);
+            this.buttonRemovePalette.Name = "buttonRemovePalette";
+            this.buttonRemovePalette.Size = new System.Drawing.Size(116, 26);
+            this.buttonRemovePalette.TabIndex = 2;
+            this.buttonRemovePalette.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.buttonRemovePalette.Values.Text = "Remove Palette";
+            this.buttonRemovePalette.Click += new System.EventHandler(this.BtnRemovePalette_Click);
+            //
+            // comboTheme
+            //
+            this.comboTheme.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.comboTheme.DropDownWidth = 400;
+            this.comboTheme.Location = new System.Drawing.Point(6, 8);
+            this.comboTheme.Name = "comboTheme";
+            this.comboTheme.Size = new System.Drawing.Size(369, 22);
+            this.comboTheme.TabIndex = 0;
+            this.comboTheme.SelectedIndexChanged += new System.EventHandler(this.ComboTheme_SelectedIndexChanged);
+            //
+            // panelTop
+            //
+            this.panelTop.Controls.Add(this.comboTheme);
+            this.panelTop.Controls.Add(this.labelSourceTitle);
+            this.panelTop.Controls.Add(this.textSourcePath);
+            this.panelTop.Controls.Add(this.buttonBrowseSource);
+            this.panelTop.Controls.Add(this.buttonAddPalette);
+            this.panelTop.Controls.Add(this.buttonRemovePalette);
+            this.panelTop.Controls.Add(this.buttonAddAll);
+            this.panelTop.Controls.Add(this.buttonClear);
+            this.panelTop.Controls.Add(this.comboSaveFormat);
+            this.panelTop.Controls.Add(this.buttonSave);
+            this.panelTop.Controls.Add(this.buttonCancel);
+            this.panelTop.Dock = System.Windows.Forms.DockStyle.Top;
+            this.panelTop.Location = new System.Drawing.Point(0, 0);
+            this.panelTop.Name = "panelTop";
+            this.panelTop.Padding = new System.Windows.Forms.Padding(8);
+            this.panelTop.Size = new System.Drawing.Size(1157, 70);
+            this.panelTop.TabIndex = 1;
+            //
+            // buttonAddAll
+            //
+            this.buttonAddAll.AutoSize = true;
+            this.buttonAddAll.Location = new System.Drawing.Point(615, 8);
+            this.buttonAddAll.Name = "buttonAddAll";
+            this.buttonAddAll.Size = new System.Drawing.Size(66, 26);
+            this.buttonAddAll.TabIndex = 3;
+            this.buttonAddAll.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.buttonAddAll.Values.Text = "Add ALL";
+            this.buttonAddAll.Click += new System.EventHandler(this.BtnAddAll_Click);
+            //
+            // buttonClear
+            //
+            this.buttonClear.AutoSize = true;
+            this.buttonClear.Location = new System.Drawing.Point(700, 8);
+            this.buttonClear.Margin = new System.Windows.Forms.Padding(16, 2, 2, 2);
+            this.buttonClear.Name = "buttonClear";
+            this.buttonClear.Size = new System.Drawing.Size(58, 26);
+            this.buttonClear.TabIndex = 4;
+            this.buttonClear.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.buttonClear.Values.Text = "Clear";
+            this.buttonClear.Click += new System.EventHandler(this.BtnClear_Click);
+            //
+            // comboSaveFormat
+            //
+            this.comboSaveFormat.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.comboSaveFormat.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.comboSaveFormat.DropDownWidth = 100;
+            this.comboSaveFormat.Items.AddRange(new object[] {
+            "CSV",
+            "JSON",
+            "XML"});
+            this.comboSaveFormat.Location = new System.Drawing.Point(935, 8);
+            this.comboSaveFormat.Margin = new System.Windows.Forms.Padding(16, 2, 2, 2);
+            this.comboSaveFormat.Name = "comboSaveFormat";
+            this.comboSaveFormat.Size = new System.Drawing.Size(63, 22);
+            this.comboSaveFormat.TabIndex = 5;
+            this.comboSaveFormat.Text = "CSV";
+            //
+            // buttonSave
+            //
+            this.buttonSave.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonSave.AutoSize = true;
+            this.buttonSave.Enabled = false;
+            this.buttonSave.Location = new System.Drawing.Point(1003, 8);
+            this.buttonSave.Name = "buttonSave";
+            this.buttonSave.Size = new System.Drawing.Size(60, 26);
+            this.buttonSave.TabIndex = 6;
+            this.buttonSave.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.buttonSave.Values.Text = "Save";
+            this.buttonSave.Click += new System.EventHandler(this.ButtonSave_Click);
+            //
+            // buttonCancel
+            //
+            this.buttonCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonCancel.AutoSize = true;
+            this.buttonCancel.Location = new System.Drawing.Point(1082, 8);
+            this.buttonCancel.Name = "buttonCancel";
+            this.buttonCancel.Size = new System.Drawing.Size(63, 26);
+            this.buttonCancel.TabIndex = 7;
+            this.buttonCancel.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.buttonCancel.Values.Text = "Cancel";
+            this.buttonCancel.Visible = false;
+            this.buttonCancel.Click += new System.EventHandler(this.BtnCancel_Click);
+            //
+            // statusStrip
+            //
+            this.statusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.statusLabel});
+            this.statusStrip.Location = new System.Drawing.Point(0, 604);
+            this.statusStrip.Name = "statusStrip";
+            this.statusStrip.Size = new System.Drawing.Size(1157, 22);
+            this.statusStrip.TabIndex = 2;
+            //
+            // statusLabel
+            //
+            this.statusLabel.Name = "statusLabel";
+            this.statusLabel.Size = new System.Drawing.Size(39, 17);
+            this.statusLabel.Text = "Ready";
+            //
+            // labelSourceTitle
+            //
+            this.labelSourceTitle.AutoSize = true;
+            this.labelSourceTitle.Location = new System.Drawing.Point(7, 36);
+            this.labelSourceTitle.Name = "labelSourceTitle";
+            this.labelSourceTitle.Size = new System.Drawing.Size(90, 18);
+            this.labelSourceTitle.TabIndex = 8;
+            this.labelSourceTitle.Values.Text = "Source path:";
+            //
+            // textSourcePath
+            //
+            this.textSourcePath.Location = new System.Drawing.Point(110, 36);
+            this.textSourcePath.Name = "textSourcePath";
+            this.textSourcePath.Size = new System.Drawing.Size(400, 24);
+            this.textSourcePath.TabIndex = 9;
+            this.textSourcePath.ReadOnly = true;
+            //
+            // buttonBrowseSource
+            //
+            this.buttonBrowseSource.AutoSize = true;
+            this.buttonBrowseSource.Location = new System.Drawing.Point(520, 36);
+            this.buttonBrowseSource.Name = "buttonBrowseSource";
+            this.buttonBrowseSource.Size = new System.Drawing.Size(116, 26);
+            this.buttonBrowseSource.TabIndex = 10;
+            this.buttonBrowseSource.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.buttonBrowseSource.Values.Text = "Browse Source";
+            this.buttonBrowseSource.Click += new System.EventHandler(this.BtnBrowseSource_Click);
+            //
+            // MainForm
+            //
+            this.ClientSize = new System.Drawing.Size(1157, 626);
+            this.Controls.Add(this.dataGridViewPalette);
+            this.Controls.Add(this.panelTop);
+            this.Controls.Add(this.statusStrip);
+            this.Name = "MainForm";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "PaletteViewer";
+            ((System.ComponentModel.ISupportInitialize)(this.dataGridViewPalette)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.comboTheme)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.panelTop)).EndInit();
+            this.panelTop.ResumeLayout(false);
+            this.panelTop.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.comboSaveFormat)).EndInit();
+            this.statusStrip.ResumeLayout(false);
+            this.statusStrip.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+    }
+}

--- a/Source/Krypton Components/TestForm/PaletteViewer/PaletteViewerForm.cs
+++ b/Source/Krypton Components/TestForm/PaletteViewer/PaletteViewerForm.cs
@@ -1,0 +1,1445 @@
+using System;
+using System.Windows.Forms;
+using Krypton.Toolkit;
+using System.Collections.Generic;
+using System.IO;
+using System.Xml;
+
+namespace TestForm
+{
+    public partial class PaletteViewerForm : KryptonForm
+    {
+        private readonly System.Collections.Generic.List<Krypton.Toolkit.PaletteBase> _palettes = new System.Collections.Generic.List<Krypton.Toolkit.PaletteBase>();
+        private System.Collections.Generic.List<System.Reflection.MethodInfo> _apiCalls;
+        private System.Collections.Generic.Dictionary<System.Reflection.MemberInfo, string> _methodEnumMapping;
+        private Krypton.Toolkit.SchemeBaseColors[] _enumValues;
+        private System.Drawing.Color[] _baselineColors;
+        private string _baselinePaletteName;
+        private string _sourcePath;
+        private System.Threading.CancellationTokenSource _addAllCts;
+        private int _highlightRowIndex = -1;
+        private bool _bulkUpdating;
+        private const int MinColumnWidth = 120;
+        private readonly WindowStateStore _winStore;
+        private readonly WindowStateInfo _winInfo;
+        private static readonly IReadOnlyDictionary<string, Krypton.Toolkit.PaletteMode> DisplayToEnum = Krypton.Toolkit.PaletteModeStrings.SupportedThemesMap;
+        private static readonly System.Collections.Generic.Dictionary<Krypton.Toolkit.PaletteMode, string> EnumToDisplay = new System.Collections.Generic.Dictionary<Krypton.Toolkit.PaletteMode, string>(System.Linq.Enumerable.ToDictionary(DisplayToEnum, kv => kv.Value, kv => kv.Key));
+        private static bool IsSparkleDisplay(string display) => display.StartsWith("Sparkle", System.StringComparison.OrdinalIgnoreCase);
+        private static bool IsSparkleMode(Krypton.Toolkit.PaletteMode mode) => mode.ToString().StartsWith("Sparkle", System.StringComparison.OrdinalIgnoreCase);
+        private static bool IsSparkleType(System.Type t) => t.Name.StartsWith("PaletteSparkle", System.StringComparison.OrdinalIgnoreCase);
+
+        private static readonly Krypton.Toolkit.PaletteMode[] LegacyProfessionalModes = new[]
+        {
+            Krypton.Toolkit.PaletteMode.ProfessionalSystem,
+            Krypton.Toolkit.PaletteMode.ProfessionalOffice2003
+        };
+
+        private static bool IsLegacyProfessionalMode(Krypton.Toolkit.PaletteMode mode) => System.Array.IndexOf(LegacyProfessionalModes, mode) >= 0;
+        private static bool IsLegacyProfessionalDisplay(string display) => DisplayToEnum.TryGetValue(display, out var m) && IsLegacyProfessionalMode(m);
+        private static bool IsLegacyProfessionalType(System.Type t) => t.Name.StartsWith("PaletteProfessional", System.StringComparison.OrdinalIgnoreCase);
+
+        private static bool IsProblematicBaseMethod(System.Reflection.MethodInfo m)
+        {
+            if (m.DeclaringType == null)
+            {
+                return false;
+            }
+
+            string typeName = m.DeclaringType.Name;
+
+            // Exclude any GetRibbonBackColor* method declared on a *Base palette class,
+            // as many of these throw or show dialogs for unsupported styles.
+            if (typeName.EndsWith("Base", System.StringComparison.Ordinal) &&
+                m.Name.StartsWith("GetRibbonBackColor", System.StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            // Add other known problematic patterns here if discovered
+
+            return false;
+        }
+
+        private readonly System.Collections.Generic.HashSet<System.Type> _processedBases = new System.Collections.Generic.HashSet<System.Type>();
+        private Krypton.Toolkit.KryptonManager kryptonManager1;
+
+        public PaletteViewerForm()
+        {
+            InitializeComponent();
+
+            // load persisted window state
+            _winStore = new WindowStateStore();
+            _winInfo = _winStore.Load();
+
+            PopulateThemeCombo(_winInfo?.LastTheme);
+
+            _sourcePath = _winInfo?.SourcePath;
+            if (this.textSourcePath != null)
+            {
+                this.textSourcePath.Text = _sourcePath ?? string.Empty;
+            }
+
+            var workArea = System.Windows.Forms.Screen.PrimaryScreen.WorkingArea;
+
+            if (_winInfo != null)
+            {
+                StartPosition = FormStartPosition.Manual;
+                Left = _winInfo.Left;
+                Top = _winInfo.Top;
+
+                var screen = System.Windows.Forms.Screen.FromPoint(new System.Drawing.Point(_winInfo.Left, _winInfo.Top));
+                var wa = screen.WorkingArea;
+                Width = System.Math.Min(_winInfo.Width, wa.Width);
+                Height = System.Math.Min(_winInfo.Height, wa.Height);
+
+                var st = _winInfo.State == FormWindowState.Minimized ? FormWindowState.Normal : _winInfo.State;
+                WindowState = st;
+            }
+            else
+            {
+                this.Size = new System.Drawing.Size(workArea.Width / 2, workArea.Height / 2);
+                this.Location = new System.Drawing.Point((workArea.Width - this.Width) / 2, (workArea.Height - this.Height) / 2);
+            }
+
+            this.FormClosing += MainForm_FormClosing;
+
+            UpdateStatus("Ready");
+
+            UpdateUIState();
+
+            // Arrange toolbar controls dynamically to prevent overlap
+            //this.panelTop.Layout += PanelTop_Layout;
+        }
+
+        public void AttachKryptonManager(Krypton.Toolkit.KryptonManager manager)
+        {
+            kryptonManager1 = manager;
+        }
+
+        private void LoadApiCalls()
+        {
+            if (_apiCalls != null)
+            {
+                return;
+            }
+
+            var baseType = typeof(Krypton.Toolkit.PaletteMicrosoft365Base);
+            var methods = baseType.GetMethods(System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public);
+
+            var list = new System.Collections.Generic.List<System.Reflection.MethodInfo>();
+
+            foreach (var m in methods)
+            {
+                if (m.IsSpecialName || IsProblematicBaseMethod(m))
+                {
+                    continue;
+                }
+
+                if (m.ReturnType != typeof(System.Drawing.Color))
+                {
+                    continue;
+                }
+
+                // Skip methods with ref/out parameters or open generics
+                bool skip = false;
+                foreach (var p in m.GetParameters())
+                {
+                    if (p.IsOut || p.ParameterType.IsByRef)
+                    {
+                        skip = true;
+                        break;
+                    }
+                }
+
+                if (skip)
+                {
+                    continue;
+                }
+
+                list.Add(m);
+            }
+
+            _apiCalls = list;
+
+            // prepare enum values array
+            _enumValues = (Krypton.Toolkit.SchemeBaseColors[])System.Enum.GetValues(typeof(Krypton.Toolkit.SchemeBaseColors));
+
+            BuildBaseRows();
+        }
+
+        private void BuildBaseRows()
+        {
+            this.dataGridViewPalette.Columns.Clear();
+            this.dataGridViewPalette.Rows.Clear();
+
+            // Column 0: Enum Index
+            var colIndex = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colIndex.HeaderText = "#";
+            colIndex.Name = "colIndex";
+            colIndex.ReadOnly = true;
+            colIndex.Frozen = true;
+            colIndex.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            colIndex.MinimumWidth = 50;
+            colIndex.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
+            this.dataGridViewPalette.Columns.Add(colIndex);
+
+            // Column 1: Enum Name
+            var colEnum = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colEnum.HeaderText = "SchemeBaseColors";
+            colEnum.Name = "colEnum";
+            colEnum.ReadOnly = true;
+            colEnum.Frozen = true;
+            colEnum.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
+            this.dataGridViewPalette.Columns.Add(colEnum);
+
+            // Column 2: API Call(s)
+            var colApi = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            colApi.HeaderText = "API Call(s)";
+            colApi.Name = "colApi";
+            colApi.ReadOnly = true;
+            colApi.MinimumWidth = 150;
+            colApi.DefaultCellStyle.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            colApi.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
+            this.dataGridViewPalette.Columns.Add(colApi);
+
+            if (_enumValues == null)
+            {
+                return;
+            }
+
+            for (int idx = 0; idx < _enumValues.Length; idx++)
+            {
+                int rowIndex = this.dataGridViewPalette.Rows.Add();
+                var row = this.dataGridViewPalette.Rows[rowIndex];
+                row.Cells[0].Value = idx; // index column
+                row.Cells[1].Value = _enumValues[idx].ToString();
+                row.Cells[2].Value = string.Empty; // API mapping
+            }
+
+            // Auto-resize columns once, then allow manual resize
+            this.dataGridViewPalette.AutoResizeColumns(System.Windows.Forms.DataGridViewAutoSizeColumnsMode.AllCells);
+            foreach (System.Windows.Forms.DataGridViewColumn col in this.dataGridViewPalette.Columns)
+            {
+                col.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            }
+
+            UpdateUIState();
+        }
+
+        private void AdjustRowHeights()
+        {
+            int baseHeight = this.dataGridViewPalette.RowTemplate.Height;
+            int apiColIndex = this.dataGridViewPalette.Columns.Contains("colApi") ? this.dataGridViewPalette.Columns["colApi"].Index : -1;
+            foreach (System.Windows.Forms.DataGridViewRow row in this.dataGridViewPalette.Rows)
+            {
+                if (row.IsNewRow)
+                {
+                    continue;
+                }
+
+                bool multi = false;
+                if (apiColIndex >= 0 && apiColIndex < row.Cells.Count)
+                {
+                    var tag = row.Cells[apiColIndex].Tag;
+                    multi = tag is bool b && b;
+                }
+
+                row.Height = multi ? baseHeight * 2 : baseHeight;
+            }
+        }
+
+        private void BuildMethodEnumMapping(Krypton.Toolkit.PaletteBase palette)
+        {
+            if (palette == null)
+            {
+                return;
+            }
+
+            var mapping = new System.Collections.Generic.Dictionary<System.Reflection.MemberInfo, string>();
+
+            System.Drawing.Color[] colorArray = TryGetPaletteColors(palette);
+
+            if (colorArray == null || colorArray.Length == 0)
+            {
+                _methodEnumMapping = mapping;
+                return;
+            }
+
+            // 1. Try to map public color-returning methods (including overrides)
+            var paletteMethods = palette.GetType().GetMethods(System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public);
+            foreach (var m in paletteMethods)
+            {
+                if (m.IsSpecialName || m.ReturnType != typeof(System.Drawing.Color) || (IsProblematicBaseMethod(m)))
+                {
+                    continue;
+                }
+
+                // Skip methods with ref/out parameters
+                bool skip = false;
+                foreach (var p in m.GetParameters())
+                {
+                    if (p.IsOut || p.ParameterType.IsByRef)
+                    {
+                        skip = true;
+                        break;
+                    }
+                }
+                if (skip)
+                {
+                    continue;
+                }
+
+                System.Drawing.Color resultColor;
+                try
+                {
+                    var parameters = m.GetParameters();
+                    object[] args = new object[parameters.Length];
+                    // Use the first enum value or default struct instance as placeholder argument
+                    for (int idx = 0; idx < parameters.Length; idx++)
+                    {
+                        var pt = parameters[idx].ParameterType;
+                        if (pt.IsEnum)
+                        {
+                            args[idx] = System.Enum.GetValues(pt).GetValue(0);
+                        }
+                        else if (pt.IsValueType)
+                        {
+                            args[idx] = System.Activator.CreateInstance(pt);
+                        }
+                        else
+                        {
+                            args[idx] = null;
+                        }
+                    }
+
+                    resultColor = (System.Drawing.Color)m.Invoke(palette, args);
+                }
+                catch (System.Reflection.TargetInvocationException tie)
+                {
+                    // Ignore known palette issues that manifest as exceptions
+                    if (tie.InnerException is System.NotImplementedException ||
+                        tie.InnerException is System.ArgumentOutOfRangeException ||
+                        tie.InnerException is System.IndexOutOfRangeException)
+                    {
+                        continue;
+                    }
+
+                    continue;
+                }
+
+                // Match against array to find enum slot
+                for (int i = 0; i < colorArray.Length; i++)
+                {
+                    if (colorArray[i].ToArgb() == resultColor.ToArgb())
+                    {
+                        if (System.Enum.IsDefined(typeof(Krypton.Toolkit.SchemeBaseColors), i))
+                        {
+                            var enumName = ((Krypton.Toolkit.SchemeBaseColors)i).ToString();
+                            mapping[m] = enumName;
+                        }
+                        break;
+                    }
+                }
+            }
+
+            // Map ColorTable properties as well
+            if (palette.ColorTable != null)
+            {
+                var ctProps = palette.ColorTable.GetType().GetProperties(System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public);
+                foreach (var prop in ctProps)
+                {
+                    if (prop.PropertyType != typeof(System.Drawing.Color) || prop.GetIndexParameters().Length > 0)
+                    {
+                        continue;
+                    }
+
+                    System.Drawing.Color c;
+                    try
+                    {
+                        c = (System.Drawing.Color)prop.GetValue(palette.ColorTable);
+                    }
+                    catch
+                    {
+                        continue;
+                    }
+
+                    for (int i = 0; i < colorArray.Length; i++)
+                    {
+                        if (colorArray[i].ToArgb() == c.ToArgb())
+                        {
+                            if (System.Enum.IsDefined(typeof(Krypton.Toolkit.SchemeBaseColors), i))
+                            {
+                                var enumName = ((Krypton.Toolkit.SchemeBaseColors)i).ToString();
+                                mapping[prop] = enumName;
+                            }
+                            break;
+                        }
+                    }
+                }
+            }
+
+            MergeEnumMethodMapping(mapping);
+
+            // Update grid mapping column
+            if (_enumValues != null)
+            {
+                // create reverse map enumName -> list of methods
+                var enumMethodMap = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>>();
+                foreach (var kvp in mapping)
+                {
+                    var enumName = kvp.Value;
+                    if (!enumMethodMap.TryGetValue(enumName, out var list))
+                    {
+                        list = new System.Collections.Generic.List<string>();
+                        enumMethodMap.Add(enumName, list);
+                    }
+                    list.Add(kvp.Key.Name);
+                }
+
+                for (int i = 0; i < _enumValues.Length; i++)
+                {
+                    var enName = _enumValues[i].ToString();
+                    if (enumMethodMap.TryGetValue(enName, out var mlist))
+                    {
+                        var joined = string.Join(" ", mlist);
+                        var apiCell = this.dataGridViewPalette.Rows[i].Cells[2];
+                        apiCell.Value = joined;
+                        apiCell.Tag = mlist.Count > 1;
+                    }
+                }
+            }
+
+            UpdateUIState();
+        }
+
+        private void AddPalette(Krypton.Toolkit.PaletteBase palette)
+        {
+            if (palette == null)
+            {
+                return;
+            }
+
+            var modeForPalette = Krypton.Toolkit.KryptonManager.GetModeForPalette(palette);
+            if (IsSparkleMode(modeForPalette) || IsSparkleType(palette.GetType()) || IsLegacyProfessionalMode(modeForPalette) || IsLegacyProfessionalType(palette.GetType()))
+            {
+                return; // skip unsupported palette types
+            }
+
+            _palettes.Add(palette);
+
+            // Build/merge mapping for each unique palette base (class that owns the _ribbonColors field)
+            var baseOwner = GetRibbonColorsOwner(palette.GetType());
+            if (baseOwner != null && !_processedBases.Contains(baseOwner))
+            {
+                BuildMethodEnumMapping(palette);
+                _processedBases.Add(baseOwner);
+            }
+
+            // Add column
+            var rawHeader = modeForPalette != Krypton.Toolkit.PaletteMode.Custom ? GetDisplayName(modeForPalette) : palette.GetType().Name;
+            var baseHeader = BreakHeader(rawHeader);
+
+            var col = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            col.HeaderText = baseHeader;
+            col.Name = palette.GetType().FullName;
+            col.ReadOnly = false;
+            col.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
+            col.HeaderCell.Style.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            col.HeaderCell.Style.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            this.dataGridViewPalette.Columns.Add(col);
+
+            int paletteColumnIndex = this.dataGridViewPalette.Columns.Count - 1;
+
+            // populate enum rows with color values
+
+            // fetch palette color array
+            System.Drawing.Color[] paletteColors = TryGetPaletteColors(palette);
+
+            // Assign baseline if not yet set
+            bool isBaseline = false;
+            if (_baselineColors == null && paletteColors != null)
+            {
+                _baselineColors = paletteColors;
+                _baselinePaletteName = palette.GetType().Name;
+                isBaseline = true;
+            }
+
+            int missingCount = 0;
+            bool sparsePalette = paletteColors == null || paletteColors.Length < _enumValues.Length / 3; // heuristics for incompatible palettes
+
+            string headerSuffix = string.Empty;
+
+            for (int i = 0; i < _enumValues.Length; i++)
+            {
+                var row = this.dataGridViewPalette.Rows[i];
+
+                bool indexPresent = paletteColors != null && i < paletteColors.Length;
+                System.Drawing.Color color = indexPresent ? paletteColors[i] : System.Drawing.Color.Transparent;
+                if (!indexPresent)
+                {
+                    // count missing only if palette is expected to support full scheme
+                    if (!sparsePalette)
+                    {
+                        missingCount++;
+                        if (string.IsNullOrEmpty(row.Cells[paletteColumnIndex].ErrorText))
+                        {
+                            row.Cells[paletteColumnIndex].ErrorText = "Missing index";
+                        }
+                    }
+                }
+                else if (color.A == 0)
+                {
+                    // Intentionally empty – mark as warning (italic text) but no error icon
+                    string label = color == System.Drawing.Color.Transparent ? "Transparent" : "EMPTY";
+                    row.Cells[paletteColumnIndex].Value = label;
+                    row.Cells[paletteColumnIndex].Style.Font = new System.Drawing.Font(this.Font, System.Drawing.FontStyle.Italic);
+                }
+
+                var cell = row.Cells[paletteColumnIndex];
+                var textColor = ContrastColor(color);
+                cell.Style.BackColor = color;
+                cell.Style.ForeColor = textColor;
+                cell.Style.SelectionBackColor = AdjustSelectionBack(color);
+                cell.Style.SelectionForeColor = textColor;
+                cell.Value = "#" + color.R.ToString("X2") + color.G.ToString("X2") + color.B.ToString("X2");
+
+                cell.ToolTipText = palette.GetType().Name + " - " + _enumValues[i];
+
+                // Legacy fallback removed – handled below for missing or intentional transparent values
+            }
+
+            // Static source check for array vs enum
+            if (!string.IsNullOrWhiteSpace(_sourcePath))
+            {
+                var issues = Classes.ThemeArrayInspector.GetIssues(palette.GetType(), _sourcePath);
+                if (issues != null && !issues.IsClean)
+                {
+                    foreach (int idx in issues.MissingIndices)
+                    {
+                        if (idx >= 0 && idx < this.dataGridViewPalette.Rows.Count)
+                        {
+                            var c = this.dataGridViewPalette.Rows[idx].Cells[paletteColumnIndex];
+                            if (string.IsNullOrEmpty(c.ErrorText)) c.ErrorText = "Missing value";
+                            if (!string.IsNullOrEmpty(c.ErrorText) && (c.ToolTipText == null || !c.ToolTipText.Contains(c.ErrorText)))
+                            {
+                                c.ToolTipText += " : " + c.ErrorText;
+                            }
+                        }
+                    }
+
+                    foreach (int idx in issues.UnlabelledIndices)
+                    {
+                        if (idx >= 0 && idx < this.dataGridViewPalette.Rows.Count)
+                        {
+                            var c = this.dataGridViewPalette.Rows[idx].Cells[paletteColumnIndex];
+                            if (string.IsNullOrEmpty(c.ErrorText)) c.ErrorText = "Unmarked value";
+                            if (!string.IsNullOrEmpty(c.ErrorText) && (c.ToolTipText == null || !c.ToolTipText.Contains(c.ErrorText)))
+                            {
+                                c.ToolTipText += " : " + c.ErrorText;
+                            }
+                        }
+                    }
+
+                    foreach (int idx in issues.OutOfOrderIndices)
+                    {
+                        if (idx >= 0 && idx < this.dataGridViewPalette.Rows.Count)
+                        {
+                            var c = this.dataGridViewPalette.Rows[idx].Cells[paletteColumnIndex];
+                            if (string.IsNullOrEmpty(c.ErrorText)) c.ErrorText = "Out-of-order";
+                            if (!string.IsNullOrEmpty(c.ErrorText) && (c.ToolTipText == null || !c.ToolTipText.Contains(c.ErrorText)))
+                            {
+                                c.ToolTipText += " : " + c.ErrorText;
+                            }
+                        }
+                    }
+
+                    foreach (int idx in issues.ExtraIndices)
+                    {
+                        if (idx >= 0 && idx < this.dataGridViewPalette.Rows.Count)
+                        {
+                            var c = this.dataGridViewPalette.Rows[idx].Cells[paletteColumnIndex];
+                            if (string.IsNullOrEmpty(c.ErrorText)) c.ErrorText = "Extra entry";
+                            if (!string.IsNullOrEmpty(c.ErrorText) && (c.ToolTipText == null || !c.ToolTipText.Contains(c.ErrorText)))
+                            {
+                                c.ToolTipText += " : " + c.ErrorText;
+                            }
+                        }
+                    }
+
+                    headerSuffix = $"\nΔ {issues.MissingCount}/{issues.UnlabelledCount}/{issues.OutOfOrderCount}/{issues.ExtraCount}";
+                }
+            }
+
+            // Update column header with summary
+            var colHeader = baseHeader;
+            if (isBaseline)
+            {
+                colHeader += "\n(baseline)";
+            }
+
+            if (sparsePalette)
+            {
+                colHeader += "\n(incompatible)";
+            }
+            else if (missingCount > 0)
+            {
+                colHeader += $"\n⚠{missingCount} missing";
+            }
+
+            colHeader += headerSuffix;
+
+            this.dataGridViewPalette.Columns[paletteColumnIndex].HeaderText = colHeader;
+            this.dataGridViewPalette.Columns[paletteColumnIndex].HeaderCell.Style.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.dataGridViewPalette.Columns[paletteColumnIndex].HeaderCell.Style.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+
+            // Recalculate header height to accommodate up to 3 lines
+            this.dataGridViewPalette.AutoResizeColumnHeadersHeight();
+
+            // Auto-size new column to contents once, then freeze
+            int preferred = col.GetPreferredWidth(System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells, true);
+            preferred = System.Math.Max(MinColumnWidth, System.Math.Min(preferred, 300));
+            col.Width = preferred;
+            col.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+
+            // ensure new column is not sortable
+            col.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
+
+            // After populating all rows for this palette, adjust row heights only if not in bulk update
+            if (!_bulkUpdating)
+            {
+                AdjustRowHeights();
+            }
+
+            UpdateUIState();
+        }
+
+        private static System.Drawing.Color ContrastColor(System.Drawing.Color c)
+        {
+            // If fully transparent, fallback to default grid text colour (black)
+            if (c.A == 0)
+            {
+                return System.Drawing.Color.Black;
+            }
+
+            // Convert sRGB to linear RGB
+            double R = c.R / 255.0;
+            double G = c.G / 255.0;
+            double B = c.B / 255.0;
+
+            R = R <= 0.03928 ? R / 12.92 : System.Math.Pow((R + 0.055) / 1.055, 2.4);
+            G = G <= 0.03928 ? G / 12.92 : System.Math.Pow((G + 0.055) / 1.055, 2.4);
+            B = B <= 0.03928 ? B / 12.92 : System.Math.Pow((B + 0.055) / 1.055, 2.4);
+
+            // Calculate relative luminance
+            double L = 0.2126 * R + 0.7152 * G + 0.0722 * B;
+
+            // Choose foreground that meets WCAG 2.0 contrast ratio of at least 4.5:1
+            // For white text contrast ratio is (1.0 + 0.05) / (L + 0.05)
+            // For black text contrast ratio is (L + 0.05) / 0.05
+            // White is better if background luminance <= 0.179
+            return L <= 0.179 ? System.Drawing.Color.White : System.Drawing.Color.Black;
+        }
+
+        private static System.Drawing.Color AdjustSelectionBack(System.Drawing.Color c)
+        {
+            // If color is dark, lighten; if light, darken.
+            double factor = 0.3; // 30% difference
+            bool isLight = ((c.R * 299 + c.G * 587 + c.B * 114) / 1000) > 128;
+            int r = isLight ? (int)(c.R * (1 - factor)) : (int)(c.R + (255 - c.R) * factor);
+            int g = isLight ? (int)(c.G * (1 - factor)) : (int)(c.G + (255 - c.G) * factor);
+            int b = isLight ? (int)(c.B * (1 - factor)) : (int)(c.B + (255 - c.B) * factor);
+            return System.Drawing.Color.FromArgb(c.A, r, g, b);
+        }
+
+        private void BtnAddPalette_Click(object sender, System.EventArgs e)
+        {
+            this.LoadApiCalls();
+
+            this.buttonAddPalette.Enabled = false;
+            this.buttonRemovePalette.Enabled = false;
+            this.Cursor = System.Windows.Forms.Cursors.WaitCursor;
+            UpdateStatus("Adding palette...");
+            System.Windows.Forms.Application.DoEvents();
+
+            try
+            {
+                if (this.comboTheme.SelectedItem is string display && DisplayToEnum.TryGetValue(display, out Krypton.Toolkit.PaletteMode mode))
+                {
+                    var palette = Krypton.Toolkit.KryptonManager.GetPaletteForMode(mode);
+
+                    if (!_palettes.Contains(palette))
+                    {
+                        AddPalette(palette);
+                    }
+                }
+            }
+            finally
+            {
+                UpdateStatus("Ready");
+                this.Cursor = System.Windows.Forms.Cursors.Default;
+                this.buttonAddPalette.Enabled = true;
+                this.buttonRemovePalette.Enabled = true;
+            }
+        }
+
+        private void BtnRemovePalette_Click(object sender, System.EventArgs e)
+        {
+            if (!(this.comboTheme.SelectedItem is string display) || !DisplayToEnum.TryGetValue(display, out Krypton.Toolkit.PaletteMode mode))
+            {
+                return; // nothing selected
+            }
+
+            var palette = _palettes.Find(p => KryptonManager.GetModeForPalette(p) == mode);
+            if (palette == null)
+            {
+                return; // selected palette not loaded
+            }
+
+            // remove from list
+            _palettes.Remove(palette);
+
+            // find column
+            var column = this.dataGridViewPalette.Columns.GetColumnCount(DataGridViewElementStates.Visible) > 0 ? this.dataGridViewPalette.Columns[palette.GetType().FullName] : null;
+            if (column != null)
+            {
+                this.dataGridViewPalette.Columns.Remove(column);
+            }
+
+            UpdateUIState();
+        }
+
+        private void PopulateThemeCombo(string preferredDisplay = "")
+        {
+            foreach (var kvp in DisplayToEnum)
+            {
+                if (kvp.Value == Krypton.Toolkit.PaletteMode.Custom)
+                {
+                    continue;
+                }
+
+                if (IsSparkleDisplay(kvp.Key) || IsSparkleMode(kvp.Value))
+                {
+                    continue; // skip sparkle
+                }
+
+                if (IsLegacyProfessionalDisplay(kvp.Key) || IsLegacyProfessionalMode(kvp.Value))
+                {
+                    continue; // skip legacy professional themes
+                }
+
+                this.comboTheme.Items.Add(kvp.Key);
+            }
+
+            if (!string.IsNullOrEmpty(preferredDisplay) && this.comboTheme.Items.Contains(preferredDisplay))
+            {
+                this.comboTheme.SelectedItem = preferredDisplay;
+            }
+            else if (kryptonManager1 != null && kryptonManager1.GlobalPaletteMode != Krypton.Toolkit.PaletteMode.Custom && EnumToDisplay.TryGetValue(kryptonManager1.GlobalPaletteMode, out string disp))
+            {
+                this.comboTheme.SelectedItem = disp;
+            }
+        }
+
+        private void ComboTheme_SelectedIndexChanged(object sender, System.EventArgs e)
+        {
+            UpdateUIState();
+        }
+
+        private async void BtnAddAll_Click(object sender, System.EventArgs e)
+        {
+            // Ensure base rows and enum array are ready
+            this.LoadApiCalls();
+
+            if (_addAllCts != null)
+            {
+                return; // already running
+            }
+
+            _addAllCts = new System.Threading.CancellationTokenSource();
+            var token = _addAllCts.Token;
+
+            this.buttonAddAll.Enabled = false;
+            this.buttonAddPalette.Enabled = false;
+            this.buttonRemovePalette.Enabled = false;
+            this.comboTheme.Enabled = false;
+            this.buttonCancel.Visible = true;
+
+            UpdateStatus("Adding all palettes...");
+
+            // Begin bulk update
+            _bulkUpdating = true;
+            this.dataGridViewPalette.SuspendLayout();
+
+            try
+            {
+                await System.Threading.Tasks.Task.Run(() =>
+                {
+                    var modes = (Krypton.Toolkit.PaletteMode[])System.Enum.GetValues(typeof(Krypton.Toolkit.PaletteMode));
+                    foreach (var mode in modes)
+                    {
+                        if (token.IsCancellationRequested)
+                        {
+                            break;
+                        }
+
+                        if (mode == Krypton.Toolkit.PaletteMode.Custom || IsSparkleMode(mode) || IsLegacyProfessionalMode(mode))
+                        {
+                            continue; // skip unsupported modes
+                        }
+
+                        var palette = Krypton.Toolkit.KryptonManager.GetPaletteForMode(mode);
+
+                        this.Invoke((System.Action)(() =>
+                        {
+                            if (!_palettes.Contains(palette))
+                            {
+                                AddPalette(palette);
+                                UpdateStatus($"Added {mode}...");
+                            }
+                        }));
+                    }
+                }, token);
+            }
+            catch (System.OperationCanceledException)
+            {
+                UpdateStatus("Add all cancelled.");
+            }
+            finally
+            {
+                // End bulk update
+                _bulkUpdating = false;
+                this.dataGridViewPalette.ResumeLayout();
+
+                // Perform final row-height adjustment once after bulk add completes
+                AdjustRowHeights();
+
+                this.buttonAddAll.Enabled = true;
+                this.buttonAddPalette.Enabled = true;
+                this.buttonRemovePalette.Enabled = true;
+                this.comboTheme.Enabled = true;
+                this.buttonCancel.Visible = false;
+
+                _addAllCts.Dispose();
+                _addAllCts = null;
+
+                UpdateStatus("Ready");
+            }
+        }
+
+        private void BtnCancel_Click(object sender, System.EventArgs e)
+        {
+            _addAllCts?.Cancel();
+        }
+
+        private void UpdateStatus(string message)
+        {
+            if (this.InvokeRequired)
+            {
+                this.BeginInvoke((System.Action)(() => UpdateStatus(message)));
+                return;
+            }
+
+            this.statusLabel.Text = message;
+        }
+
+        private void DataGridViewPalette_ColumnAdded(object sender, System.Windows.Forms.DataGridViewColumnEventArgs e)
+        {
+            // auto-size once then freeze
+            int preferred = e.Column.GetPreferredWidth(System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells, true);
+            preferred = System.Math.Max(MinColumnWidth, System.Math.Min(preferred, 300));
+            e.Column.Width = preferred;
+            e.Column.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+
+            e.Column.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
+        }
+
+        private void DataGridViewPalette_ColumnHeaderMouseClick(object sender, System.Windows.Forms.DataGridViewCellMouseEventArgs e)
+        {
+            if (e.ColumnIndex < 3)
+            {
+                return;
+            }
+
+            var column = this.dataGridViewPalette.Columns[e.ColumnIndex];
+            var palette = _palettes.Find(p => p.GetType().FullName == column.Name);
+
+            // New guard: do not activate palettes that still have missing enum values
+            if (palette != null && !string.IsNullOrWhiteSpace(_sourcePath))
+            {
+                var issues = Classes.ThemeArrayInspector.GetIssues(palette.GetType(), _sourcePath);
+                if (issues != null && issues.MissingCount > 0)
+                {
+                    UpdateStatus($"Cannot activate {palette.GetType().Name}: {issues.MissingCount} missing enum colours");
+                    return;
+                }
+            }
+
+            if (palette != null)
+            {
+                var mode = Krypton.Toolkit.KryptonManager.GetModeForPalette(palette);
+                if (mode != Krypton.Toolkit.PaletteMode.Custom)
+                {
+                    kryptonManager1.GlobalPaletteMode = mode;
+                }
+                else if (palette is Krypton.Toolkit.KryptonCustomPaletteBase cp)
+                {
+                    kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Custom;
+                    kryptonManager1.GlobalCustomPalette = cp;
+                }
+
+                string headerFlat = column.HeaderText.Replace("\n", " ").Replace("\r", " ");
+                UpdateStatus($"Activated {headerFlat}");
+            }
+        }
+
+        private void BtnClear_Click(object sender, System.EventArgs e)
+        {
+            this._palettes.Clear();
+            _baselineColors = null;
+            _baselinePaletteName = null;
+
+            BuildBaseRows();
+
+            UpdateStatus("Cleared palettes");
+
+            UpdateUIState();
+        }
+
+        private static string BreakHeader(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return text;
+            }
+
+            System.Text.StringBuilder sb = new System.Text.StringBuilder();
+            sb.Append(text[0]);
+            for (int i = 1; i < text.Length; i++)
+            {
+                char ch = text[i];
+                char prev = text[i - 1];
+                if (char.IsUpper(ch) && !char.IsUpper(prev))
+                {
+                    sb.Append('\n');
+                }
+                sb.Append(ch);
+            }
+            return sb.ToString();
+        }
+
+        private string GetDisplayName(Krypton.Toolkit.PaletteMode mode)
+        {
+            if (EnumToDisplay.TryGetValue(mode, out string display))
+            {
+                return display;
+            }
+            return mode.ToString();
+        }
+
+        private void MainForm_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            // determine bounds depending on state
+            var stateForSave = this.WindowState;
+            var bounds = stateForSave == FormWindowState.Normal ? this.Bounds : this.RestoreBounds;
+
+            var ws = new WindowStateInfo
+            {
+                Left = bounds.Left,
+                Top = bounds.Top,
+                Width = bounds.Width,
+                Height = bounds.Height,
+                State = stateForSave,
+                LastTheme = this.comboTheme.SelectedItem as string,
+                SourcePath = _sourcePath
+            };
+
+            _winStore.Save(ws);
+        }
+
+        private void DataGridViewPalette_CurrentCellChanged(object sender, System.EventArgs e)
+        {
+            if (_bulkUpdating || this.dataGridViewPalette.CurrentCell == null)
+            {
+                return;
+            }
+
+            int newIndex = this.dataGridViewPalette.CurrentCell.RowIndex;
+            if (newIndex == _highlightRowIndex)
+            {
+                return;
+            }
+
+            int old = _highlightRowIndex;
+            _highlightRowIndex = newIndex;
+
+            if (old >= 0 && old < this.dataGridViewPalette.Rows.Count)
+            {
+                this.dataGridViewPalette.InvalidateRow(old);
+            }
+            if (newIndex >= 0 && newIndex < this.dataGridViewPalette.Rows.Count)
+            {
+                this.dataGridViewPalette.InvalidateRow(newIndex);
+            }
+        }
+
+        private void DataGridViewPalette_Paint(object sender, PaintEventArgs e)
+        {
+            if (_bulkUpdating)
+            {
+                return;
+            }
+
+            if (_highlightRowIndex < 0 || _highlightRowIndex >= this.dataGridViewPalette.RowCount)
+            {
+                return;
+            }
+
+            var rowRect = this.dataGridViewPalette.GetRowDisplayRectangle(_highlightRowIndex, true);
+            if (rowRect.Width <= 0 || rowRect.Height <= 0)
+            {
+                return; // row not visible
+            }
+
+            using (var pen = new System.Drawing.Pen(System.Drawing.Color.DarkOrange, 3))
+            {
+                rowRect.Width -= 1;
+                rowRect.Height -= 1;
+                e.Graphics.DrawRectangle(pen, rowRect);
+            }
+        }
+
+        private void SaveCsv_Click(object sender, EventArgs e) => SaveGrid("csv");
+        private void SaveJson_Click(object sender, EventArgs e) => SaveGrid("json");
+        private void SaveXml_Click(object sender, EventArgs e) => SaveGrid("xml");
+
+        private void SaveGrid(string format)
+        {
+            using (var sfd = new SaveFileDialog())
+            {
+                sfd.Filter = $"{format.ToUpper()} files|*.{format}|All files|*.*";
+                sfd.DefaultExt = format;
+                if (sfd.ShowDialog(this) != DialogResult.OK)
+                {
+                    return;
+                }
+
+                try
+                {
+                    switch (format)
+                    {
+                        case "csv":
+                            File.WriteAllText(sfd.FileName, ExportCsv());
+                            break;
+                        case "json":
+                            File.WriteAllText(sfd.FileName, ExportJson());
+                            break;
+                        case "xml":
+                            ExportXml(sfd.FileName);
+                            break;
+                    }
+                    UpdateStatus($"Saved {Path.GetFileName(sfd.FileName)}");
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show(this, ex.Message, "Save Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                }
+            }
+        }
+
+        private string ExportCsv() => Classes.Exporter.ToCsv(this.dataGridViewPalette);
+
+        private string ExportJson() => Classes.Exporter.ToJson(this.dataGridViewPalette);
+
+        private void ExportXml(string fileName) => Classes.Exporter.ToXml(this.dataGridViewPalette, fileName);
+
+        private void UpdateUIState()
+        {
+            bool hasData = this.dataGridViewPalette.Columns.Count > 3 && this.dataGridViewPalette.Rows.Count > 0;
+            this.buttonSave.Enabled = hasData;
+
+            bool hasPalettes = _palettes.Count > 0;
+
+            bool canRemove = false;
+            bool canAdd = false;
+
+            if (this.comboTheme.SelectedItem is string selDisplay && DisplayToEnum.TryGetValue(selDisplay, out PaletteMode selMode))
+            {
+                canRemove = _palettes.Exists(p => KryptonManager.GetModeForPalette(p) == selMode);
+                canAdd = !canRemove;
+            }
+
+            this.buttonRemovePalette.Enabled = canRemove;
+            this.buttonAddPalette.Enabled = canAdd;
+            this.buttonClear.Enabled = hasPalettes;
+
+            // AddAll button if exists
+            if (this.buttonAddAll != null)
+            {
+                bool anyRemaining = false;
+                foreach (var kv in DisplayToEnum)
+                {
+                    if (IsSparkleDisplay(kv.Key) || IsSparkleMode(kv.Value) || IsLegacyProfessionalDisplay(kv.Key) || IsLegacyProfessionalMode(kv.Value))
+                    {
+                        continue; // skip
+                    }
+
+                    if (!_palettes.Exists(p => KryptonManager.GetModeForPalette(p) == kv.Value))
+                    {
+                        anyRemaining = true;
+                        break;
+                    }
+                }
+                this.buttonAddAll.Enabled = anyRemaining;
+            }
+        }
+
+        private void DataGridViewPalette_SelectionChanged(object sender, EventArgs e)
+        {
+            UpdateUIState();
+        }
+
+        private void ButtonSave_Click(object sender, System.EventArgs e)
+        {
+            string format = "csv";
+            if (this.comboSaveFormat.SelectedItem is string sel)
+            {
+                format = sel.ToLower();
+            }
+
+            SaveGrid(format);
+        }
+
+        private void DataGridViewPalette_EditingControlShowing(object sender, DataGridViewEditingControlShowingEventArgs e)
+        {
+            if (e.Control is TextBoxBase tb)
+            {
+                tb.ReadOnly = true; // allow selection but no edits
+                tb.BorderStyle = BorderStyle.None;
+                tb.BackColor = System.Drawing.SystemColors.Window;
+                // No need to capture or reset text – leaving it untouched avoids unwanted changes
+            }
+        }
+
+        private void DataGridViewPalette_CellPainting(object sender, DataGridViewCellPaintingEventArgs e)
+        {
+            if (_bulkUpdating)
+            {
+                return;
+            }
+
+            if (this.dataGridViewPalette.CurrentCell != null && e.RowIndex == this.dataGridViewPalette.CurrentCell.RowIndex && e.ColumnIndex == this.dataGridViewPalette.CurrentCell.ColumnIndex)
+            {
+                // Let default paint
+                e.Paint(e.CellBounds, DataGridViewPaintParts.All);
+
+                using (var pen = new System.Drawing.Pen(System.Drawing.Color.Red, 2))
+                {
+                    var rect = e.CellBounds;
+                    rect.Width -= 1;
+                    rect.Height -= 1;
+                    e.Graphics.DrawRectangle(pen, rect);
+                }
+
+                e.Handled = true;
+            }
+        }
+
+        private void DataGridViewPalette_Scroll(object sender, ScrollEventArgs e)
+        {
+            if (e.ScrollOrientation == ScrollOrientation.HorizontalScroll && !_bulkUpdating)
+            {
+                dataGridViewPalette.Refresh();
+            }
+        }
+
+        private static void TryCopy(string text)
+        {
+            const int retries = 5;
+            const int delay = 100;
+            for (int i = 0; i < retries; i++)
+            {
+                try
+                {
+                    System.Windows.Forms.Clipboard.SetDataObject(text, true);
+                    return;
+                }
+                catch (System.Runtime.InteropServices.ExternalException)
+                {
+                    System.Threading.Thread.Sleep(delay);
+                }
+            }
+        }
+
+        private static System.Type GetRibbonColorsOwner(System.Type t)
+        {
+            while (t != null && t != typeof(object))
+            {
+                var fi = t.GetField("_ribbonColors", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+                if (fi != null && fi.FieldType == typeof(System.Drawing.Color[]))
+                {
+                    return t;
+                }
+                t = t.BaseType;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Safely extracts the ribbon color array from a palette without invoking code paths that may throw for missing indices.
+        /// Order of attempts:
+        /// 1. Directly read the private <c>_ribbonColors</c> field on the owning class.
+        /// 2. Fallback to <c>ColorTable.Colors/Colours</c> reflection – wrapped to ignore IndexOutOfRange.
+        /// </summary>
+        private static System.Drawing.Color[] TryGetPaletteColors(Krypton.Toolkit.PaletteBase palette)
+        {
+            if (palette == null)
+            {
+                return null;
+            }
+
+            // Attempt direct field first (fast & safe)
+            var owner = GetRibbonColorsOwner(palette.GetType());
+            if (owner != null)
+            {
+                var fi = owner.GetField("_ribbonColors", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+                if (fi != null && fi.FieldType == typeof(System.Drawing.Color[]))
+                {
+                    if (fi.GetValue(palette) is System.Drawing.Color[] arr && arr.Length > 0)
+                    {
+                        return arr;
+                    }
+                }
+            }
+
+            // Fallback to ColorTable reflection (may throw for bad palettes)
+            try
+            {
+                var ct = palette.ColorTable;
+                if (ct != null)
+                {
+                    var prop = ct.GetType().GetProperty("Colors", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public)
+                               ?? ct.GetType().GetProperty("Colours", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public);
+
+                    if (prop != null && prop.PropertyType == typeof(System.Drawing.Color[]))
+                    {
+                        return prop.GetValue(ct) as System.Drawing.Color[];
+                    }
+                }
+            }
+            catch (System.IndexOutOfRangeException)
+            {
+                // Ignore and return null – caller treats palette as sparse/incompatible
+            }
+
+            return null;
+        }
+
+        private void MergeEnumMethodMapping(System.Collections.Generic.Dictionary<System.Reflection.MemberInfo, string> newMap)
+        {
+            if (_methodEnumMapping == null)
+            {
+                _methodEnumMapping = newMap;
+                return;
+            }
+
+            foreach (var kv in newMap)
+            {
+                if (!_methodEnumMapping.ContainsKey(kv.Key))
+                {
+                    _methodEnumMapping[kv.Key] = kv.Value;
+                }
+            }
+        }
+
+        private void PanelTop_Layout(object sender, LayoutEventArgs e)
+        {
+            if (this.panelTop == null)
+            {
+                return;
+            }
+
+            int leftPad = this.panelTop.Padding.Left + 3;
+            int rightPad = this.panelTop.Padding.Right;
+
+            // Ordered toolbar controls
+            Control[] order =
+            {
+                this.labelSourceTitle,
+                this.textSourcePath,
+                this.buttonBrowseSource,
+                this.comboTheme,
+                this.buttonAddPalette,
+                this.buttonRemovePalette,
+                this.buttonAddAll,
+                this.buttonClear,
+                this.comboSaveFormat,
+                this.buttonSave,
+                this.buttonCancel
+            };
+
+            // Gather visible controls and compute total width
+            var visibleList = new System.Collections.Generic.List<Control>();
+            int totalControlsWidth = 0;
+            foreach (var c in order)
+            {
+                if (c != null && c.Visible)
+                {
+                    visibleList.Add(c);
+                    totalControlsWidth += c.Width;
+                }
+            }
+
+            // Minimum gap between items
+            const int MinGap = 4;
+            int gap = MinGap;
+            if (visibleList.Count > 1)
+            {
+                int available = this.panelTop.Width - leftPad - rightPad - totalControlsWidth;
+                gap = System.Math.Max(MinGap, available / (visibleList.Count - 1));
+            }
+
+            int x = leftPad;
+            foreach (var ctrl in order)
+            {
+                if (ctrl == null)
+                {
+                    continue;
+                }
+
+                if (!ctrl.Visible)
+                {
+                    // Position invisible controls at current x but do not advance
+                    ctrl.Location = new System.Drawing.Point(x, ctrl.Location.Y);
+                    continue;
+                }
+
+                ctrl.Location = new System.Drawing.Point(x, (this.panelTop.Height - ctrl.Height) / 2);
+                x += ctrl.Width + gap;
+            }
+        }
+
+        private void BtnBrowseSource_Click(object sender, System.EventArgs e)
+        {
+            using (var dlg = new Krypton.Toolkit.KryptonFolderBrowserDialog())
+            {
+                if (!string.IsNullOrEmpty(_sourcePath) && System.IO.Directory.Exists(_sourcePath))
+                {
+                    dlg.SelectedPath = _sourcePath;
+                }
+
+                if (dlg.ShowDialog(this) == System.Windows.Forms.DialogResult.OK)
+                {
+                    SetSourcePath(dlg.SelectedPath);
+                }
+            }
+        }
+
+        private void SetSourcePath(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return;
+            }
+
+            if (string.Equals(_sourcePath, path, System.StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            _sourcePath = path;
+            if (this.textSourcePath != null)
+            {
+                this.textSourcePath.Text = path;
+            }
+
+            // persist immediately
+            var ws = _winInfo ?? new WindowStateInfo();
+            ws.SourcePath = path;
+            ws.Left = this.Left;
+            ws.Top = this.Top;
+            ws.Width = this.Width;
+            ws.Height = this.Height;
+            ws.State = this.WindowState;
+            ws.LastTheme = comboTheme.SelectedItem as string;
+            _winStore.Save(ws);
+
+            RecheckAllPalettes();
+        }
+
+        private void RecheckAllPalettes()
+        {
+            if (string.IsNullOrWhiteSpace(_sourcePath))
+            {
+                return;
+            }
+
+            for (int p = 0; p < _palettes.Count; p++)
+            {
+                var palette = _palettes[p];
+                var col = this.dataGridViewPalette.Columns[palette.GetType().FullName];
+                if (col == null)
+                {
+                    continue;
+                }
+                int colIndex = col.Index;
+
+                var issues = Classes.ThemeArrayInspector.GetIssues(palette.GetType(), _sourcePath);
+                if (issues == null || issues.IsClean)
+                {
+                    continue;
+                }
+
+                foreach (int idx in issues.MissingIndices)
+                {
+                    if (idx >= 0 && idx < this.dataGridViewPalette.Rows.Count)
+                    {
+                        var c = this.dataGridViewPalette.Rows[idx].Cells[colIndex];
+                        if (string.IsNullOrEmpty(c.ErrorText)) c.ErrorText = "Missing value";
+                        if (!string.IsNullOrEmpty(c.ErrorText) && (c.ToolTipText == null || !c.ToolTipText.Contains(c.ErrorText)))
+                        {
+                            c.ToolTipText += " : " + c.ErrorText;
+                        }
+                    }
+                }
+                foreach (int idx in issues.UnlabelledIndices)
+                {
+                    if (idx >= 0 && idx < this.dataGridViewPalette.Rows.Count)
+                    {
+                        var c = this.dataGridViewPalette.Rows[idx].Cells[colIndex];
+                        if (string.IsNullOrEmpty(c.ErrorText)) c.ErrorText = "Unmarked value";
+                        if (!string.IsNullOrEmpty(c.ErrorText) && (c.ToolTipText == null || !c.ToolTipText.Contains(c.ErrorText)))
+                        {
+                            c.ToolTipText += " : " + c.ErrorText;
+                        }
+                    }
+                }
+                foreach (int idx in issues.OutOfOrderIndices)
+                {
+                    if (idx >= 0 && idx < this.dataGridViewPalette.Rows.Count)
+                    {
+                        var c = this.dataGridViewPalette.Rows[idx].Cells[colIndex];
+                        if (string.IsNullOrEmpty(c.ErrorText)) c.ErrorText = "Out-of-order";
+                        if (!string.IsNullOrEmpty(c.ErrorText) && (c.ToolTipText == null || !c.ToolTipText.Contains(c.ErrorText)))
+                        {
+                            c.ToolTipText += " : " + c.ErrorText;
+                        }
+                    }
+                }
+                foreach (int idx in issues.ExtraIndices)
+                {
+                    if (idx >= 0 && idx < this.dataGridViewPalette.Rows.Count)
+                    {
+                        var c = this.dataGridViewPalette.Rows[idx].Cells[colIndex];
+                        if (string.IsNullOrEmpty(c.ErrorText)) c.ErrorText = "Extra entry";
+                        if (!string.IsNullOrEmpty(c.ErrorText) && (c.ToolTipText == null || !c.ToolTipText.Contains(c.ErrorText)))
+                        {
+                            c.ToolTipText += " : " + c.ErrorText;
+                        }
+                    }
+                }
+            }
+
+            this.dataGridViewPalette.Refresh();
+        }
+    }
+}

--- a/Source/Krypton Components/TestForm/PaletteViewer/PaletteViewerForm.resx
+++ b/Source/Krypton Components/TestForm/PaletteViewer/PaletteViewerForm.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="statusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/Source/Krypton Components/TestForm/Program.cs
+++ b/Source/Krypton Components/TestForm/Program.cs
@@ -1,22 +1,32 @@
 #region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *
  */
 #endregion
+using System.Runtime.InteropServices;
 
 namespace TestForm;
 
 internal static class Program
 {
+    [DllImport("user32.dll")]
+    static extern bool SetProcessDPIAware();
+
     /// <summary>
     ///  The main entry point for the application.
     /// </summary>
     [STAThread]
     static void Main()
     {
+        // Enable High-DPI support for Windows Forms
+        if (Environment.OSVersion.Version.Major >= 6)
+        {
+            SetProcessDPIAware();
+        }
+
         // To customize application configuration such as set high DPI settings or default font,
         // see https://aka.ms/applicationconfiguration.
         Application.EnableVisualStyles();

--- a/Source/Krypton Components/TestForm/StartScreen.Designer.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.Designer.cs
@@ -1,9 +1,9 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -75,14 +75,15 @@ namespace TestForm
             this.kbtnFadeForm = new Krypton.Toolkit.KryptonButton();
             this.kbtnCommandLinkButtons = new Krypton.Toolkit.KryptonButton();
             this.kbtnBreadCrumb = new Krypton.Toolkit.KryptonButton();
+            this.kbtnPaletteViewer = new Krypton.Toolkit.KryptonButton();
             this.kryptonManager1 = new Krypton.Toolkit.KryptonManager(this.components);
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).BeginInit();
             this.kryptonPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonThemeComboBox1)).BeginInit();
             this.SuspendLayout();
-            // 
+            //
             // kryptonPanel1
-            // 
+            //
             this.kryptonPanel1.Controls.Add(this.kbtnBlurredForm);
             this.kryptonPanel1.Controls.Add(this.kbtnSplashScreen);
             this.kryptonPanel1.Controls.Add(this.kbtnControlStyles);
@@ -100,6 +101,7 @@ namespace TestForm
             this.kryptonPanel1.Controls.Add(this.kryptonThemeComboBox1);
             this.kryptonPanel1.Controls.Add(this.kbtnPoweredByButton);
             this.kryptonPanel1.Controls.Add(this.btnColourTestimonials);
+            this.kryptonPanel1.Controls.Add(this.kbtnPaletteViewer);
             this.kryptonPanel1.Controls.Add(this.kbtnTreeView);
             this.kryptonPanel1.Controls.Add(this.kbtnExit);
             this.kryptonPanel1.Controls.Add(this.kbtnFormBorder);
@@ -121,9 +123,9 @@ namespace TestForm
             this.kryptonPanel1.Name = "kryptonPanel1";
             this.kryptonPanel1.Size = new System.Drawing.Size(358, 476);
             this.kryptonPanel1.TabIndex = 0;
-            // 
+            //
             // kbtnBlurredForm
-            // 
+            //
             this.kbtnBlurredForm.Location = new System.Drawing.Point(13, 439);
             this.kbtnBlurredForm.Margin = new System.Windows.Forms.Padding(2);
             this.kbtnBlurredForm.Name = "kbtnBlurredForm";
@@ -132,9 +134,9 @@ namespace TestForm
             this.kbtnBlurredForm.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnBlurredForm.Values.Text = "Blurred Form";
             this.kbtnBlurredForm.Click += new System.EventHandler(this.kbtnBlurredForm_Click);
-            // 
+            //
             // kbtnSplashScreen
-            // 
+            //
             this.kbtnSplashScreen.Location = new System.Drawing.Point(12, 335);
             this.kbtnSplashScreen.Margin = new System.Windows.Forms.Padding(2);
             this.kbtnSplashScreen.Name = "kbtnSplashScreen";
@@ -143,9 +145,9 @@ namespace TestForm
             this.kbtnSplashScreen.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnSplashScreen.Values.Text = "Splash Screen";
             this.kbtnSplashScreen.Click += new System.EventHandler(this.kbtnSplashScreen_Click);
-            // 
+            //
             // kbtnControlStyles
-            // 
+            //
             this.kbtnControlStyles.Location = new System.Drawing.Point(12, 120);
             this.kbtnControlStyles.Margin = new System.Windows.Forms.Padding(2);
             this.kbtnControlStyles.Name = "kbtnControlStyles";
@@ -154,9 +156,9 @@ namespace TestForm
             this.kbtnControlStyles.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnControlStyles.Values.Text = "Control Styles";
             this.kbtnControlStyles.Click += new System.EventHandler(this.kbtnControlStyles_Click);
-            // 
+            //
             // kbtnDateTime
-            // 
+            //
             this.kbtnDateTime.Location = new System.Drawing.Point(12, 147);
             this.kbtnDateTime.Margin = new System.Windows.Forms.Padding(2);
             this.kbtnDateTime.Name = "kbtnDateTime";
@@ -165,9 +167,9 @@ namespace TestForm
             this.kbtnDateTime.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnDateTime.Values.Text = "DateTime";
             this.kbtnDateTime.Click += new System.EventHandler(this.kbtnDateTime_Click);
-            // 
+            //
             // kbtnPropertyGrid
-            // 
+            //
             this.kbtnPropertyGrid.Location = new System.Drawing.Point(223, 281);
             this.kbtnPropertyGrid.Margin = new System.Windows.Forms.Padding(2);
             this.kbtnPropertyGrid.Name = "kbtnPropertyGrid";
@@ -176,9 +178,9 @@ namespace TestForm
             this.kbtnPropertyGrid.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnPropertyGrid.Values.Text = "PropertyGrid";
             this.kbtnPropertyGrid.Click += new System.EventHandler(this.kbtnPropertyGrid_Click);
-            // 
+            //
             // kbtnRibbonNavigatorWorkspace
-            // 
+            //
             this.kbtnRibbonNavigatorWorkspace.Location = new System.Drawing.Point(12, 308);
             this.kbtnRibbonNavigatorWorkspace.Margin = new System.Windows.Forms.Padding(2);
             this.kbtnRibbonNavigatorWorkspace.Name = "kbtnRibbonNavigatorWorkspace";
@@ -187,9 +189,9 @@ namespace TestForm
             this.kbtnRibbonNavigatorWorkspace.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnRibbonNavigatorWorkspace.Values.Text = "Ribbon/Navigator/Workspace";
             this.kbtnRibbonNavigatorWorkspace.Click += new System.EventHandler(this.kbtnRibbonNavigatorWorkspace_Click);
-            // 
+            //
             // kbtnAbout
-            // 
+            //
             this.kbtnAbout.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.kbtnAbout.Location = new System.Drawing.Point(12, 40);
             this.kbtnAbout.Name = "kbtnAbout";
@@ -198,9 +200,9 @@ namespace TestForm
             this.kbtnAbout.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnAbout.Values.Text = "About Box";
             this.kbtnAbout.Click += new System.EventHandler(this.kbtnAbout_Click);
-            // 
+            //
             // kbtnInputBox
-            // 
+            //
             this.kbtnInputBox.Location = new System.Drawing.Point(223, 201);
             this.kbtnInputBox.Margin = new System.Windows.Forms.Padding(2);
             this.kbtnInputBox.Name = "kbtnInputBox";
@@ -209,9 +211,9 @@ namespace TestForm
             this.kbtnInputBox.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnInputBox.Values.Text = "Input Box";
             this.kbtnInputBox.Click += new System.EventHandler(this.kbtnInputBox_Click);
-            // 
+            //
             // kbtnHeaderExamples
-            // 
+            //
             this.kbtnHeaderExamples.Location = new System.Drawing.Point(12, 201);
             this.kbtnHeaderExamples.Margin = new System.Windows.Forms.Padding(2);
             this.kbtnHeaderExamples.Name = "kbtnHeaderExamples";
@@ -220,9 +222,9 @@ namespace TestForm
             this.kbtnHeaderExamples.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnHeaderExamples.Values.Text = "Header Examples";
             this.kbtnHeaderExamples.Click += new System.EventHandler(this.kbtnHeaderExamples_Click);
-            // 
+            //
             // kbtnDataGrid
-            // 
+            //
             this.kbtnDataGrid.Location = new System.Drawing.Point(223, 120);
             this.kbtnDataGrid.Margin = new System.Windows.Forms.Padding(2);
             this.kbtnDataGrid.Name = "kbtnDataGrid";
@@ -230,9 +232,9 @@ namespace TestForm
             this.kbtnDataGrid.TabIndex = 23;
             this.kbtnDataGrid.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnDataGrid.Values.Text = "DataGrid";
-            // 
+            //
             // kbtnControlsTest
-            // 
+            //
             this.kbtnControlsTest.Location = new System.Drawing.Point(223, 93);
             this.kbtnControlsTest.Name = "kbtnControlsTest";
             this.kbtnControlsTest.Size = new System.Drawing.Size(153, 20);
@@ -240,9 +242,9 @@ namespace TestForm
             this.kbtnControlsTest.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnControlsTest.Values.Text = "Controls Test";
             this.kbtnControlsTest.Click += new System.EventHandler(this.kbtnControlsTest_Click);
-            // 
+            //
             // kbtnThemeControls
-            // 
+            //
             this.kbtnThemeControls.Location = new System.Drawing.Point(12, 362);
             this.kbtnThemeControls.Margin = new System.Windows.Forms.Padding(2);
             this.kbtnThemeControls.Name = "kbtnThemeControls";
@@ -251,9 +253,9 @@ namespace TestForm
             this.kbtnThemeControls.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnThemeControls.Values.Text = "Theme Controls";
             this.kbtnThemeControls.Click += new System.EventHandler(this.kbtnThemeControls_Click);
-            // 
+            //
             // kbtnWorkspace
-            // 
+            //
             this.kbtnWorkspace.Location = new System.Drawing.Point(12, 415);
             this.kbtnWorkspace.Margin = new System.Windows.Forms.Padding(2);
             this.kbtnWorkspace.Name = "kbtnWorkspace";
@@ -262,9 +264,9 @@ namespace TestForm
             this.kbtnWorkspace.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnWorkspace.Values.Text = "Workspace";
             this.kbtnWorkspace.Click += new System.EventHandler(this.kbtnWorkspace_Click);
-            // 
+            //
             // kbtnCalendar
-            // 
+            //
             this.kbtnCalendar.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.kbtnCalendar.Location = new System.Drawing.Point(223, 67);
             this.kbtnCalendar.Name = "kbtnCalendar";
@@ -273,9 +275,9 @@ namespace TestForm
             this.kbtnCalendar.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnCalendar.Values.Text = "Calendar";
             this.kbtnCalendar.Click += new System.EventHandler(this.kbtnCalendar_Click);
-            // 
+            //
             // kryptonThemeComboBox1
-            // 
+            //
             this.kryptonThemeComboBox1.DefaultPalette = Krypton.Toolkit.PaletteMode.Microsoft365Blue;
             this.kryptonThemeComboBox1.DropDownWidth = 417;
             this.kryptonThemeComboBox1.IntegralHeight = false;
@@ -284,9 +286,9 @@ namespace TestForm
             this.kryptonThemeComboBox1.Size = new System.Drawing.Size(366, 22);
             this.kryptonThemeComboBox1.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
             this.kryptonThemeComboBox1.TabIndex = 18;
-            // 
+            //
             // kbtnPoweredByButton
-            // 
+            //
             this.kbtnPoweredByButton.Location = new System.Drawing.Point(12, 254);
             this.kbtnPoweredByButton.Margin = new System.Windows.Forms.Padding(2);
             this.kbtnPoweredByButton.Name = "kbtnPoweredByButton";
@@ -295,9 +297,9 @@ namespace TestForm
             this.kbtnPoweredByButton.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnPoweredByButton.Values.Text = "Powered by Button";
             this.kbtnPoweredByButton.Click += new System.EventHandler(this.kbtnPoweredByButton_Click);
-            // 
+            //
             // btnColourTestimonials
-            // 
+            //
             this.btnColourTestimonials.Location = new System.Drawing.Point(223, 415);
             this.btnColourTestimonials.Margin = new System.Windows.Forms.Padding(2);
             this.btnColourTestimonials.Name = "btnColourTestimonials";
@@ -306,9 +308,20 @@ namespace TestForm
             this.btnColourTestimonials.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.btnColourTestimonials.Values.Text = "Colour Testimonials";
             this.btnColourTestimonials.Click += new System.EventHandler(this.btnColourTestimonials_Click);
-            // 
+            //
+            // kbtnPaletteViewer
+            //
+            this.kbtnPaletteViewer.Location = new System.Drawing.Point(223, 439);
+            this.kbtnPaletteViewer.Margin = new System.Windows.Forms.Padding(2);
+            this.kbtnPaletteViewer.Name = "kbtnPaletteViewer";
+            this.kbtnPaletteViewer.Size = new System.Drawing.Size(153, 20);
+            this.kbtnPaletteViewer.TabIndex = 33;
+            this.kbtnPaletteViewer.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnPaletteViewer.Values.Text = "Palette Viewer";
+            this.kbtnPaletteViewer.Click += new System.EventHandler(this.kbtnPaletteViewer_Click);
+            //
             // kbtnTreeView
-            // 
+            //
             this.kbtnTreeView.Location = new System.Drawing.Point(223, 388);
             this.kbtnTreeView.Margin = new System.Windows.Forms.Padding(2);
             this.kbtnTreeView.Name = "kbtnTreeView";
@@ -317,9 +330,9 @@ namespace TestForm
             this.kbtnTreeView.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnTreeView.Values.Text = "TreeView";
             this.kbtnTreeView.Click += new System.EventHandler(this.kbtnTreeView_Click);
-            // 
+            //
             // kbtnExit
-            // 
+            //
             this.kbtnExit.DialogResult = System.Windows.Forms.DialogResult.Cancel;
             this.kbtnExit.Location = new System.Drawing.Point(12, 493);
             this.kbtnExit.Margin = new System.Windows.Forms.Padding(2);
@@ -329,9 +342,9 @@ namespace TestForm
             this.kbtnExit.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnExit.Values.Text = "Exit";
             this.kbtnExit.Click += new System.EventHandler(this.kbtnExit_Click);
-            // 
+            //
             // kbtnFormBorder
-            // 
+            //
             this.kbtnFormBorder.Location = new System.Drawing.Point(12, 174);
             this.kbtnFormBorder.Margin = new System.Windows.Forms.Padding(2);
             this.kbtnFormBorder.Name = "kbtnFormBorder";
@@ -340,9 +353,9 @@ namespace TestForm
             this.kbtnFormBorder.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnFormBorder.Values.Text = "Form Border";
             this.kbtnFormBorder.Click += new System.EventHandler(this.kbtnFormBorder_Click);
-            // 
+            //
             // kbtnToast
-            // 
+            //
             this.kbtnToast.Location = new System.Drawing.Point(12, 388);
             this.kbtnToast.Margin = new System.Windows.Forms.Padding(2);
             this.kbtnToast.Name = "kbtnToast";
@@ -351,9 +364,9 @@ namespace TestForm
             this.kbtnToast.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnToast.Values.Text = "Toast";
             this.kbtnToast.Click += new System.EventHandler(this.kbtnToast_Click);
-            // 
+            //
             // kbtnTheme
-            // 
+            //
             this.kbtnTheme.Location = new System.Drawing.Point(223, 362);
             this.kbtnTheme.Margin = new System.Windows.Forms.Padding(2);
             this.kbtnTheme.Name = "kbtnTheme";
@@ -362,9 +375,9 @@ namespace TestForm
             this.kbtnTheme.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnTheme.Values.Text = "Theme";
             this.kbtnTheme.Click += new System.EventHandler(this.kbtnTheme_Click);
-            // 
+            //
             // kbtnTextBox
-            // 
+            //
             this.kbtnTextBox.Location = new System.Drawing.Point(223, 335);
             this.kbtnTextBox.Margin = new System.Windows.Forms.Padding(2);
             this.kbtnTextBox.Name = "kbtnTextBox";
@@ -373,9 +386,9 @@ namespace TestForm
             this.kbtnTextBox.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnTextBox.Values.Text = "TextBox";
             this.kbtnTextBox.Click += new System.EventHandler(this.kbtnTextBox_Click);
-            // 
+            //
             // kbtnRibbon
-            // 
+            //
             this.kbtnRibbon.Location = new System.Drawing.Point(223, 308);
             this.kbtnRibbon.Margin = new System.Windows.Forms.Padding(2);
             this.kbtnRibbon.Name = "kbtnRibbon";
@@ -384,9 +397,9 @@ namespace TestForm
             this.kbtnRibbon.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnRibbon.Values.Text = "Ribbon";
             this.kbtnRibbon.Click += new System.EventHandler(this.kbtnRibbon_Click);
-            // 
+            //
             // kbtnProgressBar
-            // 
+            //
             this.kbtnProgressBar.Location = new System.Drawing.Point(12, 281);
             this.kbtnProgressBar.Margin = new System.Windows.Forms.Padding(2);
             this.kbtnProgressBar.Name = "kbtnProgressBar";
@@ -395,9 +408,9 @@ namespace TestForm
             this.kbtnProgressBar.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnProgressBar.Values.Text = "ProgressBar";
             this.kbtnProgressBar.Click += new System.EventHandler(this.kbtnProgressBar_Click);
-            // 
+            //
             // kbtnButtons
-            // 
+            //
             this.kbtnButtons.Location = new System.Drawing.Point(13, 67);
             this.kbtnButtons.Name = "kbtnButtons";
             this.kbtnButtons.Size = new System.Drawing.Size(153, 20);
@@ -405,9 +418,9 @@ namespace TestForm
             this.kbtnButtons.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnButtons.Values.Text = "Buttons";
             this.kbtnButtons.Click += new System.EventHandler(this.kbtnButtons_Click);
-            // 
+            //
             // kbtnAboutBox
-            // 
+            //
             this.kbtnAboutBox.Location = new System.Drawing.Point(223, 254);
             this.kbtnAboutBox.Margin = new System.Windows.Forms.Padding(2);
             this.kbtnAboutBox.Name = "kbtnAboutBox";
@@ -416,9 +429,9 @@ namespace TestForm
             this.kbtnAboutBox.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnAboutBox.Values.Text = "Old Style Main: \"Fullscreen\"";
             this.kbtnAboutBox.Click += new System.EventHandler(this.kbtnAboutBox_Click);
-            // 
+            //
             // kbtnMessageBox
-            // 
+            //
             this.kbtnMessageBox.Location = new System.Drawing.Point(223, 228);
             this.kbtnMessageBox.Margin = new System.Windows.Forms.Padding(2);
             this.kbtnMessageBox.Name = "kbtnMessageBox";
@@ -427,9 +440,9 @@ namespace TestForm
             this.kbtnMessageBox.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnMessageBox.Values.Text = "MessageBox";
             this.kbtnMessageBox.Click += new System.EventHandler(this.kbtnMessageBox_Click);
-            // 
+            //
             // kbtnMenuToolStatusStrips
-            // 
+            //
             this.kbtnMenuToolStatusStrips.Location = new System.Drawing.Point(12, 228);
             this.kbtnMenuToolStatusStrips.Margin = new System.Windows.Forms.Padding(2);
             this.kbtnMenuToolStatusStrips.Name = "kbtnMenuToolStatusStrips";
@@ -438,9 +451,9 @@ namespace TestForm
             this.kbtnMenuToolStatusStrips.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnMenuToolStatusStrips.Values.Text = "Menu/Tool/Status Strips";
             this.kbtnMenuToolStatusStrips.Click += new System.EventHandler(this.kbtnMenuToolStatusStrips_Click);
-            // 
+            //
             // kbtnGroupBox
-            // 
+            //
             this.kbtnGroupBox.Location = new System.Drawing.Point(223, 174);
             this.kbtnGroupBox.Margin = new System.Windows.Forms.Padding(2);
             this.kbtnGroupBox.Name = "kbtnGroupBox";
@@ -449,9 +462,9 @@ namespace TestForm
             this.kbtnGroupBox.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnGroupBox.Values.Text = "GroupBox";
             this.kbtnGroupBox.Click += new System.EventHandler(this.kbtnGroupBox_Click);
-            // 
+            //
             // kbtnFadeForm
-            // 
+            //
             this.kbtnFadeForm.Location = new System.Drawing.Point(223, 147);
             this.kbtnFadeForm.Margin = new System.Windows.Forms.Padding(2);
             this.kbtnFadeForm.Name = "kbtnFadeForm";
@@ -460,9 +473,9 @@ namespace TestForm
             this.kbtnFadeForm.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnFadeForm.Values.Text = "Fade Form";
             this.kbtnFadeForm.Click += new System.EventHandler(this.kbtnFadeForm_Click);
-            // 
+            //
             // kbtnCommandLinkButtons
-            // 
+            //
             this.kbtnCommandLinkButtons.Location = new System.Drawing.Point(13, 93);
             this.kbtnCommandLinkButtons.Name = "kbtnCommandLinkButtons";
             this.kbtnCommandLinkButtons.Size = new System.Drawing.Size(153, 20);
@@ -470,9 +483,9 @@ namespace TestForm
             this.kbtnCommandLinkButtons.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnCommandLinkButtons.Values.Text = "CommandLink Buttons";
             this.kbtnCommandLinkButtons.Click += new System.EventHandler(this.kbtnCommandLinkButtons_Click);
-            // 
+            //
             // kbtnBreadCrumb
-            // 
+            //
             this.kbtnBreadCrumb.Location = new System.Drawing.Point(223, 40);
             this.kbtnBreadCrumb.Name = "kbtnBreadCrumb";
             this.kbtnBreadCrumb.Size = new System.Drawing.Size(153, 20);
@@ -480,20 +493,20 @@ namespace TestForm
             this.kbtnBreadCrumb.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnBreadCrumb.Values.Text = "BreadCrumb";
             this.kbtnBreadCrumb.Click += new System.EventHandler(this.kbtnBreadCrumb_Click);
-            // 
+            //
             // kryptonManager1
-            // 
+            //
             this.kryptonManager1.BaseFont = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.kryptonManager1.ToolkitStrings.MessageBoxStrings.LessDetails = "L&ess Details...";
             this.kryptonManager1.ToolkitStrings.MessageBoxStrings.MoreDetails = "&More Details...";
-            // 
+            //
             // StartScreen
-            // 
+            //
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
             this.CancelButton = this.kbtnExit;
-            this.ClientSize = new System.Drawing.Size(358, 476);
+            this.ClientSize = new System.Drawing.Size(390, 485);
             this.Controls.Add(this.kryptonPanel1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MaximizeBox = false;
@@ -550,5 +563,6 @@ namespace TestForm
         private KryptonButton kbtnControlStyles;
         private KryptonButton kbtnSplashScreen;
         private KryptonButton kbtnBlurredForm;
+        private KryptonButton kbtnPaletteViewer;
     }
 }

--- a/Source/Krypton Components/TestForm/StartScreen.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.cs
@@ -217,4 +217,11 @@ public partial class StartScreen : KryptonForm
     {
         new BlurExampleForm().Show();
     }
+
+    private void kbtnPaletteViewer_Click(object sender, EventArgs e)
+    {
+        var viewer = new PaletteViewerForm();
+        viewer.AttachKryptonManager(kryptonManager1);
+        viewer.Show();
+    }
 }

--- a/Source/Krypton Components/TestForm/TestForm.csproj
+++ b/Source/Krypton Components/TestForm/TestForm.csproj
@@ -45,6 +45,15 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="app.manifest" />
+    <None Include="App.config" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Reference Include="System.Design, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" Condition="$(TargetFramework.StartsWith('net4'))">
       <SpecificVersion>True</SpecificVersion>
       <Version>4.0.0.0</Version>

--- a/Source/Krypton Components/TestForm/app.manifest
+++ b/Source/Krypton Components/TestForm/app.manifest
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="Passt.Schema.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- UAC Manifest Options
+             If you want to change the Windows User Account Control level replace the
+             requestedExecutionLevel node with one of the following.
+
+        <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
+        <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
+        <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
+
+            Specifying requestedExecutionLevel element will disable file and registry virtualization.
+            Remove this element if your application requires this virtualization for backwards
+            compatibility.
+        -->
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on
+           and is designed to work with. Uncomment the appropriate elements
+           and Windows will automatically select the most compatible environment. -->
+
+      <!-- Windows Vista -->
+      <!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
+
+      <!-- Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
+
+      <!-- Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
+
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
+
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+
+      <!-- Windows 11 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+
+    </application>
+  </compatibility>
+
+  <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should
+       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config.
+
+       Makes the application long-path aware. See https://docs.microsoft.com/windows/win32/fileio/maximum-file-path-limitation -->
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+
+  <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+
+</assembly>


### PR DESCRIPTION
Added PaletteViewer form to StartScreen and adjusted layout in TestForm.

Fixed index errror in PaletteMicrosoft365Blue to prevent runtime exception (out of bounds color index). 
Also fixed enum typos in comments, which are relevant for this tool!

Included Newtonsoft.Json package reference in project file.
Added manifest/config for HighDPI display support. 
StartScreen made slightly larger to not cut off buttons.

Fixes #2287 

Usage hints: specify path to Source folder; click "Add ALL" to fill grid with all compatible palettes; scroll down/across to find cells with error flags; "Missing value" means that the row's key is missing in the palette's array (can cause exceptions!).
Grid can be exported in CSV, JSON or XML format.

Development 100% directed by tobitege, 95% implemented by OpenAI's o3 model in close cooperation. 😁 