### PR TITLE
(fix) VisualInputBox and VisualMessageBox form components (V100)

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualInputBoxRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualInputBoxRtlAwareForm.cs
@@ -21,13 +21,13 @@ internal partial class VisualInputBoxRtlAwareForm : KryptonForm
 
     public VisualInputBoxRtlAwareForm()
     {
-        SetInheritedControlOverride();
+        //SetInheritedControlOverride();
         InitializeComponent();
     }
 
     public VisualInputBoxRtlAwareForm(KryptonInputBoxData inputBoxData)
     {
-        SetInheritedControlOverride();
+        //SetInheritedControlOverride();
         _inputBoxData = inputBoxData;
 
         InitializeComponent();

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareForm.cs
@@ -38,7 +38,7 @@ internal partial class VisualMessageBoxRtlAwareForm : KryptonForm
 
     public VisualMessageBoxRtlAwareForm()
     {
-        SetInheritedControlOverride();
+        //SetInheritedControlOverride();
         InitializeComponent();
     }
 
@@ -50,7 +50,7 @@ internal partial class VisualMessageBoxRtlAwareForm : KryptonForm
         bool? showHelpButton,
         bool? showCloseButton)
     {
-        SetInheritedControlOverride();
+        //SetInheritedControlOverride();
         // Store incoming values
         _text = CommonHelper.NormalizeLineBreaks(text ?? string.Empty);
         _caption = caption;
@@ -93,8 +93,8 @@ internal partial class VisualMessageBoxRtlAwareForm : KryptonForm
 
     private void UpdateText()
     {
-        Text = string.IsNullOrEmpty(_caption) 
-            ? string.Empty 
+        Text = string.IsNullOrEmpty(_caption)
+            ? string.Empty
             : _caption!.Split(Environment.NewLine.ToCharArray())[0];
         krtbMessageText.Text = _text;
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualInputBoxForm.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualInputBoxForm.Designer.cs
@@ -42,18 +42,19 @@
             ((System.ComponentModel.ISupportInitialize)(this._kryptonPanel1)).BeginInit();
             this._kryptonPanel1.SuspendLayout();
             this.SuspendLayout();
-            // 
+            //
             // _panelMessage
-            // 
+            //
             this._panelMessage.Controls.Add(this._tableLayoutPanel1);
             this._panelMessage.Dock = System.Windows.Forms.DockStyle.Fill;
             this._panelMessage.Location = new System.Drawing.Point(0, 0);
+            this._panelMessage.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this._panelMessage.Name = "_panelMessage";
-            this._panelMessage.Size = new System.Drawing.Size(362, 118);
+            this._panelMessage.Size = new System.Drawing.Size(487, 131);
             this._panelMessage.TabIndex = 1;
-            // 
+            //
             // _tableLayoutPanel1
-            // 
+            //
             this._tableLayoutPanel1.AutoSize = true;
             this._tableLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this._tableLayoutPanel1.BackColor = System.Drawing.Color.Transparent;
@@ -71,88 +72,89 @@
             this._tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this._tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this._tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this._tableLayoutPanel1.Size = new System.Drawing.Size(350, 109);
+            this._tableLayoutPanel1.Size = new System.Drawing.Size(467, 137);
             this._tableLayoutPanel1.TabIndex = 3;
-            // 
+            //
             // _labelPrompt
-            // 
-            this._labelPrompt.Font = new System.Drawing.Font("Segoe UI", 9F);
-            this._labelPrompt.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(30)))), ((int)(((byte)(57)))), ((int)(((byte)(91)))));
+            //
             this._labelPrompt.LabelStyle = Krypton.Toolkit.LabelStyle.NormalControl;
-            this._labelPrompt.Location = new System.Drawing.Point(4, 4);
-            this._labelPrompt.Margin = new System.Windows.Forms.Padding(4);
+            this._labelPrompt.Location = new System.Drawing.Point(5, 5);
+            this._labelPrompt.Margin = new System.Windows.Forms.Padding(5, 5, 5, 5);
             this._labelPrompt.Name = "_labelPrompt";
