### PR TITLE
2296-V100-fix-visual-controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -317,7 +317,6 @@ __pycache__/
 # OpenCover UI analysis results
 OpenCover/
 
-
 Help/New/Help/
 Installer Project Files/Krypton Toolkit Suite/Krypton Toolkit Suite-cache/cacheIndex.txt
 Installer Project Files/Krypton Toolkit Suite/Krypton Toolkit Suite-cache/part1/Krypton Toolkit Suite1.cab
@@ -332,3 +331,5 @@ Source/Krypton Components/Temp.txt
 # Log files
 /Logs
 Source/Krypton Components/Krypton.Ribbon/Temp.txt
+
+.cursor/

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -1,8 +1,9 @@
 # <img src="https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/Krypton.png?raw=true"> Standard Toolkit - ChangeLog
 
-==== 
+====
 
 ## 2025-11-xx - Build 2511 (V10 - alpha) - November 2025
+* Resolved [#2296](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2296), Fix `Visual Controls' components from showing blank content.
 * Resolved [#2235](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2235), `OSUtilities` Adds OsVersionInfo to the properties.
 * Resolved [#2264](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2264), Implementation of style: `PaletteBackStyle.Control`, `PaletteContentStyle.LabelAlternateControl` and `PaletteContentStyle.LabelAlternatePanel` in all themes
 * Resolved [#2200](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2200), `KryptonAutoHiddenSlidePanel.PreFilterMessage` will now use the ActiveFormTracker.
@@ -72,7 +73,7 @@
 * Resolved [#1910](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1910), `Workspace Persistence` -> "Save to array" Causes an exception in `Toolkit.XmlHelper.Image.Save`
 * Implemented [#1117](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1117), Is it possible to have the KForm back colour as the KPanel colour
 * Resolved [#1900](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1900), Remove Obsolete `KryptonMessageBoxDep` from V100 code base
-* Resolved [#1211](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1211), Button 'drop down' arrows should use palette text colour 
+* Resolved [#1211](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1211), Button 'drop down' arrows should use palette text colour
 * Resolved [#1212](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1212), **[Breaking Change]** `KColorButton` 'drop-down' arrow should be drawn
 	- Create Scaled Drop Glyph and use for colour button and comboDrops
 	- Remove the `PaletteRedirectDropDownButton`
@@ -131,12 +132,12 @@
 * Resolved [#1909](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1909), `KryptonDataGridViewComboBoxCell` displays an empty drop-down list on the first new row.
 * Resolved [#1910](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1910), `Workspace Persistence` -> "Save to array" Causes an exception in `Toolkit.XmlHelper.Image.Save`
 * Resolved [#1900](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1211), **Deprecate** -Remove `KryptonMessageBoxDep` from V100 code base
-* Resolved [#1211](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1211), Button 'drop down' arrows should use palette text colour 
+* Resolved [#1211](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1211), Button 'drop down' arrows should use palette text colour
 * Resolved [#1212](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1212), **[Breaking Change]** `KColorButton` 'drop-down' arrow should be drawn
 	- Create Scaled Drop Glyph and use for colour button and comboDrops
 	- Remove the `PaletteRedirectDropDownButton`
 	- Remove `KryptonPaletteImagesDropDownButton`
-	- **Breaking Change**: Remove `DropDownButtonImages` from designers 
+	- **Breaking Change**: Remove `DropDownButtonImages` from designers
 * Resolved [#1887](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1887), If `KryptonPropertyGrid` has focus on groupName and loses mouse over, then it is all filled in black
 * Resolved [#1878](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1878), `KryptonListView` is missing key events
 * Resolved [#1843](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1843), `ButtonSpec` position is off due to an incorrect padding when style is set to "List Item".
@@ -148,7 +149,7 @@
 * Resolved [#1783](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1843), KForm borders incorrect
 * Resolved [#1807](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1807), `ChromeBorderWidth` and Padding
 * Resolved [#1842](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1842), `KryptonTextBox` height collapses when MultiLine is enabled.
-* Resolved [#1241](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1241), `KryptonDataGridViewComboBoxColumn` ignores `ValueMember` in data binding. 
+* Resolved [#1241](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1241), `KryptonDataGridViewComboBoxColumn` ignores `ValueMember` in data binding.
 
 
 =======
@@ -205,11 +206,11 @@
 * Resolved [#239](https://github.com/Krypton-Suite/Standard-Toolkit/issues/239), Toolstrip combo boxes do not have the theme background applied
 * Implemented [#1507](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1507), **[Breaking Change]** `KryptonThemeComboBox`, `KryptonThemeListBox` & `KryptonRibbonGroupThemeComboBox`:
 	- All controls had their code base updated to one standard.
-	- The assignment of themes via an index has been removed from all. 
+	- The assignment of themes via an index has been removed from all.
 	- The previous has been replaced by assignment per PaletteMode identifier.
 	- All controls do now react to theme changes propagated via the KryptonManager. The control will then synchronize the selected item in the list with the newly activated theme.
 	- Form designer files or your code using a theme selector control might hold references to these properties: `KryptonManager`, `ReportSelectedThemeIndex`, `ThemeSelectedIndex` & `SynchronizeDropDownWidth`. These can, safely, be removed.
-	- The DefaultPalette property is now stored in the designer file and if set, the selected palette wil be loaded when the selector control is instantiated. 
+	- The DefaultPalette property is now stored in the designer file and if set, the selected palette wil be loaded when the selector control is instantiated.
 	- The DefaultPalette property can also be used to switch palettes from code.
 * Resolved [#1502](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1502), Fixes some problems creating workspaces introduced through warnings removal.
 * Resolved [#1497](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1497), When pressing ALT to show the Ribbon KeyTips a null reference exception is thrown.
@@ -227,9 +228,9 @@
 * Resolved [#1381](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1381), **[Regression]** Docking Persistence broken since build ##.23.10.303
 * Resolved [#1356](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1356), **[Breaking Change]** AppButton colours don't change while switching themes
 	- See https://github.com/Krypton-Suite/Standard-Toolkit/issues/1356#issuecomment-2039412890
-	- `RibbonAppButton` has become `RibbonFileAppButton` 
+	- `RibbonAppButton` has become `RibbonFileAppButton`
 	- Addition `RibbonFileAppTab` to hold the tab text (Defaults to `File`)
-	- Colours for the `FileAppTab` have been moved into the `StateCommon` area 
+	- Colours for the `FileAppTab` have been moved into the `StateCommon` area
 * Resolved [#1301](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1301), **[Regression]** When Maximised - intergrated KryptonRibbon has titlebar issues
 * Resolved [#1383](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1383), Closing last Page in undocked page group prevents addition of further Pages via `KryptonDockingManager.AddToWorkspace` (fix courtesy of [stizler](https://github.com/stigzler))
 * Resolved [#1336](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1336), **[Regression]** KryptonForm has "Black Line" under Titlebar when maximised
@@ -259,7 +260,7 @@
 * Resolved [#1308](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1308), `RibbonAppButton.cs` - **FormCloseBoxVisible**: null reference exception
 * Resolved [#1266](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1266), **[Regression]** **[Breaking Change]** Since V 5.400, the QAT button is supposed to perform the close, therefore the Close Form button should not be visible
 * Resolved [#313](https://github.com/Krypton-Suite/Standard-Toolkit/issues/313), **[Regression]** `KryptonMessagebox` is not RTL compliant
-* Resolved [#1269](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1269), **[Breaking Change]** Remove AllowFormIntegrate to give consistent experience on all supported OS's 
+* Resolved [#1269](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1269), **[Breaking Change]** Remove AllowFormIntegrate to give consistent experience on all supported OS's
 * Resolved [#1268](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1268), **[Breaking Change]** Many Krypton Controls have a CornerRoundingRadius that overrides the State#### Node Rounding values. Please remove!
 * Resolved [#1245](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1245), Visual Studio do not open Form after Nuget-Package-Update
 * Resolved [#1243](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1243), Krypton Navigator - Outlook Full Nav Mode
@@ -281,7 +282,7 @@
 * Resolved [#238](https://github.com/Krypton-Suite/Standard-Toolkit/issues/238), Dark / light Mode themes do not modify the calendar control background
 * Implemented [#139](https://github.com/Krypton-Suite/Standard-Toolkit/issues/139), Themes (via KryptonManager design option) should have option to respect Current Metrics for Form Border widths
 * Implemented [#124](https://github.com/Krypton-Suite/Standard-Toolkit/issues/124), **[Breaking Change]** When setting AllowFormChrome = false, then the Form Bar should still be Theme rendered
-* Implemented [#1224](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1224), **[Breaking Change]** Move `GlobalPaletteMode` into `GlobalPalette` and rename 
+* Implemented [#1224](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1224), **[Breaking Change]** Move `GlobalPaletteMode` into `GlobalPalette` and rename
 * Implemented [#1223](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1223), Move `UseKryptonFileDialogs` to a better designer location
 * Implemented [#1222](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1222), Remove `CustomPalette` (Should be part of the palette definition)
 * Implemented [#1204](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1204), Build on `KryptonCommandLinkButtons`
@@ -319,12 +320,12 @@
 * Resolved [#1905](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1905), `Sparkle` Themes have an issue with the Background
 * Resolved [#980](https://github.com/Krypton-Suite/Standard-Toolkit/issues/980), `KryptonDockableNavigator` with pages without `AllowConfigSave` flag are incorrectly saved
 * Resolved [#1910](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1910), `Workspace Persistence` -> "Save to array" Causes an exception in `Toolkit.XmlHelper.Image.Save`
-* Resolved [#1211](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1211), Button 'drop down' arrows should use palette text colour 
+* Resolved [#1211](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1211), Button 'drop down' arrows should use palette text colour
 * Resolved [#1212](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1212), **[Breaking Change]** `KColorButton` 'drop-down' arrow should be drawn
 	- Create Scaled Drop Glyph and use for colour button and comboDrops
 	- Remove the `PaletteRedirectDropDownButton`
 	- Remove `KryptonPaletteImagesDropDownButton`
-	- **Breaking Change**: Remove `DropDownButtonImages` from designers 
+	- **Breaking Change**: Remove `DropDownButtonImages` from designers
 * Resolved [#1842](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1842), `KryptonTextBox` height collapses when MultiLine is enabled.
 * Resolved [#1399](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1399), Hard coded colour setting removed from the `KryptonRibbonTab`.
 
@@ -532,13 +533,13 @@ Cannot add items to KryptonGroupBox in WinForms Designer
 	- When the format of an Image is of Format MemoryBMP, save the image as format BMP.
 * Implemented [#756](https://github.com/Krypton-Suite/Standard-Toolkit/issues/756), Add `[AllowNull]` to a controls `Text` field
 * Resolved [#738](https://github.com/Krypton-Suite/Standard-Toolkit/issues/738), "Office 2010 - Blue (Dark Mode)": Form title text cannot be read
-* Implemented [#728](https://github.com/Krypton-Suite/Standard-Toolkit/issues/728), Bring MessageBox `States` inline with latest .Net 6 
+* Implemented [#728](https://github.com/Krypton-Suite/Standard-Toolkit/issues/728), Bring MessageBox `States` inline with latest .Net 6
 * Made enumeration `SchemeOfficeColors` public, so they can be used to make external themes
 * Resolved [#689](https://github.com/Krypton-Suite/Standard-Toolkit/issues/689), A way to remove border shadows on `KryptonToolTips`
 * Resolved [#666](https://github.com/Krypton-Suite/Standard-Toolkit/issues/666), KryptonTextBox `Validate` / `Validating` / `KeyUp` events are invoked twice
 * Resolved [#660](https://github.com/Krypton-Suite/Standard-Toolkit/issues/660), Krypton DomainUpDown control: Nearly impossible to place the cursor via the mouse
 * Resolved [#748](https://github.com/Krypton-Suite/Standard-Toolkit/issues/748), Navigator text is removed via designer changes for Navigator tabs
-* Resolved [#739](https://github.com/Krypton-Suite/Standard-Toolkit/issues/739), KryptonButton - Image stretches with increased border rounding 
+* Resolved [#739](https://github.com/Krypton-Suite/Standard-Toolkit/issues/739), KryptonButton - Image stretches with increased border rounding
 * Resolved [#688](https://github.com/Krypton-Suite/Standard-Toolkit/issues/688), KryptonComboBox / KryptonNumericUpDown / KryptonDomainUpDown Anchor Sizing no as expected when anchored Top & Bottom
 * Resolved [#722](https://github.com/Krypton-Suite/Standard-Toolkit/issues/722), KryptonRichTextBox disabled colour cannot be set
 * Resolved [#662](https://github.com/Krypton-Suite/Standard-Toolkit/issues/662), Can not "Control / Set Disabled" Background Colour Of Comboboxes, in DropDown mode
@@ -547,7 +548,7 @@ Cannot add items to KryptonGroupBox in WinForms Designer
 * Resolved [#20](https://github.com/Krypton-Suite/Standard-Toolkit/issues/20), Selected text in ComboBox is drawn in a different font
 * Resolved [#308](https://github.com/Krypton-Suite/Standard-Toolkit/issues/308), Panel AntiAlias Border Problem
 * Resolved [#734](https://github.com/Krypton-Suite/Standard-Toolkit/issues/734), Disabled Text in NumericUpDown Not visible
-* Resolved [#715](https://github.com/Krypton-Suite/Standard-Toolkit/issues/715), v65.22.4.94 - PaletteSparkleBlueBase.GetContentPadding: Specified argument was out of the range of valid values. Parameter name: style 
+* Resolved [#715](https://github.com/Krypton-Suite/Standard-Toolkit/issues/715), v65.22.4.94 - PaletteSparkleBlueBase.GetContentPadding: Specified argument was out of the range of valid values. Parameter name: style
 * Implemented the `PlacementModeConverter` for `PlacementMode` enum type
 * Implemented [#551](https://github.com/Krypton-Suite/Standard-Toolkit/issues/551), `DropShadow` should now be off and deprecated
 * Version bump `65.xx.xx.xxx` -> `70.xx.xx.xxx`
@@ -589,7 +590,7 @@ Cannot add items to KryptonGroupBox in WinForms Designer
 * Resolved [#609](https://github.com/Krypton-Suite/Standard-Toolkit/issues/609), `KryptonContextMenu`: Item text unreadable with certain themes
 	- At the moment, only the 'Black/Blue (Dark Mode)' themes are being worked on
 * Resolved [#607](https://github.com/Krypton-Suite/Standard-Toolkit/issues/607), `KryptonMessageBox` Certain length of the first line of text can push the text on the following out of the visible area (thanks to [giduac](https://github.com/giduac))
-* Some fixes for [#603](https://github.com/Krypton-Suite/Standard-Toolkit/issues/603), Title Bar Images Stretched/Cropped 
+* Some fixes for [#603](https://github.com/Krypton-Suite/Standard-Toolkit/issues/603), Title Bar Images Stretched/Cropped
 * Resolved [#596](https://github.com/Krypton-Suite/Standard-Toolkit/issues/596), ActionLists do not reflect the recommended or possible settings in the designer properties
 * Resolved [#590](https://github.com/Krypton-Suite/Standard-Toolkit/issues/590), Button text colour in certain themes is unreadable
 * Resolved [#587](https://github.com/Krypton-Suite/Standard-Toolkit/issues/587), `KryptonLabel` adds the `Paint` method by default
@@ -619,7 +620,7 @@ Cannot add items to KryptonGroupBox in WinForms Designer
 * Resolved [#441](https://github.com/Krypton-Suite/Standard-Toolkit/issues/441), Wrong Ribbon Form Height when Windows is using scaling; e.g. 200% dpi
 * Implement [#493](https://github.com/Krypton-Suite/Standard-Toolkit/issues/493), Invoke `PaletteState.Pressed` for all controlbox items in all office palettes
 * Resolved [#487](https://github.com/Krypton-Suite/Standard-Toolkit/issues/487), The position of the KryptonForm Control Buttons are too low, when no desktop scaling preference is applied
-* Implemented [#53](https://github.com/Krypton-Suite/Standard-Toolkit/issues/53), Need images of what this toolkit can give a developer on landing page 
+* Implemented [#53](https://github.com/Krypton-Suite/Standard-Toolkit/issues/53), Need images of what this toolkit can give a developer on landing page
 * Resolved [#34](https://github.com/Krypton-Suite/Standard-Toolkit/issues/34), KryptonRibbon.RibbonAppButton.AppButtonMenuItems has error
 * Resolved [#204](https://github.com/Krypton-Suite/Standard-Toolkit/issues/204), When A drop Button is disabled, it should also colour the drop item as disabled
 * Resolved [#310](https://github.com/Krypton-Suite/Standard-Toolkit/issues/310), Unsupported PaletteBackStyles are showing in the designer and causing it to crash
@@ -669,7 +670,7 @@ Cannot add items to KryptonGroupBox in WinForms Designer
 * Implemented [#396](https://github.com/Krypton-Suite/Standard-Toolkit/issues/396), Change the color button from automatically launching the dialog, and I can respond to an event to instead open my own dialog?
 * Implemented [#404](https://github.com/Krypton-Suite/Standard-Toolkit/issues/404), `KryptonInputBox` to have a default button
 * Resolved [#237](https://github.com/Krypton-Suite/Standard-Toolkit/issues/237), Office 365 - Black (Dark mode) Messes up combo boxes
-* Resolved [#403](https://github.com/Krypton-Suite/Standard-Toolkit/issues/403), Krypton.Toolkit.Nightly `Version="6.2109.272-alpha"` has removed code that was in 270 
+* Resolved [#403](https://github.com/Krypton-Suite/Standard-Toolkit/issues/403), Krypton.Toolkit.Nightly `Version="6.2109.272-alpha"` has removed code that was in 270
 * Complete [#118](https://github.com/Krypton-Suite/Standard-Toolkit/issues/118), Fix Compile Warnings and Messages
 * Implemented [#85](https://github.com/Krypton-Suite/Standard-Toolkit/issues/85), Update the project names from `2019` to `2022`
 * Updated code header year from `2021` to `2022`
@@ -714,8 +715,8 @@ Cannot add items to KryptonGroupBox in WinForms Designer
 * Resolved [#245](https://github.com/Krypton-Suite/Standard-Toolkit/issues/245), `TableLayoutPanel` should be "Kryptonised"
 * Implemented [#269](https://github.com/Krypton-Suite/Standard-Toolkit/issues/269), "Print Dialog" is in the Main Forms elements - Where is Kryptons' Standard themed equivalent
   - This *does not do* the PrintDlgEx, as that is buried too deep in the OS.
-* Resolved [#281](https://github.com/Krypton-Suite/Standard-Toolkit/issues/281), `KryptonScrollbar`: Scroll value cannot be set 
-* Resolved [#274](https://github.com/Krypton-Suite/Standard-Toolkit/issues/274), KRadioButton should use the Label(Panel) style by default 
+* Resolved [#281](https://github.com/Krypton-Suite/Standard-Toolkit/issues/281), `KryptonScrollbar`: Scroll value cannot be set
+* Resolved [#274](https://github.com/Krypton-Suite/Standard-Toolkit/issues/274), KRadioButton should use the Label(Panel) style by default
 * Resolved [#273](https://github.com/Krypton-Suite/Standard-Toolkit/issues/273), KCheckBox should use the Label(Panel) style by default
 * Resolved [#271](https://github.com/Krypton-Suite/Standard-Toolkit/issues/271), CueHint text is "Bottom" clipped by default
   - And add `TextV` to allow control for multi-line text boxes
@@ -748,7 +749,7 @@ Cannot add items to KryptonGroupBox in WinForms Designer
 ## 2021-08-03 Build 2108.1 - August 2021 (Canary Update 1)
 * Resolved [#230](https://github.com/Krypton-Suite/Standard-Toolkit/issues/230), ThemeManager does not populate with the new "Light / Dark" themes
 * Resolved [#229](https://github.com/Krypton-Suite/Standard-Toolkit/issues/229), Cannot set button text programatically
-* Resolved [#225](https://github.com/Krypton-Suite/Standard-Toolkit/issues/225), Cannot set text of a button in designer 
+* Resolved [#225](https://github.com/Krypton-Suite/Standard-Toolkit/issues/225), Cannot set text of a button in designer
 
 =======
 
@@ -792,13 +793,13 @@ Cannot add items to KryptonGroupBox in WinForms Designer
 * Implemented [#81](https://github.com/Krypton-Suite/Standard-Toolkit/issues/81), Can the "6.x.Lite" version only support .net48;net5.0-windows;net6.0-windows
 * Implemented [#79](https://github.com/Krypton-Suite/Standard-Toolkit/issues/79), Customise 'Hint' Font
 * Resolved [#77](https://github.com/Krypton-Suite/Standard-Toolkit/issues/77), When using KryptonInputBox focus is not on the edit box when it is shown
-* Resolved [#71](https://github.com/Krypton-Suite/Standard-Toolkit/issues/71), No design support while using Krypton.Ribbon in .NET 5/6 
+* Resolved [#71](https://github.com/Krypton-Suite/Standard-Toolkit/issues/71), No design support while using Krypton.Ribbon in .NET 5/6
 * Resolved [#54](https://github.com/Krypton-Suite/Standard-Toolkit/issues/54), .Net5 WinForm Project - Dropping a KLabel onto a KGroup or KGroupBox causes an Exception in Designer
 
 =======
 
 ## 2021-06-26 - Build 2106.2 - June 2021 (Update 2)
-* Resolved [#167](https://github.com/Krypton-Suite/Standard-Toolkit/issues/167), Latest Canary of `KryptonInputBox` is not usable!! 
+* Resolved [#167](https://github.com/Krypton-Suite/Standard-Toolkit/issues/167), Latest Canary of `KryptonInputBox` is not usable!!
 
 =======
 
@@ -862,7 +863,7 @@ Cannot add items to KryptonGroupBox in WinForms Designer
 ## 2020-06-01 - Build 2006 - June 2020
 * Implemented [#8](https://github.com/Krypton-Suite/Standard-Toolkit/issues/8), Is it possible to only minimize FloatingWindow in DockingManager?
 * Resolved [#9](https://github.com/Krypton-Suite/Standard-Toolkit/issues/9), Cannot place `KryptonStatusStrip` on a Form
-* Resolved [#12](https://github.com/Krypton-Suite/Standard-Toolkit/issues/12), AllowButtonSpecToolTipPriority 
+* Resolved [#12](https://github.com/Krypton-Suite/Standard-Toolkit/issues/12), AllowButtonSpecToolTipPriority
 	- If the parent Item has tooltips, and the button spec has tooltips, then the default is show both when hovering over the button spec. This can be disabled by setting AllowButtonSpecTooltipPriority to true, so that only 1 tooltip is displayed when hovering over any part of the control.
 
 =======
@@ -888,4 +889,3 @@ Cannot add items to KryptonGroupBox in WinForms Designer
 * Support for .NET Core LTS (currently 3.1)
 * Changed `490` to `500`
 * Builds from now on will be labelled as `YYMM`
-

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/Base/VisualToastNotificationBaseForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/Base/VisualToastNotificationBaseForm.cs
@@ -47,7 +47,7 @@ internal partial class VisualToastNotificationBaseForm : KryptonForm
     /// <summary>Initializes a new instance of the <see cref="VisualToastNotificationBaseForm" /> class.</summary>
     public VisualToastNotificationBaseForm()
     {
-        //SetInheritedControlOverride();
+        //SetInheritedControlOverride(); // Disabled as part of issue #2296. See the issue for details.
         InitializeComponent();
 
         _notificationResult = KryptonToastNotificationResult.None;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/Base/VisualToastNotificationBaseForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/Base/VisualToastNotificationBaseForm.cs
@@ -47,7 +47,7 @@ internal partial class VisualToastNotificationBaseForm : KryptonForm
     /// <summary>Initializes a new instance of the <see cref="VisualToastNotificationBaseForm" /> class.</summary>
     public VisualToastNotificationBaseForm()
     {
-        SetInheritedControlOverride();
+        //SetInheritedControlOverride();
         InitializeComponent();
 
         _notificationResult = KryptonToastNotificationResult.None;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualInputBoxRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualInputBoxRtlAwareForm.cs
@@ -21,13 +21,13 @@ internal partial class VisualInputBoxRtlAwareForm : KryptonForm
 
     public VisualInputBoxRtlAwareForm()
     {
-        //SetInheritedControlOverride();
+        //SetInheritedControlOverride(); // Disabled as part of issue #2296. See the issue for details.
         InitializeComponent();
     }
 
     public VisualInputBoxRtlAwareForm(KryptonInputBoxData inputBoxData)
     {
-        //SetInheritedControlOverride();
+        //SetInheritedControlOverride(); // Disabled as part of issue #2296. See the issue for details.
         _inputBoxData = inputBoxData;
 
         InitializeComponent();

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualMessageBoxRtlAwareForm.cs
@@ -38,7 +38,7 @@ internal partial class VisualMessageBoxRtlAwareForm : KryptonForm
 
     public VisualMessageBoxRtlAwareForm()
     {
-        //SetInheritedControlOverride();
+        //SetInheritedControlOverride(); // Disabled as part of issue #2296. See the issue for details.
         InitializeComponent();
     }
 
@@ -50,7 +50,7 @@ internal partial class VisualMessageBoxRtlAwareForm : KryptonForm
         bool? showHelpButton,
         bool? showCloseButton)
     {
-        //SetInheritedControlOverride();
+        //SetInheritedControlOverride(); // Disabled as part of issue #2296. See the issue for details.
         // Store incoming values
         _text = CommonHelper.NormalizeLineBreaks(text ?? string.Empty);
         _caption = caption;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualThemeBrowserFormRtlAware.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualThemeBrowserFormRtlAware.cs
@@ -22,7 +22,7 @@ internal partial class VisualThemeBrowserFormRtlAware : KryptonForm
     /// <param name="themeBrowserData">The data to create the <see cref="VisualThemeBrowserFormRtlAware"/> UI.</param>
     public VisualThemeBrowserFormRtlAware(KryptonThemeBrowserData themeBrowserData)
     {
-        //SetInheritedControlOverride();
+        //SetInheritedControlOverride(); // Disabled as part of issue #2296. See the issue for details.
         InitializeComponent();
 
         _themeBrowserData = themeBrowserData;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualThemeBrowserFormRtlAware.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/RTL Aware/VisualThemeBrowserFormRtlAware.cs
@@ -22,7 +22,7 @@ internal partial class VisualThemeBrowserFormRtlAware : KryptonForm
     /// <param name="themeBrowserData">The data to create the <see cref="VisualThemeBrowserFormRtlAware"/> UI.</param>
     public VisualThemeBrowserFormRtlAware(KryptonThemeBrowserData themeBrowserData)
     {
-        SetInheritedControlOverride();
+        //SetInheritedControlOverride();
         InitializeComponent();
 
         _themeBrowserData = themeBrowserData;
@@ -44,7 +44,10 @@ internal partial class VisualThemeBrowserFormRtlAware : KryptonForm
 
         StartPosition = _themeBrowserData.StartPosition ?? FormStartPosition.CenterScreen;
 
-        klbThemeList.SelectedIndex = _themeBrowserData.StartIndex ?? GlobalStaticValues.GLOBAL_DEFAULT_THEME_INDEX;
+        if (klbThemeList.Items.Count > 0)
+        {
+            klbThemeList.SelectedIndex = _themeBrowserData.StartIndex ?? GlobalStaticValues.GLOBAL_DEFAULT_THEME_INDEX;
+        }
 
         klblHeader.Text = KryptonManager.Strings.MiscellaneousThemeStrings.ThemeBrowserDescription;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualAboutBoxForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualAboutBoxForm.cs
@@ -25,7 +25,7 @@ internal partial class VisualAboutBoxForm : KryptonForm
 
     public VisualAboutBoxForm(KryptonAboutBoxData aboutBoxData)
     {
-        //SetInheritedControlOverride();
+        //SetInheritedControlOverride(); // Disabled as part of issue #2296. See the issue for details.
         InitializeComponent();
 
         _aboutBoxData = aboutBoxData;
@@ -39,7 +39,7 @@ internal partial class VisualAboutBoxForm : KryptonForm
 
     public VisualAboutBoxForm(KryptonAboutBoxData aboutBoxData, KryptonAboutToolkitData aboutToolkitData)
     {
-        //SetInheritedControlOverride();
+        //SetInheritedControlOverride(); // Disabled as part of issue #2296. See the issue for details.
         InitializeComponent();
 
         _showToolkitButton = aboutBoxData.ShowToolkitInformation ?? false;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualAboutBoxForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualAboutBoxForm.cs
@@ -25,7 +25,7 @@ internal partial class VisualAboutBoxForm : KryptonForm
 
     public VisualAboutBoxForm(KryptonAboutBoxData aboutBoxData)
     {
-        SetInheritedControlOverride();
+        //SetInheritedControlOverride();
         InitializeComponent();
 
         _aboutBoxData = aboutBoxData;
@@ -39,7 +39,7 @@ internal partial class VisualAboutBoxForm : KryptonForm
 
     public VisualAboutBoxForm(KryptonAboutBoxData aboutBoxData, KryptonAboutToolkitData aboutToolkitData)
     {
-        SetInheritedControlOverride();
+        //SetInheritedControlOverride();
         InitializeComponent();
 
         _showToolkitButton = aboutBoxData.ShowToolkitInformation ?? false;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
  *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *
  */
 #endregion
 
@@ -16,7 +16,7 @@
 namespace Krypton.Toolkit;
 
 /// <summary>
-/// Base class that allows a form to have custom chrome applied. You should derive 
+/// Base class that allows a form to have custom chrome applied. You should derive
 /// a class from this that performs the specific chrome drawing that is required.
 /// </summary>
 [ToolboxItem(false)]
@@ -95,7 +95,7 @@ public abstract class VisualForm : Form,
     }
 
     /// <summary>
-    /// Initialize a new instance of the VisualForm class. 
+    /// Initialize a new instance of the VisualForm class.
     /// </summary>
     protected VisualForm()
     {
@@ -136,7 +136,7 @@ public abstract class VisualForm : Form,
     }
 
     /// <summary>
-    /// Releases all resources used by the Control. 
+    /// Releases all resources used by the Control.
     /// </summary>
     /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
     protected override void Dispose(bool disposing)
@@ -233,7 +233,7 @@ public abstract class VisualForm : Form,
                 {
                     try
                     {
-                        // Set back to false in case we decide that the operating system 
+                        // Set back to false in case we decide that the operating system
                         // is not capable of supporting our custom chrome implementation
                         _useThemeFormChromeBorderWidth = false;
 
@@ -309,7 +309,7 @@ public abstract class VisualForm : Form,
                 switch (value)
                 {
                     case PaletteMode.Custom:
-                        // Do nothing, you must assign a palette to the 
+                        // Do nothing, you must assign a palette to the
                         // 'Palette' property in order to get the custom mode
                         break;
                     default:
@@ -990,7 +990,7 @@ public abstract class VisualForm : Form,
     {
         var processed = false;
 
-        // We do not process the message if on an MDI child, because doing so prevents the 
+        // We do not process the message if on an MDI child, because doing so prevents the
         // LayoutMdi call on the parent from working and cascading/tiling the children
         if (_themedApp && MdiParent is null)
         {
@@ -1090,7 +1090,7 @@ public abstract class VisualForm : Form,
                     processed = OnPaintNonClient(ref m);
                     break;
                 case 0x00AE:
-                    // Mystery message causes OS title bar buttons to draw, we want to 
+                    // Mystery message causes OS title bar buttons to draw, we want to
                     // prevent that and ignoring the messages seems to do no harm.
                     processed = true;
                     break;
@@ -1507,7 +1507,7 @@ public abstract class VisualForm : Form,
                         {
                             try
                             {
-                                // Must use the screen device context for the bitmap when drawing into the 
+                                // Must use the screen device context for the bitmap when drawing into the
                                 // bitmap otherwise the Opacity and RightToLeftLayout will not work correctly.
                                 PI.SelectObject(_screenDC, hBitmap);
 
@@ -1730,9 +1730,9 @@ public abstract class VisualForm : Form,
     private void InitializeComponent()
     {
         SuspendLayout();
-        // 
+        //
         // VisualForm
-        // 
+        //
         ClientSize = new Size(284, 261);
         Name = "VisualForm";
         ResumeLayout(false);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualInformationBoxForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualInformationBoxForm.cs
@@ -13,7 +13,7 @@ internal partial class VisualInformationBoxForm : KryptonForm
 {
     public VisualInformationBoxForm()
     {
-        SetInheritedControlOverride();
+        //SetInheritedControlOverride();
         InitializeComponent();
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualInformationBoxForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualInformationBoxForm.cs
@@ -13,7 +13,7 @@ internal partial class VisualInformationBoxForm : KryptonForm
 {
     public VisualInformationBoxForm()
     {
-        //SetInheritedControlOverride();
+        //SetInheritedControlOverride(); // Disabled as part of issue #2296. See the issue for details.
         InitializeComponent();
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualInputBoxForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualInputBoxForm.cs
@@ -30,7 +30,7 @@ public partial class VisualInputBoxForm : KryptonForm
     /// </summary>
     public VisualInputBoxForm()
     {
-        //SetInheritedControlOverride();
+        //SetInheritedControlOverride(); // Disabled as part of issue #2296. See the issue for details.
         InitializeComponent();
     }
 
@@ -38,7 +38,7 @@ public partial class VisualInputBoxForm : KryptonForm
     /// <param name="inputBoxData">The input box data.</param>
     public VisualInputBoxForm(KryptonInputBoxData inputBoxData)
     {
-        //SetInheritedControlOverride();
+        //SetInheritedControlOverride(); // Disabled as part of issue #2296. See the issue for details.
         InitializeComponent();
 
         _inputBoxData = inputBoxData;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMessageBoxForm.cs
@@ -45,7 +45,7 @@ internal partial class VisualMessageBoxForm : KryptonForm
 
     public VisualMessageBoxForm()
     {
-        //SetInheritedControlOverride();
+        //SetInheritedControlOverride(); // Disabled as part of issue #2296. See the issue for details.
         InitializeComponent();
     }
 
@@ -57,7 +57,7 @@ internal partial class VisualMessageBoxForm : KryptonForm
         bool? showHelpButton,
         bool? showCloseButton)
     {
-        //SetInheritedControlOverride();
+        //SetInheritedControlOverride(); // Disabled as part of issue #2296. See the issue for details.
         // Store incoming values
         _text = CommonHelper.NormalizeLineBreaks(text ?? string.Empty);
         _caption = caption;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMultilineStringEditorForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMultilineStringEditorForm.cs
@@ -1,8 +1,8 @@
 ﻿#region BSD License
 /*
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2022 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2022 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -28,7 +28,7 @@ internal partial class VisualMultilineStringEditorForm : KryptonForm
 
     public VisualMultilineStringEditorForm()
     {
-        SetInheritedControlOverride();
+        //SetInheritedControlOverride();
         InitializeComponent();
 
         InitialSetup();
@@ -38,7 +38,7 @@ internal partial class VisualMultilineStringEditorForm : KryptonForm
 
     public VisualMultilineStringEditorForm(string[]? contents, StringCollection? collection, bool? useRichTextBox, string? headerText, string? windowTitle)
     {
-        SetInheritedControlOverride();
+        //SetInheritedControlOverride();
         InitializeComponent();
 
         _contents = contents ?? [string.Empty];

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMultilineStringEditorForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualMultilineStringEditorForm.cs
@@ -28,7 +28,7 @@ internal partial class VisualMultilineStringEditorForm : KryptonForm
 
     public VisualMultilineStringEditorForm()
     {
-        //SetInheritedControlOverride();
+        //SetInheritedControlOverride(); // Disabled as part of issue #2296. See the issue for details.
         InitializeComponent();
 
         InitialSetup();
@@ -38,7 +38,7 @@ internal partial class VisualMultilineStringEditorForm : KryptonForm
 
     public VisualMultilineStringEditorForm(string[]? contents, StringCollection? collection, bool? useRichTextBox, string? headerText, string? windowTitle)
     {
-        //SetInheritedControlOverride();
+        //SetInheritedControlOverride(); // Disabled as part of issue #2296. See the issue for details.
         InitializeComponent();
 
         _contents = contents ?? [string.Empty];

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualSplashScreenForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualSplashScreenForm.cs
@@ -33,7 +33,7 @@ internal partial class VisualSplashScreenForm : KryptonForm/*, ISplashScreenData
     /// <param name="splashScreenData">The splash screen data.</param>
     public VisualSplashScreenForm(KryptonSplashScreenData splashScreenData)
     {
-        //SetInheritedControlOverride();
+        //SetInheritedControlOverride(); // Disabled as part of issue #2296. See the issue for details.
         InitializeComponent();
 
         _splashScreenData = splashScreenData;
@@ -47,7 +47,7 @@ internal partial class VisualSplashScreenForm : KryptonForm/*, ISplashScreenData
     /// <param name="nextWindow">The next window.</param>
     public VisualSplashScreenForm(Assembly entryAssembly, bool showProgressBar, int? timeOut, Image applicationLogo, IWin32Window? nextWindow)
     {
-        //SetInheritedControlOverride();
+        //SetInheritedControlOverride(); // Disabled as part of issue #2296. See the issue for details.
         InitializeComponent();
 
         _entryAssembly = entryAssembly;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualSplashScreenForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualSplashScreenForm.cs
@@ -33,7 +33,7 @@ internal partial class VisualSplashScreenForm : KryptonForm/*, ISplashScreenData
     /// <param name="splashScreenData">The splash screen data.</param>
     public VisualSplashScreenForm(KryptonSplashScreenData splashScreenData)
     {
-        SetInheritedControlOverride();
+        //SetInheritedControlOverride();
         InitializeComponent();
 
         _splashScreenData = splashScreenData;
@@ -47,7 +47,7 @@ internal partial class VisualSplashScreenForm : KryptonForm/*, ISplashScreenData
     /// <param name="nextWindow">The next window.</param>
     public VisualSplashScreenForm(Assembly entryAssembly, bool showProgressBar, int? timeOut, Image applicationLogo, IWin32Window? nextWindow)
     {
-        SetInheritedControlOverride();
+        //SetInheritedControlOverride();
         InitializeComponent();
 
         _entryAssembly = entryAssembly;
@@ -121,7 +121,7 @@ internal partial class VisualSplashScreenForm : KryptonForm/*, ISplashScreenData
             Hide();
 
             //_splashScreenData.NextWindow?.Show();
-                
+
         }
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualTaskDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualTaskDialog.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
  *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *
  */
 #endregion
 
@@ -123,7 +123,7 @@ public class VisualTaskDialog : KryptonForm
     /// <exception cref="ArgumentNullException"></exception>
     public VisualTaskDialog(KryptonTaskDialog taskDialog)
     {
-        SetInheritedControlOverride();
+        //SetInheritedControlOverride();
         // Must provide a valid reference
 
         _taskDialog = taskDialog ??
@@ -154,7 +154,7 @@ public class VisualTaskDialog : KryptonForm
         UpdateContents();
     }
 
-    /// <summary> 
+    /// <summary>
     /// Clean up any resources being used.
     /// </summary>
     /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
@@ -750,7 +750,7 @@ public class VisualTaskDialog : KryptonForm
             messageContentSize.Width = (int)(messageContentSize.Width * FactorDpiX);
             messageContentSize.Height = (int)(messageContentSize.Height * FactorDpiY);
 
-            // Always add on an extra 5 pixels as sometimes the measure size does not draw the last 
+            // Always add on an extra 5 pixels as sometimes the measure size does not draw the last
             // character it contains, this ensures there is always definitely enough space for it all
             messageMainSize.Width += 5;
             messageContentSize.Width += 5;
@@ -951,7 +951,7 @@ public class VisualTaskDialog : KryptonForm
         var footerTextSize = g.MeasureString(_footerText, _footerLabel.Font, 200).ToSize();
         var footerHyperlinkSize = g.MeasureString(_footerHyperlink, _footerLabel.Font, 200).ToSize();
 
-        // Always add on an extra 5 pixels as sometimes the measure size does not draw the last 
+        // Always add on an extra 5 pixels as sometimes the measure size does not draw the last
         // character it contains, this ensures there is always definitely enough space for it all
         footerTextSize.Width += 5;
         footerHyperlinkSize.Width += 5;
@@ -1171,9 +1171,9 @@ public class VisualTaskDialog : KryptonForm
         this._panelFooter.SuspendLayout();
         ((System.ComponentModel.ISupportInitialize)(this._iconFooter)).BeginInit();
         this.SuspendLayout();
-        // 
+        //
         // _panelMain
-        // 
+        //
         this._panelMain.AutoSize = true;
         this._panelMain.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
         this._panelMain.Controls.Add(this._panelMainSpacer);
@@ -1186,34 +1186,34 @@ public class VisualTaskDialog : KryptonForm
         this._panelMain.Name = "_panelMain";
         this._panelMain.Size = new System.Drawing.Size(790, 72);
         this._panelMain.TabIndex = 0;
-        // 
+        //
         // _panelMainSpacer
-        // 
+        //
         this._panelMainSpacer.Location = new System.Drawing.Point(42, 59);
         this._panelMainSpacer.Name = "_panelMainSpacer";
         this._panelMainSpacer.Size = new System.Drawing.Size(10, 10);
         this._panelMainSpacer.TabIndex = 3;
-        // 
+        //
         // _panelMainCommands
-        // 
+        //
         this._panelMainCommands.AutoSize = true;
         this._panelMainCommands.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
         this._panelMainCommands.Location = new System.Drawing.Point(208, 10);
         this._panelMainCommands.Name = "_panelMainCommands";
         this._panelMainCommands.Size = new System.Drawing.Size(0, 0);
         this._panelMainCommands.TabIndex = 2;
-        // 
+        //
         // _panelMainRadio
-        // 
+        //
         this._panelMainRadio.AutoSize = true;
         this._panelMainRadio.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
         this._panelMainRadio.Location = new System.Drawing.Point(208, 32);
         this._panelMainRadio.Name = "_panelMainRadio";
         this._panelMainRadio.Size = new System.Drawing.Size(0, 0);
         this._panelMainRadio.TabIndex = 1;
-        // 
+        //
         // _panelMainText
-        // 
+        //
         this._panelMainText.AutoSize = true;
         this._panelMainText.Controls.Add(this._messageContent);
         this._panelMainText.Controls.Add(this._messageContentMultiline);
@@ -1224,9 +1224,9 @@ public class VisualTaskDialog : KryptonForm
         this._panelMainText.Padding = new System.Windows.Forms.Padding(5, 5, 5, 0);
         this._panelMainText.Size = new System.Drawing.Size(407, 60);
         this._panelMainText.TabIndex = 0;
-        // 
+        //
         // _messageContent
-        // 
+        //
         this._messageContent.AutoSize = false;
         this._messageContent.Font = new System.Drawing.Font("Segoe UI", 9F);
         this._messageContent.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(30)))), ((int)(((byte)(57)))), ((int)(((byte)(91)))));
@@ -1236,9 +1236,9 @@ public class VisualTaskDialog : KryptonForm
         this._messageContent.Name = "_messageContent";
         this._messageContent.Size = new System.Drawing.Size(78, 15);
         this._messageContent.Text = "Content";
-        // 
+        //
         // _messageContentMultiline
-        // 
+        //
         this._messageContentMultiline.Location = new System.Drawing.Point(48, 45);
         this._messageContentMultiline.Multiline = true;
         this._messageContentMultiline.Name = "_messageContentMultiline";
@@ -1246,9 +1246,9 @@ public class VisualTaskDialog : KryptonForm
         this._messageContentMultiline.ScrollBars = System.Windows.Forms.ScrollBars.Both;
         this._messageContentMultiline.Size = new System.Drawing.Size(351, 10);
         this._messageContentMultiline.TabIndex = 4;
-        // 
+        //
         // _messageText
-        // 
+        //
         this._messageText.AutoSize = false;
         this._messageText.Font = new System.Drawing.Font("Segoe UI", 13.5F, System.Drawing.FontStyle.Bold);
         this._messageText.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(30)))), ((int)(((byte)(57)))), ((int)(((byte)(91)))));
@@ -1258,9 +1258,9 @@ public class VisualTaskDialog : KryptonForm
         this._messageText.Name = "_messageText";
         this._messageText.Size = new System.Drawing.Size(139, 27);
         this._messageText.Text = "Message Text";
-        // 
+        //
         // _panelIcon
-        // 
+        //
         this._panelIcon.AutoSize = true;
         this._panelIcon.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
         this._panelIcon.Controls.Add(this._messageIcon);
@@ -1270,9 +1270,9 @@ public class VisualTaskDialog : KryptonForm
         this._panelIcon.Padding = new System.Windows.Forms.Padding(10, 10, 0, 10);
         this._panelIcon.Size = new System.Drawing.Size(42, 52);
         this._panelIcon.TabIndex = 0;
-        // 
+        //
         // _messageIcon
-        // 
+        //
         this._messageIcon.BackColor = System.Drawing.Color.Transparent;
         this._messageIcon.Location = new System.Drawing.Point(10, 10);
         this._messageIcon.Margin = new System.Windows.Forms.Padding(0);
@@ -1280,9 +1280,9 @@ public class VisualTaskDialog : KryptonForm
         this._messageIcon.Size = new System.Drawing.Size(32, 32);
         this._messageIcon.TabIndex = 0;
         this._messageIcon.TabStop = false;
-        // 
+        //
         // _panelButtons
-        // 
+        //
         this._panelButtons.Controls.Add(this._checkBox);
         this._panelButtons.Controls.Add(this._panelButtonsBorderTop);
         this._panelButtons.Controls.Add(this._buttonOK);
@@ -1298,26 +1298,26 @@ public class VisualTaskDialog : KryptonForm
         this._panelButtons.PanelBackStyle = Krypton.Toolkit.PaletteBackStyle.PanelAlternate;
         this._panelButtons.Size = new System.Drawing.Size(790, 46);
         this._panelButtons.TabIndex = 1;
-        // 
+        //
         // _checkBox
-        // 
+        //
         this._checkBox.Location = new System.Drawing.Point(12, 12);
         this._checkBox.Name = "_checkBox";
         this._checkBox.Size = new System.Drawing.Size(75, 20);
         this._checkBox.TabIndex = 0;
         this._checkBox.Values.Text = "checkBox";
-        // 
+        //
         // _panelButtonsBorderTop
-        // 
+        //
         this._panelButtonsBorderTop.BorderStyle = Krypton.Toolkit.PaletteBorderStyle.HeaderPrimary;
         this._panelButtonsBorderTop.Dock = System.Windows.Forms.DockStyle.Top;
         this._panelButtonsBorderTop.Location = new System.Drawing.Point(0, 0);
         this._panelButtonsBorderTop.Name = "_panelButtonsBorderTop";
         this._panelButtonsBorderTop.Size = new System.Drawing.Size(790, 1);
         this._panelButtonsBorderTop.Text = "kryptonBorderEdge1";
-        // 
+        //
         // _buttonOK
-        // 
+        //
         this._buttonOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
         this._buttonOK.AutoSize = true;
         this._buttonOK.DialogResult = System.Windows.Forms.DialogResult.OK;
@@ -1329,9 +1329,9 @@ public class VisualTaskDialog : KryptonForm
         this._buttonOK.Size = new System.Drawing.Size(50, 26);
         this._buttonOK.TabIndex = 1;
         this._buttonOK.Values.Text = "OK";
-        // 
+        //
         // _buttonYes
-        // 
+        //
         this._buttonYes.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
         this._buttonYes.AutoSize = true;
         this._buttonYes.DialogResult = System.Windows.Forms.DialogResult.Yes;
@@ -1343,9 +1343,9 @@ public class VisualTaskDialog : KryptonForm
         this._buttonYes.Size = new System.Drawing.Size(50, 26);
         this._buttonYes.TabIndex = 2;
         this._buttonYes.Values.Text = "Yes";
-        // 
+        //
         // _buttonNo
-        // 
+        //
         this._buttonNo.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
         this._buttonNo.AutoSize = true;
         this._buttonNo.DialogResult = System.Windows.Forms.DialogResult.No;
@@ -1357,9 +1357,9 @@ public class VisualTaskDialog : KryptonForm
         this._buttonNo.Size = new System.Drawing.Size(50, 26);
         this._buttonNo.TabIndex = 3;
         this._buttonNo.Values.Text = "No";
-        // 
+        //
         // _buttonRetry
-        // 
+        //
         this._buttonRetry.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
         this._buttonRetry.AutoSize = true;
         this._buttonRetry.DialogResult = System.Windows.Forms.DialogResult.Retry;
@@ -1371,9 +1371,9 @@ public class VisualTaskDialog : KryptonForm
         this._buttonRetry.Size = new System.Drawing.Size(50, 26);
         this._buttonRetry.TabIndex = 5;
         this._buttonRetry.Values.Text = "Retry";
-        // 
+        //
         // _buttonCancel
-        // 
+        //
         this._buttonCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
         this._buttonCancel.AutoSize = true;
         this._buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
@@ -1385,9 +1385,9 @@ public class VisualTaskDialog : KryptonForm
         this._buttonCancel.Size = new System.Drawing.Size(57, 26);
         this._buttonCancel.TabIndex = 4;
         this._buttonCancel.Values.Text = "Cancel";
-        // 
+        //
         // _buttonClose
-        // 
+        //
         this._buttonClose.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
         this._buttonClose.AutoSize = true;
         this._buttonClose.IgnoreAltF4 = false;
@@ -1398,9 +1398,9 @@ public class VisualTaskDialog : KryptonForm
         this._buttonClose.Size = new System.Drawing.Size(50, 26);
         this._buttonClose.TabIndex = 6;
         this._buttonClose.Values.Text = "Close";
-        // 
+        //
         // _panelFooter
-        // 
+        //
         this._panelFooter.Controls.Add(this._linkLabelFooter);
         this._panelFooter.Controls.Add(this._iconFooter);
         this._panelFooter.Controls.Add(this._footerLabel);
@@ -1411,17 +1411,17 @@ public class VisualTaskDialog : KryptonForm
         this._panelFooter.PanelBackStyle = Krypton.Toolkit.PaletteBackStyle.PanelAlternate;
         this._panelFooter.Size = new System.Drawing.Size(790, 49);
         this._panelFooter.TabIndex = 2;
-        // 
+        //
         // _linkLabelFooter
-        // 
+        //
         this._linkLabelFooter.Location = new System.Drawing.Point(127, 11);
         this._linkLabelFooter.Name = "_linkLabelFooter";
         this._linkLabelFooter.Size = new System.Drawing.Size(110, 20);
         this._linkLabelFooter.TabIndex = 0;
         this._linkLabelFooter.Values.Text = "kryptonLinkLabel1";
-        // 
+        //
         // _iconFooter
-        // 
+        //
         this._iconFooter.BackColor = System.Drawing.Color.Transparent;
         this._iconFooter.Location = new System.Drawing.Point(10, 10);
         this._iconFooter.Margin = new System.Windows.Forms.Padding(0);
@@ -1429,9 +1429,9 @@ public class VisualTaskDialog : KryptonForm
         this._iconFooter.Size = new System.Drawing.Size(16, 16);
         this._iconFooter.TabIndex = 4;
         this._iconFooter.TabStop = false;
-        // 
+        //
         // _footerLabel
-        // 
+        //
         this._footerLabel.AutoSize = false;
         this._footerLabel.Font = new System.Drawing.Font("Segoe UI", 9F);
         this._footerLabel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(30)))), ((int)(((byte)(57)))), ((int)(((byte)(91)))));
@@ -1441,18 +1441,18 @@ public class VisualTaskDialog : KryptonForm
         this._footerLabel.Name = "_footerLabel";
         this._footerLabel.Size = new System.Drawing.Size(78, 15);
         this._footerLabel.Text = "Content";
-        // 
+        //
         // _panelFooterBorderTop
-        // 
+        //
         this._panelFooterBorderTop.BorderStyle = Krypton.Toolkit.PaletteBorderStyle.HeaderPrimary;
         this._panelFooterBorderTop.Dock = System.Windows.Forms.DockStyle.Top;
         this._panelFooterBorderTop.Location = new System.Drawing.Point(0, 0);
         this._panelFooterBorderTop.Name = "_panelFooterBorderTop";
         this._panelFooterBorderTop.Size = new System.Drawing.Size(790, 1);
         this._panelFooterBorderTop.Text = "kryptonBorderEdge1";
-        // 
+        //
         // VisualTaskDialog
-        // 
+        //
         this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
         this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
         this.AutoScroll = true;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualTaskDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualTaskDialog.cs
@@ -123,7 +123,7 @@ public class VisualTaskDialog : KryptonForm
     /// <exception cref="ArgumentNullException"></exception>
     public VisualTaskDialog(KryptonTaskDialog taskDialog)
     {
-        //SetInheritedControlOverride();
+        //SetInheritedControlOverride(); // Disabled as part of issue #2296. See the issue for details.
         // Must provide a valid reference
 
         _taskDialog = taskDialog ??

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualTaskDialogForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualTaskDialogForm.cs
@@ -48,7 +48,7 @@ public partial class VisualTaskDialogForm : KryptonForm
     /// <exception cref="System.ArgumentNullException">taskDialog</exception>
     public VisualTaskDialogForm(KryptonTaskDialog taskDialog)
     {
-        //SetInheritedControlOverride();
+        //SetInheritedControlOverride(); // Disabled as part of issue #2296. See the issue for details.
         // Must provide a valid reference
 
         _taskDialog = taskDialog ??

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualTaskDialogForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualTaskDialogForm.cs
@@ -48,7 +48,7 @@ public partial class VisualTaskDialogForm : KryptonForm
     /// <exception cref="System.ArgumentNullException">taskDialog</exception>
     public VisualTaskDialogForm(KryptonTaskDialog taskDialog)
     {
-        SetInheritedControlOverride();
+        //SetInheritedControlOverride();
         // Must provide a valid reference
 
         _taskDialog = taskDialog ??
@@ -662,7 +662,7 @@ public partial class VisualTaskDialogForm : KryptonForm
             messageContentSize.Width = (int)(messageContentSize.Width * FactorDpiX);
             messageContentSize.Height = (int)(messageContentSize.Height * FactorDpiY);
 
-            // Always add on an extra 5 pixels as sometimes the measure size does not draw the last 
+            // Always add on an extra 5 pixels as sometimes the measure size does not draw the last
             // character it contains, this ensures there is always definitely enough space for it all
             messageMainSize.Width += 5;
             messageContentSize.Width += 5;
@@ -863,7 +863,7 @@ public partial class VisualTaskDialogForm : KryptonForm
         var footerTextSize = g.MeasureString(_footerText, _footerLabel.Font, 200).ToSize();
         var footerHyperlinkSize = g.MeasureString(_footerHyperlink, _footerLabel.Font, 200).ToSize();
 
-        // Always add on an extra 5 pixels as sometimes the measure size does not draw the last 
+        // Always add on an extra 5 pixels as sometimes the measure size does not draw the last
         // character it contains, this ensures there is always definitely enough space for it all
         footerTextSize.Width += 5;
         footerHyperlinkSize.Width += 5;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualThemeBrowserForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualThemeBrowserForm.cs
@@ -1,8 +1,8 @@
 ﻿#region BSD License
 /*
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -22,7 +22,7 @@ internal partial class VisualThemeBrowserForm : KryptonForm
     /// <param name="themeBrowserData">The data to provide to the <see cref="VisualThemeBrowserForm"/>.</param>
     public VisualThemeBrowserForm(KryptonThemeBrowserData themeBrowserData)
     {
-        SetInheritedControlOverride();
+        //SetInheritedControlOverride();
         InitializeComponent();
 
         _themeBrowserData = themeBrowserData;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualThemeBrowserForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualThemeBrowserForm.cs
@@ -22,7 +22,7 @@ internal partial class VisualThemeBrowserForm : KryptonForm
     /// <param name="themeBrowserData">The data to provide to the <see cref="VisualThemeBrowserForm"/>.</param>
     public VisualThemeBrowserForm(KryptonThemeBrowserData themeBrowserData)
     {
-        //SetInheritedControlOverride();
+        //SetInheritedControlOverride(); // Disabled as part of issue #2296. See the issue for details.
         InitializeComponent();
 
         _themeBrowserData = themeBrowserData;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualToolkitBinaryInformationForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualToolkitBinaryInformationForm.cs
@@ -35,7 +35,7 @@ internal partial class VisualToolkitBinaryInformationForm : KryptonForm
     /// <param name="showReadmeButton">The show readme button.</param>
     public VisualToolkitBinaryInformationForm(ToolkitSupportType toolkitType, bool? showChangeLogButton, bool? showReadmeButton)
     {
-        //SetInheritedControlOverride();
+        //SetInheritedControlOverride(); // Disabled as part of issue #2296. See the issue for details.
 
         InitializeComponent();
 

--- a/Source/Krypton Components/Krypton.Toolkit/General/ModalWaitDialog.Designer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/ModalWaitDialog.Designer.cs
@@ -51,9 +51,10 @@ namespace Krypton.Toolkit
             // 
             // labelMessage
             // 
-            this.labelMessage.Location = new System.Drawing.Point(66, 20);
+            this.labelMessage.Location = new System.Drawing.Point(88, 25);
+            this.labelMessage.Margin = new System.Windows.Forms.Padding(4);
             this.labelMessage.Name = "labelMessage";
-            this.labelMessage.Size = new System.Drawing.Size(218, 20);
+            this.labelMessage.Size = new System.Drawing.Size(270, 24);
             this.labelMessage.TabIndex = 0;
             this.labelMessage.Values.Text = "Please wait for operation to complete.";
             // 
@@ -62,16 +63,18 @@ namespace Krypton.Toolkit
             this.kryptonPanel1.Controls.Add(this.labelMessage);
             this.kryptonPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonPanel1.Location = new System.Drawing.Point(0, 0);
+            this.kryptonPanel1.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonPanel1.Name = "kryptonPanel1";
-            this.kryptonPanel1.Size = new System.Drawing.Size(296, 66);
+            this.kryptonPanel1.Size = new System.Drawing.Size(421, 67);
             this.kryptonPanel1.TabIndex = 1;
             // 
             // kpbModalProgress
             // 
             this.kpbModalProgress.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.kpbModalProgress.Location = new System.Drawing.Point(0, 56);
+            this.kpbModalProgress.Location = new System.Drawing.Point(0, 55);
+            this.kpbModalProgress.Margin = new System.Windows.Forms.Padding(4);
             this.kpbModalProgress.Name = "kpbModalProgress";
-            this.kpbModalProgress.Size = new System.Drawing.Size(296, 10);
+            this.kpbModalProgress.Size = new System.Drawing.Size(421, 12);
             this.kpbModalProgress.StateCommon.Back.Color1 = System.Drawing.Color.Green;
             this.kpbModalProgress.StateDisabled.Back.ColorStyle = Krypton.Toolkit.PaletteColorStyle.OneNote;
             this.kpbModalProgress.StateNormal.Back.ColorStyle = Krypton.Toolkit.PaletteColorStyle.OneNote;
@@ -80,15 +83,14 @@ namespace Krypton.Toolkit
             // 
             // ModalWaitDialog
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(296, 66);
+            this.ClientSize = new System.Drawing.Size(421, 67);
             this.ControlBox = false;
             this.Controls.Add(this.kpbModalProgress);
             this.Controls.Add(this.kryptonPanel1);
-            this.Font = new System.Drawing.Font("Tahoma", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
-            this.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "ModalWaitDialog";

--- a/Source/Krypton Components/Krypton.Toolkit/General/ModalWaitDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/ModalWaitDialog.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
  *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *
  */
 #endregion
 
@@ -38,11 +38,11 @@ public partial class ModalWaitDialog : KryptonForm, IMessageFilter
 
     #region Identity
     /// <summary>
-    /// Initialize a new instance of the ModalWaitDialog class. 
+    /// Initialize a new instance of the ModalWaitDialog class.
     /// </summary>
     public ModalWaitDialog()
     {
-        SetInheritedControlOverride();
+        //SetInheritedControlOverride(); // Disabled as part of issue #2296. See the issue for details.
         InitializeComponent();
 
         // Remove redraw flicker by using double buffering
@@ -59,7 +59,7 @@ public partial class ModalWaitDialog : KryptonForm, IMessageFilter
     /// <param name="maximumProgressValue">The maximum progress value.</param>
     public ModalWaitDialog(bool? showProgressBar, int? minimumProgressValue, int? maximumProgressValue)
     {
-        SetInheritedControlOverride();
+        //SetInheritedControlOverride(); // Disabled as part of issue #2296. See the issue for details.
         InitializeComponent();
 
         _showProgressBar = showProgressBar ?? false;

--- a/Source/Krypton Components/TestForm/AboutBoxTest.Designer.cs
+++ b/Source/Krypton Components/TestForm/AboutBoxTest.Designer.cs
@@ -98,6 +98,7 @@ namespace TestForm
             this.kryptonButton1.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton1.Values.Text = "Cance&l";
             this.kryptonButton1.Values.UseAsADialogButton = true;
+            this.kryptonButton1.Click += new System.EventHandler(this.kryptonButton1_Click);
             // 
             // kryptonBorderEdge1
             // 

--- a/Source/Krypton Components/TestForm/AboutBoxTest.cs
+++ b/Source/Krypton Components/TestForm/AboutBoxTest.cs
@@ -1,23 +1,14 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *
  */
 #endregion
 
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
 using System.IO;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms;
 
 namespace TestForm;
 
@@ -30,12 +21,62 @@ public partial class AboutBoxTest : KryptonForm
 
     private void kbtnShow_Click(object sender, EventArgs e)
     {
+        // Validate and load assembly
+        if (string.IsNullOrWhiteSpace(kryptonTextBox1.Text))
+        {
+            MessageBox.Show("Please choose an assembly (.dll or .exe) first.", "No Assembly Selected", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            return;
+        }
+
+        var assemblyPath = kryptonTextBox1.Text;
+
+        if (!File.Exists(assemblyPath))
+        {
+            MessageBox.Show($"The file '{assemblyPath}' does not exist.", "File Not Found", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            return;
+        }
+
+        var ext = Path.GetExtension(assemblyPath).ToLowerInvariant();
+        if (ext != ".dll" && ext != ".exe")
+        {
+            MessageBox.Show("The selected file must be a .dll or .exe assembly.", "Invalid File Type", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            return;
+        }
+
+        Assembly selectedAssembly;
+        try
+        {
+            selectedAssembly = Assembly.LoadFile(assemblyPath);
+        }
+        catch (BadImageFormatException)
+        {
+            MessageBox.Show("The selected file is not a valid .NET assembly.", "Invalid Assembly", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            return;
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"An error occurred while loading the assembly:\n{ex.Message}", "Load Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            return;
+        }
+
+        Image? headerImage = null;
+        if (!string.IsNullOrWhiteSpace(kryptonTextBox3.Text) && File.Exists(kryptonTextBox3.Text))
+        {
+            headerImage = new Bitmap(kryptonTextBox3.Text);
+        }
+
+        Image? mainImage = null;
+        if (!string.IsNullOrWhiteSpace(kryptonTextBox4.Text) && File.Exists(kryptonTextBox4.Text))
+        {
+            mainImage = new Bitmap(kryptonTextBox4.Text);
+        }
+
         KryptonAboutBoxData aboutBoxData = new KryptonAboutBoxData()
         {
             ApplicationName = kryptonTextBox2.Text,
-            CurrentAssembly = Assembly.LoadFile(kryptonTextBox1.Text),
-            HeaderImage = new Bitmap(kryptonTextBox3.Text),
-            MainImage = new Bitmap(kryptonTextBox4.Text),
+            CurrentAssembly = selectedAssembly,
+            HeaderImage = headerImage,
+            MainImage = mainImage,
             ShowToolkitInformation = kchkShowToolkitInformation.Checked,
             UseFullBuiltOnDate = kchkUseFullBuiltOnDate.Checked
         };
@@ -51,7 +92,7 @@ public partial class AboutBoxTest : KryptonForm
 
         if (openFileDialog.ShowDialog() == DialogResult.OK)
         {
-            kryptonTextBox1.Text = Path.GetFullPath(openFileDialog.SafeFileName);
+            kryptonTextBox1.Text = openFileDialog.FileName;
         }
     }
 
@@ -61,7 +102,7 @@ public partial class AboutBoxTest : KryptonForm
 
         if (openFileDialog.ShowDialog() == DialogResult.OK)
         {
-            kryptonTextBox3.Text = Path.GetFullPath(openFileDialog.SafeFileName);
+            kryptonTextBox3.Text = openFileDialog.FileName;
         }
     }
 
@@ -71,7 +112,12 @@ public partial class AboutBoxTest : KryptonForm
 
         if (openFileDialog.ShowDialog() == DialogResult.OK)
         {
-            kryptonTextBox4.Text = Path.GetFullPath(openFileDialog.SafeFileName);
+            kryptonTextBox4.Text = openFileDialog.FileName;
         }
+    }
+
+    private void kryptonButton1_Click(object sender, EventArgs e)
+    {
+        Close();
     }
 }

--- a/Source/Krypton Components/TestForm/StartScreen.Designer.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.Designer.cs
@@ -76,6 +76,7 @@ namespace TestForm
             this.kbtnCommandLinkButtons = new Krypton.Toolkit.KryptonButton();
             this.kbtnBreadCrumb = new Krypton.Toolkit.KryptonButton();
             this.kbtnPaletteViewer = new Krypton.Toolkit.KryptonButton();
+            this.kbtnVisualControls = new Krypton.Toolkit.KryptonButton();
             this.kryptonManager1 = new Krypton.Toolkit.KryptonManager(this.components);
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).BeginInit();
             this.kryptonPanel1.SuspendLayout();
@@ -118,10 +119,11 @@ namespace TestForm
             this.kryptonPanel1.Controls.Add(this.kbtnFadeForm);
             this.kryptonPanel1.Controls.Add(this.kbtnCommandLinkButtons);
             this.kryptonPanel1.Controls.Add(this.kbtnBreadCrumb);
+            this.kryptonPanel1.Controls.Add(this.kbtnVisualControls);
             this.kryptonPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonPanel1.Location = new System.Drawing.Point(0, 0);
             this.kryptonPanel1.Name = "kryptonPanel1";
-            this.kryptonPanel1.Size = new System.Drawing.Size(358, 476);
+            this.kryptonPanel1.Size = new System.Drawing.Size(358, 520);
             this.kryptonPanel1.TabIndex = 0;
             //
             // kbtnBlurredForm
@@ -494,6 +496,17 @@ namespace TestForm
             this.kbtnBreadCrumb.Values.Text = "BreadCrumb";
             this.kbtnBreadCrumb.Click += new System.EventHandler(this.kbtnBreadCrumb_Click);
             //
+            // kbtnVisualControls
+            //
+            this.kbtnVisualControls.Location = new System.Drawing.Point(223, 469);
+            this.kbtnVisualControls.Margin = new System.Windows.Forms.Padding(2);
+            this.kbtnVisualControls.Name = "kbtnVisualControls";
+            this.kbtnVisualControls.Size = new System.Drawing.Size(153, 20);
+            this.kbtnVisualControls.TabIndex = 34;
+            this.kbtnVisualControls.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnVisualControls.Values.Text = "Visual Controls";
+            this.kbtnVisualControls.Click += new System.EventHandler(this.kbtnVisualControls_Click);
+            //
             // kryptonManager1
             //
             this.kryptonManager1.BaseFont = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
@@ -506,7 +519,7 @@ namespace TestForm
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
             this.CancelButton = this.kbtnExit;
-            this.ClientSize = new System.Drawing.Size(390, 485);
+            this.ClientSize = new System.Drawing.Size(390, 530);
             this.Controls.Add(this.kryptonPanel1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MaximizeBox = false;
@@ -564,5 +577,6 @@ namespace TestForm
         private KryptonButton kbtnSplashScreen;
         private KryptonButton kbtnBlurredForm;
         private KryptonButton kbtnPaletteViewer;
+        private KryptonButton kbtnVisualControls;
     }
 }

--- a/Source/Krypton Components/TestForm/StartScreen.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.cs
@@ -1,9 +1,9 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -223,5 +223,11 @@ public partial class StartScreen : KryptonForm
         var viewer = new PaletteViewerForm();
         viewer.AttachKryptonManager(kryptonManager1);
         viewer.Show();
+    }
+
+    private void kbtnVisualControls_Click(object sender, EventArgs e)
+    {
+        var vcontrols = new VisualControlsTest();
+        vcontrols.Show(this);
     }
 }

--- a/Source/Krypton Components/TestForm/TestForm.csproj
+++ b/Source/Krypton Components/TestForm/TestForm.csproj
@@ -13,6 +13,7 @@
     <ApplicationVisualStyles>true</ApplicationVisualStyles>
     <ApplicationUseCompatibleTextRendering>false</ApplicationUseCompatibleTextRendering>
     <ApplicationHighDpiMode>SystemAware</ApplicationHighDpiMode>
+    <GenerateResourceWarnOnBinaryFormatterUse>false</GenerateResourceWarnOnBinaryFormatterUse>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Krypton Components/TestForm/VisualControlsTest.Designer.cs
+++ b/Source/Krypton Components/TestForm/VisualControlsTest.Designer.cs
@@ -38,12 +38,13 @@ namespace TestForm
             this.kbtnVisualSplashScreen = new Krypton.Toolkit.KryptonButton();
             this.kbtnVisualMultilineStringEditorForm = new Krypton.Toolkit.KryptonButton();
             this.kbtnVisualInformationBoxForm = new Krypton.Toolkit.KryptonButton();
+            this.kbtnModalWaitDialog = new Krypton.Toolkit.KryptonButton();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).BeginInit();
             this.kryptonPanel1.SuspendLayout();
             this.SuspendLayout();
-            //
+            // 
             // kryptonPanel1
-            //
+            // 
             this.kryptonPanel1.Controls.Add(this.kbtnVisualToastNotification);
             this.kryptonPanel1.Controls.Add(this.kbtnVisualThemeBrowserRtlAware);
             this.kryptonPanel1.Controls.Add(this.kbtnVisualThemeBrowser);
@@ -52,15 +53,16 @@ namespace TestForm
             this.kryptonPanel1.Controls.Add(this.kbtnVisualSplashScreen);
             this.kryptonPanel1.Controls.Add(this.kbtnVisualMultilineStringEditorForm);
             this.kryptonPanel1.Controls.Add(this.kbtnVisualInformationBoxForm);
+            this.kryptonPanel1.Controls.Add(this.kbtnModalWaitDialog);
             this.kryptonPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonPanel1.Location = new System.Drawing.Point(0, 0);
             this.kryptonPanel1.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonPanel1.Name = "kryptonPanel1";
-            this.kryptonPanel1.Size = new System.Drawing.Size(387, 327);
+            this.kryptonPanel1.Size = new System.Drawing.Size(378, 363);
             this.kryptonPanel1.TabIndex = 0;
-            //
+            // 
             // kbtnVisualToastNotification
-            //
+            // 
             this.kbtnVisualToastNotification.Location = new System.Drawing.Point(18, 278);
             this.kbtnVisualToastNotification.Margin = new System.Windows.Forms.Padding(4);
             this.kbtnVisualToastNotification.Name = "kbtnVisualToastNotification";
@@ -69,9 +71,9 @@ namespace TestForm
             this.kbtnVisualToastNotification.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnVisualToastNotification.Values.Text = "VisualToastNotificationBasicForm";
             this.kbtnVisualToastNotification.Click += new System.EventHandler(this.kbtnVisualToastNotification_Click);
-            //
+            // 
             // kbtnVisualThemeBrowserRtlAware
-            //
+            // 
             this.kbtnVisualThemeBrowserRtlAware.Location = new System.Drawing.Point(18, 239);
             this.kbtnVisualThemeBrowserRtlAware.Margin = new System.Windows.Forms.Padding(4);
             this.kbtnVisualThemeBrowserRtlAware.Name = "kbtnVisualThemeBrowserRtlAware";
@@ -80,9 +82,9 @@ namespace TestForm
             this.kbtnVisualThemeBrowserRtlAware.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnVisualThemeBrowserRtlAware.Values.Text = "VisualThemeBrowserFormRtlAware";
             this.kbtnVisualThemeBrowserRtlAware.Click += new System.EventHandler(this.kbtnVisualThemeBrowserRtlAware_Click);
-            //
+            // 
             // kbtnVisualThemeBrowser
-            //
+            // 
             this.kbtnVisualThemeBrowser.Location = new System.Drawing.Point(18, 200);
             this.kbtnVisualThemeBrowser.Margin = new System.Windows.Forms.Padding(4);
             this.kbtnVisualThemeBrowser.Name = "kbtnVisualThemeBrowser";
@@ -91,9 +93,9 @@ namespace TestForm
             this.kbtnVisualThemeBrowser.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnVisualThemeBrowser.Values.Text = "VisualThemeBrowserForm";
             this.kbtnVisualThemeBrowser.Click += new System.EventHandler(this.kbtnVisualThemeBrowser_Click);
-            //
+            // 
             // kbtnVisualTaskDialog
-            //
+            // 
             this.kbtnVisualTaskDialog.Location = new System.Drawing.Point(18, 161);
             this.kbtnVisualTaskDialog.Margin = new System.Windows.Forms.Padding(4);
             this.kbtnVisualTaskDialog.Name = "kbtnVisualTaskDialog";
@@ -102,9 +104,9 @@ namespace TestForm
             this.kbtnVisualTaskDialog.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnVisualTaskDialog.Values.Text = "VisualTaskDialog";
             this.kbtnVisualTaskDialog.Click += new System.EventHandler(this.kbtnVisualTaskDialog_Click);
-            //
+            // 
             // kbtnVisualTaskDialogForm
-            //
+            // 
             this.kbtnVisualTaskDialogForm.Location = new System.Drawing.Point(18, 124);
             this.kbtnVisualTaskDialogForm.Margin = new System.Windows.Forms.Padding(4);
             this.kbtnVisualTaskDialogForm.Name = "kbtnVisualTaskDialogForm";
@@ -113,9 +115,9 @@ namespace TestForm
             this.kbtnVisualTaskDialogForm.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnVisualTaskDialogForm.Values.Text = "VisualTaskDialogForm";
             this.kbtnVisualTaskDialogForm.Click += new System.EventHandler(this.kbtnVisualTaskDialogForm_Click);
-            //
+            // 
             // kbtnVisualSplashScreen
-            //
+            // 
             this.kbtnVisualSplashScreen.Location = new System.Drawing.Point(18, 87);
             this.kbtnVisualSplashScreen.Margin = new System.Windows.Forms.Padding(4);
             this.kbtnVisualSplashScreen.Name = "kbtnVisualSplashScreen";
@@ -124,9 +126,9 @@ namespace TestForm
             this.kbtnVisualSplashScreen.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnVisualSplashScreen.Values.Text = "VisualSplashScreenForm";
             this.kbtnVisualSplashScreen.Click += new System.EventHandler(this.kbtnVisualSplashScreen_Click);
-            //
+            // 
             // kbtnVisualMultilineStringEditorForm
-            //
+            // 
             this.kbtnVisualMultilineStringEditorForm.Location = new System.Drawing.Point(18, 50);
             this.kbtnVisualMultilineStringEditorForm.Margin = new System.Windows.Forms.Padding(4);
             this.kbtnVisualMultilineStringEditorForm.Name = "kbtnVisualMultilineStringEditorForm";
@@ -135,9 +137,9 @@ namespace TestForm
             this.kbtnVisualMultilineStringEditorForm.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnVisualMultilineStringEditorForm.Values.Text = "VisualMultilineStringEditorForm";
             this.kbtnVisualMultilineStringEditorForm.Click += new System.EventHandler(this.kbtnVisualMultilineStringEditorForm_Click);
-            //
+            // 
             // kbtnVisualInformationBoxForm
-            //
+            // 
             this.kbtnVisualInformationBoxForm.Location = new System.Drawing.Point(18, 13);
             this.kbtnVisualInformationBoxForm.Margin = new System.Windows.Forms.Padding(4);
             this.kbtnVisualInformationBoxForm.Name = "kbtnVisualInformationBoxForm";
@@ -146,12 +148,22 @@ namespace TestForm
             this.kbtnVisualInformationBoxForm.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kbtnVisualInformationBoxForm.Values.Text = "VisualInformationBoxForm";
             this.kbtnVisualInformationBoxForm.Click += new System.EventHandler(this.kbtnVisualInformationBoxForm_Click);
-            //
+            // 
+            // kbtnModalWaitDialog
+            // 
+            this.kbtnModalWaitDialog.Location = new System.Drawing.Point(18, 316);
+            this.kbtnModalWaitDialog.Name = "kbtnModalWaitDialog";
+            this.kbtnModalWaitDialog.Size = new System.Drawing.Size(347, 30);
+            this.kbtnModalWaitDialog.TabIndex = 5;
+            this.kbtnModalWaitDialog.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnModalWaitDialog.Values.Text = "ModalWaitDialog";
+            this.kbtnModalWaitDialog.Click += new System.EventHandler(this.kbtnModalWaitDialog_Click);
+            // 
             // VisualControlsTest
-            //
+            // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(387, 327);
+            this.ClientSize = new System.Drawing.Size(378, 363);
             this.Controls.Add(this.kryptonPanel1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
             this.Margin = new System.Windows.Forms.Padding(4);
@@ -177,5 +189,6 @@ namespace TestForm
         private KryptonButton kbtnVisualThemeBrowser;
         private KryptonButton kbtnVisualThemeBrowserRtlAware;
         private KryptonButton kbtnVisualToastNotification;
+        private KryptonButton kbtnModalWaitDialog;
     }
 }

--- a/Source/Krypton Components/TestForm/VisualControlsTest.Designer.cs
+++ b/Source/Krypton Components/TestForm/VisualControlsTest.Designer.cs
@@ -1,0 +1,181 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2025 - 2025. All rights reserved.
+ *
+ */
+#endregion
+
+using Krypton.Toolkit;
+using System.Windows.Forms;
+
+namespace TestForm
+{
+    partial class VisualControlsTest
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        private void InitializeComponent()
+        {
+            this.kryptonPanel1 = new Krypton.Toolkit.KryptonPanel();
+            this.kbtnVisualToastNotification = new Krypton.Toolkit.KryptonButton();
+            this.kbtnVisualThemeBrowserRtlAware = new Krypton.Toolkit.KryptonButton();
+            this.kbtnVisualThemeBrowser = new Krypton.Toolkit.KryptonButton();
+            this.kbtnVisualTaskDialog = new Krypton.Toolkit.KryptonButton();
+            this.kbtnVisualTaskDialogForm = new Krypton.Toolkit.KryptonButton();
+            this.kbtnVisualSplashScreen = new Krypton.Toolkit.KryptonButton();
+            this.kbtnVisualMultilineStringEditorForm = new Krypton.Toolkit.KryptonButton();
+            this.kbtnVisualInformationBoxForm = new Krypton.Toolkit.KryptonButton();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).BeginInit();
+            this.kryptonPanel1.SuspendLayout();
+            this.SuspendLayout();
+            //
+            // kryptonPanel1
+            //
+            this.kryptonPanel1.Controls.Add(this.kbtnVisualToastNotification);
+            this.kryptonPanel1.Controls.Add(this.kbtnVisualThemeBrowserRtlAware);
+            this.kryptonPanel1.Controls.Add(this.kbtnVisualThemeBrowser);
+            this.kryptonPanel1.Controls.Add(this.kbtnVisualTaskDialog);
+            this.kryptonPanel1.Controls.Add(this.kbtnVisualTaskDialogForm);
+            this.kryptonPanel1.Controls.Add(this.kbtnVisualSplashScreen);
+            this.kryptonPanel1.Controls.Add(this.kbtnVisualMultilineStringEditorForm);
+            this.kryptonPanel1.Controls.Add(this.kbtnVisualInformationBoxForm);
+            this.kryptonPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.kryptonPanel1.Location = new System.Drawing.Point(0, 0);
+            this.kryptonPanel1.Margin = new System.Windows.Forms.Padding(4);
+            this.kryptonPanel1.Name = "kryptonPanel1";
+            this.kryptonPanel1.Size = new System.Drawing.Size(387, 327);
+            this.kryptonPanel1.TabIndex = 0;
+            //
+            // kbtnVisualToastNotification
+            //
+            this.kbtnVisualToastNotification.Location = new System.Drawing.Point(18, 278);
+            this.kbtnVisualToastNotification.Margin = new System.Windows.Forms.Padding(4);
+            this.kbtnVisualToastNotification.Name = "kbtnVisualToastNotification";
+            this.kbtnVisualToastNotification.Size = new System.Drawing.Size(347, 31);
+            this.kbtnVisualToastNotification.TabIndex = 8;
+            this.kbtnVisualToastNotification.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnVisualToastNotification.Values.Text = "VisualToastNotificationBasicForm";
+            this.kbtnVisualToastNotification.Click += new System.EventHandler(this.kbtnVisualToastNotification_Click);
+            //
+            // kbtnVisualThemeBrowserRtlAware
+            //
+            this.kbtnVisualThemeBrowserRtlAware.Location = new System.Drawing.Point(18, 239);
+            this.kbtnVisualThemeBrowserRtlAware.Margin = new System.Windows.Forms.Padding(4);
+            this.kbtnVisualThemeBrowserRtlAware.Name = "kbtnVisualThemeBrowserRtlAware";
+            this.kbtnVisualThemeBrowserRtlAware.Size = new System.Drawing.Size(347, 31);
+            this.kbtnVisualThemeBrowserRtlAware.TabIndex = 7;
+            this.kbtnVisualThemeBrowserRtlAware.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnVisualThemeBrowserRtlAware.Values.Text = "VisualThemeBrowserFormRtlAware";
+            this.kbtnVisualThemeBrowserRtlAware.Click += new System.EventHandler(this.kbtnVisualThemeBrowserRtlAware_Click);
+            //
+            // kbtnVisualThemeBrowser
+            //
+            this.kbtnVisualThemeBrowser.Location = new System.Drawing.Point(18, 200);
+            this.kbtnVisualThemeBrowser.Margin = new System.Windows.Forms.Padding(4);
+            this.kbtnVisualThemeBrowser.Name = "kbtnVisualThemeBrowser";
+            this.kbtnVisualThemeBrowser.Size = new System.Drawing.Size(347, 31);
+            this.kbtnVisualThemeBrowser.TabIndex = 6;
+            this.kbtnVisualThemeBrowser.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnVisualThemeBrowser.Values.Text = "VisualThemeBrowserForm";
+            this.kbtnVisualThemeBrowser.Click += new System.EventHandler(this.kbtnVisualThemeBrowser_Click);
+            //
+            // kbtnVisualTaskDialog
+            //
+            this.kbtnVisualTaskDialog.Location = new System.Drawing.Point(18, 161);
+            this.kbtnVisualTaskDialog.Margin = new System.Windows.Forms.Padding(4);
+            this.kbtnVisualTaskDialog.Name = "kbtnVisualTaskDialog";
+            this.kbtnVisualTaskDialog.Size = new System.Drawing.Size(347, 31);
+            this.kbtnVisualTaskDialog.TabIndex = 4;
+            this.kbtnVisualTaskDialog.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnVisualTaskDialog.Values.Text = "VisualTaskDialog";
+            this.kbtnVisualTaskDialog.Click += new System.EventHandler(this.kbtnVisualTaskDialog_Click);
+            //
+            // kbtnVisualTaskDialogForm
+            //
+            this.kbtnVisualTaskDialogForm.Location = new System.Drawing.Point(18, 124);
+            this.kbtnVisualTaskDialogForm.Margin = new System.Windows.Forms.Padding(4);
+            this.kbtnVisualTaskDialogForm.Name = "kbtnVisualTaskDialogForm";
+            this.kbtnVisualTaskDialogForm.Size = new System.Drawing.Size(347, 31);
+            this.kbtnVisualTaskDialogForm.TabIndex = 3;
+            this.kbtnVisualTaskDialogForm.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnVisualTaskDialogForm.Values.Text = "VisualTaskDialogForm";
+            this.kbtnVisualTaskDialogForm.Click += new System.EventHandler(this.kbtnVisualTaskDialogForm_Click);
+            //
+            // kbtnVisualSplashScreen
+            //
+            this.kbtnVisualSplashScreen.Location = new System.Drawing.Point(18, 87);
+            this.kbtnVisualSplashScreen.Margin = new System.Windows.Forms.Padding(4);
+            this.kbtnVisualSplashScreen.Name = "kbtnVisualSplashScreen";
+            this.kbtnVisualSplashScreen.Size = new System.Drawing.Size(347, 31);
+            this.kbtnVisualSplashScreen.TabIndex = 2;
+            this.kbtnVisualSplashScreen.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnVisualSplashScreen.Values.Text = "VisualSplashScreenForm";
+            this.kbtnVisualSplashScreen.Click += new System.EventHandler(this.kbtnVisualSplashScreen_Click);
+            //
+            // kbtnVisualMultilineStringEditorForm
+            //
+            this.kbtnVisualMultilineStringEditorForm.Location = new System.Drawing.Point(18, 50);
+            this.kbtnVisualMultilineStringEditorForm.Margin = new System.Windows.Forms.Padding(4);
+            this.kbtnVisualMultilineStringEditorForm.Name = "kbtnVisualMultilineStringEditorForm";
+            this.kbtnVisualMultilineStringEditorForm.Size = new System.Drawing.Size(347, 31);
+            this.kbtnVisualMultilineStringEditorForm.TabIndex = 1;
+            this.kbtnVisualMultilineStringEditorForm.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnVisualMultilineStringEditorForm.Values.Text = "VisualMultilineStringEditorForm";
+            this.kbtnVisualMultilineStringEditorForm.Click += new System.EventHandler(this.kbtnVisualMultilineStringEditorForm_Click);
+            //
+            // kbtnVisualInformationBoxForm
+            //
+            this.kbtnVisualInformationBoxForm.Location = new System.Drawing.Point(18, 13);
+            this.kbtnVisualInformationBoxForm.Margin = new System.Windows.Forms.Padding(4);
+            this.kbtnVisualInformationBoxForm.Name = "kbtnVisualInformationBoxForm";
+            this.kbtnVisualInformationBoxForm.Size = new System.Drawing.Size(347, 31);
+            this.kbtnVisualInformationBoxForm.TabIndex = 0;
+            this.kbtnVisualInformationBoxForm.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnVisualInformationBoxForm.Values.Text = "VisualInformationBoxForm";
+            this.kbtnVisualInformationBoxForm.Click += new System.EventHandler(this.kbtnVisualInformationBoxForm_Click);
+            //
+            // VisualControlsTest
+            //
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(387, 327);
+            this.Controls.Add(this.kryptonPanel1);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.Margin = new System.Windows.Forms.Padding(4);
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "VisualControlsTest";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Visual Controls Test";
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).EndInit();
+            this.kryptonPanel1.ResumeLayout(false);
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private KryptonPanel kryptonPanel1;
+        private KryptonButton kbtnVisualInformationBoxForm;
+        private KryptonButton kbtnVisualMultilineStringEditorForm;
+        private KryptonButton kbtnVisualSplashScreen;
+        private KryptonButton kbtnVisualTaskDialogForm;
+        private KryptonButton kbtnVisualTaskDialog;
+        private KryptonButton kbtnVisualThemeBrowser;
+        private KryptonButton kbtnVisualThemeBrowserRtlAware;
+        private KryptonButton kbtnVisualToastNotification;
+    }
+}

--- a/Source/Krypton Components/TestForm/VisualControlsTest.cs
+++ b/Source/Krypton Components/TestForm/VisualControlsTest.cs
@@ -11,6 +11,7 @@ using System;
 using System.Reflection;
 using Krypton.Toolkit;
 using System.Windows.Forms;
+using System.Threading;
 
 namespace TestForm
 {
@@ -137,6 +138,20 @@ namespace TestForm
             };
 
             ShowFormByName("VisualToastNotificationBasicForm", data);
+        }
+
+        private void kbtnModalWaitDialog_Click(object sender, EventArgs e)
+        {
+            using var waitDlg = new ModalWaitDialog(true, 0, 100);
+
+            for (int i = 0; i <= 100; i++)
+            {
+                waitDlg.UpdateProgressBarValue(i);
+                waitDlg.UpdateDialog();
+                Thread.Sleep(40);
+            }
+
+            waitDlg.Close();
         }
     }
 }

--- a/Source/Krypton Components/TestForm/VisualControlsTest.cs
+++ b/Source/Krypton Components/TestForm/VisualControlsTest.cs
@@ -1,0 +1,142 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2025 - 2025. All rights reserved.
+ *
+ */
+#endregion
+
+using System;
+using System.Reflection;
+using Krypton.Toolkit;
+using System.Windows.Forms;
+
+namespace TestForm
+{
+    public partial class VisualControlsTest : KryptonForm
+    {
+        public VisualControlsTest()
+        {
+            InitializeComponent();
+        }
+
+        private void ShowFormByName(string typeName, params object[]? args)
+        {
+            var asm = typeof(KryptonForm).Assembly; // Krypton.Toolkit assembly
+            var type = asm.GetType($"Krypton.Toolkit.{typeName}");
+            if (type == null)
+            {
+                _ = MessageBox.Show($"Type {typeName} not found.");
+                return;
+            }
+
+            try
+            {
+                var instance = Activator.CreateInstance(type, args ?? Array.Empty<object>());
+                if (instance is Form frm)
+                {
+                    // Only add dummy content when base form directly
+                    if (typeName == "VisualToastNotificationBaseForm")
+                    {
+                        var label = new KryptonLabel
+                        {
+                            Text = "Demo Toast Notification Base Form",
+                            Dock = DockStyle.Fill
+                        };
+                        frm.Controls.Add(label);
+                        frm.ClientSize = new System.Drawing.Size(350, 100);
+                    }
+
+                    frm.ShowDialog(this);
+                }
+                else if (instance != null)
+                {
+                    // try ShowEditor for MultilineStringEditor1
+                    var mi = type.GetMethod("ShowEditor", BindingFlags.Instance | BindingFlags.Public);
+                    mi?.Invoke(instance, null);
+                }
+                // Special handling for MultilineStringEditorForm to ensure content area visible
+                if (typeName.StartsWith("VisualMultilineStringEditorForm"))
+                {
+                    type.GetMethod("SetupInputCanvas", BindingFlags.NonPublic | BindingFlags.Instance)
+                        ?.Invoke(instance, null);
+                }
+            }
+            catch (Exception ex)
+            {
+                _ = MessageBox.Show($"Could not create instance of {typeName}: {ex.Message}");
+            }
+        }
+
+        private void kbtnVisualInformationBoxForm_Click(object sender, EventArgs e) =>
+            ShowFormByName("VisualInformationBoxForm");
+
+        private void kbtnVisualMultilineStringEditorForm_Click(object sender, EventArgs e) =>
+            ShowFormByName("VisualMultilineStringEditorForm", new string[] { "Alpha", "Beta", "Gamma" }, null, true, "Demo header", "Multiline Editor Demo");
+
+        private void kbtnVisualSplashScreen_Click(object sender, EventArgs e)
+        {
+            var data = new KryptonSplashScreenData
+            {
+                ShowApplicationName = true,
+                ShowVersion = true,
+                ShowProgressBar = false
+            };
+
+            ShowFormByName("VisualSplashScreenForm", data);
+        }
+
+        private void kbtnVisualTaskDialogForm_Click(object sender, EventArgs e)
+        {
+            var td = new KryptonTaskDialog
+            {
+                WindowTitle = "Demo TaskDialogForm",
+                MainInstruction = "Hello from TaskDialogForm",
+                Content = "This is a demo of VisualTaskDialogForm.",
+                Icon = KryptonMessageBoxIcon.Information
+            };
+
+            ShowFormByName("VisualTaskDialogForm", td);
+        }
+
+        private void kbtnVisualTaskDialog_Click(object sender, EventArgs e)
+        {
+            var td = new KryptonTaskDialog
+            {
+                WindowTitle = "Demo VisualTaskDialog",
+                MainInstruction = "Hello from VisualTaskDialog",
+                Content = "This is a demo of VisualTaskDialog window.",
+                Icon = KryptonMessageBoxIcon.Information
+            };
+
+            ShowFormByName("VisualTaskDialog", td);
+        }
+
+        private void kbtnVisualThemeBrowser_Click(object sender, EventArgs e)
+        {
+            var data = new KryptonThemeBrowserData { WindowTitle = "Theme Browser", StartIndex = 1 };
+            KryptonThemeBrowser.Show(data);
+        }
+
+        private void kbtnVisualThemeBrowserRtlAware_Click(object sender, EventArgs e)
+        {
+            var data = new KryptonThemeBrowserData { WindowTitle = "Theme Browser RTL", StartIndex = 1 };
+            ShowFormByName("VisualThemeBrowserFormRtlAware", data);
+        }
+
+        private void kbtnVisualToastNotification_Click(object sender, EventArgs e)
+        {
+            var data = new KryptonBasicToastNotificationData
+            {
+                NotificationTitle = "Demo Toast",
+                NotificationContent = "This is a basic toast notification.",
+                NotificationIcon = KryptonToastNotificationIcon.Information,
+                ShowCloseBox = true,
+                CountDownSeconds = 0
+            };
+
+            ShowFormByName("VisualToastNotificationBasicForm", data);
+        }
+    }
+}

--- a/Source/Krypton Components/TestForm/VisualControlsTest.resx
+++ b/Source/Krypton Components/TestForm/VisualControlsTest.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>


### PR DESCRIPTION
- Comment out SetInheritedControlOverride calls in various `Visual Controls` forms to fix empty controls.
- Added tests to TestForm with new Visual Controls button. (V100)

Files that still call SetInheritedControlOverride before InitializeComponent  
(resulting in the bug sequence that suppresses the internal panel and hides all designer controls):

1. Controls Visuals / VisualInformationBoxForm.cs  
2. Controls Visuals / VisualMultilineStringEditorForm.cs  
3. Controls Visuals / VisualSplashScreenForm.cs  
4. Controls Visuals / VisualTaskDialogForm.cs  
5. Controls Visuals / VisualTaskDialog.cs (non-*Form* but still a KryptonForm dialog)  
6. Controls Visuals / VisualMultilineStringEditor.cs (the old in-place editor, class MultilineStringEditor1)  
7. Controls Visuals / VisualThemeBrowserForm.cs  
8. Controls Visuals / RTL Aware / VisualThemeBrowserFormRtlAware.cs  
9. Controls Visuals / Notification Toast / Base / VisualToastNotificationBaseForm.cs  
10. General / ModalWaitDialog.cs

Why they should be fixed  
• In every constructor the call appears **before** any Layout/Suspend/Resume cycle.  
• The first SuspendLayout that InitializeComponent issues depends on _internalPanelState still being Inherit; the premature call flips it to True, so the internal panel is never inserted and all controls added by the designer land on an invisible container.  

Fixes #2296 

![image](https://github.com/user-attachments/assets/21aa7fd4-a116-4e7a-90a6-171fd4b6568f)
