### PR TITLE
2104-V100-fix-palette-base-leak

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Base/PaletteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Base/PaletteBase.cs
@@ -2,7 +2,7 @@
 /*
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
  *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  */
@@ -2077,5 +2077,25 @@ public abstract class PaletteBase : Component
     /// <param name="e">An EventArgs containing event data.</param>
     protected virtual void OnButtonSpecChanged(object sender, EventArgs e) => ButtonSpecChanged?.Invoke(this, e);
 
+    #endregion
+
+    #region IDisposable Implementation
+    /// <summary>
+    /// Releases the unmanaged resources used by the PaletteBase and optionally releases the managed resources.
+    /// </summary>
+    /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            // Detach from static SystemEvents to prevent memory leaks
+            SystemEvents.UserPreferenceChanged -= OnUserPreferenceChanged;
+
+            // Dispose any font resources we created
+            DisposeFonts();
+        }
+
+        base.Dispose(disposing);
+    }
     #endregion
 }


### PR DESCRIPTION
Non-static, instance-wired event handlers for PaletteBase-derived classes do not dispose automatically.

Analysis of the leak:

1. SystemEvents.UserPreferenceChanged is a static event.  
   • If objects subscribe from an instance constructor and do NOT unsubscribe, the static delegate keeps a reference to that instance, preventing it from being garbage-collected and causing a memory leak.

2. In this codebase 36 files perform the subscription.  
   • 7 UI classes (VisualPanel, VisualForm, etc.) already detach in their Dispose logic – they are safe.  
   • Most colour-table classes subscribe in a static constructor; static delegates → static handlers live for the whole process, so they do not cause an expanding leak.  
   • The Palette hierarchy (PaletteBase and every palette theme that derives from it) subscribed in the **instance** constructor but never detached. Each time a new palette object was created it was pinned in memory forever.

Root cause: PaletteBase did not unsubscribe, causing the leak.

Fixes #2104 

Fix applied:

PaletteBase now overrides Dispose and:

• Unhooks SystemEvents.UserPreferenceChanged  
• Releases font resources via existing DisposeFonts()  
• Calls base.Dispose(disposing)

This single change automatically repairs every derived palette/theme class because they all inherit the new behaviour, solving the leak across the entire codebase without touching dozens of theme files.

No other classes required modification, as all remaining subscriptions are either already balanced or static-by-design.