-            this._labelPrompt.Size = new System.Drawing.Size(47, 15);
+            this._labelPrompt.Size = new System.Drawing.Size(58, 20);
             this._labelPrompt.Text = "Prompt";
-            // 
+            //
             // _textBoxResponse
-            // 
+            //
             this._textBoxResponse.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._textBoxResponse.Location = new System.Drawing.Point(8, 26);
-            this._textBoxResponse.Margin = new System.Windows.Forms.Padding(8, 3, 8, 3);
-            this._textBoxResponse.MinimumSize = new System.Drawing.Size(333, 27);
+            this._textBoxResponse.Location = new System.Drawing.Point(11, 34);
+            this._textBoxResponse.Margin = new System.Windows.Forms.Padding(11, 4, 11, 4);
+            this._textBoxResponse.MinimumSize = new System.Drawing.Size(444, 27);
             this._textBoxResponse.Name = "_textBoxResponse";
-            this._textBoxResponse.Size = new System.Drawing.Size(334, 27);
+            this._textBoxResponse.Size = new System.Drawing.Size(445, 27);
             this._textBoxResponse.TabIndex = 0;
             this._textBoxResponse.KeyDown += new System.Windows.Forms.KeyEventHandler(this.Response_KeyDown);
-            // 
+            //
             // _kryptonBorderEdge1
-            // 
+            //
             this._kryptonBorderEdge1.AutoSize = false;
             this._kryptonBorderEdge1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._kryptonBorderEdge1.Location = new System.Drawing.Point(0, 64);
-            this._kryptonBorderEdge1.Margin = new System.Windows.Forms.Padding(0, 8, 0, 8);
+            this._kryptonBorderEdge1.Location = new System.Drawing.Point(0, 75);
+            this._kryptonBorderEdge1.Margin = new System.Windows.Forms.Padding(0, 10, 0, 10);
             this._kryptonBorderEdge1.Name = "_kryptonBorderEdge1";
-            this._kryptonBorderEdge1.Size = new System.Drawing.Size(350, 1);
+            this._kryptonBorderEdge1.Size = new System.Drawing.Size(467, 1);
             this._kryptonBorderEdge1.Text = "kryptonBorderEdge1";
-            // 
+            //
             // _kryptonPanel1
-            // 
+            //
             this._kryptonPanel1.Controls.Add(this._buttonOk);
             this._kryptonPanel1.Controls.Add(this._buttonCancel);
             this._kryptonPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this._kryptonPanel1.Location = new System.Drawing.Point(2, 75);
-            this._kryptonPanel1.Margin = new System.Windows.Forms.Padding(2, 2, 2, 8);
+            this._kryptonPanel1.Location = new System.Drawing.Point(3, 88);
+            this._kryptonPanel1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 10);
             this._kryptonPanel1.Name = "_kryptonPanel1";
-            this._kryptonPanel1.Padding = new System.Windows.Forms.Padding(0, 0, 0, 8);
-            this._kryptonPanel1.Size = new System.Drawing.Size(346, 26);
+            this._kryptonPanel1.Padding = new System.Windows.Forms.Padding(0, 0, 0, 10);
+            this._kryptonPanel1.Size = new System.Drawing.Size(461, 39);
             this._kryptonPanel1.TabIndex = 2;
-            // 
+            //
             // _buttonOk
-            // 
+            //
             this._buttonOk.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this._buttonOk.AutoSize = true;
             this._buttonOk.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this._buttonOk.Location = new System.Drawing.Point(213, 0);
-            this._buttonOk.Margin = new System.Windows.Forms.Padding(0, 0, 0, 8);
-            this._buttonOk.MinimumSize = new System.Drawing.Size(50, 26);
+            this._buttonOk.Location = new System.Drawing.Point(235, 1);
+            this._buttonOk.Margin = new System.Windows.Forms.Padding(0, 0, 0, 10);
+            this._buttonOk.MinimumSize = new System.Drawing.Size(100, 32);
             this._buttonOk.Name = "_buttonOk";
