### PR TITLE
2104-V85-LTS-fix-palette-base-leak 

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2025-08-25 - Build 2508 (Patch 8) - August 2025
+* Resolved [#2301](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2301), Fix memory leak in PaletteBase
 * Resolved [#2235](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2235), `OSUtilities` Adds OsVersionInfo to the properties.
 * Resolved [#2264](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2264), Implementation of style: `PaletteBackStyle.Control`, `PaletteContentStyle.LabelAlternateControl` and `PaletteContentStyle.LabelAlternatePanel` in all themes.
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Base/PaletteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Base/PaletteBase.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2023. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2017 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -1722,8 +1722,8 @@ namespace Krypton.Toolkit
         {
             get => _baseFont;
 
-            set 
-            { 
+            set
+            {
                 _baseFont = value;
                 DefineFonts();
                 // Call an event to force repaint style things
@@ -1874,7 +1874,7 @@ namespace Krypton.Toolkit
 
             return hsl.Color;
         }
-        #endregion       
+        #endregion
 
         #region InputControlPadding
         /// <summary>
@@ -2005,5 +2005,26 @@ namespace Krypton.Toolkit
         protected virtual void OnButtonSpecChanged(object sender, EventArgs e) => ButtonSpecChanged?.Invoke(this, e);
 
         #endregion
+
+        #region IDisposable Implementation
+        /// <summary>
+        /// Releases the unmanaged resources used by the PaletteBase and optionally releases the managed resources.
+        /// </summary>
+        /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                // Detach from static SystemEvents to prevent memory leaks.
+                SystemEvents.UserPreferenceChanged -= OnUserPreferenceChanged;
+
+                // Dispose any font resources we created.
+                DisposeFonts();
+            }
+
+            base.Dispose(disposing);
+        }
+        #endregion
+
     }
 }


### PR DESCRIPTION
Non-static, instance-wired event handlers for PaletteBase-derived classes do not dispose automatically.

Analysis of the leak:

1. SystemEvents.UserPreferenceChanged is a static event.  
   • If objects subscribe from an instance constructor and do NOT unsubscribe, the static delegate keeps a reference to that instance, preventing it from being garbage-collected and causing a memory leak.

2. In this codebase several files perform the subscription.  
   • The Palette hierarchy (PaletteBase and every palette theme that derives from it) subscribed in the **instance** constructor but never detached. Each time a new palette object was created it was pinned in memory forever.

Root cause: PaletteBase did not unsubscribe, causing the leak.

Relates to #2104 #2299 #2300 

Fix applied:

PaletteBase now overrides Dispose and:

• Unhooks SystemEvents.UserPreferenceChanged  
• Releases font resources via existing DisposeFonts()  
• Calls base.Dispose(disposing)

This single change automatically repairs every derived palette/theme class because they all inherit the new behaviour, solving the leak across the entire codebase without touching dozens of theme files.

No other classes required modification, as all remaining subscriptions are either already balanced or static-by-design.