-            this._buttonOk.Size = new System.Drawing.Size(55, 26);
+            this._buttonOk.Size = new System.Drawing.Size(100, 32);
             this._buttonOk.TabIndex = 1;
+            this._buttonOk.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this._buttonOk.Values.Text = "&OK";
-            // 
+            //
             // _buttonCancel
-            // 
+            //
             this._buttonCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this._buttonCancel.AutoSize = true;
             this._buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this._buttonCancel.Location = new System.Drawing.Point(285, 0);
+            this._buttonCancel.Location = new System.Drawing.Point(353, 1);
             this._buttonCancel.Margin = new System.Windows.Forms.Padding(0);
-            this._buttonCancel.MinimumSize = new System.Drawing.Size(50, 26);
+            this._buttonCancel.MinimumSize = new System.Drawing.Size(100, 32);
             this._buttonCancel.Name = "_buttonCancel";
-            this._buttonCancel.Size = new System.Drawing.Size(55, 26);
+            this._buttonCancel.Size = new System.Drawing.Size(100, 32);
             this._buttonCancel.TabIndex = 2;
+            this._buttonCancel.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this._buttonCancel.Values.Text = "Cance&l";
-            // 
+            //
             // VisualInputBoxForm
-            // 
+            //
             this.AcceptButton = this._buttonOk;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this._buttonCancel;
-            this.ClientSize = new System.Drawing.Size(362, 118);
+            this.ClientSize = new System.Drawing.Size(487, 131);
             this.Controls.Add(this._panelMessage);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
+            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "VisualInputBoxForm";
@@ -168,7 +170,6 @@
             this._kryptonPanel1.ResumeLayout(false);
             this._kryptonPanel1.PerformLayout();
             this.ResumeLayout(false);
-
         }
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualInputBoxForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualInputBoxForm.cs
@@ -30,7 +30,7 @@ public partial class VisualInputBoxForm : KryptonForm
     /// </summary>
     public VisualInputBoxForm()
     {
-        SetInheritedControlOverride();
+        //SetInheritedControlOverride();
         InitializeComponent();
     }
 
@@ -38,7 +38,7 @@ public partial class VisualInputBoxForm : KryptonForm
     /// <param name="inputBoxData">The input box data.</param>
     public VisualInputBoxForm(KryptonInputBoxData inputBoxData)
     {
-        SetInheritedControlOverride();
+        //SetInheritedControlOverride();
         InitializeComponent();
 
         _inputBoxData = inputBoxData;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxForm.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
  *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *
  */
 #endregion
 
@@ -17,7 +17,6 @@ namespace Krypton.Toolkit;
 
 internal partial class VisualMessageBoxForm : KryptonForm
 {
-
     #region Instance Fields
 
     private readonly bool _showHelpButton;
@@ -46,7 +45,7 @@ internal partial class VisualMessageBoxForm : KryptonForm
 
     public VisualMessageBoxForm()
     {
-        SetInheritedControlOverride();
+        //SetInheritedControlOverride();
         InitializeComponent();
     }
 
@@ -58,7 +57,7 @@ internal partial class VisualMessageBoxForm : KryptonForm
         bool? showHelpButton,
         bool? showCloseButton)
     {
-        SetInheritedControlOverride();
+        //SetInheritedControlOverride();
         // Store incoming values
         _text = CommonHelper.NormalizeLineBreaks(text ?? string.Empty);
         _caption = caption;
@@ -268,13 +267,13 @@ internal partial class VisualMessageBoxForm : KryptonForm
                     SystemSounds.Exclamation.Play();
                     break;
                 case KryptonMessageBoxIcon.Shield:
-                    _messageIcon.Image = OSUtilities.IsWindowsTen 
-                        ? UACShieldIconResources.UAC_Shield_Windows_10 
+                    _messageIcon.Image = OSUtilities.IsWindowsTen
+                        ? UACShieldIconResources.UAC_Shield_Windows_10
                         : UACShieldIconResources.UAC_Shield_Windows_7;
                     break;
                 case KryptonMessageBoxIcon.WindowsLogo:
-                    _messageIcon.Image = OSUtilities.IsWindowsTen 
-                        ? MessageBoxImageResources.Windows_8_and_10_Logo 
+                    _messageIcon.Image = OSUtilities.IsWindowsTen
+                        ? MessageBoxImageResources.Windows_8_and_10_Logo
                         : SystemIcons.WinLogo.ToBitmap();
                     break;
                 case KryptonMessageBoxIcon.Application:
@@ -517,7 +516,7 @@ internal partial class VisualMessageBoxForm : KryptonForm
             Size scaledMonitorSize = screen.WorkingArea.Size;
             scaledMonitorSize.Width = (int)(scaledMonitorSize.Width * 2 / 3.0f);
             scaledMonitorSize.Height = (int)(scaledMonitorSize.Height * 0.95f);
-                
+
             Font textFont = krtbMessageText.StateCommon.Content.GetContentShortTextFont(PaletteState.Normal) ?? KryptonManager.CurrentGlobalPalette!.BaseFont;
             Font captionFont = KryptonManager.CurrentGlobalPalette.BaseFont;
 
@@ -681,7 +680,7 @@ internal partial class VisualMessageBoxForm : KryptonForm
 
 #region Types
 /// <summary>
-/// 
+///
 /// </summary>
 public class HelpInfo
 {


### PR DESCRIPTION
Both the `KryptonInputBox` and `KryptonMessageBox` only showed an "empty" form with no controls at all.

To fix this, it was necessary to comment out `SetInheritedControlOverride();` which removed the components from the form's controls list and make them disappear.

Here's the A.I. assisted explanation why, what and how... 😃 

What that flag really does – and why it broke the message-box

1  How `KryptonForm` organises its client area  
• Every `KryptonForm` creates a hidden `KryptonPanel` called **InternalKryptonPanel**.  
  All controls that you drop on the form designer are actually added to that panel, **not** to the real `this.Controls` collection.  
• When the form first enters layout (`ResumeLayout(false)`), `KryptonForm` normally copies the controls from InternalKryptonPanel up into `base.Controls`.  
  This allows the Chrome/Caption rendering code to treat the client controls exactly like a stock WinForms form.

2  What `SetInheritedControlOverride()` does  
`SetInheritedControlOverride()` flips a private flag (`_internalPanelState = InheritBool.True`).  
When that flag is set the copy-out step in `ResumeLayout` is skipped, so the child controls remain inside the hidden panel.  

Why would you ever want that?  
– When you create a *base class* form (one that other forms inherit from in the designer) you don’t want the base class to rip its controls out of the panel before the derived designer gets a chance to insert its own controls. Calling the override keeps the base controls safely inside the panel.

3  Why it killed `VisualMessageBoxForm`  
The message-box forms are not meant to serve as designer base classes, yet the override was called unconditionally at the very top of the constructor.  
That prevented the copy-out, hence all the designer controls (icon, RichTextBox, buttons) stayed behind the chrome panel and never became visible.

Removing the two calls restores the normal path:

```
InternalKryptonPanel         →   copies to   →   this.Controls
(icon, text, buttons)                             (now visible)
```

4  What about the 20-odd other calls?  
They are almost all in **base-class-style** utility forms (multiline editor, toast notifications, theme browser, etc.) or in forms that become MDI containers.  
For those scenarios the override is valid and should remain.

Key rule:  
• Use `SetInheritedControlOverride()` **only** on a form that is intended to be inherited from or where you explicitly want the client controls to stay inside the internal panel.  
• Regular modal dialogs (message boxes, input boxes, etc.) should not call it.


P.S.: there are some more cosmetic changes related to removal of trailing spaces, which happens in my editor automatically.