### PR TITLE
2277 V95 added colors to the _schemeOfficeColors

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -4,6 +4,7 @@
 
 # 2025-08-25 - Build 2508 (Patch 8) - August 2025
 * Resolved [#2277](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2277), Added colors in the `Color[] _schemeOfficeColors`.
+* Resolved [#2300](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2300), Fix memory leak in PaletteBase
 * Resolved [#2235](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2235), `OSUtilities` Adds OsVersionInfo to the properties.
 * Resolved [#2264](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2264), Implementation of style: `PaletteBackStyle.Control`, `PaletteContentStyle.LabelAlternateControl` and `PaletteContentStyle.LabelAlternatePanel` in all themes.
 

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2025-08-25 - Build 2508 (Patch 8) - August 2025
+* Resolved [#2300](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2300), Fix memory leak in PaletteBase
 * Resolved [#2277](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2277), Added colors in the `Color[] _schemeOfficeColors`.
 * Resolved [#2235](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2235), `OSUtilities` Adds OsVersionInfo to the properties.
 * Resolved [#2264](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2264), Implementation of style: `PaletteBackStyle.Control`, `PaletteContentStyle.LabelAlternateControl` and `PaletteContentStyle.LabelAlternatePanel` in all themes.

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -4,7 +4,6 @@
 
 # 2025-08-25 - Build 2508 (Patch 8) - August 2025
 * Resolved [#2277](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2277), Added colors in the `Color[] _schemeOfficeColors`.
-* Resolved [#2300](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2300), Fix memory leak in PaletteBase
 * Resolved [#2235](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2235), `OSUtilities` Adds OsVersionInfo to the properties.
 * Resolved [#2264](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2264), Implementation of style: `PaletteBackStyle.Control`, `PaletteContentStyle.LabelAlternateControl` and `PaletteContentStyle.LabelAlternatePanel` in all themes.
 

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2025-08-25 - Build 2508 (Patch 8) - August 2025
+* Resolved [#2277](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2277), Added colors in the `Color[] _schemeOfficeColors`.
 * Resolved [#2235](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2235), `OSUtilities` Adds OsVersionInfo to the properties.
 * Resolved [#2264](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2264), Implementation of style: `PaletteBackStyle.Control`, `PaletteContentStyle.LabelAlternateControl` and `PaletteContentStyle.LabelAlternatePanel` in all themes.
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkMode.cs
@@ -284,38 +284,32 @@ namespace Krypton.Toolkit
             Color.FromArgb(140, 140, 140), // RibbonQATMini3I
             Color.FromArgb(12, Color.White), // RibbonQATMini4I
             Color.FromArgb(14, Color.White), // RibbonQATMini5I
-            Color.FromArgb(141, 144, 147), // RibbonQATFullbar1                                                      
-            Color.FromArgb(133, 135, 137), // RibbonQATFullbar2                                                      
-            Color.FromArgb(93, 96, 100), // RibbonQATFullbar3                                                      
-            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark                                                      
-            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
-            Color.FromArgb(118, 128, 142), // RibbonQATOverflow1                                                      
-            Color.FromArgb(55, 60, 67), // RibbonQATOverflow2                                                      
-            Color.FromArgb(163, 168,
-                170), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(230, 233,
-                235), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(210, 217,
-                219), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(214, 222,
-                223), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(179, 188,
-                191), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(145, 156,
-                159), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(235, 235, 235), // NavigatorMiniBackColor                                                    
-            Color.FromArgb(10, 10, 10), // GridListNormal1                                                    
-            Color.FromArgb(41, 41, 41), // GridListNormal2                                                    
-            Color.FromArgb(41, 41, 41), // GridListPressed1                                                    
-            Color.FromArgb(61, 61, 61), // GridListPressed2                                                    
-            Color.FromArgb(33, 33, 33), // GridListSelected                                                    
-            Color.FromArgb(10, 10, 10), // GridSheetColNormal1                                                    
-            Color.FromArgb(41, 41, 41), // GridSheetColNormal2                                                    
-            Color.FromArgb(224, 224, 224), // GridSheetColPressed1                                                    
-            Color.FromArgb(195, 195, 195), // GridSheetColPressed2                                                    
+            Color.FromArgb(141, 144, 147), // RibbonQATFullbar1
+            Color.FromArgb(133, 135, 137), // RibbonQATFullbar2
+            Color.FromArgb(93, 96, 100), // RibbonQATFullbar3
+            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark
+            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight
+            Color.FromArgb(118, 128, 142), // RibbonQATOverflow1
+            Color.FromArgb(55, 60, 67), // RibbonQATOverflow2
+            Color.FromArgb(163, 168, 170), // RibbonGroupSeparatorDark
+            Color.FromArgb(230, 233, 235), // RibbonGroupSeparatorLight
+            Color.FromArgb(210, 217, 219), // ButtonClusterButtonBack1
+            Color.FromArgb(214, 222, 223), // ButtonClusterButtonBack2
+            Color.FromArgb(179, 188, 191), // ButtonClusterButtonBorder1
+            Color.FromArgb(145, 156, 159), // ButtonClusterButtonBorder2
+            Color.FromArgb(235, 235, 235), // NavigatorMiniBackColor
+            Color.FromArgb(10, 10, 10), // GridListNormal1
+            Color.FromArgb(41, 41, 41), // GridListNormal2
+            Color.FromArgb(41, 41, 41), // GridListPressed1
+            Color.FromArgb(61, 61, 61), // GridListPressed2
+            Color.FromArgb(33, 33, 33), // GridListSelected
+            Color.FromArgb(10, 10, 10), // GridSheetColNormal1
+            Color.FromArgb(41, 41, 41), // GridSheetColNormal2
+            Color.FromArgb(224, 224, 224), // GridSheetColPressed1
+            Color.FromArgb(195, 195, 195), // GridSheetColPressed2
             Color.FromArgb(91, 91, 91), // GridSheetColSelected1
             Color.FromArgb(33, 33, 33), // GridSheetColSelected2
-            Color.FromArgb(237, 237, 237), // GridSheetRowNormal                                                   
+            Color.FromArgb(237, 237, 237), // GridSheetRowNormal
             Color.FromArgb(196, 196, 196), // GridSheetRowPressed
             Color.FromArgb(61, 61, 61), // GridSheetRowSelected
             Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -1234,13 +1228,13 @@ namespace Krypton.Toolkit
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1],
                         PaletteState.NormalDefaultOverride => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack1],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
-                                                        : _buttonBackColors[6],
+ ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+ : _buttonBackColors[6],
                         PaletteState.Tracking => _buttonBackColors[2],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
                         PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
-                                                        : _buttonBackColors[8],
+ ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+ : _buttonBackColors[8],
                         _ => throw DebugTools.NotImplemented(state.ToString())
                     };
                 case PaletteBackStyle.ButtonNavigatorStack:
@@ -1525,16 +1519,16 @@ namespace Krypton.Toolkit
                         PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack1] : _buttonBackColors[1],
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2],
                         PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
-                                                                ? GlobalStaticValues.EMPTY_COLOR
-                                                                : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
+         ? GlobalStaticValues.EMPTY_COLOR
+         : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2]
-                                                        : _buttonBackColors[7],
+ ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2]
+ : _buttonBackColors[7],
                         PaletteState.Tracking => _buttonBackColors[3],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
                         PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
-                                                        : _buttonBackColors[9],
+ ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+ : _buttonBackColors[9],
                         _ => throw DebugTools.NotImplemented(state.ToString())
                     };
                 case PaletteBackStyle.ButtonNavigatorStack:
@@ -1906,11 +1900,11 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
+? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
+: _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
@@ -1921,8 +1915,8 @@ namespace Krypton.Toolkit
                 },
                 PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
                 PaletteBorderStyle.InputControlStandalone or PaletteBorderStyle.InputControlRibbon or PaletteBorderStyle.InputControlCustom1 or PaletteBorderStyle.InputControlCustom2 or PaletteBorderStyle.InputControlCustom3 => state == PaletteState.Disabled
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.InputControlBorderDisabled]
-                                                        : _ribbonColours[(int)SchemeOfficeColors.InputControlBorderNormal],
+ ? _ribbonColours[(int)SchemeOfficeColors.InputControlBorderDisabled]
+ : _ribbonColours[(int)SchemeOfficeColors.InputControlBorderNormal],
                 PaletteBorderStyle.GridDataCellList or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1 or PaletteBorderStyle.GridDataCellCustom2 or PaletteBorderStyle.GridDataCellCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.GridDataCellBorder],
                 PaletteBorderStyle.ControlRibbon => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.RibbonGroupsArea1],
                 PaletteBorderStyle.ControlRibbonAppMenu => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.AppButtonBorder],
@@ -1930,8 +1924,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-                                                        : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+ ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+ : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -1951,8 +1945,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
-                                                   : _buttonBorderColors[0],
+? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
+: _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile
                     or PaletteBorderStyle.ButtonBreadCrumb
@@ -1960,8 +1954,8 @@ namespace Krypton.Toolkit
                     or PaletteBorderStyle.ButtonCommand
                     or PaletteBorderStyle.ButtonButtonSpec
                     or PaletteBorderStyle.ContextMenuItemHighlight
-                                                            ? GlobalStaticValues.EMPTY_COLOR
-                                                            : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+     ? GlobalStaticValues.EMPTY_COLOR
+     : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed
@@ -2044,12 +2038,12 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
+? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
+: _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -2068,8 +2062,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -2089,8 +2083,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
-                                                   : _buttonBorderColors[0],
+? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
+: _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[6],
@@ -2884,8 +2878,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal
                     or PaletteState.CheckedTracking
                     or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
@@ -3289,8 +3283,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal
                     or PaletteState.CheckedTracking
                     or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
@@ -3376,8 +3370,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal
                     or PaletteState.CheckedTracking
                     or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkMode.cs
@@ -1228,13 +1228,13 @@ namespace Krypton.Toolkit
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1],
                         PaletteState.NormalDefaultOverride => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack1],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
- ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
- : _buttonBackColors[6],
+                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+                                                        : _buttonBackColors[6],
                         PaletteState.Tracking => _buttonBackColors[2],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
                         PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
- ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
- : _buttonBackColors[8],
+                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+                                                        : _buttonBackColors[8],
                         _ => throw DebugTools.NotImplemented(state.ToString())
                     };
                 case PaletteBackStyle.ButtonNavigatorStack:
@@ -1519,16 +1519,16 @@ namespace Krypton.Toolkit
                         PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack1] : _buttonBackColors[1],
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2],
                         PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
-         ? GlobalStaticValues.EMPTY_COLOR
-         : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
+                                                                ? GlobalStaticValues.EMPTY_COLOR
+                                                                : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
- ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2]
- : _buttonBackColors[7],
+                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2]
+                                                        : _buttonBackColors[7],
                         PaletteState.Tracking => _buttonBackColors[3],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
                         PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
- ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
- : _buttonBackColors[9],
+                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+                                                        : _buttonBackColors[9],
                         _ => throw DebugTools.NotImplemented(state.ToString())
                     };
                 case PaletteBackStyle.ButtonNavigatorStack:
@@ -1900,11 +1900,11 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
-: _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
@@ -1915,8 +1915,8 @@ namespace Krypton.Toolkit
                 },
                 PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
                 PaletteBorderStyle.InputControlStandalone or PaletteBorderStyle.InputControlRibbon or PaletteBorderStyle.InputControlCustom1 or PaletteBorderStyle.InputControlCustom2 or PaletteBorderStyle.InputControlCustom3 => state == PaletteState.Disabled
- ? _ribbonColours[(int)SchemeOfficeColors.InputControlBorderDisabled]
- : _ribbonColours[(int)SchemeOfficeColors.InputControlBorderNormal],
+                                                        ? _ribbonColours[(int)SchemeOfficeColors.InputControlBorderDisabled]
+                                                        : _ribbonColours[(int)SchemeOfficeColors.InputControlBorderNormal],
                 PaletteBorderStyle.GridDataCellList or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1 or PaletteBorderStyle.GridDataCellCustom2 or PaletteBorderStyle.GridDataCellCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.GridDataCellBorder],
                 PaletteBorderStyle.ControlRibbon => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.RibbonGroupsArea1],
                 PaletteBorderStyle.ControlRibbonAppMenu => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.AppButtonBorder],
@@ -1924,8 +1924,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
- ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
- : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+                                                        ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+                                                        : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -1945,8 +1945,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
-? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
-: _buttonBorderColors[0],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
+                                                   : _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile
                     or PaletteBorderStyle.ButtonBreadCrumb
@@ -1954,8 +1954,8 @@ namespace Krypton.Toolkit
                     or PaletteBorderStyle.ButtonCommand
                     or PaletteBorderStyle.ButtonButtonSpec
                     or PaletteBorderStyle.ContextMenuItemHighlight
-     ? GlobalStaticValues.EMPTY_COLOR
-     : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+                                                            ? GlobalStaticValues.EMPTY_COLOR
+                                                            : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed
@@ -2038,12 +2038,12 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
-: _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -2062,8 +2062,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -2083,8 +2083,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
-? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
-: _buttonBorderColors[0],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
+                                                   : _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[6],
@@ -2878,8 +2878,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal
                     or PaletteState.CheckedTracking
                     or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
@@ -3283,8 +3283,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal
                     or PaletteState.CheckedTracking
                     or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
@@ -3370,8 +3370,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal
                     or PaletteState.CheckedTracking
                     or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkModeAlternate.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkModeAlternate.cs
@@ -286,38 +286,32 @@ namespace Krypton.Toolkit
             Color.FromArgb(140, 140, 140), // RibbonQATMini3I
             Color.FromArgb(12, Color.White), // RibbonQATMini4I
             Color.FromArgb(14, Color.White), // RibbonQATMini5I
-            Color.FromArgb(141, 144, 147), // RibbonQATFullbar1                                                      
-            Color.FromArgb(133, 135, 137), // RibbonQATFullbar2                                                      
-            Color.FromArgb(93, 96, 100), // RibbonQATFullbar3                                                      
-            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark                                                      
-            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
-            Color.FromArgb(118, 128, 142), // RibbonQATOverflow1                                                      
-            Color.FromArgb(55, 60, 67), // RibbonQATOverflow2                                                      
-            Color.FromArgb(163, 168,
-                170), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(230, 233,
-                235), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(210, 217,
-                219), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(214, 222,
-                223), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(179, 188,
-                191), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(145, 156,
-                159), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(235, 235, 235), // NavigatorMiniBackColor                                                    
-            Color.FromArgb(31, 31, 31), // GridListNormal1                                                    
-            Color.FromArgb(15, 15, 15), // GridListNormal2                                                    
-            Color.FromArgb(15, 15, 15), // GridListPressed1                                                    
-            Color.FromArgb(15, 15, 15), // GridListPressed2                                                    
-            Color.FromArgb(33, 33, 33), // GridListSelected                                                    
-            Color.FromArgb(31, 31, 31), // GridSheetColNormal1                                                    
-            Color.FromArgb(15, 15, 15), // GridSheetColNormal2                                                    
-            Color.FromArgb(224, 224, 224), // GridSheetColPressed1                                                    
-            Color.FromArgb(195, 195, 195), // GridSheetColPressed2                                                    
+            Color.FromArgb(141, 144, 147), // RibbonQATFullbar1
+            Color.FromArgb(133, 135, 137), // RibbonQATFullbar2
+            Color.FromArgb(93, 96, 100), // RibbonQATFullbar3
+            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark
+            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight
+            Color.FromArgb(118, 128, 142), // RibbonQATOverflow1
+            Color.FromArgb(55, 60, 67), // RibbonQATOverflow2
+            Color.FromArgb(163, 168, 170), // RibbonGroupSeparatorDark
+            Color.FromArgb(230, 233, 235), // RibbonGroupSeparatorLight
+            Color.FromArgb(210, 217, 219), // ButtonClusterButtonBack1
+            Color.FromArgb(214, 222, 223), // ButtonClusterButtonBack2
+            Color.FromArgb(179, 188, 191), // ButtonClusterButtonBorder1
+            Color.FromArgb(145, 156, 159), // ButtonClusterButtonBorder2
+            Color.FromArgb(235, 235, 235), // NavigatorMiniBackColor
+            Color.FromArgb(31, 31, 31), // GridListNormal1
+            Color.FromArgb(15, 15, 15), // GridListNormal2
+            Color.FromArgb(15, 15, 15), // GridListPressed1
+            Color.FromArgb(15, 15, 15), // GridListPressed2
+            Color.FromArgb(33, 33, 33), // GridListSelected
+            Color.FromArgb(31, 31, 31), // GridSheetColNormal1
+            Color.FromArgb(15, 15, 15), // GridSheetColNormal2
+            Color.FromArgb(224, 224, 224), // GridSheetColPressed1
+            Color.FromArgb(195, 195, 195), // GridSheetColPressed2
             Color.FromArgb(91, 91, 91), // GridSheetColSelected1
             Color.FromArgb(33, 33, 33), // GridSheetColSelected2
-            Color.FromArgb(237, 237, 237), // GridSheetRowNormal                                                   
+            Color.FromArgb(237, 237, 237), // GridSheetRowNormal
             Color.FromArgb(196, 196, 196), // GridSheetRowPressed
             Color.FromArgb(15, 15, 15), // GridSheetRowSelected
             Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -1231,13 +1225,13 @@ namespace Krypton.Toolkit
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1],
                         PaletteState.NormalDefaultOverride => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack1],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
-                                                        : _buttonBackColors[6],
+ ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+ : _buttonBackColors[6],
                         PaletteState.Tracking => _buttonBackColors[2],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
                         PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
-                                                        : _buttonBackColors[8],
+ ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+ : _buttonBackColors[8],
                         _ => throw DebugTools.NotImplemented(state.ToString())
                     };
                 case PaletteBackStyle.ButtonNavigatorStack:
@@ -1522,16 +1516,16 @@ namespace Krypton.Toolkit
                         PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack1] : _buttonBackColors[1],
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2],
                         PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
-                                                                ? GlobalStaticValues.EMPTY_COLOR
-                                                                : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
+         ? GlobalStaticValues.EMPTY_COLOR
+         : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2]
-                                                        : _buttonBackColors[7],
+ ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2]
+ : _buttonBackColors[7],
                         PaletteState.Tracking => _buttonBackColors[3],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
                         PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
-                                                        : _buttonBackColors[9],
+ ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+ : _buttonBackColors[9],
                         _ => throw DebugTools.NotImplemented(state.ToString())
                     };
                 case PaletteBackStyle.ButtonNavigatorStack:
@@ -1882,11 +1876,11 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
+? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
+: _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
@@ -1897,8 +1891,8 @@ namespace Krypton.Toolkit
                 },
                 PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
                 PaletteBorderStyle.InputControlStandalone or PaletteBorderStyle.InputControlRibbon or PaletteBorderStyle.InputControlCustom1 or PaletteBorderStyle.InputControlCustom2 or PaletteBorderStyle.InputControlCustom3 => state == PaletteState.Disabled
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.InputControlBorderDisabled]
-                                                        : _ribbonColours[(int)SchemeOfficeColors.InputControlBorderNormal],
+ ? _ribbonColours[(int)SchemeOfficeColors.InputControlBorderDisabled]
+ : _ribbonColours[(int)SchemeOfficeColors.InputControlBorderNormal],
                 PaletteBorderStyle.GridDataCellList or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1 or PaletteBorderStyle.GridDataCellCustom2 or PaletteBorderStyle.GridDataCellCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.GridDataCellBorder],
                 PaletteBorderStyle.ControlRibbon => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.RibbonGroupsArea1],
                 PaletteBorderStyle.ControlRibbonAppMenu => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.AppButtonBorder],
@@ -1906,8 +1900,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-                                                        : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+ ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+ : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -1927,12 +1921,12 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
-                                                   : _buttonBorderColors[0],
+? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
+: _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
-                                                            ? GlobalStaticValues.EMPTY_COLOR
-                                                            : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+     ? GlobalStaticValues.EMPTY_COLOR
+     : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
@@ -2010,12 +2004,12 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
+? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
+: _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -2034,8 +2028,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -2055,8 +2049,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
-                                                   : _buttonBorderColors[0],
+? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
+: _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[6],
@@ -2745,8 +2739,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -2827,8 +2821,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3226,8 +3220,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3307,8 +3301,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkModeAlternate.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkModeAlternate.cs
@@ -1225,13 +1225,13 @@ namespace Krypton.Toolkit
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1],
                         PaletteState.NormalDefaultOverride => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack1],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
- ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
- : _buttonBackColors[6],
+                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+                                                        : _buttonBackColors[6],
                         PaletteState.Tracking => _buttonBackColors[2],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
                         PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
- ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
- : _buttonBackColors[8],
+                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+                                                        : _buttonBackColors[8],
                         _ => throw DebugTools.NotImplemented(state.ToString())
                     };
                 case PaletteBackStyle.ButtonNavigatorStack:
@@ -1516,16 +1516,16 @@ namespace Krypton.Toolkit
                         PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack1] : _buttonBackColors[1],
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2],
                         PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
-         ? GlobalStaticValues.EMPTY_COLOR
-         : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
+                                                                ? GlobalStaticValues.EMPTY_COLOR
+                                                                : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
- ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2]
- : _buttonBackColors[7],
+                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2]
+                                                        : _buttonBackColors[7],
                         PaletteState.Tracking => _buttonBackColors[3],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
                         PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
- ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
- : _buttonBackColors[9],
+                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+                                                        : _buttonBackColors[9],
                         _ => throw DebugTools.NotImplemented(state.ToString())
                     };
                 case PaletteBackStyle.ButtonNavigatorStack:
@@ -1876,11 +1876,11 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
-: _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
@@ -1891,8 +1891,8 @@ namespace Krypton.Toolkit
                 },
                 PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
                 PaletteBorderStyle.InputControlStandalone or PaletteBorderStyle.InputControlRibbon or PaletteBorderStyle.InputControlCustom1 or PaletteBorderStyle.InputControlCustom2 or PaletteBorderStyle.InputControlCustom3 => state == PaletteState.Disabled
- ? _ribbonColours[(int)SchemeOfficeColors.InputControlBorderDisabled]
- : _ribbonColours[(int)SchemeOfficeColors.InputControlBorderNormal],
+                                                        ? _ribbonColours[(int)SchemeOfficeColors.InputControlBorderDisabled]
+                                                        : _ribbonColours[(int)SchemeOfficeColors.InputControlBorderNormal],
                 PaletteBorderStyle.GridDataCellList or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1 or PaletteBorderStyle.GridDataCellCustom2 or PaletteBorderStyle.GridDataCellCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.GridDataCellBorder],
                 PaletteBorderStyle.ControlRibbon => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.RibbonGroupsArea1],
                 PaletteBorderStyle.ControlRibbonAppMenu => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.AppButtonBorder],
@@ -1900,8 +1900,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
- ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
- : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+                                                        ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+                                                        : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -1921,12 +1921,12 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
-? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
-: _buttonBorderColors[0],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
+                                                   : _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
-     ? GlobalStaticValues.EMPTY_COLOR
-     : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+                                                            ? GlobalStaticValues.EMPTY_COLOR
+                                                            : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
@@ -2004,12 +2004,12 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
-: _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -2028,8 +2028,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -2049,8 +2049,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
-? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
-: _buttonBorderColors[0],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
+                                                   : _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[6],
@@ -2739,8 +2739,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -2821,8 +2821,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3220,8 +3220,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3301,8 +3301,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueDarkMode.cs
@@ -1204,13 +1204,13 @@ namespace Krypton.Toolkit
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1],
                         PaletteState.NormalDefaultOverride => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack1],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
-? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
-: _buttonBackColors[6],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+                                                    : _buttonBackColors[6],
                         PaletteState.Tracking => _buttonBackColors[2],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
                         PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
-     ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
-     : _buttonBackColors[8],
+                                                            ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+                                                            : _buttonBackColors[8],
                         _ => throw DebugTools.NotImplemented(state.ToString())
                     };
                 case PaletteBackStyle.ButtonNavigatorStack:
@@ -1473,16 +1473,16 @@ namespace Krypton.Toolkit
                         PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack1] : _buttonBackColors[1],
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2],
                         PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
-     ? GlobalStaticValues.EMPTY_COLOR
-     : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
+                                                            ? GlobalStaticValues.EMPTY_COLOR
+                                                            : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
-? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2]
-: _buttonBackColors[7],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2]
+                                                    : _buttonBackColors[7],
                         PaletteState.Tracking => _buttonBackColors[3],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
                         PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
- ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
- : _buttonBackColors[9],
+                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+                                                        : _buttonBackColors[9],
                         _ => throw DebugTools.NotImplemented(state.ToString())
                     };
 
@@ -1835,8 +1835,8 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
                                                 ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
@@ -1859,8 +1859,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -1880,12 +1880,12 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
-? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
-: _buttonBorderColors[0],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
+                                                   : _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
-     ? GlobalStaticValues.EMPTY_COLOR
-     : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+                                                            ? GlobalStaticValues.EMPTY_COLOR
+                                                            : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
@@ -1968,8 +1968,8 @@ namespace Krypton.Toolkit
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -1988,8 +1988,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -2009,8 +2009,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
-? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
-: _buttonBorderColors[0],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
+                                                   : _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[6],
@@ -2691,8 +2691,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -2769,8 +2769,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3168,8 +3168,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3244,8 +3244,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueDarkMode.cs
@@ -282,38 +282,38 @@ namespace Krypton.Toolkit
             Color.FromArgb(219, 231, 247), // RibbonQATMini2
             Color.FromArgb(195, 213, 236), // RibbonQATMini3
             Color.FromArgb(128, Color.White), // RibbonQATMini4
-            Color.FromArgb(72, Color.White), // RibbonQATMini5                                                       
+            Color.FromArgb(72, Color.White), // RibbonQATMini5
             Color.FromArgb(153, 176, 206), // RibbonQATMini1I
             Color.FromArgb(226, 233, 241), // RibbonQATMini2I
             Color.FromArgb(198, 210, 226), // RibbonQATMini3I
             Color.FromArgb(128, Color.White), // RibbonQATMini4I
-            Color.FromArgb(72, Color.White), // RibbonQATMini5I                                                      
-            Color.FromArgb(178, 205, 237), // RibbonQATFullbar1                                                      
-            Color.FromArgb(170, 197, 234), // RibbonQATFullbar2                                                      
-            Color.FromArgb(126, 161, 205), // RibbonQATFullbar3                                                      
-            Color.FromArgb(86, 125, 177), // RibbonQATButtonDark                                                      
-            Color.FromArgb(234, 242, 249), // RibbonQATButtonLight                                                      
-            Color.FromArgb(192, 220, 255), // RibbonQATOverflow1                                                      
-            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-            Color.FromArgb(140, 172, 211), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(248, 250, 252), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(192, 212, 241), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(200, 219, 238), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(155, 183, 224), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(117, 150, 191), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor                                                    
-            Color.FromArgb(134, 179, 236), // GridListNormal1                                                    
-            Color.FromArgb(63, 122, 197), // GridListNormal2                                                    
-            Color.FromArgb(63, 122, 197), // GridListPressed1                                                    
-            Color.FromArgb(252, 253, 255), // GridListPressed2                                                    
-            Color.FromArgb(170, 195, 240), // GridListSelected                                                    
-            Color.FromArgb(134, 179, 236), // GridSheetColNormal1                                                    
-            Color.FromArgb(63, 122, 197), // GridSheetColNormal2                                                    
-            Color.FromArgb(223, 226, 228), // GridSheetColPressed1                                                    
-            Color.FromArgb(188, 197, 210), // GridSheetColPressed2                                                    
+            Color.FromArgb(72, Color.White), // RibbonQATMini5I
+            Color.FromArgb(178, 205, 237), // RibbonQATFullbar1
+            Color.FromArgb(170, 197, 234), // RibbonQATFullbar2
+            Color.FromArgb(126, 161, 205), // RibbonQATFullbar3
+            Color.FromArgb(86, 125, 177), // RibbonQATButtonDark
+            Color.FromArgb(234, 242, 249), // RibbonQATButtonLight
+            Color.FromArgb(192, 220, 255), // RibbonQATOverflow1
+            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
+            Color.FromArgb(140, 172, 211), // RibbonGroupSeparatorDark
+            Color.FromArgb(248, 250, 252), // RibbonGroupSeparatorLight
+            Color.FromArgb(192, 212, 241), // ButtonClusterButtonBack1
+            Color.FromArgb(200, 219, 238), // ButtonClusterButtonBack2
+            Color.FromArgb(155, 183, 224), // ButtonClusterButtonBorder1
+            Color.FromArgb(117, 150, 191), // ButtonClusterButtonBorder2
+            Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor
+            Color.FromArgb(134, 179, 236), // GridListNormal1
+            Color.FromArgb(63, 122, 197), // GridListNormal2
+            Color.FromArgb(63, 122, 197), // GridListPressed1
+            Color.FromArgb(252, 253, 255), // GridListPressed2
+            Color.FromArgb(170, 195, 240), // GridListSelected
+            Color.FromArgb(134, 179, 236), // GridSheetColNormal1
+            Color.FromArgb(63, 122, 197), // GridSheetColNormal2
+            Color.FromArgb(223, 226, 228), // GridSheetColPressed1
+            Color.FromArgb(188, 197, 210), // GridSheetColPressed2
             Color.FromArgb(249, 217, 159), // GridSheetColSelected1
             Color.FromArgb(241, 193, 95), // GridSheetColSelected2
-            Color.FromArgb(228, 236, 247), // GridSheetRowNormal                                                   
+            Color.FromArgb(228, 236, 247), // GridSheetRowNormal
             Color.FromArgb(187, 196, 209), // GridSheetRowPressed
             Color.FromArgb(255, 213, 141), // GridSheetRowSelected
             Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -367,8 +367,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(198, 214, 231), // ButtonNavigatorPressed2
             Color.FromArgb(200, 219, 240), // ButtonNavigatorChecked1
             Color.FromArgb(177, 201, 228), // ButtonNavigatorChecked2
-            Color.FromArgb(201, 217,
-                239) // ToolTipBottom                                                                      
+            Color.FromArgb(201, 217, 239) // ToolTipBottom
         ];
 
         #endregion
@@ -1205,13 +1204,13 @@ namespace Krypton.Toolkit
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1],
                         PaletteState.NormalDefaultOverride => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack1],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
-                                                    : _buttonBackColors[6],
+? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+: _buttonBackColors[6],
                         PaletteState.Tracking => _buttonBackColors[2],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
                         PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
-                                                            ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
-                                                            : _buttonBackColors[8],
+     ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+     : _buttonBackColors[8],
                         _ => throw DebugTools.NotImplemented(state.ToString())
                     };
                 case PaletteBackStyle.ButtonNavigatorStack:
@@ -1474,16 +1473,16 @@ namespace Krypton.Toolkit
                         PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack1] : _buttonBackColors[1],
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2],
                         PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
-                                                            ? GlobalStaticValues.EMPTY_COLOR
-                                                            : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
+     ? GlobalStaticValues.EMPTY_COLOR
+     : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2]
-                                                    : _buttonBackColors[7],
+? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2]
+: _buttonBackColors[7],
                         PaletteState.Tracking => _buttonBackColors[3],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
                         PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
-                                                        : _buttonBackColors[9],
+ ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+ : _buttonBackColors[9],
                         _ => throw DebugTools.NotImplemented(state.ToString())
                     };
 
@@ -1836,8 +1835,8 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
                                                 ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
@@ -1860,8 +1859,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -1881,12 +1880,12 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
-                                                   : _buttonBorderColors[0],
+? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
+: _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
-                                                            ? GlobalStaticValues.EMPTY_COLOR
-                                                            : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+     ? GlobalStaticValues.EMPTY_COLOR
+     : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
@@ -1969,8 +1968,8 @@ namespace Krypton.Toolkit
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -1989,8 +1988,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -2010,8 +2009,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
-                                                   : _buttonBorderColors[0],
+? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
+: _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[6],
@@ -2692,8 +2691,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -2770,8 +2769,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3169,8 +3168,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3245,8 +3244,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueLightMode.cs
@@ -1226,13 +1226,13 @@ namespace Krypton.Toolkit
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1],
                         PaletteState.NormalDefaultOverride => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack1],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
- ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
- : _buttonBackColors[6],
+                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+                                                        : _buttonBackColors[6],
                         PaletteState.Tracking => _buttonBackColors[2],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
                         PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
-     ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
-     : _buttonBackColors[8],
+                                                            ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+                                                            : _buttonBackColors[8],
                         _ => throw DebugTools.NotImplemented(state.ToString())
                     };
                 case PaletteBackStyle.ButtonNavigatorStack:
@@ -1517,16 +1517,16 @@ namespace Krypton.Toolkit
                         PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack1] : _buttonBackColors[1],
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2],
                         PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
-         ? GlobalStaticValues.EMPTY_COLOR
-         : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
+                                                                ? GlobalStaticValues.EMPTY_COLOR
+                                                                : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
- ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2]
- : _buttonBackColors[7],
+                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2]
+                                                        : _buttonBackColors[7],
                         PaletteState.Tracking => _buttonBackColors[3],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
                         PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
-     ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
-     : _buttonBackColors[9],
+                                                            ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+                                                            : _buttonBackColors[9],
                         _ => throw DebugTools.NotImplemented(state.ToString())
                     };
                 case PaletteBackStyle.ButtonNavigatorStack:
@@ -1877,8 +1877,8 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
                                                 ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
@@ -1901,8 +1901,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -1922,12 +1922,12 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
-? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
-: _buttonBorderColors[0],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
+                                                   : _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
- ? GlobalStaticValues.EMPTY_COLOR
- : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+                                                        ? GlobalStaticValues.EMPTY_COLOR
+                                                        : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
@@ -2009,8 +2009,8 @@ namespace Krypton.Toolkit
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -2029,8 +2029,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
- ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
- : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+                                                        ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+                                                        : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -2050,8 +2050,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
-? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
-: _buttonBorderColors[0],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
+                                                   : _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[6],
@@ -2732,8 +2732,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -2810,8 +2810,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3209,8 +3209,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3285,8 +3285,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueLightMode.cs
@@ -288,44 +288,38 @@ namespace Krypton.Toolkit
             Color.FromArgb(219, 231, 247), // RibbonQATMini2
             Color.FromArgb(195, 213, 236), // RibbonQATMini3
             Color.FromArgb(128, Color.White), // RibbonQATMini4
-            Color.FromArgb(72, Color.White), // RibbonQATMini5                                                       
+            Color.FromArgb(72, Color.White), // RibbonQATMini5
             Color.FromArgb(153, 176, 206), // RibbonQATMini1I
             Color.FromArgb(226, 233, 241), // RibbonQATMini2I
             Color.FromArgb(198, 210, 226), // RibbonQATMini3I
             Color.FromArgb(128, Color.White), // RibbonQATMini4I
-            Color.FromArgb(72, Color.White), // RibbonQATMini5I                                                      
-            Color.FromArgb(178, 205, 237), // RibbonQATFullbar1                                                      
-            Color.FromArgb(170, 197, 234), // RibbonQATFullbar2                                                      
-            Color.FromArgb(126, 161, 205), // RibbonQATFullbar3                                                      
-            Color.FromArgb(86, 125, 177), // RibbonQATButtonDark                                                      
-            Color.FromArgb(234, 242, 249), // RibbonQATButtonLight                                                      
-            Color.FromArgb(192, 220, 255), // RibbonQATOverflow1                                                      
-            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-            Color.FromArgb(140, 172,
-                211), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(248, 250,
-                252), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(192, 212,
-                241), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(200, 219,
-                238), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(155, 183,
-                224), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(117, 150,
-                191), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor                                                    
-            Color.FromArgb(230, 239, 249), // GridListNormal1                                                    
-            Color.FromArgb(209, 226, 244), // GridListNormal2                                                    
-            Color.FromArgb(209, 226, 244), // GridListPressed1                                                    
-            Color.FromArgb(252, 253, 255), // GridListPressed2                                                    
-            Color.FromArgb(168, 200, 234), // GridListSelected                                                    
-            Color.FromArgb(230, 239, 249), // GridSheetColNormal1                                                    
-            Color.FromArgb(209, 226, 244), // GridSheetColNormal2                                                    
-            Color.FromArgb(223, 226, 228), // GridSheetColPressed1                                                    
-            Color.FromArgb(188, 197, 210), // GridSheetColPressed2                                                    
+            Color.FromArgb(72, Color.White), // RibbonQATMini5I
+            Color.FromArgb(178, 205, 237), // RibbonQATFullbar1
+            Color.FromArgb(170, 197, 234), // RibbonQATFullbar2
+            Color.FromArgb(126, 161, 205), // RibbonQATFullbar3
+            Color.FromArgb(86, 125, 177), // RibbonQATButtonDark
+            Color.FromArgb(234, 242, 249), // RibbonQATButtonLight
+            Color.FromArgb(192, 220, 255), // RibbonQATOverflow1
+            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
+            Color.FromArgb(140, 172, 211), // RibbonGroupSeparatorDark
+            Color.FromArgb(248, 250, 252), // RibbonGroupSeparatorLight
+            Color.FromArgb(192, 212, 241), // ButtonClusterButtonBack1
+            Color.FromArgb(200, 219, 238), // ButtonClusterButtonBack2
+            Color.FromArgb(155, 183, 224), // ButtonClusterButtonBorder1
+            Color.FromArgb(117, 150, 191), // ButtonClusterButtonBorder2
+            Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor
+            Color.FromArgb(230, 239, 249), // GridListNormal1
+            Color.FromArgb(209, 226, 244), // GridListNormal2
+            Color.FromArgb(209, 226, 244), // GridListPressed1
+            Color.FromArgb(252, 253, 255), // GridListPressed2
+            Color.FromArgb(168, 200, 234), // GridListSelected
+            Color.FromArgb(230, 239, 249), // GridSheetColNormal1
+            Color.FromArgb(209, 226, 244), // GridSheetColNormal2
+            Color.FromArgb(223, 226, 228), // GridSheetColPressed1
+            Color.FromArgb(188, 197, 210), // GridSheetColPressed2
             Color.FromArgb(188, 213, 239), // GridSheetColSelected1
             Color.FromArgb(168, 200, 234), // GridSheetColSelected2
-            Color.FromArgb(228, 236, 247), // GridSheetRowNormal                                                   
+            Color.FromArgb(228, 236, 247), // GridSheetRowNormal
             Color.FromArgb(187, 196, 209), // GridSheetRowPressed
             Color.FromArgb(255, 213, 141), // GridSheetRowSelected
             Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -379,8 +373,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(198, 214, 231), // ButtonNavigatorPressed2
             Color.FromArgb(200, 219, 240), // ButtonNavigatorChecked1
             Color.FromArgb(177, 201, 228), // ButtonNavigatorChecked2
-            Color.FromArgb(201, 217,
-                239) // ToolTipBottom                                                                      
+            Color.FromArgb(201, 217, 239) // ToolTipBottom
         ];
 
         #endregion
@@ -1233,13 +1226,13 @@ namespace Krypton.Toolkit
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1],
                         PaletteState.NormalDefaultOverride => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack1],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
-                                                        : _buttonBackColors[6],
+ ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+ : _buttonBackColors[6],
                         PaletteState.Tracking => _buttonBackColors[2],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
                         PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
-                                                            ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
-                                                            : _buttonBackColors[8],
+     ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+     : _buttonBackColors[8],
                         _ => throw DebugTools.NotImplemented(state.ToString())
                     };
                 case PaletteBackStyle.ButtonNavigatorStack:
@@ -1524,16 +1517,16 @@ namespace Krypton.Toolkit
                         PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack1] : _buttonBackColors[1],
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2],
                         PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
-                                                                ? GlobalStaticValues.EMPTY_COLOR
-                                                                : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
+         ? GlobalStaticValues.EMPTY_COLOR
+         : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2]
-                                                        : _buttonBackColors[7],
+ ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2]
+ : _buttonBackColors[7],
                         PaletteState.Tracking => _buttonBackColors[3],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
                         PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
-                                                            ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
-                                                            : _buttonBackColors[9],
+     ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+     : _buttonBackColors[9],
                         _ => throw DebugTools.NotImplemented(state.ToString())
                     };
                 case PaletteBackStyle.ButtonNavigatorStack:
@@ -1884,8 +1877,8 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
                                                 ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
@@ -1908,8 +1901,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -1929,12 +1922,12 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
-                                                   : _buttonBorderColors[0],
+? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
+: _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
-                                                        ? GlobalStaticValues.EMPTY_COLOR
-                                                        : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+ ? GlobalStaticValues.EMPTY_COLOR
+ : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
@@ -2016,8 +2009,8 @@ namespace Krypton.Toolkit
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -2036,8 +2029,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-                                                        : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+ ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+ : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -2057,8 +2050,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
-                                                   : _buttonBorderColors[0],
+? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
+: _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[6],
@@ -2739,8 +2732,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -2817,8 +2810,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3216,8 +3209,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3292,8 +3285,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverDarkMode.cs
@@ -1234,13 +1234,13 @@ namespace Krypton.Toolkit
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1],
                         PaletteState.NormalDefaultOverride => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack1],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
- ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
- : _buttonBackColors[6],
+                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+                                                        : _buttonBackColors[6],
                         PaletteState.Tracking => _buttonBackColors[2],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
                         PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
-     ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
-     : _buttonBackColors[8],
+                                                            ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+                                                            : _buttonBackColors[8],
                         _ => throw DebugTools.NotImplemented(state.ToString())
                     };
                 case PaletteBackStyle.ButtonNavigatorStack:
@@ -1500,16 +1500,16 @@ namespace Krypton.Toolkit
                         PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack1] : _buttonBackColors[1],
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2],
                         PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
-         ? GlobalStaticValues.EMPTY_COLOR
-         : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
+                                                                ? GlobalStaticValues.EMPTY_COLOR
+                                                                : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
- ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2]
- : _buttonBackColors[7],
+                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2]
+                                                        : _buttonBackColors[7],
                         PaletteState.Tracking => _buttonBackColors[3],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
                         PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
- ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
- : _buttonBackColors[9],
+                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+                                                        : _buttonBackColors[9],
                         _ => throw DebugTools.NotImplemented(state.ToString())
                     };
                 case PaletteBackStyle.ButtonNavigatorStack:
@@ -1860,8 +1860,8 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
                                                 ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
@@ -1884,8 +1884,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -1905,12 +1905,12 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
-? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
-: _buttonBorderColors[0],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
+                                                   : _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
-     ? GlobalStaticValues.EMPTY_COLOR
-     : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+                                                            ? GlobalStaticValues.EMPTY_COLOR
+                                                            : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
@@ -1992,8 +1992,8 @@ namespace Krypton.Toolkit
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
- ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
- : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                        ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                        : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -2012,8 +2012,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -2033,8 +2033,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
-? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
-: _buttonBorderColors[0],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
+                                                   : _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[6],
@@ -2715,8 +2715,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -2793,8 +2793,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3192,8 +3192,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3268,8 +3268,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverDarkMode.cs
@@ -283,38 +283,38 @@ namespace Krypton.Toolkit
             Color.FromArgb(210, 215, 221), // RibbonQATMini2
             Color.FromArgb(195, 200, 206), // RibbonQATMini3
             Color.FromArgb(10, Color.White), // RibbonQATMini4
-            Color.FromArgb(32, Color.White), // RibbonQATMini5                                                       
+            Color.FromArgb(32, Color.White), // RibbonQATMini5
             Color.FromArgb(200, 200, 200), // RibbonQATMini1I
             Color.FromArgb(233, 234, 238), // RibbonQATMini2I
             Color.FromArgb(223, 224, 228), // RibbonQATMini3I
             Color.FromArgb(10, Color.White), // RibbonQATMini4I
-            Color.FromArgb(32, Color.White), // RibbonQATMini5I                                                       
-            Color.FromArgb(217, 222, 230), // RibbonQATFullbar1                                                      
-            Color.FromArgb(214, 219, 227), // RibbonQATFullbar2                                                      
-            Color.FromArgb(194, 201, 212), // RibbonQATFullbar3                                                      
-            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark                                                      
-            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
-            Color.FromArgb(219, 218, 228), // RibbonQATOverflow1                                                      
-            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-            Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor                                                    
-            Color.FromArgb(119, 132, 161), // GridListNormal1                                                    
-            Color.FromArgb(83, 99, 136), // GridListNormal2                                                    
-            Color.FromArgb(83, 99, 136), // GridListPressed1                                                    
-            Color.FromArgb(252, 253, 253), // GridListPressed2                                                    
-            Color.FromArgb(83, 99, 136), // GridListSelected                                                    
-            Color.FromArgb(119, 132, 161), // GridSheetColNormal1                                                    
-            Color.FromArgb(83, 99, 136), // GridSheetColNormal2                                                    
-            Color.FromArgb(208, 208, 208), // GridSheetColPressed1                                                    
-            Color.FromArgb(166, 166, 166), // GridSheetColPressed2                                                    
+            Color.FromArgb(32, Color.White), // RibbonQATMini5I
+            Color.FromArgb(217, 222, 230), // RibbonQATFullbar1
+            Color.FromArgb(214, 219, 227), // RibbonQATFullbar2
+            Color.FromArgb(194, 201, 212), // RibbonQATFullbar3
+            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark
+            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight
+            Color.FromArgb(219, 218, 228), // RibbonQATOverflow1
+            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
+            Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark
+            Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight
+            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1
+            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2
+            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1
+            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2
+            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor
+            Color.FromArgb(119, 132, 161), // GridListNormal1
+            Color.FromArgb(83, 99, 136), // GridListNormal2
+            Color.FromArgb(83, 99, 136), // GridListPressed1
+            Color.FromArgb(252, 253, 253), // GridListPressed2
+            Color.FromArgb(83, 99, 136), // GridListSelected
+            Color.FromArgb(119, 132, 161), // GridSheetColNormal1
+            Color.FromArgb(83, 99, 136), // GridSheetColNormal2
+            Color.FromArgb(208, 208, 208), // GridSheetColPressed1
+            Color.FromArgb(166, 166, 166), // GridSheetColPressed2
             Color.FromArgb(54, 64, 88), // GridSheetColSelected1
             Color.FromArgb(83, 99, 136), // GridSheetColSelected2
-            Color.FromArgb(231, 231, 231), // GridSheetRowNormal                                                   
+            Color.FromArgb(231, 231, 231), // GridSheetRowNormal
             Color.FromArgb(184, 191, 196), // GridSheetRowPressed
             Color.FromArgb(245, 199, 149), // GridSheetRowSelected
             Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -368,7 +368,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(225, 226, 230), // ButtonNavigatorPressed2
             Color.FromArgb(222, 227, 234), // ButtonNavigatorChecked1
             Color.FromArgb(206, 214, 221), // ButtonNavigatorChecked2
-            Color.FromArgb(221, 221, 221) // ToolTipBottom                                                                      
+            Color.FromArgb(221, 221, 221) // ToolTipBottom
         ];
 
         #endregion
@@ -1234,13 +1234,13 @@ namespace Krypton.Toolkit
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1],
                         PaletteState.NormalDefaultOverride => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack1],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
-                                                        : _buttonBackColors[6],
+ ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+ : _buttonBackColors[6],
                         PaletteState.Tracking => _buttonBackColors[2],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
                         PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
-                                                            ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
-                                                            : _buttonBackColors[8],
+     ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+     : _buttonBackColors[8],
                         _ => throw DebugTools.NotImplemented(state.ToString())
                     };
                 case PaletteBackStyle.ButtonNavigatorStack:
@@ -1500,16 +1500,16 @@ namespace Krypton.Toolkit
                         PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack1] : _buttonBackColors[1],
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2],
                         PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
-                                                                ? GlobalStaticValues.EMPTY_COLOR
-                                                                : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
+         ? GlobalStaticValues.EMPTY_COLOR
+         : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2]
-                                                        : _buttonBackColors[7],
+ ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2]
+ : _buttonBackColors[7],
                         PaletteState.Tracking => _buttonBackColors[3],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
                         PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
-                                                        : _buttonBackColors[9],
+ ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+ : _buttonBackColors[9],
                         _ => throw DebugTools.NotImplemented(state.ToString())
                     };
                 case PaletteBackStyle.ButtonNavigatorStack:
@@ -1860,8 +1860,8 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
                                                 ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
@@ -1884,8 +1884,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -1905,12 +1905,12 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
-                                                   : _buttonBorderColors[0],
+? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
+: _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
-                                                            ? GlobalStaticValues.EMPTY_COLOR
-                                                            : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+     ? GlobalStaticValues.EMPTY_COLOR
+     : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
@@ -1992,8 +1992,8 @@ namespace Krypton.Toolkit
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                        : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+ ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+ : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -2012,8 +2012,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -2033,8 +2033,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
-                                                   : _buttonBorderColors[0],
+? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
+: _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[6],
@@ -2715,8 +2715,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -2793,8 +2793,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3192,8 +3192,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3268,8 +3268,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverLightMode.cs
@@ -287,38 +287,38 @@ namespace Krypton.Toolkit
             Color.FromArgb(210, 215, 221), // RibbonQATMini2
             Color.FromArgb(195, 200, 206), // RibbonQATMini3
             Color.FromArgb(10, Color.White), // RibbonQATMini4
-            Color.FromArgb(32, Color.White), // RibbonQATMini5                                                       
+            Color.FromArgb(32, Color.White), // RibbonQATMini5
             Color.FromArgb(200, 200, 200), // RibbonQATMini1I
             Color.FromArgb(233, 234, 238), // RibbonQATMini2I
             Color.FromArgb(223, 224, 228), // RibbonQATMini3I
             Color.FromArgb(10, Color.White), // RibbonQATMini4I
-            Color.FromArgb(32, Color.White), // RibbonQATMini5I                                                       
-            Color.FromArgb(217, 222, 230), // RibbonQATFullbar1                                                      
-            Color.FromArgb(214, 219, 227), // RibbonQATFullbar2                                                      
-            Color.FromArgb(194, 201, 212), // RibbonQATFullbar3                                                      
-            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark                                                      
-            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
-            Color.FromArgb(219, 218, 228), // RibbonQATOverflow1                                                      
-            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-            Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor                                                    
-            Color.FromArgb(224, 225, 231), // GridListNormal1                                                    
-            Color.FromArgb(195, 198, 209), // GridListNormal2                                                    
-            Color.FromArgb(195, 198, 209), // GridListPressed1                                                    
-            Color.FromArgb(252, 253, 253), // GridListPressed2                                                    
-            Color.FromArgb(195, 198, 209), // GridListSelected                                                    
-            Color.FromArgb(224, 225, 231), // GridSheetColNormal1                                                    
-            Color.FromArgb(195, 198, 209), // GridSheetColNormal2                                                    
-            Color.FromArgb(208, 208, 208), // GridSheetColPressed1                                                    
-            Color.FromArgb(166, 166, 166), // GridSheetColPressed2                                                    
+            Color.FromArgb(32, Color.White), // RibbonQATMini5I
+            Color.FromArgb(217, 222, 230), // RibbonQATFullbar1
+            Color.FromArgb(214, 219, 227), // RibbonQATFullbar2
+            Color.FromArgb(194, 201, 212), // RibbonQATFullbar3
+            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark
+            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight
+            Color.FromArgb(219, 218, 228), // RibbonQATOverflow1
+            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
+            Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark
+            Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight
+            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1
+            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2
+            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1
+            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2
+            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor
+            Color.FromArgb(224, 225, 231), // GridListNormal1
+            Color.FromArgb(195, 198, 209), // GridListNormal2
+            Color.FromArgb(195, 198, 209), // GridListPressed1
+            Color.FromArgb(252, 253, 253), // GridListPressed2
+            Color.FromArgb(195, 198, 209), // GridListSelected
+            Color.FromArgb(224, 225, 231), // GridSheetColNormal1
+            Color.FromArgb(195, 198, 209), // GridSheetColNormal2
+            Color.FromArgb(208, 208, 208), // GridSheetColPressed1
+            Color.FromArgb(166, 166, 166), // GridSheetColPressed2
             Color.FromArgb(54, 64, 88), // GridSheetColSelected1
             Color.FromArgb(195, 198, 209), // GridSheetColSelected2
-            Color.FromArgb(231, 231, 231), // GridSheetRowNormal                                                   
+            Color.FromArgb(231, 231, 231), // GridSheetRowNormal
             Color.FromArgb(184, 191, 196), // GridSheetRowPressed
             Color.FromArgb(245, 199, 149), // GridSheetRowSelected
             Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -372,7 +372,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(225, 226, 230), // ButtonNavigatorPressed2
             Color.FromArgb(222, 227, 234), // ButtonNavigatorChecked1
             Color.FromArgb(206, 214, 221), // ButtonNavigatorChecked2
-            Color.FromArgb(221, 221, 221) // ToolTipBottom                                                                      
+            Color.FromArgb(221, 221, 221) // ToolTipBottom               
         ];
 
         #endregion
@@ -1227,13 +1227,13 @@ namespace Krypton.Toolkit
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1],
                         PaletteState.NormalDefaultOverride => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack1],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
-                                                        : _buttonBackColors[6],
+ ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+ : _buttonBackColors[6],
                         PaletteState.Tracking => _buttonBackColors[2],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
                         PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
-                                                        : _buttonBackColors[8],
+ ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+ : _buttonBackColors[8],
                         _ => throw DebugTools.NotImplemented(state.ToString())
                     };
                 case PaletteBackStyle.ButtonNavigatorStack:
@@ -1518,16 +1518,16 @@ namespace Krypton.Toolkit
                         PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack1] : _buttonBackColors[1],
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2],
                         PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
-                                                            ? GlobalStaticValues.EMPTY_COLOR
-                                                            : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
+     ? GlobalStaticValues.EMPTY_COLOR
+     : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2]
-                                                        : _buttonBackColors[7],
+ ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2]
+ : _buttonBackColors[7],
                         PaletteState.Tracking => _buttonBackColors[3],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
                         PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
-                                                        : _buttonBackColors[9],
+ ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+ : _buttonBackColors[9],
                         _ => throw DebugTools.NotImplemented(state.ToString())
                     };
                 case PaletteBackStyle.ButtonNavigatorStack:
@@ -1878,11 +1878,11 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
+? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
+: _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
@@ -1902,8 +1902,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -1923,12 +1923,12 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
-                                                   : _buttonBorderColors[0],
+? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
+: _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
-                                                            ? GlobalStaticValues.EMPTY_COLOR
-                                                            : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+     ? GlobalStaticValues.EMPTY_COLOR
+     : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
@@ -2010,8 +2010,8 @@ namespace Krypton.Toolkit
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -2030,8 +2030,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -2051,8 +2051,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
-                                                   : _buttonBorderColors[0],
+? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
+: _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[6],
@@ -2733,8 +2733,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -2811,8 +2811,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3210,8 +3210,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3286,8 +3286,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverLightMode.cs
@@ -1227,13 +1227,13 @@ namespace Krypton.Toolkit
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1],
                         PaletteState.NormalDefaultOverride => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack1],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
- ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
- : _buttonBackColors[6],
+                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+                                                        : _buttonBackColors[6],
                         PaletteState.Tracking => _buttonBackColors[2],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
                         PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
- ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
- : _buttonBackColors[8],
+                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+                                                        : _buttonBackColors[8],
                         _ => throw DebugTools.NotImplemented(state.ToString())
                     };
                 case PaletteBackStyle.ButtonNavigatorStack:
@@ -1518,16 +1518,16 @@ namespace Krypton.Toolkit
                         PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack1] : _buttonBackColors[1],
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2],
                         PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
-     ? GlobalStaticValues.EMPTY_COLOR
-     : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
+                                                            ? GlobalStaticValues.EMPTY_COLOR
+                                                            : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
- ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2]
- : _buttonBackColors[7],
+                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2]
+                                                        : _buttonBackColors[7],
                         PaletteState.Tracking => _buttonBackColors[3],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
                         PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
- ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
- : _buttonBackColors[9],
+                                                        ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1]
+                                                        : _buttonBackColors[9],
                         _ => throw DebugTools.NotImplemented(state.ToString())
                     };
                 case PaletteBackStyle.ButtonNavigatorStack:
@@ -1878,11 +1878,11 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
-: _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
@@ -1902,8 +1902,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -1923,12 +1923,12 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
-? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
-: _buttonBorderColors[0],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
+                                                   : _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
-     ? GlobalStaticValues.EMPTY_COLOR
-     : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+                                                            ? GlobalStaticValues.EMPTY_COLOR
+                                                            : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
@@ -2010,8 +2010,8 @@ namespace Krypton.Toolkit
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -2030,8 +2030,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -2051,8 +2051,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
                 {
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
-? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
-: _buttonBorderColors[0],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2]
+                                                   : _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[6],
@@ -2733,8 +2733,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -2811,8 +2811,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3210,8 +3210,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3286,8 +3286,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Non Official Themes/PaletteMicrosoft365Blue.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Non Official Themes/PaletteMicrosoft365Blue.cs
@@ -287,44 +287,38 @@ namespace Krypton.Toolkit
             Color.FromArgb(219, 231, 247), // RibbonQATMini2
             Color.FromArgb(195, 213, 236), // RibbonQATMini3
             Color.FromArgb(128, Color.White), // RibbonQATMini4
-            Color.FromArgb(72, Color.White), // RibbonQATMini5                                                       
+            Color.FromArgb(72, Color.White), // RibbonQATMini5
             Color.FromArgb(153, 176, 206), // RibbonQATMini1I
             Color.FromArgb(226, 233, 241), // RibbonQATMini2I
             Color.FromArgb(198, 210, 226), // RibbonQATMini3I
             Color.FromArgb(128, Color.White), // RibbonQATMini4I
-            Color.FromArgb(72, Color.White), // RibbonQATMini5I                                                      
-            Color.FromArgb(213, 232, 254), // RibbonQATFullbar1                                                      
-            Color.FromArgb(205, 223, 245), // RibbonQATFullbar2                                                      
-            Color.FromArgb(114, 142, 173), // RibbonQATFullbar3                                                      
-            Color.FromArgb(90, 90, 90), // RibbonQATButtonDark                                                      
-            Color.FromArgb(207, 214, 224), // RibbonQATButtonLight                                                      
-            Color.FromArgb(222, 236, 252), // RibbonQATOverflow1                                                      
-            Color.FromArgb(123, 139, 156), // RibbonQATOverflow2                                                      
-            Color.FromArgb(145, 166,
-                194), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(239, 245,
-                250), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(192, 212,
-                241), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(200, 219,
-                238), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(155, 183,
-                224), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(117, 150,
-                191), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor                                                    
-            Color.FromArgb(244, 249, 255), // GridListNormal1                                                    
-            Color.FromArgb(218, 231, 245), // GridListNormal2                                                    
-            Color.FromArgb(198, 211, 225), // GridListPressed1                                                    
-            Color.FromArgb(244, 249, 255), // GridListPressed2                                                    
-            Color.FromArgb(160, 185, 230), // GridListSelected                                                    
-            Color.FromArgb(233, 246, 255), // GridSheetColNormal1                                                    
-            Color.FromArgb(213, 226, 240), // GridSheetColNormal2                                                    
-            Color.FromArgb(255, 223, 107), // GridSheetColPressed1                                                    
-            Color.FromArgb(255, 252, 230), // GridSheetColPressed2                                                    
+            Color.FromArgb(72, Color.White), // RibbonQATMini5I
+            Color.FromArgb(213, 232, 254), // RibbonQATFullbar1
+            Color.FromArgb(205, 223, 245), // RibbonQATFullbar2
+            Color.FromArgb(114, 142, 173), // RibbonQATFullbar3
+            Color.FromArgb(90, 90, 90), // RibbonQATButtonDark
+            Color.FromArgb(207, 214, 224), // RibbonQATButtonLight
+            Color.FromArgb(222, 236, 252), // RibbonQATOverflow1
+            Color.FromArgb(123, 139, 156), // RibbonQATOverflow2
+            Color.FromArgb(145, 166, 194), // RibbonGroupSeparatorDark
+            Color.FromArgb(239, 245, 250), // RibbonGroupSeparatorLight
+            Color.FromArgb(192, 212, 241), // ButtonClusterButtonBack1
+            Color.FromArgb(200, 219, 238), // ButtonClusterButtonBack2
+            Color.FromArgb(155, 183, 224), // ButtonClusterButtonBorder1
+            Color.FromArgb(117, 150, 191), // ButtonClusterButtonBorder2
+            Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor
+            Color.FromArgb(244, 249, 255), // GridListNormal1
+            Color.FromArgb(218, 231, 245), // GridListNormal2
+            Color.FromArgb(198, 211, 225), // GridListPressed1
+            Color.FromArgb(244, 249, 255), // GridListPressed2
+            Color.FromArgb(160, 185, 230), // GridListSelected
+            Color.FromArgb(233, 246, 255), // GridSheetColNormal1
+            Color.FromArgb(213, 226, 240), // GridSheetColNormal2
+            Color.FromArgb(255, 223, 107), // GridSheetColPressed1
+            Color.FromArgb(255, 252, 230), // GridSheetColPressed2
             Color.FromArgb(255, 211, 89), // GridSheetColSelected1
             Color.FromArgb(255, 239, 113), // GridSheetColSelected2
-            Color.FromArgb(218, 231, 245), // GridSheetRowNormal                                                   
+            Color.FromArgb(218, 231, 245), // GridSheetRowNormal
             Color.FromArgb(255, 223, 107), // GridSheetRowPressed
             Color.FromArgb(245, 210, 87), // GridSheetRowSelected
             Color.FromArgb(218, 220, 221), // GridDataCellBorder
@@ -378,8 +372,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(198, 214, 231), // ButtonNavigatorPressed2
             Color.FromArgb(200, 219, 240), // ButtonNavigatorChecked1
             Color.FromArgb(177, 201, 228), // ButtonNavigatorChecked2
-            Color.FromArgb(201, 217,
-                239) // ToolTipBottom                                                                      
+            Color.FromArgb(201, 217, 239) // ToolTipBottom
         ];
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Black.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Black.cs
@@ -303,32 +303,32 @@ namespace Krypton.Toolkit
             Color.FromArgb(140, 140, 140), // RibbonQATMini3I
             Color.FromArgb(12, Color.White), // RibbonQATMini4I
             Color.FromArgb(14, Color.White), // RibbonQATMini5I
-            Color.FromArgb(132, 132, 132), // RibbonQATFullbar1                                                      
-            Color.FromArgb(121, 121, 121), // RibbonQATFullbar2                                                      
-            Color.FromArgb(50, 49, 49), // RibbonQATFullbar3                                                      
-            Color.FromArgb(90, 90, 90), // RibbonQATButtonDark                                                      
-            Color.FromArgb(174, 174, 175), // RibbonQATButtonLight                                                      
-            Color.FromArgb(161, 161, 161), // RibbonQATOverflow1                                                      
-            Color.FromArgb(68, 68, 68), // RibbonQATOverflow2                                                      
-            Color.FromArgb(82, 82, 82), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(190, 190, 190), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(210, 217, 219), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(214, 222, 223), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(179, 188, 191), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(145, 156, 159), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(235, 235, 235), // NavigatorMiniBackColor                                                    
-            Color.FromArgb(205, 205, 205), // GridListNormal1                                                    
-            Color.FromArgb(166, 166, 166), // GridListNormal2                                                    
-            Color.FromArgb(166, 166, 166), // GridListPressed1                                                    
-            Color.FromArgb(205, 205, 205), // GridListPressed2                                                    
-            Color.FromArgb(150, 150, 150), // GridListSelected                                                    
-            Color.FromArgb(220, 220, 220), // GridSheetColNormal1                                                    
-            Color.FromArgb(200, 200, 200), // GridSheetColNormal2                                                    
-            Color.FromArgb(255, 223, 107), // GridSheetColPressed1                                                    
-            Color.FromArgb(255, 252, 230), // GridSheetColPressed2                                                    
+            Color.FromArgb(132, 132, 132), // RibbonQATFullbar1
+            Color.FromArgb(121, 121, 121), // RibbonQATFullbar2
+            Color.FromArgb(50, 49, 49), // RibbonQATFullbar3
+            Color.FromArgb(90, 90, 90), // RibbonQATButtonDark
+            Color.FromArgb(174, 174, 175), // RibbonQATButtonLight
+            Color.FromArgb(161, 161, 161), // RibbonQATOverflow1
+            Color.FromArgb(68, 68, 68), // RibbonQATOverflow2
+            Color.FromArgb(82, 82, 82), // RibbonGroupSeparatorDark
+            Color.FromArgb(190, 190, 190), // RibbonGroupSeparatorLight
+            Color.FromArgb(210, 217, 219), // ButtonClusterButtonBack1
+            Color.FromArgb(214, 222, 223), // ButtonClusterButtonBack2
+            Color.FromArgb(179, 188, 191), // ButtonClusterButtonBorder1
+            Color.FromArgb(145, 156, 159), // ButtonClusterButtonBorder2
+            Color.FromArgb(235, 235, 235), // NavigatorMiniBackColor
+            Color.FromArgb(205, 205, 205), // GridListNormal1
+            Color.FromArgb(166, 166, 166), // GridListNormal2
+            Color.FromArgb(166, 166, 166), // GridListPressed1
+            Color.FromArgb(205, 205, 205), // GridListPressed2
+            Color.FromArgb(150, 150, 150), // GridListSelected
+            Color.FromArgb(220, 220, 220), // GridSheetColNormal1
+            Color.FromArgb(200, 200, 200), // GridSheetColNormal2
+            Color.FromArgb(255, 223, 107), // GridSheetColPressed1
+            Color.FromArgb(255, 252, 230), // GridSheetColPressed2
             Color.FromArgb(255, 211, 89), // GridSheetColSelected1
             Color.FromArgb(255, 239, 113), // GridSheetColSelected2
-            Color.FromArgb(205, 205, 205), // GridSheetRowNormal                                                   
+            Color.FromArgb(205, 205, 205), // GridSheetRowNormal
             Color.FromArgb(255, 223, 107), // GridSheetRowPressed
             Color.FromArgb(245, 210, 87), // GridSheetRowSelected
             Color.FromArgb(218, 220, 221), // GridDataCellBorder
@@ -382,7 +382,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(148, 148, 143), // ButtonNavigatorPressed2
             Color.FromArgb(91, 91, 91), // ButtonNavigatorChecked1
             Color.FromArgb(73, 73, 73), // ButtonNavigatorChecked2
-            Color.FromArgb(201, 201, 201) // ToolTipBottom                                                                      
+            Color.FromArgb(201, 201, 201) // ToolTipBottom
         ];
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365DarkGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365DarkGray.cs
@@ -434,126 +434,126 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
- PaletteButtonSpecStyle.FormClose => state switch
- {
-  PaletteState.Tracking => _formCloseActive,
-  PaletteState.Normal => _formCloseNormal,
-  PaletteState.Pressed => _formClosePressed,
-  _ => _formCloseDisabled
- },
- PaletteButtonSpecStyle.FormMin => state switch
- {
-  PaletteState.Normal => _formMinimiseNormal,
-  PaletteState.Tracking => _formMinimiseActive,
-  PaletteState.Pressed => _formMinimisePressed,
-  _ => _formMinimiseDisabled
- },
- PaletteButtonSpecStyle.FormMax => state switch
- {
-  PaletteState.Normal => _formMaximiseNormal,
-  PaletteState.Tracking => _formMaximiseActive,
-  PaletteState.Pressed => _formMaximisePressed,
-  _ => _formMaximiseDisabled
- },
- PaletteButtonSpecStyle.FormRestore => state switch
- {
-  PaletteState.Normal => _formRestoreNormal,
-  PaletteState.Tracking => _formRestoreActive,
-  PaletteState.Pressed => _formRestorePressed,
-  _ => _formRestoreDisabled
- },
- PaletteButtonSpecStyle.FormHelp => state switch
- {
-  PaletteState.Tracking => _formHelpActive,
-  PaletteState.Pressed => _formHelpPressed,
-  PaletteState.Normal => _formHelpNormal,
-  _ => _formHelpDisabled
- },
- PaletteButtonSpecStyle.New => state switch
- {
-  PaletteState.Normal => _integratedToolbarNewNormal,
-  PaletteState.Disabled => _integratedToolbarNewDisabled,
-  _ => _integratedToolbarNewDisabled
- },
- PaletteButtonSpecStyle.Open => state switch
- {
-  PaletteState.Normal => _integratedToolbarOpenNormal,
-  PaletteState.Disabled => _integratedToolbarOpenDisabled,
-  _ => _integratedToolbarOpenDisabled
- },
- PaletteButtonSpecStyle.SaveAll => state switch
- {
-  PaletteState.Normal => _integratedToolbarSaveAllNormal,
-  PaletteState.Disabled => _integratedToolbarSaveAllDisabled,
-  _ => _integratedToolbarSaveAllDisabled
- },
- PaletteButtonSpecStyle.SaveAs => state switch
- {
-  PaletteState.Normal => _integratedToolbarSaveAsNormal,
-  PaletteState.Disabled => _integratedToolbarSaveAsDisabled,
-  _ => _integratedToolbarSaveAsDisabled
- },
- PaletteButtonSpecStyle.Save => state switch
- {
-  PaletteState.Normal => _integratedToolbarSaveNormal,
-  PaletteState.Disabled => _integratedToolbarSaveDisabled,
-  _ => _integratedToolbarSaveDisabled
- },
- PaletteButtonSpecStyle.Cut => state switch
- {
-  PaletteState.Normal => _integratedToolbarCutNormal,
-  PaletteState.Disabled => _integratedToolbarCutDisabled,
-  _ => _integratedToolbarCutDisabled
- },
- PaletteButtonSpecStyle.Copy => state switch
- {
-  PaletteState.Normal => _integratedToolbarCopyNormal,
-  PaletteState.Disabled => _integratedToolbarCopyDisabled,
-  _ => _integratedToolbarCopyDisabled
- },
- PaletteButtonSpecStyle.Paste => state switch
- {
-  PaletteState.Normal => _integratedToolbarPasteNormal,
-  PaletteState.Disabled => _integratedToolbarPasteDisabled,
-  _ => _integratedToolbarPasteDisabled
- },
- PaletteButtonSpecStyle.Undo => state switch
- {
-  PaletteState.Normal => _integratedToolbarUndoNormal,
-  PaletteState.Disabled => _integratedToolbarUndoDisabled,
-  _ => _integratedToolbarUndoDisabled
- },
- PaletteButtonSpecStyle.Redo => state switch
- {
-  PaletteState.Normal => _integratedToolbarRedoNormal,
-  PaletteState.Disabled => _integratedToolbarRedoDisabled,
-  _ => _integratedToolbarRedoDisabled
- },
- PaletteButtonSpecStyle.PageSetup => state switch
- {
-  PaletteState.Normal => _integratedToolbarPageSetupNormal,
-  PaletteState.Disabled => _integratedToolbarPageSetupDisabled,
-  _ => _integratedToolbarPageSetupDisabled
- },
- PaletteButtonSpecStyle.PrintPreview => state switch
- {
-  PaletteState.Normal => _integratedToolbarPrintPreviewNormal,
-  PaletteState.Disabled => _integratedToolbarPrintPreviewDisabled,
-  _ => _integratedToolbarPrintPreviewDisabled
- },
- PaletteButtonSpecStyle.Print => state switch
- {
-  PaletteState.Normal => _integratedToolbarPrintNormal,
-  PaletteState.Disabled => _integratedToolbarPrintDisabled,
-  _ => _integratedToolbarPrintDisabled
- },
- PaletteButtonSpecStyle.QuickPrint => state switch
- {
-  PaletteState.Normal => _integratedToolbarQuickPrintNormal,
-  PaletteState.Disabled => _integratedToolbarQuickPrintDisabled,
-  _ => _integratedToolbarQuickPrintDisabled
- },
- _ => base.GetButtonSpecImage(style, state)
+                                                     PaletteButtonSpecStyle.FormClose => state switch
+                                                     {
+                                                         PaletteState.Tracking => _formCloseActive,
+                                                         PaletteState.Normal => _formCloseNormal,
+                                                         PaletteState.Pressed => _formClosePressed,
+                                                         _ => _formCloseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMin => state switch
+                                                     {
+                                                         PaletteState.Normal => _formMinimiseNormal,
+                                                         PaletteState.Tracking => _formMinimiseActive,
+                                                         PaletteState.Pressed => _formMinimisePressed,
+                                                         _ => _formMinimiseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMax => state switch
+                                                     {
+                                                         PaletteState.Normal => _formMaximiseNormal,
+                                                         PaletteState.Tracking => _formMaximiseActive,
+                                                         PaletteState.Pressed => _formMaximisePressed,
+                                                         _ => _formMaximiseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormRestore => state switch
+                                                     {
+                                                         PaletteState.Normal => _formRestoreNormal,
+                                                         PaletteState.Tracking => _formRestoreActive,
+                                                         PaletteState.Pressed => _formRestorePressed,
+                                                         _ => _formRestoreDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormHelp => state switch
+                                                     {
+                                                         PaletteState.Tracking => _formHelpActive,
+                                                         PaletteState.Pressed => _formHelpPressed,
+                                                         PaletteState.Normal => _formHelpNormal,
+                                                         _ => _formHelpDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.New => state switch
+                                                     {
+                                                         PaletteState.Normal => _integratedToolbarNewNormal,
+                                                         PaletteState.Disabled => _integratedToolbarNewDisabled,
+                                                         _ => _integratedToolbarNewDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.Open => state switch
+                                                     {
+                                                         PaletteState.Normal => _integratedToolbarOpenNormal,
+                                                         PaletteState.Disabled => _integratedToolbarOpenDisabled,
+                                                         _ => _integratedToolbarOpenDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.SaveAll => state switch
+                                                     {
+                                                         PaletteState.Normal => _integratedToolbarSaveAllNormal,
+                                                         PaletteState.Disabled => _integratedToolbarSaveAllDisabled,
+                                                         _ => _integratedToolbarSaveAllDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.SaveAs => state switch
+                                                     {
+                                                         PaletteState.Normal => _integratedToolbarSaveAsNormal,
+                                                         PaletteState.Disabled => _integratedToolbarSaveAsDisabled,
+                                                         _ => _integratedToolbarSaveAsDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.Save => state switch
+                                                     {
+                                                         PaletteState.Normal => _integratedToolbarSaveNormal,
+                                                         PaletteState.Disabled => _integratedToolbarSaveDisabled,
+                                                         _ => _integratedToolbarSaveDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.Cut => state switch
+                                                     {
+                                                         PaletteState.Normal => _integratedToolbarCutNormal,
+                                                         PaletteState.Disabled => _integratedToolbarCutDisabled,
+                                                         _ => _integratedToolbarCutDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.Copy => state switch
+                                                     {
+                                                         PaletteState.Normal => _integratedToolbarCopyNormal,
+                                                         PaletteState.Disabled => _integratedToolbarCopyDisabled,
+                                                         _ => _integratedToolbarCopyDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.Paste => state switch
+                                                     {
+                                                         PaletteState.Normal => _integratedToolbarPasteNormal,
+                                                         PaletteState.Disabled => _integratedToolbarPasteDisabled,
+                                                         _ => _integratedToolbarPasteDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.Undo => state switch
+                                                     {
+                                                         PaletteState.Normal => _integratedToolbarUndoNormal,
+                                                         PaletteState.Disabled => _integratedToolbarUndoDisabled,
+                                                         _ => _integratedToolbarUndoDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.Redo => state switch
+                                                     {
+                                                         PaletteState.Normal => _integratedToolbarRedoNormal,
+                                                         PaletteState.Disabled => _integratedToolbarRedoDisabled,
+                                                         _ => _integratedToolbarRedoDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.PageSetup => state switch
+                                                     {
+                                                         PaletteState.Normal => _integratedToolbarPageSetupNormal,
+                                                         PaletteState.Disabled => _integratedToolbarPageSetupDisabled,
+                                                         _ => _integratedToolbarPageSetupDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.PrintPreview => state switch
+                                                     {
+                                                         PaletteState.Normal => _integratedToolbarPrintPreviewNormal,
+                                                         PaletteState.Disabled => _integratedToolbarPrintPreviewDisabled,
+                                                         _ => _integratedToolbarPrintPreviewDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.Print => state switch
+                                                     {
+                                                         PaletteState.Normal => _integratedToolbarPrintNormal,
+                                                         PaletteState.Disabled => _integratedToolbarPrintDisabled,
+                                                         _ => _integratedToolbarPrintDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.QuickPrint => state switch
+                                                     {
+                                                         PaletteState.Normal => _integratedToolbarQuickPrintNormal,
+                                                         PaletteState.Disabled => _integratedToolbarQuickPrintDisabled,
+                                                         _ => _integratedToolbarQuickPrintDisabled
+                                                     },
+                                                     _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365DarkGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365DarkGray.cs
@@ -267,7 +267,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(226, 229, 234), // RibbonGroupFrameInside2
             Color.FromArgb(220, 224, 231), // RibbonGroupFrameInside3
             Color.FromArgb(232, 234, 238), // RibbonGroupFrameInside4
-            Color.FromArgb(139, 136, 134), // RibbonGroupCollapsedText         
+            Color.FromArgb(139, 136, 134), // RibbonGroupCollapsedText
             Color.FromArgb(179, 185, 195), // AlternatePressedBack1
             Color.FromArgb(216, 224, 224), // AlternatePressedBack2
             Color.FromArgb(125, 125, 125), // AlternatePressedBorder1
@@ -281,38 +281,38 @@ namespace Krypton.Toolkit
             Color.FromArgb(210, 215, 221), // RibbonQATMini2
             Color.FromArgb(195, 200, 206), // RibbonQATMini3
             Color.FromArgb(10, Color.White), // RibbonQATMini4
-            Color.FromArgb(32, Color.White), // RibbonQATMini5                                                       
+            Color.FromArgb(32, Color.White), // RibbonQATMini5
             Color.FromArgb(200, 200, 200), // RibbonQATMini1I
             Color.FromArgb(233, 234, 238), // RibbonQATMini2I
             Color.FromArgb(223, 224, 228), // RibbonQATMini3I
             Color.FromArgb(10, Color.White), // RibbonQATMini4I
-            Color.FromArgb(32, Color.White), // RibbonQATMini5I                                                       
-            Color.FromArgb(217, 222, 230), // RibbonQATFullbar1                                                      
-            Color.FromArgb(214, 219, 227), // RibbonQATFullbar2                                                      
-            Color.FromArgb(194, 201, 212), // RibbonQATFullbar3                                                      
-            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark                                                      
-            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
-            Color.FromArgb(219, 218, 228), // RibbonQATOverflow1                                                      
-            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-            Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor                                                    
-            Color.White, // GridListNormal1                                                    
-            Color.FromArgb(212, 215, 219), // GridListNormal2                                                    
-            Color.FromArgb(210, 213, 218), // GridListPressed1                                                    
-            Color.FromArgb(252, 253, 253), // GridListPressed2                                                    
-            Color.FromArgb(186, 189, 194), // GridListSelected                                                    
-            Color.FromArgb(241, 243, 243), // GridSheetColNormal1                                                    
-            Color.FromArgb(200, 201, 202), // GridSheetColNormal2                                                    
-            Color.FromArgb(208, 208, 208), // GridSheetColPressed1                                                    
-            Color.FromArgb(166, 166, 166), // GridSheetColPressed2                                                    
+            Color.FromArgb(32, Color.White), // RibbonQATMini5I
+            Color.FromArgb(217, 222, 230), // RibbonQATFullbar1
+            Color.FromArgb(214, 219, 227), // RibbonQATFullbar2
+            Color.FromArgb(194, 201, 212), // RibbonQATFullbar3
+            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark
+            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight
+            Color.FromArgb(219, 218, 228), // RibbonQATOverflow1
+            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
+            Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark
+            Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight
+            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1
+            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2
+            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1
+            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2
+            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor
+            Color.White, // GridListNormal1
+            Color.FromArgb(212, 215, 219), // GridListNormal2
+            Color.FromArgb(210, 213, 218), // GridListPressed1
+            Color.FromArgb(252, 253, 253), // GridListPressed2
+            Color.FromArgb(186, 189, 194), // GridListSelected
+            Color.FromArgb(241, 243, 243), // GridSheetColNormal1
+            Color.FromArgb(200, 201, 202), // GridSheetColNormal2
+            Color.FromArgb(208, 208, 208), // GridSheetColPressed1
+            Color.FromArgb(166, 166, 166), // GridSheetColPressed2
             Color.FromArgb(255, 204, 153), // GridSheetColSelected1
             Color.FromArgb(255, 155, 104), // GridSheetColSelected2
-            Color.FromArgb(231, 231, 231), // GridSheetRowNormal                                                   
+            Color.FromArgb(231, 231, 231), // GridSheetRowNormal
             Color.FromArgb(184, 191, 196), // GridSheetRowPressed
             Color.FromArgb(245, 199, 149), // GridSheetRowSelected
             Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -352,6 +352,8 @@ namespace Krypton.Toolkit
             GlobalStaticValues.EMPTY_COLOR, // RibbonTabTracking4
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder3
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder4
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder5
+            Color.FromArgb(139, 136, 134), // RibbonGroupTitleText
             GlobalStaticValues.EMPTY_COLOR, // RibbonDropArrowLight
             GlobalStaticValues.EMPTY_COLOR, // RibbonDropArrowDark
             Color.FromArgb(237, 242, 248), // HeaderDockInactiveBack1
@@ -364,7 +366,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(225, 226, 230), // ButtonNavigatorPressed2
             Color.FromArgb(222, 227, 234), // ButtonNavigatorChecked1
             Color.FromArgb(206, 214, 221), // ButtonNavigatorChecked2
-            Color.FromArgb(221, 221, 221) // ToolTipBottom                                                                      
+            Color.FromArgb(221, 221, 221) // ToolTipBottom
         ];
 
         #endregion
@@ -432,126 +434,126 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
-                                                     PaletteButtonSpecStyle.FormClose => state switch
-                                                     {
-                                                         PaletteState.Tracking => _formCloseActive,
-                                                         PaletteState.Normal => _formCloseNormal,
-                                                         PaletteState.Pressed => _formClosePressed,
-                                                         _ => _formCloseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMin => state switch
-                                                     {
-                                                         PaletteState.Normal => _formMinimiseNormal,
-                                                         PaletteState.Tracking => _formMinimiseActive,
-                                                         PaletteState.Pressed => _formMinimisePressed,
-                                                         _ => _formMinimiseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMax => state switch
-                                                     {
-                                                         PaletteState.Normal => _formMaximiseNormal,
-                                                         PaletteState.Tracking => _formMaximiseActive,
-                                                         PaletteState.Pressed => _formMaximisePressed,
-                                                         _ => _formMaximiseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormRestore => state switch
-                                                     {
-                                                         PaletteState.Normal => _formRestoreNormal,
-                                                         PaletteState.Tracking => _formRestoreActive,
-                                                         PaletteState.Pressed => _formRestorePressed,
-                                                         _ => _formRestoreDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormHelp => state switch
-                                                     {
-                                                         PaletteState.Tracking => _formHelpActive,
-                                                         PaletteState.Pressed => _formHelpPressed,
-                                                         PaletteState.Normal => _formHelpNormal,
-                                                         _ => _formHelpDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.New => state switch
-                                                     {
-                                                         PaletteState.Normal => _integratedToolbarNewNormal,
-                                                         PaletteState.Disabled => _integratedToolbarNewDisabled,
-                                                         _ => _integratedToolbarNewDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.Open => state switch
-                                                     {
-                                                         PaletteState.Normal => _integratedToolbarOpenNormal,
-                                                         PaletteState.Disabled => _integratedToolbarOpenDisabled,
-                                                         _ => _integratedToolbarOpenDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.SaveAll => state switch
-                                                     {
-                                                         PaletteState.Normal => _integratedToolbarSaveAllNormal,
-                                                         PaletteState.Disabled => _integratedToolbarSaveAllDisabled,
-                                                         _ => _integratedToolbarSaveAllDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.SaveAs => state switch
-                                                     {
-                                                         PaletteState.Normal => _integratedToolbarSaveAsNormal,
-                                                         PaletteState.Disabled => _integratedToolbarSaveAsDisabled,
-                                                         _ => _integratedToolbarSaveAsDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.Save => state switch
-                                                     {
-                                                         PaletteState.Normal => _integratedToolbarSaveNormal,
-                                                         PaletteState.Disabled => _integratedToolbarSaveDisabled,
-                                                         _ => _integratedToolbarSaveDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.Cut => state switch
-                                                     {
-                                                         PaletteState.Normal => _integratedToolbarCutNormal,
-                                                         PaletteState.Disabled => _integratedToolbarCutDisabled,
-                                                         _ => _integratedToolbarCutDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.Copy => state switch
-                                                     {
-                                                         PaletteState.Normal => _integratedToolbarCopyNormal,
-                                                         PaletteState.Disabled => _integratedToolbarCopyDisabled,
-                                                         _ => _integratedToolbarCopyDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.Paste => state switch
-                                                     {
-                                                         PaletteState.Normal => _integratedToolbarPasteNormal,
-                                                         PaletteState.Disabled => _integratedToolbarPasteDisabled,
-                                                         _ => _integratedToolbarPasteDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.Undo => state switch
-                                                     {
-                                                         PaletteState.Normal => _integratedToolbarUndoNormal,
-                                                         PaletteState.Disabled => _integratedToolbarUndoDisabled,
-                                                         _ => _integratedToolbarUndoDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.Redo => state switch
-                                                     {
-                                                         PaletteState.Normal => _integratedToolbarRedoNormal,
-                                                         PaletteState.Disabled => _integratedToolbarRedoDisabled,
-                                                         _ => _integratedToolbarRedoDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.PageSetup => state switch
-                                                     {
-                                                         PaletteState.Normal => _integratedToolbarPageSetupNormal,
-                                                         PaletteState.Disabled => _integratedToolbarPageSetupDisabled,
-                                                         _ => _integratedToolbarPageSetupDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.PrintPreview => state switch
-                                                     {
-                                                         PaletteState.Normal => _integratedToolbarPrintPreviewNormal,
-                                                         PaletteState.Disabled => _integratedToolbarPrintPreviewDisabled,
-                                                         _ => _integratedToolbarPrintPreviewDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.Print => state switch
-                                                     {
-                                                         PaletteState.Normal => _integratedToolbarPrintNormal,
-                                                         PaletteState.Disabled => _integratedToolbarPrintDisabled,
-                                                         _ => _integratedToolbarPrintDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.QuickPrint => state switch
-                                                     {
-                                                         PaletteState.Normal => _integratedToolbarQuickPrintNormal,
-                                                         PaletteState.Disabled => _integratedToolbarQuickPrintDisabled,
-                                                         _ => _integratedToolbarQuickPrintDisabled
-                                                     },
-                                                     _ => base.GetButtonSpecImage(style, state)
+ PaletteButtonSpecStyle.FormClose => state switch
+ {
+  PaletteState.Tracking => _formCloseActive,
+  PaletteState.Normal => _formCloseNormal,
+  PaletteState.Pressed => _formClosePressed,
+  _ => _formCloseDisabled
+ },
+ PaletteButtonSpecStyle.FormMin => state switch
+ {
+  PaletteState.Normal => _formMinimiseNormal,
+  PaletteState.Tracking => _formMinimiseActive,
+  PaletteState.Pressed => _formMinimisePressed,
+  _ => _formMinimiseDisabled
+ },
+ PaletteButtonSpecStyle.FormMax => state switch
+ {
+  PaletteState.Normal => _formMaximiseNormal,
+  PaletteState.Tracking => _formMaximiseActive,
+  PaletteState.Pressed => _formMaximisePressed,
+  _ => _formMaximiseDisabled
+ },
+ PaletteButtonSpecStyle.FormRestore => state switch
+ {
+  PaletteState.Normal => _formRestoreNormal,
+  PaletteState.Tracking => _formRestoreActive,
+  PaletteState.Pressed => _formRestorePressed,
+  _ => _formRestoreDisabled
+ },
+ PaletteButtonSpecStyle.FormHelp => state switch
+ {
+  PaletteState.Tracking => _formHelpActive,
+  PaletteState.Pressed => _formHelpPressed,
+  PaletteState.Normal => _formHelpNormal,
+  _ => _formHelpDisabled
+ },
+ PaletteButtonSpecStyle.New => state switch
+ {
+  PaletteState.Normal => _integratedToolbarNewNormal,
+  PaletteState.Disabled => _integratedToolbarNewDisabled,
+  _ => _integratedToolbarNewDisabled
+ },
+ PaletteButtonSpecStyle.Open => state switch
+ {
+  PaletteState.Normal => _integratedToolbarOpenNormal,
+  PaletteState.Disabled => _integratedToolbarOpenDisabled,
+  _ => _integratedToolbarOpenDisabled
+ },
+ PaletteButtonSpecStyle.SaveAll => state switch
+ {
+  PaletteState.Normal => _integratedToolbarSaveAllNormal,
+  PaletteState.Disabled => _integratedToolbarSaveAllDisabled,
+  _ => _integratedToolbarSaveAllDisabled
+ },
+ PaletteButtonSpecStyle.SaveAs => state switch
+ {
+  PaletteState.Normal => _integratedToolbarSaveAsNormal,
+  PaletteState.Disabled => _integratedToolbarSaveAsDisabled,
+  _ => _integratedToolbarSaveAsDisabled
+ },
+ PaletteButtonSpecStyle.Save => state switch
+ {
+  PaletteState.Normal => _integratedToolbarSaveNormal,
+  PaletteState.Disabled => _integratedToolbarSaveDisabled,
+  _ => _integratedToolbarSaveDisabled
+ },
+ PaletteButtonSpecStyle.Cut => state switch
+ {
+  PaletteState.Normal => _integratedToolbarCutNormal,
+  PaletteState.Disabled => _integratedToolbarCutDisabled,
+  _ => _integratedToolbarCutDisabled
+ },
+ PaletteButtonSpecStyle.Copy => state switch
+ {
+  PaletteState.Normal => _integratedToolbarCopyNormal,
+  PaletteState.Disabled => _integratedToolbarCopyDisabled,
+  _ => _integratedToolbarCopyDisabled
+ },
+ PaletteButtonSpecStyle.Paste => state switch
+ {
+  PaletteState.Normal => _integratedToolbarPasteNormal,
+  PaletteState.Disabled => _integratedToolbarPasteDisabled,
+  _ => _integratedToolbarPasteDisabled
+ },
+ PaletteButtonSpecStyle.Undo => state switch
+ {
+  PaletteState.Normal => _integratedToolbarUndoNormal,
+  PaletteState.Disabled => _integratedToolbarUndoDisabled,
+  _ => _integratedToolbarUndoDisabled
+ },
+ PaletteButtonSpecStyle.Redo => state switch
+ {
+  PaletteState.Normal => _integratedToolbarRedoNormal,
+  PaletteState.Disabled => _integratedToolbarRedoDisabled,
+  _ => _integratedToolbarRedoDisabled
+ },
+ PaletteButtonSpecStyle.PageSetup => state switch
+ {
+  PaletteState.Normal => _integratedToolbarPageSetupNormal,
+  PaletteState.Disabled => _integratedToolbarPageSetupDisabled,
+  _ => _integratedToolbarPageSetupDisabled
+ },
+ PaletteButtonSpecStyle.PrintPreview => state switch
+ {
+  PaletteState.Normal => _integratedToolbarPrintPreviewNormal,
+  PaletteState.Disabled => _integratedToolbarPrintPreviewDisabled,
+  _ => _integratedToolbarPrintPreviewDisabled
+ },
+ PaletteButtonSpecStyle.Print => state switch
+ {
+  PaletteState.Normal => _integratedToolbarPrintNormal,
+  PaletteState.Disabled => _integratedToolbarPrintDisabled,
+  _ => _integratedToolbarPrintDisabled
+ },
+ PaletteButtonSpecStyle.QuickPrint => state switch
+ {
+  PaletteState.Normal => _integratedToolbarQuickPrintNormal,
+  PaletteState.Disabled => _integratedToolbarQuickPrintDisabled,
+  _ => _integratedToolbarQuickPrintDisabled
+ },
+ _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Silver.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Silver.cs
@@ -276,7 +276,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(254, 254, 254), // RibbonGroupFrameInside2
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupFrameInside3
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupFrameInside4
-            Color.FromArgb(59, 59, 59), // RibbonGroupCollapsedText         
+            Color.FromArgb(59, 59, 59), // RibbonGroupCollapsedText
             Color.FromArgb(179, 185, 195), // AlternatePressedBack1
             Color.FromArgb(216, 224, 224), // AlternatePressedBack2
             Color.FromArgb(125, 125, 125), // AlternatePressedBorder1
@@ -290,44 +290,38 @@ namespace Krypton.Toolkit
             Color.FromArgb(210, 215, 221), // RibbonQATMini2
             Color.FromArgb(195, 200, 206), // RibbonQATMini3
             Color.FromArgb(10, Color.White), // RibbonQATMini4
-            Color.FromArgb(32, Color.White), // RibbonQATMini5                                                       
+            Color.FromArgb(32, Color.White), // RibbonQATMini5
             Color.FromArgb(200, 200, 200), // RibbonQATMini1I
             Color.FromArgb(233, 234, 238), // RibbonQATMini2I
             Color.FromArgb(223, 224, 228), // RibbonQATMini3I
             Color.FromArgb(10, Color.White), // RibbonQATMini4I
-            Color.FromArgb(32, Color.White), // RibbonQATMini5I                                                       
-            Color.FromArgb(223, 227, 234), // RibbonQATFullbar1                                                      
-            Color.FromArgb(213, 217, 222), // RibbonQATFullbar2                                                      
-            Color.FromArgb(135, 140, 146), // RibbonQATFullbar3                                                      
-            Color.FromArgb(90, 90, 90), // RibbonQATButtonDark                                                      
-            Color.FromArgb(210, 212, 215), // RibbonQATButtonLight                                                      
-            Color.FromArgb(233, 237, 241), // RibbonQATOverflow1                                                      
-            Color.FromArgb(138, 144, 150), // RibbonQATOverflow2                                                      
-            Color.FromArgb(191, 195,
-                199), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(255, 255,
-                255), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(231, 234,
-                238), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(241, 243,
-                243), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(197, 198,
-                199), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(157, 158,
-                159), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor                                                    
-            Color.FromArgb(248, 252, 255), // GridListNormal1                                                    
-            Color.FromArgb(223, 227, 232), // GridListNormal2                                                    
-            Color.FromArgb(203, 207, 212), // GridListPressed1                                                    
-            Color.White, // GridListPressed2                                                    
-            Color.FromArgb(186, 189, 194), // GridListSelected                                                    
-            Color.FromArgb(238, 241, 247), // GridSheetColNormal1                                                    
-            Color.FromArgb(218, 222, 227), // GridSheetColNormal2                                                    
-            Color.FromArgb(255, 223, 107), // GridSheetColPressed1                                                    
-            Color.FromArgb(255, 252, 230), // GridSheetColPressed2                                                    
+            Color.FromArgb(32, Color.White), // RibbonQATMini5I
+            Color.FromArgb(223, 227, 234), // RibbonQATFullbar1
+            Color.FromArgb(213, 217, 222), // RibbonQATFullbar2
+            Color.FromArgb(135, 140, 146), // RibbonQATFullbar3
+            Color.FromArgb(90, 90, 90), // RibbonQATButtonDark
+            Color.FromArgb(210, 212, 215), // RibbonQATButtonLight
+            Color.FromArgb(233, 237, 241), // RibbonQATOverflow1
+            Color.FromArgb(138, 144, 150), // RibbonQATOverflow2
+            Color.FromArgb(191, 195, 199), // RibbonGroupSeparatorDark
+            Color.FromArgb(255, 255, 255), // RibbonGroupSeparatorLight
+            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1
+            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2
+            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1
+            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2
+            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor
+            Color.FromArgb(248, 252, 255), // GridListNormal1
+            Color.FromArgb(223, 227, 232), // GridListNormal2
+            Color.FromArgb(203, 207, 212), // GridListPressed1
+            Color.White, // GridListPressed2
+            Color.FromArgb(186, 189, 194), // GridListSelected
+            Color.FromArgb(238, 241, 247), // GridSheetColNormal1
+            Color.FromArgb(218, 222, 227), // GridSheetColNormal2
+            Color.FromArgb(255, 223, 107), // GridSheetColPressed1
+            Color.FromArgb(255, 252, 230), // GridSheetColPressed2
             Color.FromArgb(255, 211, 89), // GridSheetColSelected1
             Color.FromArgb(255, 239, 113), // GridSheetColSelected2
-            Color.FromArgb(223, 227, 232), // GridSheetRowNormal                                                   
+            Color.FromArgb(223, 227, 232), // GridSheetRowNormal
             Color.FromArgb(255, 223, 107), // GridSheetRowPressed
             Color.FromArgb(245, 210, 87), // GridSheetRowSelected
             Color.FromArgb(218, 220, 221), // GridDataCellBorder
@@ -362,8 +356,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(255, 255, 255), // RibbonGalleryBackNormal
             Color.FromArgb(255, 255, 255), // RibbonGalleryBackTracking
             Color.FromArgb(250, 250, 250), // RibbonGalleryBack1
-            Color.FromArgb(228, 231,
-                235), // RibbonGalleryBack2                                                                                                                                      Color.FromArgb(177, 181, 186),    // RibbonTabTracking1
+            Color.FromArgb(228, 231, 235), // RibbonGalleryBack2 //Color.FromArgb(177, 181, 186),    // RibbonTabTracking1
             Color.FromArgb(229, 231, 235), // RibbonTabTracking3
             Color.FromArgb(231, 233, 235), // RibbonTabTracking4
             Color.FromArgb(176, 182, 188), // RibbonGroupBorder3
@@ -382,8 +375,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(225, 226, 230), // ButtonNavigatorPressed2
             Color.FromArgb(222, 227, 234), // ButtonNavigatorChecked1
             Color.FromArgb(206, 214, 221), // ButtonNavigatorChecked2
-            Color.FromArgb(221, 221,
-                221) // ToolTipBottom                                                                      
+            Color.FromArgb(221, 221, 221) // ToolTipBottom
         ];
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365White.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365White.cs
@@ -436,126 +436,126 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
-                                                     PaletteButtonSpecStyle.FormClose => state switch
-                                                     {
-                                                         PaletteState.Tracking => _formCloseActive,
-                                                         PaletteState.Normal => _formCloseNormal,
-                                                         PaletteState.Pressed => _formClosePressed,
-                                                         _ => _formCloseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMin => state switch
-                                                     {
-                                                         PaletteState.Normal => _formMinimiseNormal,
-                                                         PaletteState.Tracking => _formMinimiseActive,
-                                                         PaletteState.Pressed => _formMinimisePressed,
-                                                         _ => _formMinimiseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMax => state switch
-                                                     {
-                                                         PaletteState.Normal => _formMaximiseNormal,
-                                                         PaletteState.Tracking => _formMaximiseActive,
-                                                         PaletteState.Pressed => _formMaximisePressed,
-                                                         _ => _formMaximiseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormRestore => state switch
-                                                     {
-                                                         PaletteState.Normal => _formRestoreNormal,
-                                                         PaletteState.Tracking => _formRestoreActive,
-                                                         PaletteState.Pressed => _formRestorePressed,
-                                                         _ => _formRestoreDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormHelp => state switch
-                                                     {
-                                                         PaletteState.Tracking => _formHelpActive,
-                                                         PaletteState.Pressed => _formHelpPressed,
-                                                         PaletteState.Normal => _formHelpNormal,
-                                                         _ => _formHelpDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.New => state switch
-                                                     {
-                                                         PaletteState.Normal => _integratedToolbarNewNormal,
-                                                         PaletteState.Disabled => _integratedToolbarNewDisabled,
-                                                         _ => _integratedToolbarNewDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.Open => state switch
-                                                     {
-                                                         PaletteState.Normal => _integratedToolbarOpenNormal,
-                                                         PaletteState.Disabled => _integratedToolbarOpenDisabled,
-                                                         _ => _integratedToolbarOpenDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.SaveAll => state switch
-                                                     {
-                                                         PaletteState.Normal => _integratedToolbarSaveAllNormal,
-                                                         PaletteState.Disabled => _integratedToolbarSaveAllDisabled,
-                                                         _ => _integratedToolbarSaveAllDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.SaveAs => state switch
-                                                     {
-                                                         PaletteState.Normal => _integratedToolbarSaveAsNormal,
-                                                         PaletteState.Disabled => _integratedToolbarSaveAsDisabled,
-                                                         _ => _integratedToolbarSaveAsDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.Save => state switch
-                                                     {
-                                                         PaletteState.Normal => _integratedToolbarSaveNormal,
-                                                         PaletteState.Disabled => _integratedToolbarSaveDisabled,
-                                                         _ => _integratedToolbarSaveDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.Cut => state switch
-                                                     {
-                                                         PaletteState.Normal => _integratedToolbarCutNormal,
-                                                         PaletteState.Disabled => _integratedToolbarCutDisabled,
-                                                         _ => _integratedToolbarCutDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.Copy => state switch
-                                                     {
-                                                         PaletteState.Normal => _integratedToolbarCopyNormal,
-                                                         PaletteState.Disabled => _integratedToolbarCopyDisabled,
-                                                         _ => _integratedToolbarCopyDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.Paste => state switch
-                                                     {
-                                                         PaletteState.Normal => _integratedToolbarPasteNormal,
-                                                         PaletteState.Disabled => _integratedToolbarPasteDisabled,
-                                                         _ => _integratedToolbarPasteDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.Undo => state switch
-                                                     {
-                                                         PaletteState.Normal => _integratedToolbarUndoNormal,
-                                                         PaletteState.Disabled => _integratedToolbarUndoDisabled,
-                                                         _ => _integratedToolbarUndoDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.Redo => state switch
-                                                     {
-                                                         PaletteState.Normal => _integratedToolbarRedoNormal,
-                                                         PaletteState.Disabled => _integratedToolbarRedoDisabled,
-                                                         _ => _integratedToolbarRedoDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.PageSetup => state switch
-                                                     {
-                                                         PaletteState.Normal => _integratedToolbarPageSetupNormal,
-                                                         PaletteState.Disabled => _integratedToolbarPageSetupDisabled,
-                                                         _ => _integratedToolbarPageSetupDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.PrintPreview => state switch
-                                                     {
-                                                         PaletteState.Normal => _integratedToolbarPrintPreviewNormal,
-                                                         PaletteState.Disabled => _integratedToolbarPrintPreviewDisabled,
-                                                         _ => _integratedToolbarPrintPreviewDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.Print => state switch
-                                                     {
-                                                         PaletteState.Normal => _integratedToolbarPrintNormal,
-                                                         PaletteState.Disabled => _integratedToolbarPrintDisabled,
-                                                         _ => _integratedToolbarPrintDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.QuickPrint => state switch
-                                                     {
-                                                         PaletteState.Normal => _integratedToolbarQuickPrintNormal,
-                                                         PaletteState.Disabled => _integratedToolbarQuickPrintDisabled,
-                                                         _ => _integratedToolbarQuickPrintDisabled
-                                                     },
-                                                     _ => base.GetButtonSpecImage(style, state)
+ PaletteButtonSpecStyle.FormClose => state switch
+ {
+  PaletteState.Tracking => _formCloseActive,
+  PaletteState.Normal => _formCloseNormal,
+  PaletteState.Pressed => _formClosePressed,
+  _ => _formCloseDisabled
+ },
+ PaletteButtonSpecStyle.FormMin => state switch
+ {
+  PaletteState.Normal => _formMinimiseNormal,
+  PaletteState.Tracking => _formMinimiseActive,
+  PaletteState.Pressed => _formMinimisePressed,
+  _ => _formMinimiseDisabled
+ },
+ PaletteButtonSpecStyle.FormMax => state switch
+ {
+  PaletteState.Normal => _formMaximiseNormal,
+  PaletteState.Tracking => _formMaximiseActive,
+  PaletteState.Pressed => _formMaximisePressed,
+  _ => _formMaximiseDisabled
+ },
+ PaletteButtonSpecStyle.FormRestore => state switch
+ {
+  PaletteState.Normal => _formRestoreNormal,
+  PaletteState.Tracking => _formRestoreActive,
+  PaletteState.Pressed => _formRestorePressed,
+  _ => _formRestoreDisabled
+ },
+ PaletteButtonSpecStyle.FormHelp => state switch
+ {
+  PaletteState.Tracking => _formHelpActive,
+  PaletteState.Pressed => _formHelpPressed,
+  PaletteState.Normal => _formHelpNormal,
+  _ => _formHelpDisabled
+ },
+ PaletteButtonSpecStyle.New => state switch
+ {
+  PaletteState.Normal => _integratedToolbarNewNormal,
+  PaletteState.Disabled => _integratedToolbarNewDisabled,
+  _ => _integratedToolbarNewDisabled
+ },
+ PaletteButtonSpecStyle.Open => state switch
+ {
+  PaletteState.Normal => _integratedToolbarOpenNormal,
+  PaletteState.Disabled => _integratedToolbarOpenDisabled,
+  _ => _integratedToolbarOpenDisabled
+ },
+ PaletteButtonSpecStyle.SaveAll => state switch
+ {
+  PaletteState.Normal => _integratedToolbarSaveAllNormal,
+  PaletteState.Disabled => _integratedToolbarSaveAllDisabled,
+  _ => _integratedToolbarSaveAllDisabled
+ },
+ PaletteButtonSpecStyle.SaveAs => state switch
+ {
+  PaletteState.Normal => _integratedToolbarSaveAsNormal,
+  PaletteState.Disabled => _integratedToolbarSaveAsDisabled,
+  _ => _integratedToolbarSaveAsDisabled
+ },
+ PaletteButtonSpecStyle.Save => state switch
+ {
+  PaletteState.Normal => _integratedToolbarSaveNormal,
+  PaletteState.Disabled => _integratedToolbarSaveDisabled,
+  _ => _integratedToolbarSaveDisabled
+ },
+ PaletteButtonSpecStyle.Cut => state switch
+ {
+  PaletteState.Normal => _integratedToolbarCutNormal,
+  PaletteState.Disabled => _integratedToolbarCutDisabled,
+  _ => _integratedToolbarCutDisabled
+ },
+ PaletteButtonSpecStyle.Copy => state switch
+ {
+  PaletteState.Normal => _integratedToolbarCopyNormal,
+  PaletteState.Disabled => _integratedToolbarCopyDisabled,
+  _ => _integratedToolbarCopyDisabled
+ },
+ PaletteButtonSpecStyle.Paste => state switch
+ {
+  PaletteState.Normal => _integratedToolbarPasteNormal,
+  PaletteState.Disabled => _integratedToolbarPasteDisabled,
+  _ => _integratedToolbarPasteDisabled
+ },
+ PaletteButtonSpecStyle.Undo => state switch
+ {
+  PaletteState.Normal => _integratedToolbarUndoNormal,
+  PaletteState.Disabled => _integratedToolbarUndoDisabled,
+  _ => _integratedToolbarUndoDisabled
+ },
+ PaletteButtonSpecStyle.Redo => state switch
+ {
+  PaletteState.Normal => _integratedToolbarRedoNormal,
+  PaletteState.Disabled => _integratedToolbarRedoDisabled,
+  _ => _integratedToolbarRedoDisabled
+ },
+ PaletteButtonSpecStyle.PageSetup => state switch
+ {
+  PaletteState.Normal => _integratedToolbarPageSetupNormal,
+  PaletteState.Disabled => _integratedToolbarPageSetupDisabled,
+  _ => _integratedToolbarPageSetupDisabled
+ },
+ PaletteButtonSpecStyle.PrintPreview => state switch
+ {
+  PaletteState.Normal => _integratedToolbarPrintPreviewNormal,
+  PaletteState.Disabled => _integratedToolbarPrintPreviewDisabled,
+  _ => _integratedToolbarPrintPreviewDisabled
+ },
+ PaletteButtonSpecStyle.Print => state switch
+ {
+  PaletteState.Normal => _integratedToolbarPrintNormal,
+  PaletteState.Disabled => _integratedToolbarPrintDisabled,
+  _ => _integratedToolbarPrintDisabled
+ },
+ PaletteButtonSpecStyle.QuickPrint => state switch
+ {
+  PaletteState.Normal => _integratedToolbarQuickPrintNormal,
+  PaletteState.Disabled => _integratedToolbarQuickPrintDisabled,
+  _ => _integratedToolbarQuickPrintDisabled
+ },
+ _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365White.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365White.cs
@@ -436,126 +436,126 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
- PaletteButtonSpecStyle.FormClose => state switch
- {
-  PaletteState.Tracking => _formCloseActive,
-  PaletteState.Normal => _formCloseNormal,
-  PaletteState.Pressed => _formClosePressed,
-  _ => _formCloseDisabled
- },
- PaletteButtonSpecStyle.FormMin => state switch
- {
-  PaletteState.Normal => _formMinimiseNormal,
-  PaletteState.Tracking => _formMinimiseActive,
-  PaletteState.Pressed => _formMinimisePressed,
-  _ => _formMinimiseDisabled
- },
- PaletteButtonSpecStyle.FormMax => state switch
- {
-  PaletteState.Normal => _formMaximiseNormal,
-  PaletteState.Tracking => _formMaximiseActive,
-  PaletteState.Pressed => _formMaximisePressed,
-  _ => _formMaximiseDisabled
- },
- PaletteButtonSpecStyle.FormRestore => state switch
- {
-  PaletteState.Normal => _formRestoreNormal,
-  PaletteState.Tracking => _formRestoreActive,
-  PaletteState.Pressed => _formRestorePressed,
-  _ => _formRestoreDisabled
- },
- PaletteButtonSpecStyle.FormHelp => state switch
- {
-  PaletteState.Tracking => _formHelpActive,
-  PaletteState.Pressed => _formHelpPressed,
-  PaletteState.Normal => _formHelpNormal,
-  _ => _formHelpDisabled
- },
- PaletteButtonSpecStyle.New => state switch
- {
-  PaletteState.Normal => _integratedToolbarNewNormal,
-  PaletteState.Disabled => _integratedToolbarNewDisabled,
-  _ => _integratedToolbarNewDisabled
- },
- PaletteButtonSpecStyle.Open => state switch
- {
-  PaletteState.Normal => _integratedToolbarOpenNormal,
-  PaletteState.Disabled => _integratedToolbarOpenDisabled,
-  _ => _integratedToolbarOpenDisabled
- },
- PaletteButtonSpecStyle.SaveAll => state switch
- {
-  PaletteState.Normal => _integratedToolbarSaveAllNormal,
-  PaletteState.Disabled => _integratedToolbarSaveAllDisabled,
-  _ => _integratedToolbarSaveAllDisabled
- },
- PaletteButtonSpecStyle.SaveAs => state switch
- {
-  PaletteState.Normal => _integratedToolbarSaveAsNormal,
-  PaletteState.Disabled => _integratedToolbarSaveAsDisabled,
-  _ => _integratedToolbarSaveAsDisabled
- },
- PaletteButtonSpecStyle.Save => state switch
- {
-  PaletteState.Normal => _integratedToolbarSaveNormal,
-  PaletteState.Disabled => _integratedToolbarSaveDisabled,
-  _ => _integratedToolbarSaveDisabled
- },
- PaletteButtonSpecStyle.Cut => state switch
- {
-  PaletteState.Normal => _integratedToolbarCutNormal,
-  PaletteState.Disabled => _integratedToolbarCutDisabled,
-  _ => _integratedToolbarCutDisabled
- },
- PaletteButtonSpecStyle.Copy => state switch
- {
-  PaletteState.Normal => _integratedToolbarCopyNormal,
-  PaletteState.Disabled => _integratedToolbarCopyDisabled,
-  _ => _integratedToolbarCopyDisabled
- },
- PaletteButtonSpecStyle.Paste => state switch
- {
-  PaletteState.Normal => _integratedToolbarPasteNormal,
-  PaletteState.Disabled => _integratedToolbarPasteDisabled,
-  _ => _integratedToolbarPasteDisabled
- },
- PaletteButtonSpecStyle.Undo => state switch
- {
-  PaletteState.Normal => _integratedToolbarUndoNormal,
-  PaletteState.Disabled => _integratedToolbarUndoDisabled,
-  _ => _integratedToolbarUndoDisabled
- },
- PaletteButtonSpecStyle.Redo => state switch
- {
-  PaletteState.Normal => _integratedToolbarRedoNormal,
-  PaletteState.Disabled => _integratedToolbarRedoDisabled,
-  _ => _integratedToolbarRedoDisabled
- },
- PaletteButtonSpecStyle.PageSetup => state switch
- {
-  PaletteState.Normal => _integratedToolbarPageSetupNormal,
-  PaletteState.Disabled => _integratedToolbarPageSetupDisabled,
-  _ => _integratedToolbarPageSetupDisabled
- },
- PaletteButtonSpecStyle.PrintPreview => state switch
- {
-  PaletteState.Normal => _integratedToolbarPrintPreviewNormal,
-  PaletteState.Disabled => _integratedToolbarPrintPreviewDisabled,
-  _ => _integratedToolbarPrintPreviewDisabled
- },
- PaletteButtonSpecStyle.Print => state switch
- {
-  PaletteState.Normal => _integratedToolbarPrintNormal,
-  PaletteState.Disabled => _integratedToolbarPrintDisabled,
-  _ => _integratedToolbarPrintDisabled
- },
- PaletteButtonSpecStyle.QuickPrint => state switch
- {
-  PaletteState.Normal => _integratedToolbarQuickPrintNormal,
-  PaletteState.Disabled => _integratedToolbarQuickPrintDisabled,
-  _ => _integratedToolbarQuickPrintDisabled
- },
- _ => base.GetButtonSpecImage(style, state)
+                                                     PaletteButtonSpecStyle.FormClose => state switch
+                                                     {
+                                                         PaletteState.Tracking => _formCloseActive,
+                                                         PaletteState.Normal => _formCloseNormal,
+                                                         PaletteState.Pressed => _formClosePressed,
+                                                         _ => _formCloseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMin => state switch
+                                                     {
+                                                         PaletteState.Normal => _formMinimiseNormal,
+                                                         PaletteState.Tracking => _formMinimiseActive,
+                                                         PaletteState.Pressed => _formMinimisePressed,
+                                                         _ => _formMinimiseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMax => state switch
+                                                     {
+                                                         PaletteState.Normal => _formMaximiseNormal,
+                                                         PaletteState.Tracking => _formMaximiseActive,
+                                                         PaletteState.Pressed => _formMaximisePressed,
+                                                         _ => _formMaximiseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormRestore => state switch
+                                                     {
+                                                         PaletteState.Normal => _formRestoreNormal,
+                                                         PaletteState.Tracking => _formRestoreActive,
+                                                         PaletteState.Pressed => _formRestorePressed,
+                                                         _ => _formRestoreDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormHelp => state switch
+                                                     {
+                                                         PaletteState.Tracking => _formHelpActive,
+                                                         PaletteState.Pressed => _formHelpPressed,
+                                                         PaletteState.Normal => _formHelpNormal,
+                                                         _ => _formHelpDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.New => state switch
+                                                     {
+                                                         PaletteState.Normal => _integratedToolbarNewNormal,
+                                                         PaletteState.Disabled => _integratedToolbarNewDisabled,
+                                                         _ => _integratedToolbarNewDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.Open => state switch
+                                                     {
+                                                         PaletteState.Normal => _integratedToolbarOpenNormal,
+                                                         PaletteState.Disabled => _integratedToolbarOpenDisabled,
+                                                         _ => _integratedToolbarOpenDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.SaveAll => state switch
+                                                     {
+                                                         PaletteState.Normal => _integratedToolbarSaveAllNormal,
+                                                         PaletteState.Disabled => _integratedToolbarSaveAllDisabled,
+                                                         _ => _integratedToolbarSaveAllDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.SaveAs => state switch
+                                                     {
+                                                         PaletteState.Normal => _integratedToolbarSaveAsNormal,
+                                                         PaletteState.Disabled => _integratedToolbarSaveAsDisabled,
+                                                         _ => _integratedToolbarSaveAsDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.Save => state switch
+                                                     {
+                                                         PaletteState.Normal => _integratedToolbarSaveNormal,
+                                                         PaletteState.Disabled => _integratedToolbarSaveDisabled,
+                                                         _ => _integratedToolbarSaveDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.Cut => state switch
+                                                     {
+                                                         PaletteState.Normal => _integratedToolbarCutNormal,
+                                                         PaletteState.Disabled => _integratedToolbarCutDisabled,
+                                                         _ => _integratedToolbarCutDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.Copy => state switch
+                                                     {
+                                                         PaletteState.Normal => _integratedToolbarCopyNormal,
+                                                         PaletteState.Disabled => _integratedToolbarCopyDisabled,
+                                                         _ => _integratedToolbarCopyDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.Paste => state switch
+                                                     {
+                                                         PaletteState.Normal => _integratedToolbarPasteNormal,
+                                                         PaletteState.Disabled => _integratedToolbarPasteDisabled,
+                                                         _ => _integratedToolbarPasteDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.Undo => state switch
+                                                     {
+                                                         PaletteState.Normal => _integratedToolbarUndoNormal,
+                                                         PaletteState.Disabled => _integratedToolbarUndoDisabled,
+                                                         _ => _integratedToolbarUndoDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.Redo => state switch
+                                                     {
+                                                         PaletteState.Normal => _integratedToolbarRedoNormal,
+                                                         PaletteState.Disabled => _integratedToolbarRedoDisabled,
+                                                         _ => _integratedToolbarRedoDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.PageSetup => state switch
+                                                     {
+                                                         PaletteState.Normal => _integratedToolbarPageSetupNormal,
+                                                         PaletteState.Disabled => _integratedToolbarPageSetupDisabled,
+                                                         _ => _integratedToolbarPageSetupDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.PrintPreview => state switch
+                                                     {
+                                                         PaletteState.Normal => _integratedToolbarPrintPreviewNormal,
+                                                         PaletteState.Disabled => _integratedToolbarPrintPreviewDisabled,
+                                                         _ => _integratedToolbarPrintPreviewDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.Print => state switch
+                                                     {
+                                                         PaletteState.Normal => _integratedToolbarPrintNormal,
+                                                         PaletteState.Disabled => _integratedToolbarPrintDisabled,
+                                                         _ => _integratedToolbarPrintDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.QuickPrint => state switch
+                                                     {
+                                                         PaletteState.Normal => _integratedToolbarQuickPrintNormal,
+                                                         PaletteState.Disabled => _integratedToolbarQuickPrintDisabled,
+                                                         _ => _integratedToolbarQuickPrintDisabled
+                                                     },
+                                                     _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlackDarkMode.cs
@@ -518,43 +518,43 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
-  PaletteButtonSpecStyle.FormClose => state switch
-  {
-  PaletteState.Disabled => _blackCloseDisabled,
-  PaletteState.Tracking => _blackCloseActive,
-  PaletteState.Pressed => _blackClosePressed,
-  _ => _blackCloseNormal
-  },
-  PaletteButtonSpecStyle.FormMin => state switch
-  {
-  PaletteState.Disabled => _blackMinimiseDisabled,
-  PaletteState.Tracking => _blackMinimiseActive,
-  PaletteState.Pressed => _blackMinimisePressed,
-  _ => _blackMinimiseNormal
-  },
-  PaletteButtonSpecStyle.FormMax => state switch
-  {
-  PaletteState.Disabled => _blackMaximiseDisabled,
-  PaletteState.Tracking => _blackMaximiseActive,
-  PaletteState.Pressed => _blackMaximisePressed,
-  _ => _blackMaximiseNormal
-  },
-  PaletteButtonSpecStyle.FormRestore => state switch
-  {
-  PaletteState.Disabled => _blackRestoreDisabled,
-  PaletteState.Tracking => _blackRestoreActive,
-  PaletteState.Pressed => _blackRestorePressed,
-  _ => _blackRestoreNormal
-  },
-  PaletteButtonSpecStyle.FormHelp => state switch
-  {
-  PaletteState.Disabled => _blackHelpDisabled,
-  PaletteState.Tracking => _blackHelpActive,
-  _ => _blackHelpNormal
-  },
-  PaletteButtonSpecStyle.RibbonMinimize => _blackRibbonMinimize,
-  PaletteButtonSpecStyle.RibbonExpand => _blackRibbonExpand,
-  _ => base.GetButtonSpecImage(style, state)
+                                                     PaletteButtonSpecStyle.FormClose => state switch
+                                                     {
+                                                         PaletteState.Disabled => _blackCloseDisabled,
+                                                         PaletteState.Tracking => _blackCloseActive,
+                                                         PaletteState.Pressed => _blackClosePressed,
+                                                         _ => _blackCloseNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMin => state switch
+                                                     {
+                                                         PaletteState.Disabled => _blackMinimiseDisabled,
+                                                         PaletteState.Tracking => _blackMinimiseActive,
+                                                         PaletteState.Pressed => _blackMinimisePressed,
+                                                         _ => _blackMinimiseNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMax => state switch
+                                                     {
+                                                         PaletteState.Disabled => _blackMaximiseDisabled,
+                                                         PaletteState.Tracking => _blackMaximiseActive,
+                                                         PaletteState.Pressed => _blackMaximisePressed,
+                                                         _ => _blackMaximiseNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormRestore => state switch
+                                                     {
+                                                         PaletteState.Disabled => _blackRestoreDisabled,
+                                                         PaletteState.Tracking => _blackRestoreActive,
+                                                         PaletteState.Pressed => _blackRestorePressed,
+                                                         _ => _blackRestoreNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormHelp => state switch
+                                                     {
+                                                         PaletteState.Disabled => _blackHelpDisabled,
+                                                         PaletteState.Tracking => _blackHelpActive,
+                                                         _ => _blackHelpNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.RibbonMinimize => _blackRibbonMinimize,
+                                                     PaletteButtonSpecStyle.RibbonExpand => _blackRibbonExpand,
+                                                     _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 
@@ -1675,8 +1675,8 @@ namespace Krypton.Toolkit
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2] : _buttonBackColors[7],
                         PaletteState.Tracking => _buttonBackColors[3],
                         PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBackStyle.ButtonAlternate
- ? _ribbonColours[(int)SchemeOfficeColors.AlternatePressedBack2]
- : _buttonBackColors[5],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.AlternatePressedBack2]
+                                                    : _buttonBackColors[5],
                         PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1] : _buttonBackColors[9],
                         _ => throw DebugTools.NotImplemented(state.ToString())
                     };
@@ -2566,11 +2566,11 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
- ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
- : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
- ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
- : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
@@ -2590,8 +2590,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuInnerBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
- ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
- : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+                                                        ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+                                                        : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm or PaletteBorderStyle.ButtonFormClose => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -2692,8 +2692,8 @@ namespace Krypton.Toolkit
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
- ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
- : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -2712,8 +2712,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuInnerBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
- ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
- : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm or PaletteBorderStyle.ButtonFormClose => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -3435,8 +3435,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3516,8 +3516,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3926,8 +3926,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -4005,8 +4005,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -5925,9 +5925,9 @@ namespace Krypton.Toolkit
         private static Color[] _propertyGridColors =
         [
             Color.FromArgb(33, 33, 33), // HelpBackColor
- Color.FromArgb(255, 255, 255), // HelpForeColor
- Color.Silver,     // LineColor
- Color.FromArgb(255, 255, 255)  // CategoryForeColor
+                                                        Color.FromArgb(255, 255, 255), // HelpForeColor
+                                                        Color.Silver,     // LineColor
+                                                        Color.FromArgb(255, 255, 255)  // CategoryForeColor
         ];
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlackDarkMode.cs
@@ -189,7 +189,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(222, 225, 229), // RibbonGroupFrameInside2
             Color.FromArgb(214, 218, 223), // RibbonGroupFrameInside3
             Color.FromArgb(222, 225, 230), // RibbonGroupFrameInside4
-            Color.FromArgb(70, 70, 70), // RibbonGroupCollapsedText         
+            Color.FromArgb(70, 70, 70), // RibbonGroupCollapsedText
             Color.FromArgb(158, 163, 172), // AlternatePressedBack1
             Color.FromArgb(212, 215, 216), // AlternatePressedBack2
             Color.FromArgb(124, 125, 125), // AlternatePressedBorder1
@@ -209,38 +209,32 @@ namespace Krypton.Toolkit
             Color.FromArgb(140, 140, 140), // RibbonQATMini3I
             Color.FromArgb(12, Color.White), // RibbonQATMini4I
             Color.FromArgb(14, Color.White), // RibbonQATMini5I
-            Color.FromArgb(141, 144, 147), // RibbonQATFullbar1                                                      
-            Color.FromArgb(133, 135, 137), // RibbonQATFullbar2                                                      
-            Color.FromArgb(93, 96, 100), // RibbonQATFullbar3                                                      
-            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark                                                      
-            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
-            Color.FromArgb(118, 128, 142), // RibbonQATOverflow1                                                      
-            Color.FromArgb(55, 60, 67), // RibbonQATOverflow2                                                      
-            Color.FromArgb(163, 168,
-                170), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(230, 233,
-                235), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(210, 217,
-                219), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(214, 222,
-                223), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(179, 188,
-                191), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(145, 156,
-                159), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(235, 235, 235), // NavigatorMiniBackColor                                                    
-            Color.FromArgb(10, 10, 10), // GridListNormal1                                                    
-            Color.FromArgb(41, 41, 41), // GridListNormal2                                                    
-            Color.FromArgb(41, 41, 41), // GridListPressed1                                                    
-            Color.FromArgb(61, 61, 61), // GridListPressed2                                                    
-            Color.FromArgb(33, 33, 33), // GridListSelected                                                    
-            Color.FromArgb(10, 10, 10), // GridSheetColNormal1                                                    
-            Color.FromArgb(41, 41, 41), // GridSheetColNormal2                                                    
-            Color.FromArgb(224, 224, 224), // GridSheetColPressed1                                                    
-            Color.FromArgb(195, 195, 195), // GridSheetColPressed2                                                    
+            Color.FromArgb(141, 144, 147), // RibbonQATFullbar1
+            Color.FromArgb(133, 135, 137), // RibbonQATFullbar2
+            Color.FromArgb(93, 96, 100), // RibbonQATFullbar3
+            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark
+            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight
+            Color.FromArgb(118, 128, 142), // RibbonQATOverflow1
+            Color.FromArgb(55, 60, 67), // RibbonQATOverflow2
+            Color.FromArgb(163, 168, 170), // RibbonGroupSeparatorDark
+            Color.FromArgb(230, 233, 235), // RibbonGroupSeparatorLight
+            Color.FromArgb(210, 217, 219), // ButtonClusterButtonBack1
+            Color.FromArgb(214, 222, 223), // ButtonClusterButtonBack2
+            Color.FromArgb(179, 188, 191), // ButtonClusterButtonBorder1
+            Color.FromArgb(145, 156, 159), // ButtonClusterButtonBorder2
+            Color.FromArgb(235, 235, 235), // NavigatorMiniBackColor 
+            Color.FromArgb(10, 10, 10), // GridListNormal1 
+            Color.FromArgb(41, 41, 41), // GridListNormal2 
+            Color.FromArgb(41, 41, 41), // GridListPressed1 
+            Color.FromArgb(61, 61, 61), // GridListPressed2 
+            Color.FromArgb(33, 33, 33), // GridListSelected 
+            Color.FromArgb(10, 10, 10), // GridSheetColNormal1 
+            Color.FromArgb(41, 41, 41), // GridSheetColNormal2 
+            Color.FromArgb(224, 224, 224), // GridSheetColPressed1 
+            Color.FromArgb(195, 195, 195), // GridSheetColPressed2 
             Color.FromArgb(91, 91, 91), // GridSheetColSelected1
             Color.FromArgb(33, 33, 33), // GridSheetColSelected2
-            Color.FromArgb(237, 237, 237), // GridSheetRowNormal                                                   
+            Color.FromArgb(237, 237, 237), // GridSheetRowNormal
             Color.FromArgb(196, 196, 196), // GridSheetRowPressed
             Color.FromArgb(61, 61, 61), // GridSheetRowSelected
             Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -280,6 +274,8 @@ namespace Krypton.Toolkit
             GlobalStaticValues.EMPTY_COLOR, // RibbonTabTracking4
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder3
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder4
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder5
+            Color.FromArgb(255, 255, 255), // RibbonGroupTitleText
             Color.FromArgb(225, 225, 225), // RibbonDropArrowLight
             Color.FromArgb(103, 103, 103) // RibbonDropArrowDark
         ];
@@ -522,43 +518,43 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
-                                                     PaletteButtonSpecStyle.FormClose => state switch
-                                                     {
-                                                         PaletteState.Disabled => _blackCloseDisabled,
-                                                         PaletteState.Tracking => _blackCloseActive,
-                                                         PaletteState.Pressed => _blackClosePressed,
-                                                         _ => _blackCloseNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMin => state switch
-                                                     {
-                                                         PaletteState.Disabled => _blackMinimiseDisabled,
-                                                         PaletteState.Tracking => _blackMinimiseActive,
-                                                         PaletteState.Pressed => _blackMinimisePressed,
-                                                         _ => _blackMinimiseNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMax => state switch
-                                                     {
-                                                         PaletteState.Disabled => _blackMaximiseDisabled,
-                                                         PaletteState.Tracking => _blackMaximiseActive,
-                                                         PaletteState.Pressed => _blackMaximisePressed,
-                                                         _ => _blackMaximiseNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormRestore => state switch
-                                                     {
-                                                         PaletteState.Disabled => _blackRestoreDisabled,
-                                                         PaletteState.Tracking => _blackRestoreActive,
-                                                         PaletteState.Pressed => _blackRestorePressed,
-                                                         _ => _blackRestoreNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormHelp => state switch
-                                                     {
-                                                         PaletteState.Disabled => _blackHelpDisabled,
-                                                         PaletteState.Tracking => _blackHelpActive,
-                                                         _ => _blackHelpNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.RibbonMinimize => _blackRibbonMinimize,
-                                                     PaletteButtonSpecStyle.RibbonExpand => _blackRibbonExpand,
-                                                     _ => base.GetButtonSpecImage(style, state)
+  PaletteButtonSpecStyle.FormClose => state switch
+  {
+  PaletteState.Disabled => _blackCloseDisabled,
+  PaletteState.Tracking => _blackCloseActive,
+  PaletteState.Pressed => _blackClosePressed,
+  _ => _blackCloseNormal
+  },
+  PaletteButtonSpecStyle.FormMin => state switch
+  {
+  PaletteState.Disabled => _blackMinimiseDisabled,
+  PaletteState.Tracking => _blackMinimiseActive,
+  PaletteState.Pressed => _blackMinimisePressed,
+  _ => _blackMinimiseNormal
+  },
+  PaletteButtonSpecStyle.FormMax => state switch
+  {
+  PaletteState.Disabled => _blackMaximiseDisabled,
+  PaletteState.Tracking => _blackMaximiseActive,
+  PaletteState.Pressed => _blackMaximisePressed,
+  _ => _blackMaximiseNormal
+  },
+  PaletteButtonSpecStyle.FormRestore => state switch
+  {
+  PaletteState.Disabled => _blackRestoreDisabled,
+  PaletteState.Tracking => _blackRestoreActive,
+  PaletteState.Pressed => _blackRestorePressed,
+  _ => _blackRestoreNormal
+  },
+  PaletteButtonSpecStyle.FormHelp => state switch
+  {
+  PaletteState.Disabled => _blackHelpDisabled,
+  PaletteState.Tracking => _blackHelpActive,
+  _ => _blackHelpNormal
+  },
+  PaletteButtonSpecStyle.RibbonMinimize => _blackRibbonMinimize,
+  PaletteButtonSpecStyle.RibbonExpand => _blackRibbonExpand,
+  _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 
@@ -1679,8 +1675,8 @@ namespace Krypton.Toolkit
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2] : _buttonBackColors[7],
                         PaletteState.Tracking => _buttonBackColors[3],
                         PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBackStyle.ButtonAlternate
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.AlternatePressedBack2]
-                                                    : _buttonBackColors[5],
+ ? _ribbonColours[(int)SchemeOfficeColors.AlternatePressedBack2]
+ : _buttonBackColors[5],
                         PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1] : _buttonBackColors[9],
                         _ => throw DebugTools.NotImplemented(state.ToString())
                     };
@@ -2570,11 +2566,11 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+ ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+ : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
+ ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
+ : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
@@ -2594,8 +2590,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuInnerBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-                                                        : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+ ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+ : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm or PaletteBorderStyle.ButtonFormClose => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -2696,8 +2692,8 @@ namespace Krypton.Toolkit
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+ ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+ : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -2716,8 +2712,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuInnerBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+ ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+ : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm or PaletteBorderStyle.ButtonFormClose => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -3439,8 +3435,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3520,8 +3516,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3930,8 +3926,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -4009,8 +4005,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -5929,9 +5925,9 @@ namespace Krypton.Toolkit
         private static Color[] _propertyGridColors =
         [
             Color.FromArgb(33, 33, 33), // HelpBackColor
-                                                        Color.FromArgb(255, 255, 255), // HelpForeColor
-                                                        Color.Silver,     // LineColor
-                                                        Color.FromArgb(255, 255, 255)  // CategoryForeColor
+ Color.FromArgb(255, 255, 255), // HelpForeColor
+ Color.Silver,     // LineColor
+ Color.FromArgb(255, 255, 255)  // CategoryForeColor
         ];
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueDarkMode.cs
@@ -358,42 +358,42 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
- PaletteButtonSpecStyle.FormClose => state switch
- {
-  PaletteState.Disabled => _blueCloseDisabled,
-  PaletteState.Tracking => _blueCloseActive,
-  PaletteState.Pressed => _blueClosePressed,
-  _ => _blueCloseNormal
- },
- PaletteButtonSpecStyle.FormMin => state switch
- {
-  PaletteState.Disabled => _blueMinimiseDisabled,
-  PaletteState.Tracking => _blueMinimiseActive,
-  PaletteState.Pressed => _blueMinimisePressed,
-  _ => _blueMinimiseNormal
- },
- PaletteButtonSpecStyle.FormMax => state switch
- {
-  PaletteState.Disabled => _blueMaximiseDisabled,
-  PaletteState.Tracking => _blueMaximiseActive,
-  PaletteState.Pressed => _blueMaximisePressed,
-  _ => _blueMaximiseNormal
- },
- PaletteButtonSpecStyle.FormRestore => state switch
- {
-  PaletteState.Disabled => _blueRestoreDisabled,
-  PaletteState.Tracking => _blueRestoreActive,
-  PaletteState.Pressed => _blueRestorePressed,
-  _ => _blueRestoreNormal
- },
- PaletteButtonSpecStyle.FormHelp => state switch
- {
-  PaletteState.Disabled => _blueHelpDisabled,
-  PaletteState.Tracking => _blueHelpActive,
-  PaletteState.Pressed => _blueHelpPressed,
-  _ => _blueHelpNormal
- },
- _ => base.GetButtonSpecImage(style, state)
+                                                     PaletteButtonSpecStyle.FormClose => state switch
+                                                     {
+                                                         PaletteState.Disabled => _blueCloseDisabled,
+                                                         PaletteState.Tracking => _blueCloseActive,
+                                                         PaletteState.Pressed => _blueClosePressed,
+                                                         _ => _blueCloseNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMin => state switch
+                                                     {
+                                                         PaletteState.Disabled => _blueMinimiseDisabled,
+                                                         PaletteState.Tracking => _blueMinimiseActive,
+                                                         PaletteState.Pressed => _blueMinimisePressed,
+                                                         _ => _blueMinimiseNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMax => state switch
+                                                     {
+                                                         PaletteState.Disabled => _blueMaximiseDisabled,
+                                                         PaletteState.Tracking => _blueMaximiseActive,
+                                                         PaletteState.Pressed => _blueMaximisePressed,
+                                                         _ => _blueMaximiseNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormRestore => state switch
+                                                     {
+                                                         PaletteState.Disabled => _blueRestoreDisabled,
+                                                         PaletteState.Tracking => _blueRestoreActive,
+                                                         PaletteState.Pressed => _blueRestorePressed,
+                                                         _ => _blueRestoreNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormHelp => state switch
+                                                     {
+                                                         PaletteState.Disabled => _blueHelpDisabled,
+                                                         PaletteState.Tracking => _blueHelpActive,
+                                                         PaletteState.Pressed => _blueHelpPressed,
+                                                         _ => _blueHelpNormal
+                                                     },
+                                                     _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 
@@ -614,80 +614,80 @@ namespace Krypton.Toolkit
         private static readonly Color[] _ribbonGroupCollapsedBackContext =
         [
             Color.FromArgb(48, 255, 255, 255),
-                         Color.FromArgb(235, 235, 235)
+                                                                                Color.FromArgb(235, 235, 235)
         ];
         private static readonly Color[] _ribbonGroupCollapsedBackContextTracking =
         [
             Color.FromArgb(48, 255, 255, 255),
-                                 Color.FromArgb(235, 235, 235)
+                                                                                        Color.FromArgb(235, 235, 235)
         ];
 
         private static readonly Color[] _ribbonGroupCollapsedBorderContext =
         [
             Color.FromArgb(128, 199, 199, 199),
-                         Color.FromArgb(199, 199, 199),
-                         Color.FromArgb(48, 255, 255, 255),
-                         Color.FromArgb(235, 235, 235)
+                                                                                Color.FromArgb(199, 199, 199),
+                                                                                Color.FromArgb(48, 255, 255, 255),
+                                                                                Color.FromArgb(235, 235, 235)
         ];
 
         private static readonly Color[] _ribbonGroupCollapsedBorderContextTracking =
         [
             Color.FromArgb(128, 168, 184, 196),
-                                 Color.FromArgb(168, 184, 196),
-                                 Color.FromArgb(48, 255, 255, 255),
-                                 Color.FromArgb(192, 207, 220)
+                                                                                        Color.FromArgb(168, 184, 196),
+                                                                                        Color.FromArgb(48, 255, 255, 255),
+                                                                                        Color.FromArgb(192, 207, 220)
         ];
 
         private static readonly Color[] _appButtonNormal =
         [
             Color.FromArgb(243, 245, 248),
-         Color.FromArgb(214, 220, 231),
-         Color.FromArgb(188, 198, 211),
-         Color.FromArgb(254, 254, 255),
-         Color.FromArgb(206, 213, 225)
+                                                                Color.FromArgb(214, 220, 231),
+                                                                Color.FromArgb(188, 198, 211),
+                                                                Color.FromArgb(254, 254, 255),
+                                                                Color.FromArgb(206, 213, 225)
         ];
 
         private static readonly Color[] _appButtonTrack =
         [
             Color.FromArgb(255, 251, 230),
-         Color.FromArgb(180, 210, 255),
-         Color.FromArgb(96, 147, 235),
-         Color.FromArgb(110, 150, 240),
-         Color.FromArgb(115, 155, 245)
+                                                                Color.FromArgb(180, 210, 255),
+                                                                Color.FromArgb(96, 147, 235),
+                                                                Color.FromArgb(110, 150, 240),
+                                                                Color.FromArgb(115, 155, 245)
         ];
 
         private static readonly Color[] _appButtonPressed =
         [
             Color.FromArgb(185, 215, 250),
-         Color.FromArgb(190, 220, 245),
-         Color.FromArgb(98, 155, 230),
-         Color.FromArgb(110, 160, 225),
-         Color.FromArgb(120, 175, 240)
+                                                                Color.FromArgb(190, 220, 245),
+                                                                Color.FromArgb(98, 155, 230),
+                                                                Color.FromArgb(110, 160, 225),
+                                                                Color.FromArgb(120, 175, 240)
         ];
 
         private static readonly Color[] _buttonBorderColors =
         [
             Color.FromArgb(212, 212, 212), // Button, Disabled, Border
-             Color.FromArgb(179, 209, 255), // Button, Tracking, Border 1
-             Color.FromArgb(179, 209, 249), // Button, Tracking, Border 2
-             Color.FromArgb(96, 147, 230), // Button, Pressed, Border 1
-             Color.FromArgb(32, 98, 200), // Button, Pressed, Border 2
-             Color.FromArgb(96, 147, 235), // Button, Checked, Border 1
-             Color.FromArgb(63, 122, 220)  // Button, Checked, Border 2
+                                                                    Color.FromArgb(179, 209, 255), // Button, Tracking, Border 1
+                                                                    Color.FromArgb(179, 209, 249), // Button, Tracking, Border 2
+                                                                    Color.FromArgb(96, 147, 230), // Button, Pressed, Border 1
+                                                                    Color.FromArgb(32, 98, 200), // Button, Pressed, Border 2
+                                                                    Color.FromArgb(96, 147, 235), // Button, Checked, Border 1
+                                                                    Color.FromArgb(63, 122, 220)  // Button, Checked, Border 2
         ];
 
         private static readonly Color[] _buttonBackColors =
         [
             Color.FromArgb(221, 221, 221), // Button, Disabled, Back 1
-         Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
-         Color.FromArgb(141, 168, 203), // Button, Tracking, Back 1
-         Color.FromArgb(95, 127, 169), // Button, Tracking, Back 2
-         Color.FromArgb(96, 150, 220), // Button, Pressed, Back 1
-         Color.FromArgb(179, 209, 247), // Button, Pressed, Back 2
-         Color.FromArgb(32, 98, 183), // Button, Checked, Back 1
-         Color.FromArgb(141, 180, 230), // Button, Checked, Back 2
-         Color.FromArgb(63, 122, 197), // Button, Checked Tracking, Back 1
-         Color.FromArgb(96, 147, 213)  // Button, Checked Tracking, Back 2
+                                                                Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
+                                                                Color.FromArgb(141, 168, 203), // Button, Tracking, Back 1
+                                                                Color.FromArgb(95, 127, 169), // Button, Tracking, Back 2
+                                                                Color.FromArgb(96, 150, 220), // Button, Pressed, Back 1
+                                                                Color.FromArgb(179, 209, 247), // Button, Pressed, Back 2
+                                                                Color.FromArgb(32, 98, 183), // Button, Checked, Back 1
+                                                                Color.FromArgb(141, 180, 230), // Button, Checked, Back 2
+                                                                Color.FromArgb(63, 122, 197), // Button, Checked Tracking, Back 1
+                                                                Color.FromArgb(96, 147, 213)  // Button, Checked Tracking, Back 2
         ];
 
         #endregion
@@ -1878,8 +1878,8 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
                                                 ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
@@ -1902,8 +1902,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuInnerBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm or PaletteBorderStyle.ButtonFormClose => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -1927,8 +1927,8 @@ namespace Krypton.Toolkit
                                          ? _ribbonColours[(int)SchemeOfficeColors.ButtonClusterButtonBorder1]
                                          : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
-     ? GlobalStaticValues.EMPTY_COLOR
-     : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+                                                            ? GlobalStaticValues.EMPTY_COLOR
+                                                            : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBorderStyle.ButtonAlternate
@@ -2004,8 +2004,8 @@ namespace Krypton.Toolkit
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
- ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
- : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                        ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                        : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -2024,8 +2024,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuInnerBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm or PaletteBorderStyle.ButtonFormClose => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -2742,8 +2742,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -2818,8 +2818,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3228,8 +3228,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3302,8 +3302,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueDarkMode.cs
@@ -202,44 +202,38 @@ namespace Krypton.Toolkit
             Color.FromArgb(219, 231, 247), // RibbonQATMini2
             Color.FromArgb(195, 213, 236), // RibbonQATMini3
             Color.FromArgb(128, Color.White), // RibbonQATMini4
-            Color.FromArgb(72, Color.White), // RibbonQATMini5                                                       
+            Color.FromArgb(72, Color.White), // RibbonQATMini5
             Color.FromArgb(153, 176, 206), // RibbonQATMini1I
             Color.FromArgb(226, 233, 241), // RibbonQATMini2I
             Color.FromArgb(198, 210, 226), // RibbonQATMini3I
             Color.FromArgb(128, Color.White), // RibbonQATMini4I
-            Color.FromArgb(72, Color.White), // RibbonQATMini5I                                                      
-            Color.FromArgb(178, 205, 237), // RibbonQATFullbar1                                                      
-            Color.FromArgb(170, 197, 234), // RibbonQATFullbar2                                                      
-            Color.FromArgb(126, 161, 205), // RibbonQATFullbar3                                                      
-            Color.FromArgb(86, 125, 177), // RibbonQATButtonDark                                                      
-            Color.FromArgb(234, 242, 249), // RibbonQATButtonLight                                                      
-            Color.FromArgb(192, 220, 255), // RibbonQATOverflow1                                                      
-            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-            Color.FromArgb(140, 172,
-                211), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(248, 250,
-                252), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(192, 212,
-                241), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(200, 219,
-                238), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(155, 183,
-                224), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(117, 150,
-                191), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor                                                    
-            Color.FromArgb(134, 179, 236), // GridListNormal1                                                    
-            Color.FromArgb(63, 122, 197), // GridListNormal2                                                    
-            Color.FromArgb(63, 122, 197), // GridListPressed1                                                    
-            Color.FromArgb(252, 253, 255), // GridListPressed2                                                    
-            Color.FromArgb(170, 195, 240), // GridListSelected                                                    
-            Color.FromArgb(134, 179, 236), // GridSheetColNormal1                                                    
-            Color.FromArgb(63, 122, 197), // GridSheetColNormal2                                                    
-            Color.FromArgb(223, 226, 228), // GridSheetColPressed1                                                    
-            Color.FromArgb(188, 197, 210), // GridSheetColPressed2                                                    
+            Color.FromArgb(72, Color.White), // RibbonQATMini5I
+            Color.FromArgb(178, 205, 237), // RibbonQATFullbar1
+            Color.FromArgb(170, 197, 234), // RibbonQATFullbar2
+            Color.FromArgb(126, 161, 205), // RibbonQATFullbar3
+            Color.FromArgb(86, 125, 177), // RibbonQATButtonDark
+            Color.FromArgb(234, 242, 249), // RibbonQATButtonLight
+            Color.FromArgb(192, 220, 255), // RibbonQATOverflow1
+            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
+            Color.FromArgb(140, 172, 211), // RibbonGroupSeparatorDark
+            Color.FromArgb(248, 250, 252), // RibbonGroupSeparatorLight
+            Color.FromArgb(192, 212, 241), // ButtonClusterButtonBack1
+            Color.FromArgb(200, 219, 238), // ButtonClusterButtonBack2
+            Color.FromArgb(155, 183, 224), // ButtonClusterButtonBorder1
+            Color.FromArgb(117, 150, 191), // ButtonClusterButtonBorder2
+            Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor
+            Color.FromArgb(134, 179, 236), // GridListNormal1
+            Color.FromArgb(63, 122, 197), // GridListNormal2
+            Color.FromArgb(63, 122, 197), // GridListPressed1
+            Color.FromArgb(252, 253, 255), // GridListPressed2
+            Color.FromArgb(170, 195, 240), // GridListSelected
+            Color.FromArgb(134, 179, 236), // GridSheetColNormal1
+            Color.FromArgb(63, 122, 197), // GridSheetColNormal2
+            Color.FromArgb(223, 226, 228), // GridSheetColPressed1
+            Color.FromArgb(188, 197, 210), // GridSheetColPressed2
             Color.FromArgb(249, 217, 159), // GridSheetColSelected1
             Color.FromArgb(241, 193, 95), // GridSheetColSelected2
-            Color.FromArgb(228, 236, 247), // GridSheetRowNormal                                                   
+            Color.FromArgb(228, 236, 247), // GridSheetRowNormal
             Color.FromArgb(187, 196, 209), // GridSheetRowPressed
             Color.FromArgb(255, 213, 141), // GridSheetRowSelected
             Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -279,6 +273,8 @@ namespace Krypton.Toolkit
             GlobalStaticValues.EMPTY_COLOR, // RibbonTabTracking4
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder3
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder4
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder5
+            Color.FromArgb(21,66, 139), // RibbonGroupTitleText
             GlobalStaticValues.EMPTY_COLOR, // RibbonDropArrowLight
             GlobalStaticValues.EMPTY_COLOR // RibbonDropArrowDark
         ];
@@ -362,42 +358,42 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
-                                                     PaletteButtonSpecStyle.FormClose => state switch
-                                                     {
-                                                         PaletteState.Disabled => _blueCloseDisabled,
-                                                         PaletteState.Tracking => _blueCloseActive,
-                                                         PaletteState.Pressed => _blueClosePressed,
-                                                         _ => _blueCloseNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMin => state switch
-                                                     {
-                                                         PaletteState.Disabled => _blueMinimiseDisabled,
-                                                         PaletteState.Tracking => _blueMinimiseActive,
-                                                         PaletteState.Pressed => _blueMinimisePressed,
-                                                         _ => _blueMinimiseNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMax => state switch
-                                                     {
-                                                         PaletteState.Disabled => _blueMaximiseDisabled,
-                                                         PaletteState.Tracking => _blueMaximiseActive,
-                                                         PaletteState.Pressed => _blueMaximisePressed,
-                                                         _ => _blueMaximiseNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormRestore => state switch
-                                                     {
-                                                         PaletteState.Disabled => _blueRestoreDisabled,
-                                                         PaletteState.Tracking => _blueRestoreActive,
-                                                         PaletteState.Pressed => _blueRestorePressed,
-                                                         _ => _blueRestoreNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormHelp => state switch
-                                                     {
-                                                         PaletteState.Disabled => _blueHelpDisabled,
-                                                         PaletteState.Tracking => _blueHelpActive,
-                                                         PaletteState.Pressed => _blueHelpPressed,
-                                                         _ => _blueHelpNormal
-                                                     },
-                                                     _ => base.GetButtonSpecImage(style, state)
+ PaletteButtonSpecStyle.FormClose => state switch
+ {
+  PaletteState.Disabled => _blueCloseDisabled,
+  PaletteState.Tracking => _blueCloseActive,
+  PaletteState.Pressed => _blueClosePressed,
+  _ => _blueCloseNormal
+ },
+ PaletteButtonSpecStyle.FormMin => state switch
+ {
+  PaletteState.Disabled => _blueMinimiseDisabled,
+  PaletteState.Tracking => _blueMinimiseActive,
+  PaletteState.Pressed => _blueMinimisePressed,
+  _ => _blueMinimiseNormal
+ },
+ PaletteButtonSpecStyle.FormMax => state switch
+ {
+  PaletteState.Disabled => _blueMaximiseDisabled,
+  PaletteState.Tracking => _blueMaximiseActive,
+  PaletteState.Pressed => _blueMaximisePressed,
+  _ => _blueMaximiseNormal
+ },
+ PaletteButtonSpecStyle.FormRestore => state switch
+ {
+  PaletteState.Disabled => _blueRestoreDisabled,
+  PaletteState.Tracking => _blueRestoreActive,
+  PaletteState.Pressed => _blueRestorePressed,
+  _ => _blueRestoreNormal
+ },
+ PaletteButtonSpecStyle.FormHelp => state switch
+ {
+  PaletteState.Disabled => _blueHelpDisabled,
+  PaletteState.Tracking => _blueHelpActive,
+  PaletteState.Pressed => _blueHelpPressed,
+  _ => _blueHelpNormal
+ },
+ _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 
@@ -618,80 +614,80 @@ namespace Krypton.Toolkit
         private static readonly Color[] _ribbonGroupCollapsedBackContext =
         [
             Color.FromArgb(48, 255, 255, 255),
-                                                                                Color.FromArgb(235, 235, 235)
+                         Color.FromArgb(235, 235, 235)
         ];
         private static readonly Color[] _ribbonGroupCollapsedBackContextTracking =
         [
             Color.FromArgb(48, 255, 255, 255),
-                                                                                        Color.FromArgb(235, 235, 235)
+                                 Color.FromArgb(235, 235, 235)
         ];
 
         private static readonly Color[] _ribbonGroupCollapsedBorderContext =
         [
             Color.FromArgb(128, 199, 199, 199),
-                                                                                Color.FromArgb(199, 199, 199),
-                                                                                Color.FromArgb(48, 255, 255, 255),
-                                                                                Color.FromArgb(235, 235, 235)
+                         Color.FromArgb(199, 199, 199),
+                         Color.FromArgb(48, 255, 255, 255),
+                         Color.FromArgb(235, 235, 235)
         ];
 
         private static readonly Color[] _ribbonGroupCollapsedBorderContextTracking =
         [
             Color.FromArgb(128, 168, 184, 196),
-                                                                                        Color.FromArgb(168, 184, 196),
-                                                                                        Color.FromArgb(48, 255, 255, 255),
-                                                                                        Color.FromArgb(192, 207, 220)
+                                 Color.FromArgb(168, 184, 196),
+                                 Color.FromArgb(48, 255, 255, 255),
+                                 Color.FromArgb(192, 207, 220)
         ];
 
         private static readonly Color[] _appButtonNormal =
         [
             Color.FromArgb(243, 245, 248),
-                                                                Color.FromArgb(214, 220, 231),
-                                                                Color.FromArgb(188, 198, 211),
-                                                                Color.FromArgb(254, 254, 255),
-                                                                Color.FromArgb(206, 213, 225)
+         Color.FromArgb(214, 220, 231),
+         Color.FromArgb(188, 198, 211),
+         Color.FromArgb(254, 254, 255),
+         Color.FromArgb(206, 213, 225)
         ];
 
         private static readonly Color[] _appButtonTrack =
         [
             Color.FromArgb(255, 251, 230),
-                                                                Color.FromArgb(180, 210, 255),
-                                                                Color.FromArgb(96, 147, 235),
-                                                                Color.FromArgb(110, 150, 240),
-                                                                Color.FromArgb(115, 155, 245)
+         Color.FromArgb(180, 210, 255),
+         Color.FromArgb(96, 147, 235),
+         Color.FromArgb(110, 150, 240),
+         Color.FromArgb(115, 155, 245)
         ];
 
         private static readonly Color[] _appButtonPressed =
         [
             Color.FromArgb(185, 215, 250),
-                                                                Color.FromArgb(190, 220, 245),
-                                                                Color.FromArgb(98, 155, 230),
-                                                                Color.FromArgb(110, 160, 225),
-                                                                Color.FromArgb(120, 175, 240)
+         Color.FromArgb(190, 220, 245),
+         Color.FromArgb(98, 155, 230),
+         Color.FromArgb(110, 160, 225),
+         Color.FromArgb(120, 175, 240)
         ];
 
         private static readonly Color[] _buttonBorderColors =
         [
             Color.FromArgb(212, 212, 212), // Button, Disabled, Border
-                                                                    Color.FromArgb(179, 209, 255), // Button, Tracking, Border 1
-                                                                    Color.FromArgb(179, 209, 249), // Button, Tracking, Border 2
-                                                                    Color.FromArgb(96, 147, 230), // Button, Pressed, Border 1
-                                                                    Color.FromArgb(32, 98, 200), // Button, Pressed, Border 2
-                                                                    Color.FromArgb(96, 147, 235), // Button, Checked, Border 1
-                                                                    Color.FromArgb(63, 122, 220)  // Button, Checked, Border 2
+             Color.FromArgb(179, 209, 255), // Button, Tracking, Border 1
+             Color.FromArgb(179, 209, 249), // Button, Tracking, Border 2
+             Color.FromArgb(96, 147, 230), // Button, Pressed, Border 1
+             Color.FromArgb(32, 98, 200), // Button, Pressed, Border 2
+             Color.FromArgb(96, 147, 235), // Button, Checked, Border 1
+             Color.FromArgb(63, 122, 220)  // Button, Checked, Border 2
         ];
 
         private static readonly Color[] _buttonBackColors =
         [
             Color.FromArgb(221, 221, 221), // Button, Disabled, Back 1
-                                                                Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
-                                                                Color.FromArgb(141, 168, 203), // Button, Tracking, Back 1
-                                                                Color.FromArgb(95, 127, 169), // Button, Tracking, Back 2
-                                                                Color.FromArgb(96, 150, 220), // Button, Pressed, Back 1
-                                                                Color.FromArgb(179, 209, 247), // Button, Pressed, Back 2
-                                                                Color.FromArgb(32, 98, 183), // Button, Checked, Back 1
-                                                                Color.FromArgb(141, 180, 230), // Button, Checked, Back 2
-                                                                Color.FromArgb(63, 122, 197), // Button, Checked Tracking, Back 1
-                                                                Color.FromArgb(96, 147, 213)  // Button, Checked Tracking, Back 2
+         Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
+         Color.FromArgb(141, 168, 203), // Button, Tracking, Back 1
+         Color.FromArgb(95, 127, 169), // Button, Tracking, Back 2
+         Color.FromArgb(96, 150, 220), // Button, Pressed, Back 1
+         Color.FromArgb(179, 209, 247), // Button, Pressed, Back 2
+         Color.FromArgb(32, 98, 183), // Button, Checked, Back 1
+         Color.FromArgb(141, 180, 230), // Button, Checked, Back 2
+         Color.FromArgb(63, 122, 197), // Button, Checked Tracking, Back 1
+         Color.FromArgb(96, 147, 213)  // Button, Checked Tracking, Back 2
         ];
 
         #endregion
@@ -1882,8 +1878,8 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
                                                 ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
@@ -1906,8 +1902,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuInnerBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm or PaletteBorderStyle.ButtonFormClose => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -1931,8 +1927,8 @@ namespace Krypton.Toolkit
                                          ? _ribbonColours[(int)SchemeOfficeColors.ButtonClusterButtonBorder1]
                                          : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
-                                                            ? GlobalStaticValues.EMPTY_COLOR
-                                                            : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+     ? GlobalStaticValues.EMPTY_COLOR
+     : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBorderStyle.ButtonAlternate
@@ -2008,8 +2004,8 @@ namespace Krypton.Toolkit
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                        : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+ ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+ : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -2028,8 +2024,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuInnerBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm or PaletteBorderStyle.ButtonFormClose => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -2746,8 +2742,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -2822,8 +2818,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3232,8 +3228,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3306,8 +3302,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueLightMode.cs
@@ -360,42 +360,42 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
-  PaletteButtonSpecStyle.FormClose => state switch
-  {
-  PaletteState.Disabled => _blueCloseDisabled,
-  PaletteState.Tracking => _blueCloseActive,
-  PaletteState.Pressed => _blueClosePressed,
-  _ => _blueCloseNormal
-  },
-  PaletteButtonSpecStyle.FormMin => state switch
-  {
-  PaletteState.Disabled => _blueMinimiseDisabled,
-  PaletteState.Tracking => _blueMinimiseActive,
-  PaletteState.Pressed => _blueMinimisePressed,
-  _ => _blueMinimiseNormal
-  },
-  PaletteButtonSpecStyle.FormMax => state switch
-  {
-  PaletteState.Disabled => _blueMaximiseDisabled,
-  PaletteState.Tracking => _blueMaximiseActive,
-  PaletteState.Pressed => _blueMaximisePressed,
-  _ => _blueMaximiseNormal
-  },
-  PaletteButtonSpecStyle.FormRestore => state switch
-  {
-  PaletteState.Disabled => _blueRestoreDisabled,
-  PaletteState.Tracking => _blueRestoreActive,
-  PaletteState.Pressed => _blueRestorePressed,
-  _ => _blueRestoreNormal
-  },
-  PaletteButtonSpecStyle.FormHelp => state switch
-  {
-  PaletteState.Disabled => _blueHelpDisabled,
-  PaletteState.Tracking => _blueHelpActive,
-  PaletteState.Pressed => _blueHelpPressed,
-  _ => _blueHelpNormal
-  },
-  _ => base.GetButtonSpecImage(style, state)
+                                                     PaletteButtonSpecStyle.FormClose => state switch
+                                                     {
+                                                         PaletteState.Disabled => _blueCloseDisabled,
+                                                         PaletteState.Tracking => _blueCloseActive,
+                                                         PaletteState.Pressed => _blueClosePressed,
+                                                         _ => _blueCloseNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMin => state switch
+                                                     {
+                                                         PaletteState.Disabled => _blueMinimiseDisabled,
+                                                         PaletteState.Tracking => _blueMinimiseActive,
+                                                         PaletteState.Pressed => _blueMinimisePressed,
+                                                         _ => _blueMinimiseNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMax => state switch
+                                                     {
+                                                         PaletteState.Disabled => _blueMaximiseDisabled,
+                                                         PaletteState.Tracking => _blueMaximiseActive,
+                                                         PaletteState.Pressed => _blueMaximisePressed,
+                                                         _ => _blueMaximiseNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormRestore => state switch
+                                                     {
+                                                         PaletteState.Disabled => _blueRestoreDisabled,
+                                                         PaletteState.Tracking => _blueRestoreActive,
+                                                         PaletteState.Pressed => _blueRestorePressed,
+                                                         _ => _blueRestoreNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormHelp => state switch
+                                                     {
+                                                         PaletteState.Disabled => _blueHelpDisabled,
+                                                         PaletteState.Tracking => _blueHelpActive,
+                                                         PaletteState.Pressed => _blueHelpPressed,
+                                                         _ => _blueHelpNormal
+                                                     },
+                                                     _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 
@@ -629,25 +629,25 @@ namespace Krypton.Toolkit
         private static readonly Color[] _buttonBorderColors =
         [
             Color.FromArgb(212, 212, 212), // Button, Disabled, Border
-         Color.FromArgb(168, 200, 234), // Button, Tracking, Border 1
-         Color.FromArgb(170, 210, 245), // Button, Tracking, Border 2
-         Color.FromArgb(155, 205, 230), // Button, Pressed, Border 1
-         Color.FromArgb(150, 200, 225), // Button, Pressed, Border 2
-         Color.FromArgb(148, 197,  220), // Button, Checked, Border 1
-         Color.FromArgb(160, 205, 240)  // Button, Checked, Border 2
+                                                                Color.FromArgb(168, 200, 234), // Button, Tracking, Border 1
+                                                                Color.FromArgb(170, 210, 245), // Button, Tracking, Border 2
+                                                                Color.FromArgb(155, 205, 230), // Button, Pressed, Border 1
+                                                                Color.FromArgb(150, 200, 225), // Button, Pressed, Border 2
+                                                                Color.FromArgb(148, 197,  220), // Button, Checked, Border 1
+                                                                Color.FromArgb(160, 205, 240)  // Button, Checked, Border 2
         ];
         private static readonly Color[] _buttonBackColors =
         [
             Color.FromArgb(221, 221, 221), // Button, Disabled, Back 1
-         Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
-         Color.FromArgb(188, 213, 239), // Button, Tracking, Back 1
-         Color.FromArgb(168, 200, 234), // Button, Tracking, Back 2
-         Color.FromArgb(209, 226, 244), // Button, Pressed, Back 1
-         Color.FromArgb(188, 213, 239), // Button, Pressed, Back 2
-         Color.FromArgb(189, 213, 233), // Button, Checked, Back 1
-         Color.FromArgb(188, 213, 239), // Button, Checked, Back 2
-         Color.FromArgb(209, 226, 244), // Button, Checked Tracking, Back 1
-         Color.FromArgb(210, 226, 244)  // Button, Checked Tracking, Back 2
+                                                                Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
+                                                                Color.FromArgb(188, 213, 239), // Button, Tracking, Back 1
+                                                                Color.FromArgb(168, 200, 234), // Button, Tracking, Back 2
+                                                                Color.FromArgb(209, 226, 244), // Button, Pressed, Back 1
+                                                                Color.FromArgb(188, 213, 239), // Button, Pressed, Back 2
+                                                                Color.FromArgb(189, 213, 233), // Button, Checked, Back 1
+                                                                Color.FromArgb(188, 213, 239), // Button, Checked, Back 2
+                                                                Color.FromArgb(209, 226, 244), // Button, Checked Tracking, Back 1
+                                                                Color.FromArgb(210, 226, 244)  // Button, Checked Tracking, Back 2
         ];
 
         #endregion
@@ -1175,8 +1175,8 @@ namespace Krypton.Toolkit
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1] : _buttonBackColors[6],
                         PaletteState.Tracking => _buttonBackColors[2],
                         PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBackStyle.ButtonAlternate
- ? _ribbonColours[(int)SchemeOfficeColors.AlternatePressedBack1]
- : _buttonBackColors[4],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.AlternatePressedBack1]
+                                                    : _buttonBackColors[4],
                         PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1] : _buttonBackColors[8],
                         _ => throw DebugTools.NotImplemented(state.ToString())
                     };
@@ -2354,8 +2354,8 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
- ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
- : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
                                                 ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
@@ -2378,8 +2378,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuInnerBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
- ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
- : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm or PaletteBorderStyle.ButtonFormClose => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -2403,8 +2403,8 @@ namespace Krypton.Toolkit
                                          ? _ribbonColours[(int)SchemeOfficeColors.ButtonClusterButtonBorder1]
                                          : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
-     ? GlobalStaticValues.EMPTY_COLOR
-     : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+                                                            ? GlobalStaticValues.EMPTY_COLOR
+                                                            : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBorderStyle.ButtonAlternate
@@ -2476,12 +2476,12 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
- ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
- : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
- ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
- : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -2500,8 +2500,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuInnerBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
- ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
- : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm or PaletteBorderStyle.ButtonFormClose => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -3218,8 +3218,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3294,8 +3294,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3704,8 +3704,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3778,8 +3778,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueLightMode.cs
@@ -204,44 +204,38 @@ namespace Krypton.Toolkit
             Color.FromArgb(219, 231, 247), // RibbonQATMini2
             Color.FromArgb(195, 213, 236), // RibbonQATMini3
             Color.FromArgb(128, Color.White), // RibbonQATMini4
-            Color.FromArgb(72, Color.White), // RibbonQATMini5                                                       
+            Color.FromArgb(72, Color.White), // RibbonQATMini5
             Color.FromArgb(153, 176, 206), // RibbonQATMini1I
             Color.FromArgb(226, 233, 241), // RibbonQATMini2I
             Color.FromArgb(198, 210, 226), // RibbonQATMini3I
             Color.FromArgb(128, Color.White), // RibbonQATMini4I
-            Color.FromArgb(72, Color.White), // RibbonQATMini5I                                                      
-            Color.FromArgb(178, 205, 237), // RibbonQATFullbar1                                                      
-            Color.FromArgb(170, 197, 234), // RibbonQATFullbar2                                                      
-            Color.FromArgb(126, 161, 205), // RibbonQATFullbar3                                                      
-            Color.FromArgb(86, 125, 177), // RibbonQATButtonDark                                                      
-            Color.FromArgb(234, 242, 249), // RibbonQATButtonLight                                                      
-            Color.FromArgb(192, 220, 255), // RibbonQATOverflow1                                                      
-            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-            Color.FromArgb(140, 172,
-                211), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(248, 250,
-                252), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(192, 212,
-                241), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(200, 219,
-                238), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(155, 183,
-                224), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(117, 150,
-                191), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor                                                    
-            Color.FromArgb(230, 239, 249), // GridListNormal1                                                    
-            Color.FromArgb(209, 226, 244), // GridListNormal2                                                    
-            Color.FromArgb(209, 226, 244), // GridListPressed1                                                    
-            Color.FromArgb(252, 253, 255), // GridListPressed2                                                    
-            Color.FromArgb(168, 200, 234), // GridListSelected                                                    
-            Color.FromArgb(230, 239, 249), // GridSheetColNormal1                                                    
-            Color.FromArgb(209, 226, 244), // GridSheetColNormal2                                                    
-            Color.FromArgb(223, 226, 228), // GridSheetColPressed1                                                    
-            Color.FromArgb(188, 197, 210), // GridSheetColPressed2                                                    
+            Color.FromArgb(72, Color.White), // RibbonQATMini5I
+            Color.FromArgb(178, 205, 237), // RibbonQATFullbar1
+            Color.FromArgb(170, 197, 234), // RibbonQATFullbar2
+            Color.FromArgb(126, 161, 205), // RibbonQATFullbar3
+            Color.FromArgb(86, 125, 177), // RibbonQATButtonDark
+            Color.FromArgb(234, 242, 249), // RibbonQATButtonLight
+            Color.FromArgb(192, 220, 255), // RibbonQATOverflow1
+            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
+            Color.FromArgb(140, 172, 211), // RibbonGroupSeparatorDark
+            Color.FromArgb(248, 250, 252), // RibbonGroupSeparatorLight
+            Color.FromArgb(192, 212, 241), // ButtonClusterButtonBack1
+            Color.FromArgb(200, 219, 238), // ButtonClusterButtonBack2
+            Color.FromArgb(155, 183, 224), // ButtonClusterButtonBorder1
+            Color.FromArgb(117, 150, 191), // ButtonClusterButtonBorder2
+            Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor
+            Color.FromArgb(230, 239, 249), // GridListNormal1
+            Color.FromArgb(209, 226, 244), // GridListNormal2
+            Color.FromArgb(209, 226, 244), // GridListPressed1
+            Color.FromArgb(252, 253, 255), // GridListPressed2
+            Color.FromArgb(168, 200, 234), // GridListSelected
+            Color.FromArgb(230, 239, 249), // GridSheetColNormal1
+            Color.FromArgb(209, 226, 244), // GridSheetColNormal2
+            Color.FromArgb(223, 226, 228), // GridSheetColPressed1
+            Color.FromArgb(188, 197, 210), // GridSheetColPressed2
             Color.FromArgb(188, 213, 239), // GridSheetColSelected1
             Color.FromArgb(168, 200, 234), // GridSheetColSelected2
-            Color.FromArgb(228, 236, 247), // GridSheetRowNormal                                                   
+            Color.FromArgb(228, 236, 247), // GridSheetRowNormal
             Color.FromArgb(187, 196, 209), // GridSheetRowPressed
             Color.FromArgb(255, 213, 141), // GridSheetRowSelected
             Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -281,6 +275,8 @@ namespace Krypton.Toolkit
             GlobalStaticValues.EMPTY_COLOR, // RibbonTabTracking4
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder3
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder4
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder5
+            Color.FromArgb(21,66, 139), // RibbonGroupTitleText
             GlobalStaticValues.EMPTY_COLOR, // RibbonDropArrowLight
             GlobalStaticValues.EMPTY_COLOR // RibbonDropArrowDark
         ];
@@ -364,42 +360,42 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
-                                                     PaletteButtonSpecStyle.FormClose => state switch
-                                                     {
-                                                         PaletteState.Disabled => _blueCloseDisabled,
-                                                         PaletteState.Tracking => _blueCloseActive,
-                                                         PaletteState.Pressed => _blueClosePressed,
-                                                         _ => _blueCloseNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMin => state switch
-                                                     {
-                                                         PaletteState.Disabled => _blueMinimiseDisabled,
-                                                         PaletteState.Tracking => _blueMinimiseActive,
-                                                         PaletteState.Pressed => _blueMinimisePressed,
-                                                         _ => _blueMinimiseNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMax => state switch
-                                                     {
-                                                         PaletteState.Disabled => _blueMaximiseDisabled,
-                                                         PaletteState.Tracking => _blueMaximiseActive,
-                                                         PaletteState.Pressed => _blueMaximisePressed,
-                                                         _ => _blueMaximiseNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormRestore => state switch
-                                                     {
-                                                         PaletteState.Disabled => _blueRestoreDisabled,
-                                                         PaletteState.Tracking => _blueRestoreActive,
-                                                         PaletteState.Pressed => _blueRestorePressed,
-                                                         _ => _blueRestoreNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormHelp => state switch
-                                                     {
-                                                         PaletteState.Disabled => _blueHelpDisabled,
-                                                         PaletteState.Tracking => _blueHelpActive,
-                                                         PaletteState.Pressed => _blueHelpPressed,
-                                                         _ => _blueHelpNormal
-                                                     },
-                                                     _ => base.GetButtonSpecImage(style, state)
+  PaletteButtonSpecStyle.FormClose => state switch
+  {
+  PaletteState.Disabled => _blueCloseDisabled,
+  PaletteState.Tracking => _blueCloseActive,
+  PaletteState.Pressed => _blueClosePressed,
+  _ => _blueCloseNormal
+  },
+  PaletteButtonSpecStyle.FormMin => state switch
+  {
+  PaletteState.Disabled => _blueMinimiseDisabled,
+  PaletteState.Tracking => _blueMinimiseActive,
+  PaletteState.Pressed => _blueMinimisePressed,
+  _ => _blueMinimiseNormal
+  },
+  PaletteButtonSpecStyle.FormMax => state switch
+  {
+  PaletteState.Disabled => _blueMaximiseDisabled,
+  PaletteState.Tracking => _blueMaximiseActive,
+  PaletteState.Pressed => _blueMaximisePressed,
+  _ => _blueMaximiseNormal
+  },
+  PaletteButtonSpecStyle.FormRestore => state switch
+  {
+  PaletteState.Disabled => _blueRestoreDisabled,
+  PaletteState.Tracking => _blueRestoreActive,
+  PaletteState.Pressed => _blueRestorePressed,
+  _ => _blueRestoreNormal
+  },
+  PaletteButtonSpecStyle.FormHelp => state switch
+  {
+  PaletteState.Disabled => _blueHelpDisabled,
+  PaletteState.Tracking => _blueHelpActive,
+  PaletteState.Pressed => _blueHelpPressed,
+  _ => _blueHelpNormal
+  },
+  _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 
@@ -633,25 +629,25 @@ namespace Krypton.Toolkit
         private static readonly Color[] _buttonBorderColors =
         [
             Color.FromArgb(212, 212, 212), // Button, Disabled, Border
-                                                                Color.FromArgb(168, 200, 234), // Button, Tracking, Border 1
-                                                                Color.FromArgb(170, 210, 245), // Button, Tracking, Border 2
-                                                                Color.FromArgb(155, 205, 230), // Button, Pressed, Border 1
-                                                                Color.FromArgb(150, 200, 225), // Button, Pressed, Border 2
-                                                                Color.FromArgb(148, 197,  220), // Button, Checked, Border 1
-                                                                Color.FromArgb(160, 205, 240)  // Button, Checked, Border 2
+         Color.FromArgb(168, 200, 234), // Button, Tracking, Border 1
+         Color.FromArgb(170, 210, 245), // Button, Tracking, Border 2
+         Color.FromArgb(155, 205, 230), // Button, Pressed, Border 1
+         Color.FromArgb(150, 200, 225), // Button, Pressed, Border 2
+         Color.FromArgb(148, 197,  220), // Button, Checked, Border 1
+         Color.FromArgb(160, 205, 240)  // Button, Checked, Border 2
         ];
         private static readonly Color[] _buttonBackColors =
         [
             Color.FromArgb(221, 221, 221), // Button, Disabled, Back 1
-                                                                Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
-                                                                Color.FromArgb(188, 213, 239), // Button, Tracking, Back 1
-                                                                Color.FromArgb(168, 200, 234), // Button, Tracking, Back 2
-                                                                Color.FromArgb(209, 226, 244), // Button, Pressed, Back 1
-                                                                Color.FromArgb(188, 213, 239), // Button, Pressed, Back 2
-                                                                Color.FromArgb(189, 213, 233), // Button, Checked, Back 1
-                                                                Color.FromArgb(188, 213, 239), // Button, Checked, Back 2
-                                                                Color.FromArgb(209, 226, 244), // Button, Checked Tracking, Back 1
-                                                                Color.FromArgb(210, 226, 244)  // Button, Checked Tracking, Back 2
+         Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
+         Color.FromArgb(188, 213, 239), // Button, Tracking, Back 1
+         Color.FromArgb(168, 200, 234), // Button, Tracking, Back 2
+         Color.FromArgb(209, 226, 244), // Button, Pressed, Back 1
+         Color.FromArgb(188, 213, 239), // Button, Pressed, Back 2
+         Color.FromArgb(189, 213, 233), // Button, Checked, Back 1
+         Color.FromArgb(188, 213, 239), // Button, Checked, Back 2
+         Color.FromArgb(209, 226, 244), // Button, Checked Tracking, Back 1
+         Color.FromArgb(210, 226, 244)  // Button, Checked Tracking, Back 2
         ];
 
         #endregion
@@ -1179,8 +1175,8 @@ namespace Krypton.Toolkit
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1] : _buttonBackColors[6],
                         PaletteState.Tracking => _buttonBackColors[2],
                         PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBackStyle.ButtonAlternate
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.AlternatePressedBack1]
-                                                    : _buttonBackColors[4],
+ ? _ribbonColours[(int)SchemeOfficeColors.AlternatePressedBack1]
+ : _buttonBackColors[4],
                         PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack1] : _buttonBackColors[8],
                         _ => throw DebugTools.NotImplemented(state.ToString())
                     };
@@ -2358,8 +2354,8 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+ ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+ : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
                                                 ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
@@ -2382,8 +2378,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuInnerBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+ ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+ : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm or PaletteBorderStyle.ButtonFormClose => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -2407,8 +2403,8 @@ namespace Krypton.Toolkit
                                          ? _ribbonColours[(int)SchemeOfficeColors.ButtonClusterButtonBorder1]
                                          : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
-                                                            ? GlobalStaticValues.EMPTY_COLOR
-                                                            : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+     ? GlobalStaticValues.EMPTY_COLOR
+     : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBorderStyle.ButtonAlternate
@@ -2480,12 +2476,12 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
+ ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
+ : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+ ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+ : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -2504,8 +2500,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuInnerBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+ ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+ : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm or PaletteBorderStyle.ButtonFormClose => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -3222,8 +3218,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3298,8 +3294,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3708,8 +3704,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3782,8 +3778,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverDarkMode.cs
@@ -200,7 +200,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(226, 229, 234), // RibbonGroupFrameInside2
             Color.FromArgb(220, 224, 231), // RibbonGroupFrameInside3
             Color.FromArgb(232, 234, 238), // RibbonGroupFrameInside4
-            Color.FromArgb(76, 83, 92), // RibbonGroupCollapsedText         
+            Color.FromArgb(76, 83, 92), // RibbonGroupCollapsedText
             Color.FromArgb(179, 185, 195), // AlternatePressedBack1
             Color.FromArgb(216, 224, 224), // AlternatePressedBack2
             Color.FromArgb(125, 125, 125), // AlternatePressedBorder1
@@ -214,38 +214,38 @@ namespace Krypton.Toolkit
             Color.FromArgb(210, 215, 221), // RibbonQATMini2
             Color.FromArgb(195, 200, 206), // RibbonQATMini3
             Color.FromArgb(10, Color.White), // RibbonQATMini4
-            Color.FromArgb(32, Color.White), // RibbonQATMini5                                                       
+            Color.FromArgb(32, Color.White), // RibbonQATMini5
             Color.FromArgb(200, 200, 200), // RibbonQATMini1I
             Color.FromArgb(233, 234, 238), // RibbonQATMini2I
             Color.FromArgb(223, 224, 228), // RibbonQATMini3I
             Color.FromArgb(10, Color.White), // RibbonQATMini4I
-            Color.FromArgb(32, Color.White), // RibbonQATMini5I                                                       
-            Color.FromArgb(217, 222, 230), // RibbonQATFullbar1                                                      
-            Color.FromArgb(214, 219, 227), // RibbonQATFullbar2                                                      
-            Color.FromArgb(194, 201, 212), // RibbonQATFullbar3                                                      
-            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark                                                      
-            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
-            Color.FromArgb(219, 218, 228), // RibbonQATOverflow1                                                      
-            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-            Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor                                                    
-            Color.FromArgb(119, 132, 161), // GridListNormal1                                                    
-            Color.FromArgb(83, 99, 136), // GridListNormal2                                                    
-            Color.FromArgb(83, 99, 136), // GridListPressed1                                                    
-            Color.FromArgb(252, 253, 253), // GridListPressed2                                                    
-            Color.FromArgb(83, 99, 136), // GridListSelected                                                    
-            Color.FromArgb(119, 132, 161), // GridSheetColNormal1                                                    
-            Color.FromArgb(83, 99, 136), // GridSheetColNormal2                                                    
-            Color.FromArgb(208, 208, 208), // GridSheetColPressed1                                                    
-            Color.FromArgb(166, 166, 166), // GridSheetColPressed2                                                    
+            Color.FromArgb(32, Color.White), // RibbonQATMini5I
+            Color.FromArgb(217, 222, 230), // RibbonQATFullbar1
+            Color.FromArgb(214, 219, 227), // RibbonQATFullbar2
+            Color.FromArgb(194, 201, 212), // RibbonQATFullbar3
+            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark
+            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight
+            Color.FromArgb(219, 218, 228), // RibbonQATOverflow1
+            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
+            Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark
+            Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight
+            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1
+            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2
+            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1
+            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2
+            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor 
+            Color.FromArgb(119, 132, 161), // GridListNormal1 
+            Color.FromArgb(83, 99, 136), // GridListNormal2 
+            Color.FromArgb(83, 99, 136), // GridListPressed1 
+            Color.FromArgb(252, 253, 253), // GridListPressed2 
+            Color.FromArgb(83, 99, 136), // GridListSelected 
+            Color.FromArgb(119, 132, 161), // GridSheetColNormal1 
+            Color.FromArgb(83, 99, 136), // GridSheetColNormal2 
+            Color.FromArgb(208, 208, 208), // GridSheetColPressed1 
+            Color.FromArgb(166, 166, 166), // GridSheetColPressed2 
             Color.FromArgb(54, 64, 88), // GridSheetColSelected1
             Color.FromArgb(83, 99, 136), // GridSheetColSelected2
-            Color.FromArgb(231, 231, 231), // GridSheetRowNormal                                                   
+            Color.FromArgb(231, 231, 231), // GridSheetRowNormal
             Color.FromArgb(184, 191, 196), // GridSheetRowPressed
             Color.FromArgb(245, 199, 149), // GridSheetRowSelected
             Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -285,6 +285,8 @@ namespace Krypton.Toolkit
             GlobalStaticValues.EMPTY_COLOR, // RibbonTabTracking4
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder3
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder4
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder5
+            Color.FromArgb(24, 24, 24), // RibbonGroupTitleText
             GlobalStaticValues.EMPTY_COLOR, // RibbonDropArrowLight
             GlobalStaticValues.EMPTY_COLOR // RibbonDropArrowDark
         ];
@@ -368,42 +370,42 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
-                                                     PaletteButtonSpecStyle.FormClose => state switch
-                                                     {
-                                                         PaletteState.Disabled => _silverCloseDisabled,
-                                                         PaletteState.Tracking => _silverCloseActive,
-                                                         PaletteState.Pressed => _silverClosePressed,
-                                                         _ => _silverCloseNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMin => state switch
-                                                     {
-                                                         PaletteState.Disabled => _silverMinimiseDisabled,
-                                                         PaletteState.Tracking => _silverMinimiseActive,
-                                                         PaletteState.Pressed => _silverMinimisePressed,
-                                                         _ => _silverMinimiseNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMax => state switch
-                                                     {
-                                                         PaletteState.Disabled => _silverMaximiseDisabled,
-                                                         PaletteState.Tracking => _silverMaximiseActive,
-                                                         PaletteState.Pressed => _silverMaximisePressed,
-                                                         _ => _silverMaximiseNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormRestore => state switch
-                                                     {
-                                                         PaletteState.Disabled => _silverRestoreDisabled,
-                                                         PaletteState.Tracking => _silverRestoreActive,
-                                                         PaletteState.Pressed => _silverRestorePressed,
-                                                         _ => _silverRestoreNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormHelp => state switch
-                                                     {
-                                                         PaletteState.Disabled => _silverHelpDisabled,
-                                                         PaletteState.Tracking => _silverHelpActive,
-                                                         PaletteState.Pressed => _silverHelpPressed,
-                                                         _ => _silverHelpNormal
-                                                     },
-                                                     _ => base.GetButtonSpecImage(style, state)
+  PaletteButtonSpecStyle.FormClose => state switch
+  {
+  PaletteState.Disabled => _silverCloseDisabled,
+  PaletteState.Tracking => _silverCloseActive,
+  PaletteState.Pressed => _silverClosePressed,
+  _ => _silverCloseNormal
+  },
+  PaletteButtonSpecStyle.FormMin => state switch
+  {
+  PaletteState.Disabled => _silverMinimiseDisabled,
+  PaletteState.Tracking => _silverMinimiseActive,
+  PaletteState.Pressed => _silverMinimisePressed,
+  _ => _silverMinimiseNormal
+  },
+  PaletteButtonSpecStyle.FormMax => state switch
+  {
+  PaletteState.Disabled => _silverMaximiseDisabled,
+  PaletteState.Tracking => _silverMaximiseActive,
+  PaletteState.Pressed => _silverMaximisePressed,
+  _ => _silverMaximiseNormal
+  },
+  PaletteButtonSpecStyle.FormRestore => state switch
+  {
+  PaletteState.Disabled => _silverRestoreDisabled,
+  PaletteState.Tracking => _silverRestoreActive,
+  PaletteState.Pressed => _silverRestorePressed,
+  _ => _silverRestoreNormal
+  },
+  PaletteButtonSpecStyle.FormHelp => state switch
+  {
+  PaletteState.Disabled => _silverHelpDisabled,
+  PaletteState.Tracking => _silverHelpActive,
+  PaletteState.Pressed => _silverHelpPressed,
+  _ => _silverHelpNormal
+  },
+  _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion    
 
@@ -2332,8 +2334,8 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+ ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+ : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
                                                 ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
@@ -2381,8 +2383,8 @@ namespace Krypton.Toolkit
                                          ? _ribbonColours[(int)SchemeOfficeColors.ButtonClusterButtonBorder1]
                                          : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
-                                                            ? GlobalStaticValues.EMPTY_COLOR
-                                                            : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+     ? GlobalStaticValues.EMPTY_COLOR
+     : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBorderStyle.ButtonAlternate
@@ -2458,8 +2460,8 @@ namespace Krypton.Toolkit
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                        : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+ ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+ : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -2478,8 +2480,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuInnerBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-                                                        : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+ ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+ : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm or PaletteBorderStyle.ButtonFormClose => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -3196,8 +3198,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3272,8 +3274,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3682,8 +3684,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3756,8 +3758,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverDarkMode.cs
@@ -370,42 +370,42 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
-  PaletteButtonSpecStyle.FormClose => state switch
-  {
-  PaletteState.Disabled => _silverCloseDisabled,
-  PaletteState.Tracking => _silverCloseActive,
-  PaletteState.Pressed => _silverClosePressed,
-  _ => _silverCloseNormal
-  },
-  PaletteButtonSpecStyle.FormMin => state switch
-  {
-  PaletteState.Disabled => _silverMinimiseDisabled,
-  PaletteState.Tracking => _silverMinimiseActive,
-  PaletteState.Pressed => _silverMinimisePressed,
-  _ => _silverMinimiseNormal
-  },
-  PaletteButtonSpecStyle.FormMax => state switch
-  {
-  PaletteState.Disabled => _silverMaximiseDisabled,
-  PaletteState.Tracking => _silverMaximiseActive,
-  PaletteState.Pressed => _silverMaximisePressed,
-  _ => _silverMaximiseNormal
-  },
-  PaletteButtonSpecStyle.FormRestore => state switch
-  {
-  PaletteState.Disabled => _silverRestoreDisabled,
-  PaletteState.Tracking => _silverRestoreActive,
-  PaletteState.Pressed => _silverRestorePressed,
-  _ => _silverRestoreNormal
-  },
-  PaletteButtonSpecStyle.FormHelp => state switch
-  {
-  PaletteState.Disabled => _silverHelpDisabled,
-  PaletteState.Tracking => _silverHelpActive,
-  PaletteState.Pressed => _silverHelpPressed,
-  _ => _silverHelpNormal
-  },
-  _ => base.GetButtonSpecImage(style, state)
+                                                     PaletteButtonSpecStyle.FormClose => state switch
+                                                     {
+                                                         PaletteState.Disabled => _silverCloseDisabled,
+                                                         PaletteState.Tracking => _silverCloseActive,
+                                                         PaletteState.Pressed => _silverClosePressed,
+                                                         _ => _silverCloseNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMin => state switch
+                                                     {
+                                                         PaletteState.Disabled => _silverMinimiseDisabled,
+                                                         PaletteState.Tracking => _silverMinimiseActive,
+                                                         PaletteState.Pressed => _silverMinimisePressed,
+                                                         _ => _silverMinimiseNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMax => state switch
+                                                     {
+                                                         PaletteState.Disabled => _silverMaximiseDisabled,
+                                                         PaletteState.Tracking => _silverMaximiseActive,
+                                                         PaletteState.Pressed => _silverMaximisePressed,
+                                                         _ => _silverMaximiseNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormRestore => state switch
+                                                     {
+                                                         PaletteState.Disabled => _silverRestoreDisabled,
+                                                         PaletteState.Tracking => _silverRestoreActive,
+                                                         PaletteState.Pressed => _silverRestorePressed,
+                                                         _ => _silverRestoreNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormHelp => state switch
+                                                     {
+                                                         PaletteState.Disabled => _silverHelpDisabled,
+                                                         PaletteState.Tracking => _silverHelpActive,
+                                                         PaletteState.Pressed => _silverHelpPressed,
+                                                         _ => _silverHelpNormal
+                                                     },
+                                                     _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion    
 
@@ -2334,8 +2334,8 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
- ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
- : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
                                                 ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
@@ -2383,8 +2383,8 @@ namespace Krypton.Toolkit
                                          ? _ribbonColours[(int)SchemeOfficeColors.ButtonClusterButtonBorder1]
                                          : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
-     ? GlobalStaticValues.EMPTY_COLOR
-     : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+                                                            ? GlobalStaticValues.EMPTY_COLOR
+                                                            : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBorderStyle.ButtonAlternate
@@ -2460,8 +2460,8 @@ namespace Krypton.Toolkit
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
- ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
- : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                        ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                        : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -2480,8 +2480,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuInnerBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
- ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
- : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+                                                        ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+                                                        : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm or PaletteBorderStyle.ButtonFormClose => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -3198,8 +3198,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3274,8 +3274,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3684,8 +3684,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3758,8 +3758,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverLightMode.cs
@@ -200,7 +200,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(226, 229, 234), // RibbonGroupFrameInside2
             Color.FromArgb(220, 224, 231), // RibbonGroupFrameInside3
             Color.FromArgb(232, 234, 238), // RibbonGroupFrameInside4
-            Color.FromArgb(76, 83, 92), // RibbonGroupCollapsedText         
+            Color.FromArgb(76, 83, 92), // RibbonGroupCollapsedText
             Color.FromArgb(179, 185, 195), // AlternatePressedBack1
             Color.FromArgb(216, 224, 224), // AlternatePressedBack2
             Color.FromArgb(125, 125, 125), // AlternatePressedBorder1
@@ -214,38 +214,38 @@ namespace Krypton.Toolkit
             Color.FromArgb(210, 215, 221), // RibbonQATMini2
             Color.FromArgb(195, 200, 206), // RibbonQATMini3
             Color.FromArgb(10, Color.White), // RibbonQATMini4
-            Color.FromArgb(32, Color.White), // RibbonQATMini5                                                       
+            Color.FromArgb(32, Color.White), // RibbonQATMini5
             Color.FromArgb(200, 200, 200), // RibbonQATMini1I
             Color.FromArgb(233, 234, 238), // RibbonQATMini2I
             Color.FromArgb(223, 224, 228), // RibbonQATMini3I
             Color.FromArgb(10, Color.White), // RibbonQATMini4I
-            Color.FromArgb(32, Color.White), // RibbonQATMini5I                                                       
-            Color.FromArgb(217, 222, 230), // RibbonQATFullbar1                                                      
-            Color.FromArgb(214, 219, 227), // RibbonQATFullbar2                                                      
-            Color.FromArgb(194, 201, 212), // RibbonQATFullbar3                                                      
-            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark                                                      
-            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
-            Color.FromArgb(219, 218, 228), // RibbonQATOverflow1                                                      
-            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-            Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor                                                    
-            Color.FromArgb(224, 225, 231), // GridListNormal1                                                    
-            Color.FromArgb(195, 198, 209), // GridListNormal2                                                    
-            Color.FromArgb(195, 198, 209), // GridListPressed1                                                    
-            Color.FromArgb(252, 253, 253), // GridListPressed2                                                    
-            Color.FromArgb(195, 198, 209), // GridListSelected                                                    
-            Color.FromArgb(224, 225, 231), // GridSheetColNormal1                                                    
-            Color.FromArgb(195, 198, 209), // GridSheetColNormal2                                                    
-            Color.FromArgb(208, 208, 208), // GridSheetColPressed1                                                    
-            Color.FromArgb(166, 166, 166), // GridSheetColPressed2                                                    
+            Color.FromArgb(32, Color.White), // RibbonQATMini5I
+            Color.FromArgb(217, 222, 230), // RibbonQATFullbar1
+            Color.FromArgb(214, 219, 227), // RibbonQATFullbar2
+            Color.FromArgb(194, 201, 212), // RibbonQATFullbar3
+            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark
+            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight
+            Color.FromArgb(219, 218, 228), // RibbonQATOverflow1
+            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
+            Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark
+            Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight
+            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1
+            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2
+            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1
+            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2
+            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor 
+            Color.FromArgb(224, 225, 231), // GridListNormal1
+            Color.FromArgb(195, 198, 209), // GridListNormal2
+            Color.FromArgb(195, 198, 209), // GridListPressed1
+            Color.FromArgb(252, 253, 253), // GridListPressed2
+            Color.FromArgb(195, 198, 209), // GridListSelected
+            Color.FromArgb(224, 225, 231), // GridSheetColNormal1
+            Color.FromArgb(195, 198, 209), // GridSheetColNormal2
+            Color.FromArgb(208, 208, 208), // GridSheetColPressed1
+            Color.FromArgb(166, 166, 166), // GridSheetColPressed2
             Color.FromArgb(54, 64, 88), // GridSheetColSelected1
             Color.FromArgb(195, 198, 209), // GridSheetColSelected2
-            Color.FromArgb(231, 231, 231), // GridSheetRowNormal                                                   
+            Color.FromArgb(231, 231, 231), // GridSheetRowNormal
             Color.FromArgb(184, 191, 196), // GridSheetRowPressed
             Color.FromArgb(245, 199, 149), // GridSheetRowSelected
             Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -285,6 +285,8 @@ namespace Krypton.Toolkit
             GlobalStaticValues.EMPTY_COLOR, // RibbonTabTracking4
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder3
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder4
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder5
+            Color.FromArgb(24, 24, 24), // RibbonGroupTitleText
             GlobalStaticValues.EMPTY_COLOR, // RibbonDropArrowLight
             GlobalStaticValues.EMPTY_COLOR // RibbonDropArrowDark
         ];
@@ -368,42 +370,42 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
-                                                     PaletteButtonSpecStyle.FormClose => state switch
-                                                     {
-                                                         PaletteState.Disabled => _silverCloseDisabled,
-                                                         PaletteState.Tracking => _silverCloseActive,
-                                                         PaletteState.Pressed => _silverClosePressed,
-                                                         _ => _silverCloseNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMin => state switch
-                                                     {
-                                                         PaletteState.Disabled => _silverMinimiseDisabled,
-                                                         PaletteState.Tracking => _silverMinimiseActive,
-                                                         PaletteState.Pressed => _silverMinimisePressed,
-                                                         _ => _silverMinimiseNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMax => state switch
-                                                     {
-                                                         PaletteState.Disabled => _silverMaximiseDisabled,
-                                                         PaletteState.Tracking => _silverMaximiseActive,
-                                                         PaletteState.Pressed => _silverMaximisePressed,
-                                                         _ => _silverMaximiseNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormRestore => state switch
-                                                     {
-                                                         PaletteState.Disabled => _silverRestoreDisabled,
-                                                         PaletteState.Tracking => _silverRestoreActive,
-                                                         PaletteState.Pressed => _silverRestorePressed,
-                                                         _ => _silverRestoreNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormHelp => state switch
-                                                     {
-                                                         PaletteState.Disabled => _silverHelpDisabled,
-                                                         PaletteState.Tracking => _silverHelpActive,
-                                                         PaletteState.Pressed => _silverHelpPressed,
-                                                         _ => _silverHelpNormal
-                                                     },
-                                                     _ => base.GetButtonSpecImage(style, state)
+  PaletteButtonSpecStyle.FormClose => state switch
+  {
+  PaletteState.Disabled => _silverCloseDisabled,
+  PaletteState.Tracking => _silverCloseActive,
+  PaletteState.Pressed => _silverClosePressed,
+  _ => _silverCloseNormal
+  },
+  PaletteButtonSpecStyle.FormMin => state switch
+  {
+  PaletteState.Disabled => _silverMinimiseDisabled,
+  PaletteState.Tracking => _silverMinimiseActive,
+  PaletteState.Pressed => _silverMinimisePressed,
+  _ => _silverMinimiseNormal
+  },
+  PaletteButtonSpecStyle.FormMax => state switch
+  {
+  PaletteState.Disabled => _silverMaximiseDisabled,
+  PaletteState.Tracking => _silverMaximiseActive,
+  PaletteState.Pressed => _silverMaximisePressed,
+  _ => _silverMaximiseNormal
+  },
+  PaletteButtonSpecStyle.FormRestore => state switch
+  {
+  PaletteState.Disabled => _silverRestoreDisabled,
+  PaletteState.Tracking => _silverRestoreActive,
+  PaletteState.Pressed => _silverRestorePressed,
+  _ => _silverRestoreNormal
+  },
+  PaletteButtonSpecStyle.FormHelp => state switch
+  {
+  PaletteState.Disabled => _silverHelpDisabled,
+  PaletteState.Tracking => _silverHelpActive,
+  PaletteState.Pressed => _silverHelpPressed,
+  _ => _silverHelpNormal
+  },
+  _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion    
 
@@ -2379,8 +2381,8 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+ ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+ : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
                                                 ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
@@ -2428,8 +2430,8 @@ namespace Krypton.Toolkit
                                              ? _ribbonColours[(int)SchemeOfficeColors.ButtonClusterButtonBorder1]
                                              : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
-                                                    ? GlobalStaticValues.EMPTY_COLOR
-                                                    : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+ ? GlobalStaticValues.EMPTY_COLOR
+ : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBorderStyle.ButtonAlternate
@@ -2509,8 +2511,8 @@ namespace Krypton.Toolkit
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+ ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+ : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -2529,8 +2531,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuInnerBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+ ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+ : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm or PaletteBorderStyle.ButtonFormClose => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -3247,8 +3249,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3323,8 +3325,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3733,8 +3735,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3807,8 +3809,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverLightMode.cs
@@ -370,42 +370,42 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
-  PaletteButtonSpecStyle.FormClose => state switch
-  {
-  PaletteState.Disabled => _silverCloseDisabled,
-  PaletteState.Tracking => _silverCloseActive,
-  PaletteState.Pressed => _silverClosePressed,
-  _ => _silverCloseNormal
-  },
-  PaletteButtonSpecStyle.FormMin => state switch
-  {
-  PaletteState.Disabled => _silverMinimiseDisabled,
-  PaletteState.Tracking => _silverMinimiseActive,
-  PaletteState.Pressed => _silverMinimisePressed,
-  _ => _silverMinimiseNormal
-  },
-  PaletteButtonSpecStyle.FormMax => state switch
-  {
-  PaletteState.Disabled => _silverMaximiseDisabled,
-  PaletteState.Tracking => _silverMaximiseActive,
-  PaletteState.Pressed => _silverMaximisePressed,
-  _ => _silverMaximiseNormal
-  },
-  PaletteButtonSpecStyle.FormRestore => state switch
-  {
-  PaletteState.Disabled => _silverRestoreDisabled,
-  PaletteState.Tracking => _silverRestoreActive,
-  PaletteState.Pressed => _silverRestorePressed,
-  _ => _silverRestoreNormal
-  },
-  PaletteButtonSpecStyle.FormHelp => state switch
-  {
-  PaletteState.Disabled => _silverHelpDisabled,
-  PaletteState.Tracking => _silverHelpActive,
-  PaletteState.Pressed => _silverHelpPressed,
-  _ => _silverHelpNormal
-  },
-  _ => base.GetButtonSpecImage(style, state)
+                                                     PaletteButtonSpecStyle.FormClose => state switch
+                                                     {
+                                                         PaletteState.Disabled => _silverCloseDisabled,
+                                                         PaletteState.Tracking => _silverCloseActive,
+                                                         PaletteState.Pressed => _silverClosePressed,
+                                                         _ => _silverCloseNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMin => state switch
+                                                     {
+                                                         PaletteState.Disabled => _silverMinimiseDisabled,
+                                                         PaletteState.Tracking => _silverMinimiseActive,
+                                                         PaletteState.Pressed => _silverMinimisePressed,
+                                                         _ => _silverMinimiseNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMax => state switch
+                                                     {
+                                                         PaletteState.Disabled => _silverMaximiseDisabled,
+                                                         PaletteState.Tracking => _silverMaximiseActive,
+                                                         PaletteState.Pressed => _silverMaximisePressed,
+                                                         _ => _silverMaximiseNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormRestore => state switch
+                                                     {
+                                                         PaletteState.Disabled => _silverRestoreDisabled,
+                                                         PaletteState.Tracking => _silverRestoreActive,
+                                                         PaletteState.Pressed => _silverRestorePressed,
+                                                         _ => _silverRestoreNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormHelp => state switch
+                                                     {
+                                                         PaletteState.Disabled => _silverHelpDisabled,
+                                                         PaletteState.Tracking => _silverHelpActive,
+                                                         PaletteState.Pressed => _silverHelpPressed,
+                                                         _ => _silverHelpNormal
+                                                     },
+                                                     _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion    
 
@@ -2381,8 +2381,8 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
- ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
- : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
                                                 ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
@@ -2430,8 +2430,8 @@ namespace Krypton.Toolkit
                                              ? _ribbonColours[(int)SchemeOfficeColors.ButtonClusterButtonBorder1]
                                              : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
- ? GlobalStaticValues.EMPTY_COLOR
- : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+                                                    ? GlobalStaticValues.EMPTY_COLOR
+                                                    : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBorderStyle.ButtonAlternate
@@ -2511,8 +2511,8 @@ namespace Krypton.Toolkit
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
- ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
- : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -2531,8 +2531,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuInnerBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
- ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
- : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm or PaletteBorderStyle.ButtonFormClose => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -3249,8 +3249,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3325,8 +3325,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3735,8 +3735,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3809,8 +3809,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Non Official Themes/PaletteOffice2007DarkGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Non Official Themes/PaletteOffice2007DarkGray.cs
@@ -196,7 +196,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(226, 229, 234), // RibbonGroupFrameInside2
             Color.FromArgb(220, 224, 231), // RibbonGroupFrameInside3
             Color.FromArgb(232, 234, 238), // RibbonGroupFrameInside4
-            Color.FromArgb(68, 68, 68), // RibbonGroupCollapsedText         
+            Color.FromArgb(68, 68, 68), // RibbonGroupCollapsedText
             Color.FromArgb(179, 185, 195), // AlternatePressedBack1
             Color.FromArgb(216, 224, 224), // AlternatePressedBack2
             Color.FromArgb(125, 125, 125), // AlternatePressedBorder1
@@ -210,38 +210,38 @@ namespace Krypton.Toolkit
             Color.FromArgb(210, 215, 221), // RibbonQATMini2
             Color.FromArgb(195, 200, 206), // RibbonQATMini3
             Color.FromArgb(10, Color.White), // RibbonQATMini4
-            Color.FromArgb(32, Color.White), // RibbonQATMini5                                                       
+            Color.FromArgb(32, Color.White), // RibbonQATMini5
             Color.FromArgb(200, 200, 200), // RibbonQATMini1I
             Color.FromArgb(233, 234, 238), // RibbonQATMini2I
             Color.FromArgb(223, 224, 228), // RibbonQATMini3I
             Color.FromArgb(10, Color.White), // RibbonQATMini4I
-            Color.FromArgb(32, Color.White), // RibbonQATMini5I                                                       
-            Color.FromArgb(217, 222, 230), // RibbonQATFullbar1                                                      
-            Color.FromArgb(214, 219, 227), // RibbonQATFullbar2                                                      
-            Color.FromArgb(194, 201, 212), // RibbonQATFullbar3                                                      
-            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark                                                      
-            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
-            Color.FromArgb(219, 218, 228), // RibbonQATOverflow1                                                      
-            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-            Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor                                                    
-            Color.White, // GridListNormal1                                                    
-            Color.FromArgb(212, 215, 219), // GridListNormal2                                                    
-            Color.FromArgb(210, 213, 218), // GridListPressed1                                                    
-            Color.FromArgb(252, 253, 253), // GridListPressed2                                                    
-            Color.FromArgb(186, 189, 194), // GridListSelected                                                    
-            Color.FromArgb(241, 243, 243), // GridSheetColNormal1                                                    
-            Color.FromArgb(200, 201, 202), // GridSheetColNormal2                                                    
-            Color.FromArgb(208, 208, 208), // GridSheetColPressed1                                                    
-            Color.FromArgb(166, 166, 166), // GridSheetColPressed2                                                    
+            Color.FromArgb(32, Color.White), // RibbonQATMini5I
+            Color.FromArgb(217, 222, 230), // RibbonQATFullbar1
+            Color.FromArgb(214, 219, 227), // RibbonQATFullbar2
+            Color.FromArgb(194, 201, 212), // RibbonQATFullbar3
+            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark
+            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight
+            Color.FromArgb(219, 218, 228), // RibbonQATOverflow1
+            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
+            Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark
+            Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight
+            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1
+            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2
+            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1
+            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2
+            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor 
+            Color.White, // GridListNormal1 
+            Color.FromArgb(212, 215, 219), // GridListNormal2 
+            Color.FromArgb(210, 213, 218), // GridListPressed1 
+            Color.FromArgb(252, 253, 253), // GridListPressed2 
+            Color.FromArgb(186, 189, 194), // GridListSelected 
+            Color.FromArgb(241, 243, 243), // GridSheetColNormal1 
+            Color.FromArgb(200, 201, 202), // GridSheetColNormal2 
+            Color.FromArgb(208, 208, 208), // GridSheetColPressed1 
+            Color.FromArgb(166, 166, 166), // GridSheetColPressed2 
             Color.FromArgb(255, 204, 153), // GridSheetColSelected1
             Color.FromArgb(255, 155, 104), // GridSheetColSelected2
-            Color.FromArgb(231, 231, 231), // GridSheetRowNormal                                                   
+            Color.FromArgb(231, 231, 231), // GridSheetRowNormal
             Color.FromArgb(184, 191, 196), // GridSheetRowPressed
             Color.FromArgb(245, 199, 149), // GridSheetRowSelected
             Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -281,6 +281,8 @@ namespace Krypton.Toolkit
             GlobalStaticValues.EMPTY_COLOR, // RibbonTabTracking4
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder3
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder4
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder5
+            Color.FromArgb(119, 119, 119), // RibbonGroupTitleText
             GlobalStaticValues.EMPTY_COLOR, // RibbonDropArrowLight
             GlobalStaticValues.EMPTY_COLOR // RibbonDropArrowDark
         ];

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Non Official Themes/PaletteOffice2007White.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Non Official Themes/PaletteOffice2007White.cs
@@ -376,42 +376,42 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
-  PaletteButtonSpecStyle.FormClose => state switch
-  {
-  PaletteState.Disabled => _silverCloseDisabled,
-  PaletteState.Tracking => _silverCloseActive,
-  PaletteState.Pressed => _silverClosePressed,
-  _ => _silverCloseNormal
-  },
-  PaletteButtonSpecStyle.FormMin => state switch
-  {
-  PaletteState.Disabled => _silverMinimiseDisabled,
-  PaletteState.Tracking => _silverMinimiseActive,
-  PaletteState.Pressed => _silverMinimisePressed,
-  _ => _silverMinimiseNormal
-  },
-  PaletteButtonSpecStyle.FormMax => state switch
-  {
-  PaletteState.Disabled => _silverMaximiseDisabled,
-  PaletteState.Tracking => _silverMaximiseActive,
-  PaletteState.Pressed => _silverMaximisePressed,
-  _ => _silverMaximiseNormal
-  },
-  PaletteButtonSpecStyle.FormRestore => state switch
-  {
-  PaletteState.Disabled => _silverRestoreDisabled,
-  PaletteState.Tracking => _silverRestoreActive,
-  PaletteState.Pressed => _silverRestorePressed,
-  _ => _silverRestoreNormal
-  },
-  PaletteButtonSpecStyle.FormHelp => state switch
-  {
-  PaletteState.Disabled => _silverHelpDisabled,
-  PaletteState.Tracking => _silverHelpActive,
-  PaletteState.Pressed => _silverHelpPressed,
-  _ => _silverHelpNormal
-  },
-  _ => base.GetButtonSpecImage(style, state)
+                                                     PaletteButtonSpecStyle.FormClose => state switch
+                                                     {
+                                                         PaletteState.Disabled => _silverCloseDisabled,
+                                                         PaletteState.Tracking => _silverCloseActive,
+                                                         PaletteState.Pressed => _silverClosePressed,
+                                                         _ => _silverCloseNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMin => state switch
+                                                     {
+                                                         PaletteState.Disabled => _silverMinimiseDisabled,
+                                                         PaletteState.Tracking => _silverMinimiseActive,
+                                                         PaletteState.Pressed => _silverMinimisePressed,
+                                                         _ => _silverMinimiseNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMax => state switch
+                                                     {
+                                                         PaletteState.Disabled => _silverMaximiseDisabled,
+                                                         PaletteState.Tracking => _silverMaximiseActive,
+                                                         PaletteState.Pressed => _silverMaximisePressed,
+                                                         _ => _silverMaximiseNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormRestore => state switch
+                                                     {
+                                                         PaletteState.Disabled => _silverRestoreDisabled,
+                                                         PaletteState.Tracking => _silverRestoreActive,
+                                                         PaletteState.Pressed => _silverRestorePressed,
+                                                         _ => _silverRestoreNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormHelp => state switch
+                                                     {
+                                                         PaletteState.Disabled => _silverHelpDisabled,
+                                                         PaletteState.Tracking => _silverHelpActive,
+                                                         PaletteState.Pressed => _silverHelpPressed,
+                                                         _ => _silverHelpNormal
+                                                     },
+                                                     _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion    
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Non Official Themes/PaletteOffice2007White.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Non Official Themes/PaletteOffice2007White.cs
@@ -209,38 +209,38 @@ namespace Krypton.Toolkit
             Color.FromArgb(210, 215, 221),    // RibbonQATMini2
             Color.FromArgb(195, 200, 206),    // RibbonQATMini3
             Color.FromArgb(10, Color.White),  // RibbonQATMini4
-            Color.FromArgb(32, Color.White),  // RibbonQATMini5                                                       
+            Color.FromArgb(32, Color.White),  // RibbonQATMini5
             Color.FromArgb(200, 200, 200),    // RibbonQATMini1I
             Color.FromArgb(233, 234, 238),    // RibbonQATMini2I
             Color.FromArgb(223, 224, 228),    // RibbonQATMini3I
             Color.FromArgb(10, Color.White),  // RibbonQATMini4I
-            Color.FromArgb(32, Color.White),  // RibbonQATMini5I                                                       
-            Color.FromArgb(223, 227, 234),    // RibbonQATFullbar1                                                      
-            Color.FromArgb(213, 217, 222),    // RibbonQATFullbar2                                                      
-            Color.FromArgb(135, 140, 146),    // RibbonQATFullbar3                                                      
-            Color.FromArgb( 90,  90,  90),    // RibbonQATButtonDark                                                      
-            Color.FromArgb(210, 212, 215),    // RibbonQATButtonLight                                                      
-            Color.FromArgb(233, 237, 241),    // RibbonQATOverflow1                                                      
-            Color.FromArgb(138, 144, 150),    // RibbonQATOverflow2                                                      
-            Color.FromArgb(191, 195, 199),    // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(255, 255, 255),    // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(231, 234, 238),    // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(241, 243, 243),    // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(197, 198, 199),    // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(157, 158, 159),    // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(238, 238, 244),    // NavigatorMiniBackColor                                                    
-            Color.White,    // GridListNormal1                                                    
-            Color.White,    // GridListNormal2                                                    
-            Color.FromArgb(203, 207, 212),    // GridListPressed1                                                    
-            Color.White,                      // GridListPressed2                                                    
-            Color.FromArgb(186, 189, 194),    // GridListSelected                                                    
-            Color.FromArgb(238, 241, 247),    // GridSheetColNormal1                                                    
-            Color.FromArgb(218, 222, 227),    // GridSheetColNormal2                                                    
-            Color.FromArgb(255, 223, 107),    // GridSheetColPressed1                                                    
-            Color.FromArgb(255, 252, 230),    // GridSheetColPressed2                                                    
+            Color.FromArgb(32, Color.White),  // RibbonQATMini5I
+            Color.FromArgb(223, 227, 234),    // RibbonQATFullbar1
+            Color.FromArgb(213, 217, 222),    // RibbonQATFullbar2
+            Color.FromArgb(135, 140, 146),    // RibbonQATFullbar3
+            Color.FromArgb( 90,  90,  90),    // RibbonQATButtonDark
+            Color.FromArgb(210, 212, 215),    // RibbonQATButtonLight
+            Color.FromArgb(233, 237, 241),    // RibbonQATOverflow1
+            Color.FromArgb(138, 144, 150),    // RibbonQATOverflow2
+            Color.FromArgb(191, 195, 199),    // RibbonGroupSeparatorDark
+            Color.FromArgb(255, 255, 255),    // RibbonGroupSeparatorLight
+            Color.FromArgb(231, 234, 238),    // ButtonClusterButtonBack1
+            Color.FromArgb(241, 243, 243),    // ButtonClusterButtonBack2
+            Color.FromArgb(197, 198, 199),    // ButtonClusterButtonBorder1
+            Color.FromArgb(157, 158, 159),    // ButtonClusterButtonBorder2
+            Color.FromArgb(238, 238, 244),    // NavigatorMiniBackColor 
+            Color.White,    // GridListNormal1 
+            Color.White,    // GridListNormal2 
+            Color.FromArgb(203, 207, 212),    // GridListPressed1 
+            Color.White,                      // GridListPressed2 
+            Color.FromArgb(186, 189, 194),    // GridListSelected 
+            Color.FromArgb(238, 241, 247),    // GridSheetColNormal1 
+            Color.FromArgb(218, 222, 227),    // GridSheetColNormal2 
+            Color.FromArgb(255, 223, 107),    // GridSheetColPressed1 
+            Color.FromArgb(255, 252, 230),    // GridSheetColPressed2 
             Color.FromArgb(255, 211,  89),    // GridSheetColSelected1
             Color.FromArgb(255, 239, 113),    // GridSheetColSelected2
-            Color.FromArgb(223, 227, 232),    // GridSheetRowNormal                                                   
+            Color.FromArgb(223, 227, 232),    // GridSheetRowNormal
             Color.FromArgb(255, 223, 107),    // GridSheetRowPressed
             Color.FromArgb(245, 210,  87),    // GridSheetRowSelected
             Color.FromArgb(218, 220, 221),    // GridDataCellBorder
@@ -275,7 +275,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(255, 255, 255),    // RibbonGalleryBackNormal
             Color.FromArgb(255, 255, 255),    // RibbonGalleryBackTracking
             Color.FromArgb(250, 250, 250),    // RibbonGalleryBack1
-            Color.FromArgb(228, 231, 235),    // RibbonGalleryBack2                                                                                                                                      Color.FromArgb(177, 181, 186),    // RibbonTabTracking1
+            Color.FromArgb(228, 231, 235),    // RibbonGalleryBack2    Color.FromArgb(177, 181, 186),    // RibbonTabTracking1
             Color.FromArgb(229, 231, 235),    // RibbonTabTracking3
             Color.FromArgb(231, 233, 235),    // RibbonTabTracking4
             Color.FromArgb(176, 182, 188),    // RibbonGroupBorder3
@@ -294,7 +294,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(225, 226, 230),    // ButtonNavigatorPressed2
             Color.FromArgb(222, 227, 234),    // ButtonNavigatorChecked1
             Color.FromArgb(206, 214, 221),    // ButtonNavigatorChecked2
-            Color.FromArgb(221, 221, 221) // ToolTipBottom                                                                      
+            Color.FromArgb(221, 221, 221) // ToolTipBottom
         ];
 
         #endregion
@@ -376,42 +376,42 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
-                                                     PaletteButtonSpecStyle.FormClose => state switch
-                                                     {
-                                                         PaletteState.Disabled => _silverCloseDisabled,
-                                                         PaletteState.Tracking => _silverCloseActive,
-                                                         PaletteState.Pressed => _silverClosePressed,
-                                                         _ => _silverCloseNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMin => state switch
-                                                     {
-                                                         PaletteState.Disabled => _silverMinimiseDisabled,
-                                                         PaletteState.Tracking => _silverMinimiseActive,
-                                                         PaletteState.Pressed => _silverMinimisePressed,
-                                                         _ => _silverMinimiseNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMax => state switch
-                                                     {
-                                                         PaletteState.Disabled => _silverMaximiseDisabled,
-                                                         PaletteState.Tracking => _silverMaximiseActive,
-                                                         PaletteState.Pressed => _silverMaximisePressed,
-                                                         _ => _silverMaximiseNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormRestore => state switch
-                                                     {
-                                                         PaletteState.Disabled => _silverRestoreDisabled,
-                                                         PaletteState.Tracking => _silverRestoreActive,
-                                                         PaletteState.Pressed => _silverRestorePressed,
-                                                         _ => _silverRestoreNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormHelp => state switch
-                                                     {
-                                                         PaletteState.Disabled => _silverHelpDisabled,
-                                                         PaletteState.Tracking => _silverHelpActive,
-                                                         PaletteState.Pressed => _silverHelpPressed,
-                                                         _ => _silverHelpNormal
-                                                     },
-                                                     _ => base.GetButtonSpecImage(style, state)
+  PaletteButtonSpecStyle.FormClose => state switch
+  {
+  PaletteState.Disabled => _silverCloseDisabled,
+  PaletteState.Tracking => _silverCloseActive,
+  PaletteState.Pressed => _silverClosePressed,
+  _ => _silverCloseNormal
+  },
+  PaletteButtonSpecStyle.FormMin => state switch
+  {
+  PaletteState.Disabled => _silverMinimiseDisabled,
+  PaletteState.Tracking => _silverMinimiseActive,
+  PaletteState.Pressed => _silverMinimisePressed,
+  _ => _silverMinimiseNormal
+  },
+  PaletteButtonSpecStyle.FormMax => state switch
+  {
+  PaletteState.Disabled => _silverMaximiseDisabled,
+  PaletteState.Tracking => _silverMaximiseActive,
+  PaletteState.Pressed => _silverMaximisePressed,
+  _ => _silverMaximiseNormal
+  },
+  PaletteButtonSpecStyle.FormRestore => state switch
+  {
+  PaletteState.Disabled => _silverRestoreDisabled,
+  PaletteState.Tracking => _silverRestoreActive,
+  PaletteState.Pressed => _silverRestorePressed,
+  _ => _silverRestoreNormal
+  },
+  PaletteButtonSpecStyle.FormHelp => state switch
+  {
+  PaletteState.Disabled => _silverHelpDisabled,
+  PaletteState.Tracking => _silverHelpActive,
+  PaletteState.Pressed => _silverHelpPressed,
+  _ => _silverHelpNormal
+  },
+  _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion    
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Official Themes/PaletteOffice2007Black.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Official Themes/PaletteOffice2007Black.cs
@@ -201,7 +201,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(222, 225, 229), // RibbonGroupFrameInside2
             Color.FromArgb(214, 218, 223), // RibbonGroupFrameInside3
             Color.FromArgb(222, 225, 230), // RibbonGroupFrameInside4
-            Color.FromArgb(70, 70, 70), // RibbonGroupCollapsedText         
+            Color.FromArgb(70, 70, 70), // RibbonGroupCollapsedText
             Color.FromArgb(158, 163, 172), // AlternatePressedBack1
             Color.FromArgb(212, 215, 216), // AlternatePressedBack2
             Color.FromArgb(124, 125, 125), // AlternatePressedBorder1
@@ -221,38 +221,32 @@ namespace Krypton.Toolkit
             Color.FromArgb(140, 140, 140), // RibbonQATMini3I
             Color.FromArgb(12, Color.White), // RibbonQATMini4I
             Color.FromArgb(14, Color.White), // RibbonQATMini5I
-            Color.FromArgb(141, 144, 147), // RibbonQATFullbar1                                                      
-            Color.FromArgb(133, 135, 137), // RibbonQATFullbar2                                                      
-            Color.FromArgb(93, 96, 100), // RibbonQATFullbar3                                                      
-            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark                                                      
-            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
-            Color.FromArgb(118, 128, 142), // RibbonQATOverflow1                                                      
-            Color.FromArgb(55, 60, 67), // RibbonQATOverflow2                                                      
-            Color.FromArgb(163, 168,
-                170), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(230, 233,
-                235), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(210, 217,
-                219), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(214, 222,
-                223), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(179, 188,
-                191), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(145, 156,
-                159), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(235, 235, 235), // NavigatorMiniBackColor                                                    
-            Color.White, // GridListNormal1                                                    
-            Color.FromArgb(212, 215, 219), // GridListNormal2                                                    
-            Color.FromArgb(210, 213, 218), // GridListPressed1                                                    
-            Color.FromArgb(252, 253, 253), // GridListPressed2                                                    
-            Color.FromArgb(186, 189, 194), // GridListSelected                                                    
-            Color.FromArgb(248, 248, 248), // GridSheetColNormal1                                                    
-            Color.FromArgb(222, 222, 222), // GridSheetColNormal2                                                    
-            Color.FromArgb(224, 224, 224), // GridSheetColPressed1                                                    
-            Color.FromArgb(195, 195, 195), // GridSheetColPressed2                                                    
+            Color.FromArgb(141, 144, 147), // RibbonQATFullbar1
+            Color.FromArgb(133, 135, 137), // RibbonQATFullbar2
+            Color.FromArgb(93, 96, 100), // RibbonQATFullbar3
+            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark
+            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight
+            Color.FromArgb(118, 128, 142), // RibbonQATOverflow1
+            Color.FromArgb(55, 60, 67), // RibbonQATOverflow2
+            Color.FromArgb(163, 168, 170), // RibbonGroupSeparatorDark
+            Color.FromArgb(230, 233, 235), // RibbonGroupSeparatorLight
+            Color.FromArgb(210, 217, 219), // ButtonClusterButtonBack1
+            Color.FromArgb(214, 222, 223), // ButtonClusterButtonBack2
+            Color.FromArgb(179, 188, 191), // ButtonClusterButtonBorder1
+            Color.FromArgb(145, 156, 159), // ButtonClusterButtonBorder2
+            Color.FromArgb(235, 235, 235), // NavigatorMiniBackColor 
+            Color.White, // GridListNormal1 
+            Color.FromArgb(212, 215, 219), // GridListNormal2 
+            Color.FromArgb(210, 213, 218), // GridListPressed1 
+            Color.FromArgb(252, 253, 253), // GridListPressed2 
+            Color.FromArgb(186, 189, 194), // GridListSelected 
+            Color.FromArgb(248, 248, 248), // GridSheetColNormal1 
+            Color.FromArgb(222, 222, 222), // GridSheetColNormal2 
+            Color.FromArgb(224, 224, 224), // GridSheetColPressed1 
+            Color.FromArgb(195, 195, 195), // GridSheetColPressed2 
             Color.FromArgb(249, 217, 159), // GridSheetColSelected1
             Color.FromArgb(241, 193, 95), // GridSheetColSelected2
-            Color.FromArgb(237, 237, 237), // GridSheetRowNormal                                                   
+            Color.FromArgb(237, 237, 237), // GridSheetRowNormal
             Color.FromArgb(196, 196, 196), // GridSheetRowPressed
             Color.FromArgb(255, 213, 141), // GridSheetRowSelected
             Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -292,6 +286,8 @@ namespace Krypton.Toolkit
             GlobalStaticValues.EMPTY_COLOR, // RibbonTabTracking4
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder3
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder4
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder5
+            Color.FromArgb(255, 255, 255), // RibbonGroupTitleText
             Color.FromArgb(225, 225, 225), // RibbonDropArrowLight
             Color.FromArgb(103, 103, 103) // RibbonDropArrowDark
         ];
@@ -536,43 +532,43 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
-                                                     PaletteButtonSpecStyle.FormClose => state switch
-                                                     {
-                                                         PaletteState.Disabled => _blackCloseDisabled,
-                                                         PaletteState.Tracking => _blackCloseActive,
-                                                         PaletteState.Pressed => _blackClosePressed,
-                                                         _ => _blackCloseNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMin => state switch
-                                                     {
-                                                         PaletteState.Disabled => _blackMinimiseDisabled,
-                                                         PaletteState.Tracking => _blackMinimiseActive,
-                                                         PaletteState.Pressed => _blackMinimisePressed,
-                                                         _ => _blackMinimiseNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMax => state switch
-                                                     {
-                                                         PaletteState.Disabled => _blackMaximiseDisabled,
-                                                         PaletteState.Tracking => _blackMaximiseActive,
-                                                         PaletteState.Pressed => _blackMaximisePressed,
-                                                         _ => _blackMaximiseNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormRestore => state switch
-                                                     {
-                                                         PaletteState.Disabled => _blackRestoreDisabled,
-                                                         PaletteState.Tracking => _blackRestoreActive,
-                                                         PaletteState.Pressed => _blackRestorePressed,
-                                                         _ => _blackRestoreNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormHelp => state switch
-                                                     {
-                                                         PaletteState.Disabled => _blackHelpDisabled,
-                                                         PaletteState.Tracking => _blackHelpActive,
-                                                         _ => _blackHelpNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.RibbonMinimize => _blackRibbonMinimize,
-                                                     PaletteButtonSpecStyle.RibbonExpand => _blackRibbonExpand,
-                                                     _ => base.GetButtonSpecImage(style, state)
+  PaletteButtonSpecStyle.FormClose => state switch
+  {
+  PaletteState.Disabled => _blackCloseDisabled,
+  PaletteState.Tracking => _blackCloseActive,
+  PaletteState.Pressed => _blackClosePressed,
+  _ => _blackCloseNormal
+  },
+  PaletteButtonSpecStyle.FormMin => state switch
+  {
+  PaletteState.Disabled => _blackMinimiseDisabled,
+  PaletteState.Tracking => _blackMinimiseActive,
+  PaletteState.Pressed => _blackMinimisePressed,
+  _ => _blackMinimiseNormal
+  },
+  PaletteButtonSpecStyle.FormMax => state switch
+  {
+  PaletteState.Disabled => _blackMaximiseDisabled,
+  PaletteState.Tracking => _blackMaximiseActive,
+  PaletteState.Pressed => _blackMaximisePressed,
+  _ => _blackMaximiseNormal
+  },
+  PaletteButtonSpecStyle.FormRestore => state switch
+  {
+  PaletteState.Disabled => _blackRestoreDisabled,
+  PaletteState.Tracking => _blackRestoreActive,
+  PaletteState.Pressed => _blackRestorePressed,
+  _ => _blackRestoreNormal
+  },
+  PaletteButtonSpecStyle.FormHelp => state switch
+  {
+  PaletteState.Disabled => _blackHelpDisabled,
+  PaletteState.Tracking => _blackHelpActive,
+  _ => _blackHelpNormal
+  },
+  PaletteButtonSpecStyle.RibbonMinimize => _blackRibbonMinimize,
+  PaletteButtonSpecStyle.RibbonExpand => _blackRibbonExpand,
+  _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Official Themes/PaletteOffice2007Black.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Official Themes/PaletteOffice2007Black.cs
@@ -532,43 +532,43 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
-  PaletteButtonSpecStyle.FormClose => state switch
-  {
-  PaletteState.Disabled => _blackCloseDisabled,
-  PaletteState.Tracking => _blackCloseActive,
-  PaletteState.Pressed => _blackClosePressed,
-  _ => _blackCloseNormal
-  },
-  PaletteButtonSpecStyle.FormMin => state switch
-  {
-  PaletteState.Disabled => _blackMinimiseDisabled,
-  PaletteState.Tracking => _blackMinimiseActive,
-  PaletteState.Pressed => _blackMinimisePressed,
-  _ => _blackMinimiseNormal
-  },
-  PaletteButtonSpecStyle.FormMax => state switch
-  {
-  PaletteState.Disabled => _blackMaximiseDisabled,
-  PaletteState.Tracking => _blackMaximiseActive,
-  PaletteState.Pressed => _blackMaximisePressed,
-  _ => _blackMaximiseNormal
-  },
-  PaletteButtonSpecStyle.FormRestore => state switch
-  {
-  PaletteState.Disabled => _blackRestoreDisabled,
-  PaletteState.Tracking => _blackRestoreActive,
-  PaletteState.Pressed => _blackRestorePressed,
-  _ => _blackRestoreNormal
-  },
-  PaletteButtonSpecStyle.FormHelp => state switch
-  {
-  PaletteState.Disabled => _blackHelpDisabled,
-  PaletteState.Tracking => _blackHelpActive,
-  _ => _blackHelpNormal
-  },
-  PaletteButtonSpecStyle.RibbonMinimize => _blackRibbonMinimize,
-  PaletteButtonSpecStyle.RibbonExpand => _blackRibbonExpand,
-  _ => base.GetButtonSpecImage(style, state)
+                                                     PaletteButtonSpecStyle.FormClose => state switch
+                                                     {
+                                                         PaletteState.Disabled => _blackCloseDisabled,
+                                                         PaletteState.Tracking => _blackCloseActive,
+                                                         PaletteState.Pressed => _blackClosePressed,
+                                                         _ => _blackCloseNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMin => state switch
+                                                     {
+                                                         PaletteState.Disabled => _blackMinimiseDisabled,
+                                                         PaletteState.Tracking => _blackMinimiseActive,
+                                                         PaletteState.Pressed => _blackMinimisePressed,
+                                                         _ => _blackMinimiseNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMax => state switch
+                                                     {
+                                                         PaletteState.Disabled => _blackMaximiseDisabled,
+                                                         PaletteState.Tracking => _blackMaximiseActive,
+                                                         PaletteState.Pressed => _blackMaximisePressed,
+                                                         _ => _blackMaximiseNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormRestore => state switch
+                                                     {
+                                                         PaletteState.Disabled => _blackRestoreDisabled,
+                                                         PaletteState.Tracking => _blackRestoreActive,
+                                                         PaletteState.Pressed => _blackRestorePressed,
+                                                         _ => _blackRestoreNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormHelp => state switch
+                                                     {
+                                                         PaletteState.Disabled => _blackHelpDisabled,
+                                                         PaletteState.Tracking => _blackHelpActive,
+                                                         _ => _blackHelpNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.RibbonMinimize => _blackRibbonMinimize,
+                                                     PaletteButtonSpecStyle.RibbonExpand => _blackRibbonExpand,
+                                                     _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Official Themes/PaletteOffice2007Blue.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Official Themes/PaletteOffice2007Blue.cs
@@ -369,42 +369,42 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
-  PaletteButtonSpecStyle.FormClose => state switch
-  {
-  PaletteState.Disabled => _blueCloseDisabled,
-  PaletteState.Tracking => _blueCloseActive,
-  PaletteState.Pressed => _blueClosePressed,
-  _ => _blueCloseNormal
-  },
-  PaletteButtonSpecStyle.FormMin => state switch
-  {
-  PaletteState.Disabled => _blueMinimiseDisabled,
-  PaletteState.Tracking => _blueMinimiseActive,
-  PaletteState.Pressed => _blueMinimisePressed,
-  _ => _blueMinimiseNormal
-  },
-  PaletteButtonSpecStyle.FormMax => state switch
-  {
-  PaletteState.Disabled => _blueMaximiseDisabled,
-  PaletteState.Tracking => _blueMaximiseActive,
-  PaletteState.Pressed => _blueMaximisePressed,
-  _ => _blueMaximiseNormal
-  },
-  PaletteButtonSpecStyle.FormRestore => state switch
-  {
-  PaletteState.Disabled => _blueRestoreDisabled,
-  PaletteState.Tracking => _blueRestoreActive,
-  PaletteState.Pressed => _blueRestorePressed,
-  _ => _blueRestoreNormal
-  },
-  PaletteButtonSpecStyle.FormHelp => state switch
-  {
-  PaletteState.Disabled => _blueHelpDisabled,
-  PaletteState.Tracking => _blueHelpActive,
-  PaletteState.Pressed => _blueHelpPressed,
-  _ => _blueHelpNormal
-  },
-  _ => base.GetButtonSpecImage(style, state)
+                                                     PaletteButtonSpecStyle.FormClose => state switch
+                                                     {
+                                                         PaletteState.Disabled => _blueCloseDisabled,
+                                                         PaletteState.Tracking => _blueCloseActive,
+                                                         PaletteState.Pressed => _blueClosePressed,
+                                                         _ => _blueCloseNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMin => state switch
+                                                     {
+                                                         PaletteState.Disabled => _blueMinimiseDisabled,
+                                                         PaletteState.Tracking => _blueMinimiseActive,
+                                                         PaletteState.Pressed => _blueMinimisePressed,
+                                                         _ => _blueMinimiseNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMax => state switch
+                                                     {
+                                                         PaletteState.Disabled => _blueMaximiseDisabled,
+                                                         PaletteState.Tracking => _blueMaximiseActive,
+                                                         PaletteState.Pressed => _blueMaximisePressed,
+                                                         _ => _blueMaximiseNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormRestore => state switch
+                                                     {
+                                                         PaletteState.Disabled => _blueRestoreDisabled,
+                                                         PaletteState.Tracking => _blueRestoreActive,
+                                                         PaletteState.Pressed => _blueRestorePressed,
+                                                         _ => _blueRestoreNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormHelp => state switch
+                                                     {
+                                                         PaletteState.Disabled => _blueHelpDisabled,
+                                                         PaletteState.Tracking => _blueHelpActive,
+                                                         PaletteState.Pressed => _blueHelpPressed,
+                                                         _ => _blueHelpNormal
+                                                     },
+                                                     _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Official Themes/PaletteOffice2007Blue.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Official Themes/PaletteOffice2007Blue.cs
@@ -212,38 +212,38 @@ namespace Krypton.Toolkit
             Color.FromArgb(219, 231, 247),    // RibbonQATMini2
             Color.FromArgb(195, 213, 236),    // RibbonQATMini3
             Color.FromArgb(128, Color.White), // RibbonQATMini4
-            Color.FromArgb(72, Color.White),  // RibbonQATMini5                                                       
+            Color.FromArgb(72, Color.White),  // RibbonQATMini5
             Color.FromArgb(153, 176, 206),    // RibbonQATMini1I
             Color.FromArgb(226, 233, 241),    // RibbonQATMini2I
             Color.FromArgb(198, 210, 226),    // RibbonQATMini3I
             Color.FromArgb(128, Color.White), // RibbonQATMini4I
-            Color.FromArgb(72, Color.White),  // RibbonQATMini5I                                                      
-            Color.FromArgb(178, 205, 237),    // RibbonQATFullbar1                                                      
-            Color.FromArgb(170, 197, 234),    // RibbonQATFullbar2                                                      
-            Color.FromArgb(126, 161, 205),    // RibbonQATFullbar3                                                      
-            Color.FromArgb( 86, 125, 177),    // RibbonQATButtonDark                                                      
-            Color.FromArgb(234, 242, 249),    // RibbonQATButtonLight                                                      
-            Color.FromArgb(192, 220, 255),    // RibbonQATOverflow1                                                      
-            Color.FromArgb( 55, 100, 160),    // RibbonQATOverflow2                                                      
-            Color.FromArgb(140, 172, 211),    // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(248, 250, 252),    // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(192, 212, 241),    // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(200, 219, 238),    // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(155, 183, 224),    // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(117, 150, 191),    // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(213, 228, 242),    // NavigatorMiniBackColor                                                    
-            Color.White,                      // GridListNormal1                                                    
-            Color.FromArgb(196, 221, 255),    // GridListNormal2                                                    
-            Color.FromArgb(194, 220, 255),    // GridListPressed1                                                    
-            Color.FromArgb(252, 253, 255),    // GridListPressed2                                                    
-            Color.FromArgb(170, 195, 240),    // GridListSelected                                                    
-            Color.FromArgb(249, 252, 253),    // GridSheetColNormal1                                                    
-            Color.FromArgb(211, 219, 233),    // GridSheetColNormal2                                                    
-            Color.FromArgb(223, 226, 228),    // GridSheetColPressed1                                                    
-            Color.FromArgb(188, 197, 210),    // GridSheetColPressed2                                                    
+            Color.FromArgb(72, Color.White),  // RibbonQATMini5I
+            Color.FromArgb(178, 205, 237),    // RibbonQATFullbar1
+            Color.FromArgb(170, 197, 234),    // RibbonQATFullbar2
+            Color.FromArgb(126, 161, 205),    // RibbonQATFullbar3
+            Color.FromArgb( 86, 125, 177),    // RibbonQATButtonDark
+            Color.FromArgb(234, 242, 249),    // RibbonQATButtonLight
+            Color.FromArgb(192, 220, 255),    // RibbonQATOverflow1
+            Color.FromArgb( 55, 100, 160),    // RibbonQATOverflow2
+            Color.FromArgb(140, 172, 211),    // RibbonGroupSeparatorDark
+            Color.FromArgb(248, 250, 252),    // RibbonGroupSeparatorLight
+            Color.FromArgb(192, 212, 241),    // ButtonClusterButtonBack1
+            Color.FromArgb(200, 219, 238),    // ButtonClusterButtonBack2
+            Color.FromArgb(155, 183, 224),    // ButtonClusterButtonBorder1
+            Color.FromArgb(117, 150, 191),    // ButtonClusterButtonBorder2
+            Color.FromArgb(213, 228, 242),    // NavigatorMiniBackColor 
+            Color.White,                      // GridListNormal1 
+            Color.FromArgb(196, 221, 255),    // GridListNormal2 
+            Color.FromArgb(194, 220, 255),    // GridListPressed1 
+            Color.FromArgb(252, 253, 255),    // GridListPressed2 
+            Color.FromArgb(170, 195, 240),    // GridListSelected 
+            Color.FromArgb(249, 252, 253),    // GridSheetColNormal1 
+            Color.FromArgb(211, 219, 233),    // GridSheetColNormal2 
+            Color.FromArgb(223, 226, 228),    // GridSheetColPressed1 
+            Color.FromArgb(188, 197, 210),    // GridSheetColPressed2 
             Color.FromArgb(249, 217, 159),    // GridSheetColSelected1
             Color.FromArgb(241, 193,  95),    // GridSheetColSelected2
-            Color.FromArgb(228, 236, 247),    // GridSheetRowNormal                                                   
+            Color.FromArgb(228, 236, 247),    // GridSheetRowNormal
             Color.FromArgb(187, 196, 209),    // GridSheetRowPressed
             Color.FromArgb(255, 213, 141),    // GridSheetRowSelected
             Color.FromArgb(188, 195, 209),    // GridDataCellBorder
@@ -279,12 +279,14 @@ namespace Krypton.Toolkit
             Color.FromArgb(236, 243, 251),    // RibbonGalleryBackTracking
             Color.FromArgb(193, 213, 241),    // RibbonGalleryBack1
             Color.FromArgb(215, 233, 251),    // RibbonGalleryBack2
-            GlobalStaticValues.EMPTY_COLOR,                      // RibbonTabTracking3
-            GlobalStaticValues.EMPTY_COLOR,                      // RibbonTabTracking4
-            GlobalStaticValues.EMPTY_COLOR,                      // RibbonGroupBorder3
-            GlobalStaticValues.EMPTY_COLOR,                      // RibbonGroupBorder4
-            GlobalStaticValues.EMPTY_COLOR,                      // RibbonDropArrowLight
-            GlobalStaticValues.EMPTY_COLOR // RibbonDropArrowDark
+            GlobalStaticValues.EMPTY_COLOR,   // RibbonTabTracking3
+            GlobalStaticValues.EMPTY_COLOR,   // RibbonTabTracking4
+            GlobalStaticValues.EMPTY_COLOR,   // RibbonGroupBorder3
+            GlobalStaticValues.EMPTY_COLOR,   // RibbonGroupBorder4
+            GlobalStaticValues.EMPTY_COLOR,   // RibbonGroupBorder5
+            Color.FromArgb(21, 66, 139),      // RibbonGroupTitleText
+            GlobalStaticValues.EMPTY_COLOR,   // RibbonDropArrowLight
+            GlobalStaticValues.EMPTY_COLOR    // RibbonDropArrowDark
         ];
 
         #endregion
@@ -367,42 +369,42 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
-                                                     PaletteButtonSpecStyle.FormClose => state switch
-                                                     {
-                                                         PaletteState.Disabled => _blueCloseDisabled,
-                                                         PaletteState.Tracking => _blueCloseActive,
-                                                         PaletteState.Pressed => _blueClosePressed,
-                                                         _ => _blueCloseNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMin => state switch
-                                                     {
-                                                         PaletteState.Disabled => _blueMinimiseDisabled,
-                                                         PaletteState.Tracking => _blueMinimiseActive,
-                                                         PaletteState.Pressed => _blueMinimisePressed,
-                                                         _ => _blueMinimiseNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMax => state switch
-                                                     {
-                                                         PaletteState.Disabled => _blueMaximiseDisabled,
-                                                         PaletteState.Tracking => _blueMaximiseActive,
-                                                         PaletteState.Pressed => _blueMaximisePressed,
-                                                         _ => _blueMaximiseNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormRestore => state switch
-                                                     {
-                                                         PaletteState.Disabled => _blueRestoreDisabled,
-                                                         PaletteState.Tracking => _blueRestoreActive,
-                                                         PaletteState.Pressed => _blueRestorePressed,
-                                                         _ => _blueRestoreNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormHelp => state switch
-                                                     {
-                                                         PaletteState.Disabled => _blueHelpDisabled,
-                                                         PaletteState.Tracking => _blueHelpActive,
-                                                         PaletteState.Pressed => _blueHelpPressed,
-                                                         _ => _blueHelpNormal
-                                                     },
-                                                     _ => base.GetButtonSpecImage(style, state)
+  PaletteButtonSpecStyle.FormClose => state switch
+  {
+  PaletteState.Disabled => _blueCloseDisabled,
+  PaletteState.Tracking => _blueCloseActive,
+  PaletteState.Pressed => _blueClosePressed,
+  _ => _blueCloseNormal
+  },
+  PaletteButtonSpecStyle.FormMin => state switch
+  {
+  PaletteState.Disabled => _blueMinimiseDisabled,
+  PaletteState.Tracking => _blueMinimiseActive,
+  PaletteState.Pressed => _blueMinimisePressed,
+  _ => _blueMinimiseNormal
+  },
+  PaletteButtonSpecStyle.FormMax => state switch
+  {
+  PaletteState.Disabled => _blueMaximiseDisabled,
+  PaletteState.Tracking => _blueMaximiseActive,
+  PaletteState.Pressed => _blueMaximisePressed,
+  _ => _blueMaximiseNormal
+  },
+  PaletteButtonSpecStyle.FormRestore => state switch
+  {
+  PaletteState.Disabled => _blueRestoreDisabled,
+  PaletteState.Tracking => _blueRestoreActive,
+  PaletteState.Pressed => _blueRestorePressed,
+  _ => _blueRestoreNormal
+  },
+  PaletteButtonSpecStyle.FormHelp => state switch
+  {
+  PaletteState.Disabled => _blueHelpDisabled,
+  PaletteState.Tracking => _blueHelpActive,
+  PaletteState.Pressed => _blueHelpPressed,
+  _ => _blueHelpNormal
+  },
+  _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Official Themes/PaletteOffice2007Silver.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Official Themes/PaletteOffice2007Silver.cs
@@ -198,7 +198,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(226, 229, 234),    // RibbonGroupFrameInside2
             Color.FromArgb(220, 224, 231),    // RibbonGroupFrameInside3
             Color.FromArgb(232, 234, 238),    // RibbonGroupFrameInside4
-            Color.FromArgb( 76,  83,  92),    // RibbonGroupCollapsedText         
+            Color.FromArgb( 76,  83,  92),    // RibbonGroupCollapsedText
             Color.FromArgb(179, 185, 195),    // AlternatePressedBack1
             Color.FromArgb(216, 224, 224),    // AlternatePressedBack2
             Color.FromArgb(125, 125, 125),    // AlternatePressedBorder1
@@ -212,38 +212,38 @@ namespace Krypton.Toolkit
             Color.FromArgb(210, 215, 221),    // RibbonQATMini2
             Color.FromArgb(195, 200, 206),    // RibbonQATMini3
             Color.FromArgb(10, Color.White),  // RibbonQATMini4
-            Color.FromArgb(32, Color.White),  // RibbonQATMini5                                                       
+            Color.FromArgb(32, Color.White),  // RibbonQATMini5
             Color.FromArgb(200, 200, 200),    // RibbonQATMini1I
             Color.FromArgb(233, 234, 238),    // RibbonQATMini2I
             Color.FromArgb(223, 224, 228),    // RibbonQATMini3I
             Color.FromArgb(10, Color.White),  // RibbonQATMini4I
-            Color.FromArgb(32, Color.White),  // RibbonQATMini5I                                                       
-            Color.FromArgb(217, 222, 230),    // RibbonQATFullbar1                                                      
-            Color.FromArgb(214, 219, 227),    // RibbonQATFullbar2                                                      
-            Color.FromArgb(194, 201, 212),    // RibbonQATFullbar3                                                      
-            Color.FromArgb(103, 103, 103),    // RibbonQATButtonDark                                                      
-            Color.FromArgb(225, 225, 225),    // RibbonQATButtonLight                                                      
-            Color.FromArgb(219, 218, 228),    // RibbonQATOverflow1                                                      
-            Color.FromArgb( 55, 100, 160),    // RibbonQATOverflow2                                                      
-            Color.FromArgb(173, 177, 181),    // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(232, 235, 237),    // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(231, 234, 238),    // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(241, 243, 243),    // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(197, 198, 199),    // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(157, 158, 159),    // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(238, 238, 244),    // NavigatorMiniBackColor                                                    
-            Color.White,                      // GridListNormal1                                                    
-            Color.FromArgb(212, 215, 219),    // GridListNormal2                                                    
-            Color.FromArgb(210, 213, 218),    // GridListPressed1                                                    
-            Color.FromArgb(252, 253, 253),    // GridListPressed2                                                    
-            Color.FromArgb(186, 189, 194),    // GridListSelected                                                    
-            Color.FromArgb(241, 243, 243),    // GridSheetColNormal1                                                    
-            Color.FromArgb(200, 201, 202),    // GridSheetColNormal2                                                    
-            Color.FromArgb(208, 208, 208),    // GridSheetColPressed1                                                    
-            Color.FromArgb(166, 166, 166),    // GridSheetColPressed2                                                    
+            Color.FromArgb(32, Color.White),  // RibbonQATMini5I
+            Color.FromArgb(217, 222, 230),    // RibbonQATFullbar1
+            Color.FromArgb(214, 219, 227),    // RibbonQATFullbar2
+            Color.FromArgb(194, 201, 212),    // RibbonQATFullbar3
+            Color.FromArgb(103, 103, 103),    // RibbonQATButtonDark
+            Color.FromArgb(225, 225, 225),    // RibbonQATButtonLight
+            Color.FromArgb(219, 218, 228),    // RibbonQATOverflow1
+            Color.FromArgb( 55, 100, 160),    // RibbonQATOverflow2
+            Color.FromArgb(173, 177, 181),    // RibbonGroupSeparatorDark
+            Color.FromArgb(232, 235, 237),    // RibbonGroupSeparatorLight
+            Color.FromArgb(231, 234, 238),    // ButtonClusterButtonBack1
+            Color.FromArgb(241, 243, 243),    // ButtonClusterButtonBack2
+            Color.FromArgb(197, 198, 199),    // ButtonClusterButtonBorder1
+            Color.FromArgb(157, 158, 159),    // ButtonClusterButtonBorder2
+            Color.FromArgb(238, 238, 244),    // NavigatorMiniBackColor 
+            Color.White,                      // GridListNormal1 
+            Color.FromArgb(212, 215, 219),    // GridListNormal2 
+            Color.FromArgb(210, 213, 218),    // GridListPressed1 
+            Color.FromArgb(252, 253, 253),    // GridListPressed2 
+            Color.FromArgb(186, 189, 194),    // GridListSelected 
+            Color.FromArgb(241, 243, 243),    // GridSheetColNormal1 
+            Color.FromArgb(200, 201, 202),    // GridSheetColNormal2 
+            Color.FromArgb(208, 208, 208),    // GridSheetColPressed1 
+            Color.FromArgb(166, 166, 166),    // GridSheetColPressed2 
             Color.FromArgb(255, 204, 153),    // GridSheetColSelected1
             Color.FromArgb(255, 155, 104),    // GridSheetColSelected2
-            Color.FromArgb(231, 231, 231),    // GridSheetRowNormal                                                   
+            Color.FromArgb(231, 231, 231),    // GridSheetRowNormal
             Color.FromArgb(184, 191, 196),    // GridSheetRowPressed
             Color.FromArgb(245, 199, 149),    // GridSheetRowSelected
             Color.FromArgb(188, 195, 209),    // GridDataCellBorder
@@ -279,12 +279,14 @@ namespace Krypton.Toolkit
             Color.FromArgb(240, 241, 242),    // RibbonGalleryBackTracking
             Color.FromArgb(195, 200, 209),    // RibbonGalleryBack1
             Color.FromArgb(217, 220, 224),    // RibbonGalleryBack2
-            GlobalStaticValues.EMPTY_COLOR,                      // RibbonTabTracking3
-            GlobalStaticValues.EMPTY_COLOR,                      // RibbonTabTracking4
-            GlobalStaticValues.EMPTY_COLOR,                      // RibbonGroupBorder3
-            GlobalStaticValues.EMPTY_COLOR,                      // RibbonGroupBorder4
-            GlobalStaticValues.EMPTY_COLOR,                      // RibbonDropArrowLight
-            GlobalStaticValues.EMPTY_COLOR // RibbonDropArrowDark
+            GlobalStaticValues.EMPTY_COLOR,   // RibbonTabTracking3
+            GlobalStaticValues.EMPTY_COLOR,   // RibbonTabTracking4
+            GlobalStaticValues.EMPTY_COLOR,   // RibbonGroupBorder3
+            GlobalStaticValues.EMPTY_COLOR,   // RibbonGroupBorder4
+            GlobalStaticValues.EMPTY_COLOR,   // RibbonGroupBorder5
+            Color.FromArgb(56, 63, 70),       // RibbonGroupTitleText
+            GlobalStaticValues.EMPTY_COLOR,   // RibbonDropArrowLight
+            GlobalStaticValues.EMPTY_COLOR    // RibbonDropArrowDark
         ];
 
         #endregion
@@ -367,42 +369,42 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
-                                                     PaletteButtonSpecStyle.FormClose => state switch
-                                                     {
-                                                         PaletteState.Disabled => _silverCloseDisabled,
-                                                         PaletteState.Tracking => _silverCloseActive,
-                                                         PaletteState.Pressed => _silverClosePressed,
-                                                         _ => _silverCloseNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMin => state switch
-                                                     {
-                                                         PaletteState.Disabled => _silverMinimiseDisabled,
-                                                         PaletteState.Tracking => _silverMinimiseActive,
-                                                         PaletteState.Pressed => _silverMinimisePressed,
-                                                         _ => _silverMinimiseNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMax => state switch
-                                                     {
-                                                         PaletteState.Disabled => _silverMaximiseDisabled,
-                                                         PaletteState.Tracking => _silverMaximiseActive,
-                                                         PaletteState.Pressed => _silverMaximisePressed,
-                                                         _ => _silverMaximiseNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormRestore => state switch
-                                                     {
-                                                         PaletteState.Disabled => _silverRestoreDisabled,
-                                                         PaletteState.Tracking => _silverRestoreActive,
-                                                         PaletteState.Pressed => _silverRestorePressed,
-                                                         _ => _silverRestoreNormal
-                                                     },
-                                                     PaletteButtonSpecStyle.FormHelp => state switch
-                                                     {
-                                                         PaletteState.Disabled => _silverHelpDisabled,
-                                                         PaletteState.Tracking => _silverHelpActive,
-                                                         PaletteState.Pressed => _silverHelpPressed,
-                                                         _ => _silverHelpNormal
-                                                     },
-                                                     _ => base.GetButtonSpecImage(style, state)
+  PaletteButtonSpecStyle.FormClose => state switch
+  {
+  PaletteState.Disabled => _silverCloseDisabled,
+  PaletteState.Tracking => _silverCloseActive,
+  PaletteState.Pressed => _silverClosePressed,
+  _ => _silverCloseNormal
+  },
+  PaletteButtonSpecStyle.FormMin => state switch
+  {
+  PaletteState.Disabled => _silverMinimiseDisabled,
+  PaletteState.Tracking => _silverMinimiseActive,
+  PaletteState.Pressed => _silverMinimisePressed,
+  _ => _silverMinimiseNormal
+  },
+  PaletteButtonSpecStyle.FormMax => state switch
+  {
+  PaletteState.Disabled => _silverMaximiseDisabled,
+  PaletteState.Tracking => _silverMaximiseActive,
+  PaletteState.Pressed => _silverMaximisePressed,
+  _ => _silverMaximiseNormal
+  },
+  PaletteButtonSpecStyle.FormRestore => state switch
+  {
+  PaletteState.Disabled => _silverRestoreDisabled,
+  PaletteState.Tracking => _silverRestoreActive,
+  PaletteState.Pressed => _silverRestorePressed,
+  _ => _silverRestoreNormal
+  },
+  PaletteButtonSpecStyle.FormHelp => state switch
+  {
+  PaletteState.Disabled => _silverHelpDisabled,
+  PaletteState.Tracking => _silverHelpActive,
+  PaletteState.Pressed => _silverHelpPressed,
+  _ => _silverHelpNormal
+  },
+  _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion    
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Official Themes/PaletteOffice2007Silver.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Official Themes/PaletteOffice2007Silver.cs
@@ -369,42 +369,42 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
-  PaletteButtonSpecStyle.FormClose => state switch
-  {
-  PaletteState.Disabled => _silverCloseDisabled,
-  PaletteState.Tracking => _silverCloseActive,
-  PaletteState.Pressed => _silverClosePressed,
-  _ => _silverCloseNormal
-  },
-  PaletteButtonSpecStyle.FormMin => state switch
-  {
-  PaletteState.Disabled => _silverMinimiseDisabled,
-  PaletteState.Tracking => _silverMinimiseActive,
-  PaletteState.Pressed => _silverMinimisePressed,
-  _ => _silverMinimiseNormal
-  },
-  PaletteButtonSpecStyle.FormMax => state switch
-  {
-  PaletteState.Disabled => _silverMaximiseDisabled,
-  PaletteState.Tracking => _silverMaximiseActive,
-  PaletteState.Pressed => _silverMaximisePressed,
-  _ => _silverMaximiseNormal
-  },
-  PaletteButtonSpecStyle.FormRestore => state switch
-  {
-  PaletteState.Disabled => _silverRestoreDisabled,
-  PaletteState.Tracking => _silverRestoreActive,
-  PaletteState.Pressed => _silverRestorePressed,
-  _ => _silverRestoreNormal
-  },
-  PaletteButtonSpecStyle.FormHelp => state switch
-  {
-  PaletteState.Disabled => _silverHelpDisabled,
-  PaletteState.Tracking => _silverHelpActive,
-  PaletteState.Pressed => _silverHelpPressed,
-  _ => _silverHelpNormal
-  },
-  _ => base.GetButtonSpecImage(style, state)
+                                                     PaletteButtonSpecStyle.FormClose => state switch
+                                                     {
+                                                         PaletteState.Disabled => _silverCloseDisabled,
+                                                         PaletteState.Tracking => _silverCloseActive,
+                                                         PaletteState.Pressed => _silverClosePressed,
+                                                         _ => _silverCloseNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMin => state switch
+                                                     {
+                                                         PaletteState.Disabled => _silverMinimiseDisabled,
+                                                         PaletteState.Tracking => _silverMinimiseActive,
+                                                         PaletteState.Pressed => _silverMinimisePressed,
+                                                         _ => _silverMinimiseNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMax => state switch
+                                                     {
+                                                         PaletteState.Disabled => _silverMaximiseDisabled,
+                                                         PaletteState.Tracking => _silverMaximiseActive,
+                                                         PaletteState.Pressed => _silverMaximisePressed,
+                                                         _ => _silverMaximiseNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormRestore => state switch
+                                                     {
+                                                         PaletteState.Disabled => _silverRestoreDisabled,
+                                                         PaletteState.Tracking => _silverRestoreActive,
+                                                         PaletteState.Pressed => _silverRestorePressed,
+                                                         _ => _silverRestoreNormal
+                                                     },
+                                                     PaletteButtonSpecStyle.FormHelp => state switch
+                                                     {
+                                                         PaletteState.Disabled => _silverHelpDisabled,
+                                                         PaletteState.Tracking => _silverHelpActive,
+                                                         PaletteState.Pressed => _silverHelpPressed,
+                                                         _ => _silverHelpNormal
+                                                     },
+                                                     _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion    
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlackDarkMode.cs
@@ -239,38 +239,32 @@ namespace Krypton.Toolkit
             Color.FromArgb(140, 140, 140), // RibbonQATMini3I
             Color.FromArgb(12, Color.White), // RibbonQATMini4I
             Color.FromArgb(14, Color.White), // RibbonQATMini5I
-            Color.FromArgb(141, 144, 147), // RibbonQATFullbar1                                                      
-            Color.FromArgb(133, 135, 137), // RibbonQATFullbar2                                                      
-            Color.FromArgb(93, 96, 100), // RibbonQATFullbar3                                                      
-            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark                                                      
-            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
-            Color.FromArgb(118, 128, 142), // RibbonQATOverflow1                                                      
-            Color.FromArgb(55, 60, 67), // RibbonQATOverflow2                                                      
-            Color.FromArgb(163, 168,
-                170), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(230, 233,
-                235), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(210, 217,
-                219), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(214, 222,
-                223), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(179, 188,
-                191), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(145, 156,
-                159), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(235, 235, 235), // NavigatorMiniBackColor                                                    
-            Color.FromArgb(10, 10, 10), // GridListNormal1                                                    
-            Color.FromArgb(41, 41, 41), // GridListNormal2                                                    
-            Color.FromArgb(41, 41, 41), // GridListPressed1                                                    
-            Color.FromArgb(61, 61, 61), // GridListPressed2                                                    
-            Color.FromArgb(33, 33, 33), // GridListSelected                                                    
-            Color.FromArgb(10, 10, 10), // GridSheetColNormal1                                                    
-            Color.FromArgb(41, 41, 41), // GridSheetColNormal2                                                    
-            Color.FromArgb(224, 224, 224), // GridSheetColPressed1                                                    
-            Color.FromArgb(195, 195, 195), // GridSheetColPressed2                                                    
+            Color.FromArgb(141, 144, 147), // RibbonQATFullbar1
+            Color.FromArgb(133, 135, 137), // RibbonQATFullbar2
+            Color.FromArgb(93, 96, 100), // RibbonQATFullbar3
+            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark
+            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight
+            Color.FromArgb(118, 128, 142), // RibbonQATOverflow1
+            Color.FromArgb(55, 60, 67), // RibbonQATOverflow2
+            Color.FromArgb(163, 168, 170), // RibbonGroupSeparatorDark
+            Color.FromArgb(230, 233, 235), // RibbonGroupSeparatorLight
+            Color.FromArgb(210, 217, 219), // ButtonClusterButtonBack1
+            Color.FromArgb(214, 222, 223), // ButtonClusterButtonBack2
+            Color.FromArgb(179, 188, 191), // ButtonClusterButtonBorder1
+            Color.FromArgb(145, 156, 159), // ButtonClusterButtonBorder2
+            Color.FromArgb(235, 235, 235), // NavigatorMiniBackColor
+            Color.FromArgb(10, 10, 10), // GridListNormal1
+            Color.FromArgb(41, 41, 41), // GridListNormal2
+            Color.FromArgb(41, 41, 41), // GridListPressed1
+            Color.FromArgb(61, 61, 61), // GridListPressed2
+            Color.FromArgb(33, 33, 33), // GridListSelected
+            Color.FromArgb(10, 10, 10), // GridSheetColNormal1
+            Color.FromArgb(41, 41, 41), // GridSheetColNormal2
+            Color.FromArgb(224, 224, 224), // GridSheetColPressed1
+            Color.FromArgb(195, 195, 195), // GridSheetColPressed2
             Color.FromArgb(91, 91, 91), // GridSheetColSelected1
             Color.FromArgb(33, 33, 33), // GridSheetColSelected2
-            Color.FromArgb(237, 237, 237), // GridSheetRowNormal                                                   
+            Color.FromArgb(237, 237, 237), // GridSheetRowNormal
             Color.FromArgb(196, 196, 196), // GridSheetRowPressed
             Color.FromArgb(61, 61, 61), // GridSheetRowSelected
             Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -310,6 +304,8 @@ namespace Krypton.Toolkit
             GlobalStaticValues.EMPTY_COLOR, // RibbonTabTracking4
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder3
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder4
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder5
+            Color.FromArgb(255, 255, 255), // RibbonGroupTitleText
             Color.FromArgb(225, 225, 225), // RibbonDropArrowLight
             Color.FromArgb(103, 103, 103), // RibbonDropArrowDark
             Color.FromArgb(137, 137, 137), // HeaderDockInactiveBack1
@@ -322,7 +318,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(148, 148, 143), // ButtonNavigatorPressed2
             Color.FromArgb(91, 91, 91), // ButtonNavigatorChecked1
             Color.FromArgb(73, 73, 73), // ButtonNavigatorChecked2
-            Color.FromArgb(91, 91, 91) // ToolTipBottom                                                                      
+            Color.FromArgb(91, 91, 91) // ToolTipBottom
         ];
 
         #endregion
@@ -649,47 +645,47 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
-                                                     PaletteButtonSpecStyle.PendantClose => _buttonSpecPendantClose,
-                                                     PaletteButtonSpecStyle.PendantMin => _buttonSpecPendantMin,
-                                                     PaletteButtonSpecStyle.PendantRestore => _buttonSpecPendantRestore,
-                                                     PaletteButtonSpecStyle.FormClose => state switch
-                                                     {
-                                                         PaletteState.Tracking => _formCloseActive,
-                                                         PaletteState.Normal => _formCloseNormal,
-                                                         PaletteState.Pressed => _formClosePressed,
-                                                         _ => _formCloseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMin => state switch
-                                                     {
-                                                         PaletteState.Normal => _formMinimiseNormal,
-                                                         PaletteState.Tracking => _formMinimiseActive,
-                                                         PaletteState.Pressed => _formMinimisePressed,
-                                                         _ => _formMinimiseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMax => state switch
-                                                     {
-                                                         PaletteState.Normal => _formMaximiseNormal,
-                                                         PaletteState.Tracking => _formMaximiseActive,
-                                                         PaletteState.Pressed => _formMaximisePressed,
-                                                         _ => _formMaximiseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormRestore => state switch
-                                                     {
-                                                         PaletteState.Normal => _formRestoreNormal,
-                                                         PaletteState.Tracking => _formRestoreActive,
-                                                         PaletteState.Pressed => _formRestorePressed,
-                                                         _ => _formRestoreDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormHelp => state switch
-                                                     {
-                                                         PaletteState.Tracking => _formHelpActive,
-                                                         PaletteState.Pressed => _formHelpPressed,
-                                                         PaletteState.Normal => _formHelpNormal,
-                                                         _ => _formHelpDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.RibbonMinimize => _buttonSpecRibbonMinimize,
-                                                     PaletteButtonSpecStyle.RibbonExpand => _buttonSpecRibbonExpand,
-                                                     _ => base.GetButtonSpecImage(style, state)
+ PaletteButtonSpecStyle.PendantClose => _buttonSpecPendantClose,
+ PaletteButtonSpecStyle.PendantMin => _buttonSpecPendantMin,
+ PaletteButtonSpecStyle.PendantRestore => _buttonSpecPendantRestore,
+ PaletteButtonSpecStyle.FormClose => state switch
+ {
+  PaletteState.Tracking => _formCloseActive,
+  PaletteState.Normal => _formCloseNormal,
+  PaletteState.Pressed => _formClosePressed,
+  _ => _formCloseDisabled
+ },
+ PaletteButtonSpecStyle.FormMin => state switch
+ {
+  PaletteState.Normal => _formMinimiseNormal,
+  PaletteState.Tracking => _formMinimiseActive,
+  PaletteState.Pressed => _formMinimisePressed,
+  _ => _formMinimiseDisabled
+ },
+ PaletteButtonSpecStyle.FormMax => state switch
+ {
+  PaletteState.Normal => _formMaximiseNormal,
+  PaletteState.Tracking => _formMaximiseActive,
+  PaletteState.Pressed => _formMaximisePressed,
+  _ => _formMaximiseDisabled
+ },
+ PaletteButtonSpecStyle.FormRestore => state switch
+ {
+  PaletteState.Normal => _formRestoreNormal,
+  PaletteState.Tracking => _formRestoreActive,
+  PaletteState.Pressed => _formRestorePressed,
+  _ => _formRestoreDisabled
+ },
+ PaletteButtonSpecStyle.FormHelp => state switch
+ {
+  PaletteState.Tracking => _formHelpActive,
+  PaletteState.Pressed => _formHelpPressed,
+  PaletteState.Normal => _formHelpNormal,
+  _ => _formHelpDisabled
+ },
+ PaletteButtonSpecStyle.RibbonMinimize => _buttonSpecRibbonMinimize,
+ PaletteButtonSpecStyle.RibbonExpand => _buttonSpecRibbonExpand,
+ _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 
@@ -1042,10 +1038,10 @@ namespace Krypton.Toolkit
         /// <param name="radioButtonArray">Array of images for radio button.</param>
         /// <param name="trackBarColors">Array of track bar specific colors.</param>
         protected PaletteOffice2010BlackDarkModeBase([DisallowNull] Color[] schemeColors,
-                                                     [DisallowNull] ImageList checkBoxList,
-                                                     [DisallowNull] ImageList galleryButtonList,
-                                                     [DisallowNull] Image?[] radioButtonArray,
-                                                     Color[] trackBarColors)
+ [DisallowNull] ImageList checkBoxList,
+ [DisallowNull] ImageList galleryButtonList,
+ [DisallowNull] Image?[] radioButtonArray,
+ Color[] trackBarColors)
         {
             Debug.Assert(schemeColors != null);
             Debug.Assert(checkBoxList != null);
@@ -1726,8 +1722,8 @@ namespace Krypton.Toolkit
                         PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack1] : _buttonBackColors[1],
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2],
                         PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
-                                                                ? GlobalStaticValues.EMPTY_COLOR
-                                                                : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
+         ? GlobalStaticValues.EMPTY_COLOR
+         : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2] : _buttonBackColors[7],
                         PaletteState.Tracking => _buttonBackColors[3],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
@@ -2082,8 +2078,8 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
                                                 ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
@@ -2106,8 +2102,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -2129,8 +2125,8 @@ namespace Krypton.Toolkit
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2] : _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
-                                                            ? GlobalStaticValues.EMPTY_COLOR
-                                                            : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+     ? GlobalStaticValues.EMPTY_COLOR
+     : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
@@ -2212,8 +2208,8 @@ namespace Krypton.Toolkit
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -2232,8 +2228,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-                                                        : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+ ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+ : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -3011,8 +3007,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3094,8 +3090,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3494,8 +3490,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3576,8 +3572,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlackDarkMode.cs
@@ -645,47 +645,47 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
- PaletteButtonSpecStyle.PendantClose => _buttonSpecPendantClose,
- PaletteButtonSpecStyle.PendantMin => _buttonSpecPendantMin,
- PaletteButtonSpecStyle.PendantRestore => _buttonSpecPendantRestore,
- PaletteButtonSpecStyle.FormClose => state switch
- {
-  PaletteState.Tracking => _formCloseActive,
-  PaletteState.Normal => _formCloseNormal,
-  PaletteState.Pressed => _formClosePressed,
-  _ => _formCloseDisabled
- },
- PaletteButtonSpecStyle.FormMin => state switch
- {
-  PaletteState.Normal => _formMinimiseNormal,
-  PaletteState.Tracking => _formMinimiseActive,
-  PaletteState.Pressed => _formMinimisePressed,
-  _ => _formMinimiseDisabled
- },
- PaletteButtonSpecStyle.FormMax => state switch
- {
-  PaletteState.Normal => _formMaximiseNormal,
-  PaletteState.Tracking => _formMaximiseActive,
-  PaletteState.Pressed => _formMaximisePressed,
-  _ => _formMaximiseDisabled
- },
- PaletteButtonSpecStyle.FormRestore => state switch
- {
-  PaletteState.Normal => _formRestoreNormal,
-  PaletteState.Tracking => _formRestoreActive,
-  PaletteState.Pressed => _formRestorePressed,
-  _ => _formRestoreDisabled
- },
- PaletteButtonSpecStyle.FormHelp => state switch
- {
-  PaletteState.Tracking => _formHelpActive,
-  PaletteState.Pressed => _formHelpPressed,
-  PaletteState.Normal => _formHelpNormal,
-  _ => _formHelpDisabled
- },
- PaletteButtonSpecStyle.RibbonMinimize => _buttonSpecRibbonMinimize,
- PaletteButtonSpecStyle.RibbonExpand => _buttonSpecRibbonExpand,
- _ => base.GetButtonSpecImage(style, state)
+                                                     PaletteButtonSpecStyle.PendantClose => _buttonSpecPendantClose,
+                                                     PaletteButtonSpecStyle.PendantMin => _buttonSpecPendantMin,
+                                                     PaletteButtonSpecStyle.PendantRestore => _buttonSpecPendantRestore,
+                                                     PaletteButtonSpecStyle.FormClose => state switch
+                                                     {
+                                                         PaletteState.Tracking => _formCloseActive,
+                                                         PaletteState.Normal => _formCloseNormal,
+                                                         PaletteState.Pressed => _formClosePressed,
+                                                         _ => _formCloseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMin => state switch
+                                                     {
+                                                         PaletteState.Normal => _formMinimiseNormal,
+                                                         PaletteState.Tracking => _formMinimiseActive,
+                                                         PaletteState.Pressed => _formMinimisePressed,
+                                                         _ => _formMinimiseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMax => state switch
+                                                     {
+                                                         PaletteState.Normal => _formMaximiseNormal,
+                                                         PaletteState.Tracking => _formMaximiseActive,
+                                                         PaletteState.Pressed => _formMaximisePressed,
+                                                         _ => _formMaximiseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormRestore => state switch
+                                                     {
+                                                         PaletteState.Normal => _formRestoreNormal,
+                                                         PaletteState.Tracking => _formRestoreActive,
+                                                         PaletteState.Pressed => _formRestorePressed,
+                                                         _ => _formRestoreDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormHelp => state switch
+                                                     {
+                                                         PaletteState.Tracking => _formHelpActive,
+                                                         PaletteState.Pressed => _formHelpPressed,
+                                                         PaletteState.Normal => _formHelpNormal,
+                                                         _ => _formHelpDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.RibbonMinimize => _buttonSpecRibbonMinimize,
+                                                     PaletteButtonSpecStyle.RibbonExpand => _buttonSpecRibbonExpand,
+                                                     _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 
@@ -1038,10 +1038,10 @@ namespace Krypton.Toolkit
         /// <param name="radioButtonArray">Array of images for radio button.</param>
         /// <param name="trackBarColors">Array of track bar specific colors.</param>
         protected PaletteOffice2010BlackDarkModeBase([DisallowNull] Color[] schemeColors,
- [DisallowNull] ImageList checkBoxList,
- [DisallowNull] ImageList galleryButtonList,
- [DisallowNull] Image?[] radioButtonArray,
- Color[] trackBarColors)
+                                                     [DisallowNull] ImageList checkBoxList,
+                                                     [DisallowNull] ImageList galleryButtonList,
+                                                     [DisallowNull] Image?[] radioButtonArray,
+                                                     Color[] trackBarColors)
         {
             Debug.Assert(schemeColors != null);
             Debug.Assert(checkBoxList != null);
@@ -1722,8 +1722,8 @@ namespace Krypton.Toolkit
                         PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack1] : _buttonBackColors[1],
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2],
                         PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
-         ? GlobalStaticValues.EMPTY_COLOR
-         : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
+                                                                ? GlobalStaticValues.EMPTY_COLOR
+                                                                : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2] : _buttonBackColors[7],
                         PaletteState.Tracking => _buttonBackColors[3],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
@@ -2078,8 +2078,8 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
                                                 ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
@@ -2102,8 +2102,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -2125,8 +2125,8 @@ namespace Krypton.Toolkit
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2] : _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
-     ? GlobalStaticValues.EMPTY_COLOR
-     : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+                                                            ? GlobalStaticValues.EMPTY_COLOR
+                                                            : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
@@ -2208,8 +2208,8 @@ namespace Krypton.Toolkit
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -2228,8 +2228,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
- ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
- : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+                                                        ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+                                                        : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -3007,8 +3007,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3090,8 +3090,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3490,8 +3490,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3572,8 +3572,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueDarkMode.cs
@@ -386,42 +386,42 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
- PaletteButtonSpecStyle.FormClose => state switch
- {
-  PaletteState.Tracking => _formCloseActive,
-  PaletteState.Normal => _formCloseNormal,
-  PaletteState.Pressed => _formClosePressed,
-  _ => _formCloseDisabled
- },
- PaletteButtonSpecStyle.FormMin => state switch
- {
-  PaletteState.Normal => _formMinimiseNormal,
-  PaletteState.Tracking => _formMinimiseActive,
-  PaletteState.Pressed => _formMinimisePressed,
-  _ => _formMinimiseDisabled
- },
- PaletteButtonSpecStyle.FormMax => state switch
- {
-  PaletteState.Normal => _formMaximiseNormal,
-  PaletteState.Tracking => _formMaximiseActive,
-  PaletteState.Pressed => _formMaximisePressed,
-  _ => _formMaximiseDisabled
- },
- PaletteButtonSpecStyle.FormRestore => state switch
- {
-  PaletteState.Normal => _formRestoreNormal,
-  PaletteState.Tracking => _formRestoreActive,
-  PaletteState.Pressed => _formRestorePressed,
-  _ => _formRestoreDisabled
- },
- PaletteButtonSpecStyle.FormHelp => state switch
- {
-  PaletteState.Tracking => _formHelpActive,
-  PaletteState.Pressed => _formHelpPressed,
-  PaletteState.Normal => _formHelpNormal,
-  _ => _formHelpDisabled
- },
- _ => base.GetButtonSpecImage(style, state)
+                                                     PaletteButtonSpecStyle.FormClose => state switch
+                                                     {
+                                                         PaletteState.Tracking => _formCloseActive,
+                                                         PaletteState.Normal => _formCloseNormal,
+                                                         PaletteState.Pressed => _formClosePressed,
+                                                         _ => _formCloseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMin => state switch
+                                                     {
+                                                         PaletteState.Normal => _formMinimiseNormal,
+                                                         PaletteState.Tracking => _formMinimiseActive,
+                                                         PaletteState.Pressed => _formMinimisePressed,
+                                                         _ => _formMinimiseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMax => state switch
+                                                     {
+                                                         PaletteState.Normal => _formMaximiseNormal,
+                                                         PaletteState.Tracking => _formMaximiseActive,
+                                                         PaletteState.Pressed => _formMaximisePressed,
+                                                         _ => _formMaximiseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormRestore => state switch
+                                                     {
+                                                         PaletteState.Normal => _formRestoreNormal,
+                                                         PaletteState.Tracking => _formRestoreActive,
+                                                         PaletteState.Pressed => _formRestorePressed,
+                                                         _ => _formRestoreDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormHelp => state switch
+                                                     {
+                                                         PaletteState.Tracking => _formHelpActive,
+                                                         PaletteState.Pressed => _formHelpPressed,
+                                                         PaletteState.Normal => _formHelpNormal,
+                                                         _ => _formHelpDisabled
+                                                     },
+                                                     _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 
@@ -615,53 +615,53 @@ namespace Krypton.Toolkit
         private static readonly Color[] _appButtonNormal =
         [
             Color.FromArgb(243, 245, 248),
-         Color.FromArgb(214, 220, 231),
-         Color.FromArgb(188, 198, 211),
-         Color.FromArgb(254, 254, 255),
-         Color.FromArgb(206, 213, 225)
+                                                                Color.FromArgb(214, 220, 231),
+                                                                Color.FromArgb(188, 198, 211),
+                                                                Color.FromArgb(254, 254, 255),
+                                                                Color.FromArgb(206, 213, 225)
         ];
 
         private static readonly Color[] _appButtonTrack =
         [
             Color.FromArgb(255, 251, 230),
-         Color.FromArgb(180, 210, 255),
-         Color.FromArgb(96, 147, 235),
-         Color.FromArgb(110, 150, 240),
-         Color.FromArgb(115, 155, 245)
+                                                                Color.FromArgb(180, 210, 255),
+                                                                Color.FromArgb(96, 147, 235),
+                                                                Color.FromArgb(110, 150, 240),
+                                                                Color.FromArgb(115, 155, 245)
         ];
 
         private static readonly Color[] _appButtonPressed =
         [
             Color.FromArgb(185, 215, 250),
-         Color.FromArgb(190, 220, 245),
-         Color.FromArgb(98, 155, 230),
-         Color.FromArgb(110, 160, 225),
-         Color.FromArgb(120, 175, 240)
+                                                                Color.FromArgb(190, 220, 245),
+                                                                Color.FromArgb(98, 155, 230),
+                                                                Color.FromArgb(110, 160, 225),
+                                                                Color.FromArgb(120, 175, 240)
         ];
 
         private static readonly Color[] _buttonBorderColors =
         [
             Color.FromArgb(212, 212, 212), // Button, Disabled, Border
-             Color.FromArgb(179, 209, 255), // Button, Tracking, Border 1
-             Color.FromArgb(179, 209, 249), // Button, Tracking, Border 2
-             Color.FromArgb(96, 147, 230), // Button, Pressed, Border 1
-             Color.FromArgb(32, 98, 200), // Button, Pressed, Border 2
-             Color.FromArgb(96, 147, 235), // Button, Checked, Border 1
-             Color.FromArgb(63, 122, 220)  // Button, Checked, Border 2
+                                                                    Color.FromArgb(179, 209, 255), // Button, Tracking, Border 1
+                                                                    Color.FromArgb(179, 209, 249), // Button, Tracking, Border 2
+                                                                    Color.FromArgb(96, 147, 230), // Button, Pressed, Border 1
+                                                                    Color.FromArgb(32, 98, 200), // Button, Pressed, Border 2
+                                                                    Color.FromArgb(96, 147, 235), // Button, Checked, Border 1
+                                                                    Color.FromArgb(63, 122, 220)  // Button, Checked, Border 2
         ];
 
         private static readonly Color[] _buttonBackColors =
         [
             Color.FromArgb(221, 221, 221), // Button, Disabled, Back 1
-         Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
-         Color.FromArgb(141, 168, 203), // Button, Tracking, Back 1
-         Color.FromArgb(95, 127, 169), // Button, Tracking, Back 2
-         Color.FromArgb(96, 150, 220), // Button, Pressed, Back 1
-         Color.FromArgb(179, 209, 247), // Button, Pressed, Back 2
-         Color.FromArgb(32, 98, 183), // Button, Checked, Back 1
-         Color.FromArgb(141, 180, 230), // Button, Checked, Back 2
-         Color.FromArgb(63, 122, 197), // Button, Checked Tracking, Back 1
-         Color.FromArgb(96, 147, 213)  // Button, Checked Tracking, Back 2
+                                                                Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
+                                                                Color.FromArgb(141, 168, 203), // Button, Tracking, Back 1
+                                                                Color.FromArgb(95, 127, 169), // Button, Tracking, Back 2
+                                                                Color.FromArgb(96, 150, 220), // Button, Pressed, Back 1
+                                                                Color.FromArgb(179, 209, 247), // Button, Pressed, Back 2
+                                                                Color.FromArgb(32, 98, 183), // Button, Checked, Back 1
+                                                                Color.FromArgb(141, 180, 230), // Button, Checked, Back 2
+                                                                Color.FromArgb(63, 122, 197), // Button, Checked Tracking, Back 1
+                                                                Color.FromArgb(96, 147, 213)  // Button, Checked Tracking, Back 2
         ];
 
         #endregion
@@ -1370,8 +1370,8 @@ namespace Krypton.Toolkit
                         PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack1] : _buttonBackColors[1],
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2],
                         PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
-     ? GlobalStaticValues.EMPTY_COLOR
-     : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
+                                                            ? GlobalStaticValues.EMPTY_COLOR
+                                                            : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2] : _buttonBackColors[7],
                         PaletteState.Tracking => _buttonBackColors[3],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
@@ -1726,8 +1726,8 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
                                                 ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
@@ -1750,8 +1750,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -1773,8 +1773,8 @@ namespace Krypton.Toolkit
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2] : _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
- ? GlobalStaticValues.EMPTY_COLOR
- : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+                                                        ? GlobalStaticValues.EMPTY_COLOR
+                                                        : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
@@ -1856,8 +1856,8 @@ namespace Krypton.Toolkit
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
- ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
- : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                        ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                        : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -1876,8 +1876,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -2650,8 +2650,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -2728,8 +2728,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3127,8 +3127,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3203,8 +3203,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueDarkMode.cs
@@ -233,38 +233,38 @@ namespace Krypton.Toolkit
             Color.FromArgb(219, 231, 247), // RibbonQATMini2
             Color.FromArgb(195, 213, 236), // RibbonQATMini3
             Color.FromArgb(128, Color.White), // RibbonQATMini4
-            Color.FromArgb(72, Color.White), // RibbonQATMini5                                                       
+            Color.FromArgb(72, Color.White), // RibbonQATMini5
             Color.FromArgb(153, 176, 206), // RibbonQATMini1I
             Color.FromArgb(226, 233, 241), // RibbonQATMini2I
             Color.FromArgb(198, 210, 226), // RibbonQATMini3I
             Color.FromArgb(128, Color.White), // RibbonQATMini4I
-            Color.FromArgb(72, Color.White), // RibbonQATMini5I                                                      
-            Color.FromArgb(178, 205, 237), // RibbonQATFullbar1                                                      
-            Color.FromArgb(170, 197, 234), // RibbonQATFullbar2                                                      
-            Color.FromArgb(126, 161, 205), // RibbonQATFullbar3                                                      
-            Color.FromArgb(86, 125, 177), // RibbonQATButtonDark                                                      
-            Color.FromArgb(234, 242, 249), // RibbonQATButtonLight                                                      
-            Color.FromArgb(192, 220, 255), // RibbonQATOverflow1                                                      
-            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-            Color.FromArgb(140, 172, 211), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(248, 250, 252), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(192, 212, 241), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(200, 219, 238), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(155, 183, 224), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(117, 150, 191), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor                                                    
-            Color.FromArgb(134, 179, 236), // GridListNormal1                                                    
-            Color.FromArgb(63, 122, 197), // GridListNormal2                                                    
-            Color.FromArgb(63, 122, 197), // GridListPressed1                                                    
-            Color.FromArgb(252, 253, 255), // GridListPressed2                                                    
-            Color.FromArgb(170, 195, 240), // GridListSelected                                                    
-            Color.FromArgb(134, 179, 236), // GridSheetColNormal1                                                    
-            Color.FromArgb(63, 122, 197), // GridSheetColNormal2                                                    
-            Color.FromArgb(223, 226, 228), // GridSheetColPressed1                                                    
-            Color.FromArgb(188, 197, 210), // GridSheetColPressed2                                                    
+            Color.FromArgb(72, Color.White), // RibbonQATMini5I
+            Color.FromArgb(178, 205, 237), // RibbonQATFullbar1
+            Color.FromArgb(170, 197, 234), // RibbonQATFullbar2
+            Color.FromArgb(126, 161, 205), // RibbonQATFullbar3
+            Color.FromArgb(86, 125, 177), // RibbonQATButtonDark
+            Color.FromArgb(234, 242, 249), // RibbonQATButtonLight
+            Color.FromArgb(192, 220, 255), // RibbonQATOverflow1
+            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
+            Color.FromArgb(140, 172, 211), // RibbonGroupSeparatorDark
+            Color.FromArgb(248, 250, 252), // RibbonGroupSeparatorLight
+            Color.FromArgb(192, 212, 241), // ButtonClusterButtonBack1
+            Color.FromArgb(200, 219, 238), // ButtonClusterButtonBack2
+            Color.FromArgb(155, 183, 224), // ButtonClusterButtonBorder1
+            Color.FromArgb(117, 150, 191), // ButtonClusterButtonBorder2
+            Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor
+            Color.FromArgb(134, 179, 236), // GridListNormal1
+            Color.FromArgb(63, 122, 197), // GridListNormal2
+            Color.FromArgb(63, 122, 197), // GridListPressed1
+            Color.FromArgb(252, 253, 255), // GridListPressed2
+            Color.FromArgb(170, 195, 240), // GridListSelected
+            Color.FromArgb(134, 179, 236), // GridSheetColNormal1
+            Color.FromArgb(63, 122, 197), // GridSheetColNormal2
+            Color.FromArgb(223, 226, 228), // GridSheetColPressed1
+            Color.FromArgb(188, 197, 210), // GridSheetColPressed2
             Color.FromArgb(249, 217, 159), // GridSheetColSelected1
             Color.FromArgb(241, 193, 95), // GridSheetColSelected2
-            Color.FromArgb(228, 236, 247), // GridSheetRowNormal                                                   
+            Color.FromArgb(228, 236, 247), // GridSheetRowNormal
             Color.FromArgb(187, 196, 209), // GridSheetRowPressed
             Color.FromArgb(255, 213, 141), // GridSheetRowSelected
             Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -318,7 +318,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(198, 214, 231), // ButtonNavigatorPressed2
             Color.FromArgb(200, 219, 240), // ButtonNavigatorChecked1
             Color.FromArgb(177, 201, 228), // ButtonNavigatorChecked2
-            Color.FromArgb(201, 217, 239) // ToolTipBottom                                                                      
+            Color.FromArgb(201, 217, 239) // ToolTipBottom
         ];
 
         #endregion
@@ -386,42 +386,42 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
-                                                     PaletteButtonSpecStyle.FormClose => state switch
-                                                     {
-                                                         PaletteState.Tracking => _formCloseActive,
-                                                         PaletteState.Normal => _formCloseNormal,
-                                                         PaletteState.Pressed => _formClosePressed,
-                                                         _ => _formCloseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMin => state switch
-                                                     {
-                                                         PaletteState.Normal => _formMinimiseNormal,
-                                                         PaletteState.Tracking => _formMinimiseActive,
-                                                         PaletteState.Pressed => _formMinimisePressed,
-                                                         _ => _formMinimiseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMax => state switch
-                                                     {
-                                                         PaletteState.Normal => _formMaximiseNormal,
-                                                         PaletteState.Tracking => _formMaximiseActive,
-                                                         PaletteState.Pressed => _formMaximisePressed,
-                                                         _ => _formMaximiseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormRestore => state switch
-                                                     {
-                                                         PaletteState.Normal => _formRestoreNormal,
-                                                         PaletteState.Tracking => _formRestoreActive,
-                                                         PaletteState.Pressed => _formRestorePressed,
-                                                         _ => _formRestoreDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormHelp => state switch
-                                                     {
-                                                         PaletteState.Tracking => _formHelpActive,
-                                                         PaletteState.Pressed => _formHelpPressed,
-                                                         PaletteState.Normal => _formHelpNormal,
-                                                         _ => _formHelpDisabled
-                                                     },
-                                                     _ => base.GetButtonSpecImage(style, state)
+ PaletteButtonSpecStyle.FormClose => state switch
+ {
+  PaletteState.Tracking => _formCloseActive,
+  PaletteState.Normal => _formCloseNormal,
+  PaletteState.Pressed => _formClosePressed,
+  _ => _formCloseDisabled
+ },
+ PaletteButtonSpecStyle.FormMin => state switch
+ {
+  PaletteState.Normal => _formMinimiseNormal,
+  PaletteState.Tracking => _formMinimiseActive,
+  PaletteState.Pressed => _formMinimisePressed,
+  _ => _formMinimiseDisabled
+ },
+ PaletteButtonSpecStyle.FormMax => state switch
+ {
+  PaletteState.Normal => _formMaximiseNormal,
+  PaletteState.Tracking => _formMaximiseActive,
+  PaletteState.Pressed => _formMaximisePressed,
+  _ => _formMaximiseDisabled
+ },
+ PaletteButtonSpecStyle.FormRestore => state switch
+ {
+  PaletteState.Normal => _formRestoreNormal,
+  PaletteState.Tracking => _formRestoreActive,
+  PaletteState.Pressed => _formRestorePressed,
+  _ => _formRestoreDisabled
+ },
+ PaletteButtonSpecStyle.FormHelp => state switch
+ {
+  PaletteState.Tracking => _formHelpActive,
+  PaletteState.Pressed => _formHelpPressed,
+  PaletteState.Normal => _formHelpNormal,
+  _ => _formHelpDisabled
+ },
+ _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 
@@ -615,53 +615,53 @@ namespace Krypton.Toolkit
         private static readonly Color[] _appButtonNormal =
         [
             Color.FromArgb(243, 245, 248),
-                                                                Color.FromArgb(214, 220, 231),
-                                                                Color.FromArgb(188, 198, 211),
-                                                                Color.FromArgb(254, 254, 255),
-                                                                Color.FromArgb(206, 213, 225)
+         Color.FromArgb(214, 220, 231),
+         Color.FromArgb(188, 198, 211),
+         Color.FromArgb(254, 254, 255),
+         Color.FromArgb(206, 213, 225)
         ];
 
         private static readonly Color[] _appButtonTrack =
         [
             Color.FromArgb(255, 251, 230),
-                                                                Color.FromArgb(180, 210, 255),
-                                                                Color.FromArgb(96, 147, 235),
-                                                                Color.FromArgb(110, 150, 240),
-                                                                Color.FromArgb(115, 155, 245)
+         Color.FromArgb(180, 210, 255),
+         Color.FromArgb(96, 147, 235),
+         Color.FromArgb(110, 150, 240),
+         Color.FromArgb(115, 155, 245)
         ];
 
         private static readonly Color[] _appButtonPressed =
         [
             Color.FromArgb(185, 215, 250),
-                                                                Color.FromArgb(190, 220, 245),
-                                                                Color.FromArgb(98, 155, 230),
-                                                                Color.FromArgb(110, 160, 225),
-                                                                Color.FromArgb(120, 175, 240)
+         Color.FromArgb(190, 220, 245),
+         Color.FromArgb(98, 155, 230),
+         Color.FromArgb(110, 160, 225),
+         Color.FromArgb(120, 175, 240)
         ];
 
         private static readonly Color[] _buttonBorderColors =
         [
             Color.FromArgb(212, 212, 212), // Button, Disabled, Border
-                                                                    Color.FromArgb(179, 209, 255), // Button, Tracking, Border 1
-                                                                    Color.FromArgb(179, 209, 249), // Button, Tracking, Border 2
-                                                                    Color.FromArgb(96, 147, 230), // Button, Pressed, Border 1
-                                                                    Color.FromArgb(32, 98, 200), // Button, Pressed, Border 2
-                                                                    Color.FromArgb(96, 147, 235), // Button, Checked, Border 1
-                                                                    Color.FromArgb(63, 122, 220)  // Button, Checked, Border 2
+             Color.FromArgb(179, 209, 255), // Button, Tracking, Border 1
+             Color.FromArgb(179, 209, 249), // Button, Tracking, Border 2
+             Color.FromArgb(96, 147, 230), // Button, Pressed, Border 1
+             Color.FromArgb(32, 98, 200), // Button, Pressed, Border 2
+             Color.FromArgb(96, 147, 235), // Button, Checked, Border 1
+             Color.FromArgb(63, 122, 220)  // Button, Checked, Border 2
         ];
 
         private static readonly Color[] _buttonBackColors =
         [
             Color.FromArgb(221, 221, 221), // Button, Disabled, Back 1
-                                                                Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
-                                                                Color.FromArgb(141, 168, 203), // Button, Tracking, Back 1
-                                                                Color.FromArgb(95, 127, 169), // Button, Tracking, Back 2
-                                                                Color.FromArgb(96, 150, 220), // Button, Pressed, Back 1
-                                                                Color.FromArgb(179, 209, 247), // Button, Pressed, Back 2
-                                                                Color.FromArgb(32, 98, 183), // Button, Checked, Back 1
-                                                                Color.FromArgb(141, 180, 230), // Button, Checked, Back 2
-                                                                Color.FromArgb(63, 122, 197), // Button, Checked Tracking, Back 1
-                                                                Color.FromArgb(96, 147, 213)  // Button, Checked Tracking, Back 2
+         Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
+         Color.FromArgb(141, 168, 203), // Button, Tracking, Back 1
+         Color.FromArgb(95, 127, 169), // Button, Tracking, Back 2
+         Color.FromArgb(96, 150, 220), // Button, Pressed, Back 1
+         Color.FromArgb(179, 209, 247), // Button, Pressed, Back 2
+         Color.FromArgb(32, 98, 183), // Button, Checked, Back 1
+         Color.FromArgb(141, 180, 230), // Button, Checked, Back 2
+         Color.FromArgb(63, 122, 197), // Button, Checked Tracking, Back 1
+         Color.FromArgb(96, 147, 213)  // Button, Checked Tracking, Back 2
         ];
 
         #endregion
@@ -1370,8 +1370,8 @@ namespace Krypton.Toolkit
                         PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack1] : _buttonBackColors[1],
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2],
                         PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
-                                                            ? GlobalStaticValues.EMPTY_COLOR
-                                                            : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
+     ? GlobalStaticValues.EMPTY_COLOR
+     : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2] : _buttonBackColors[7],
                         PaletteState.Tracking => _buttonBackColors[3],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
@@ -1726,8 +1726,8 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
                                                 ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
@@ -1750,8 +1750,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -1773,8 +1773,8 @@ namespace Krypton.Toolkit
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2] : _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
-                                                        ? GlobalStaticValues.EMPTY_COLOR
-                                                        : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+ ? GlobalStaticValues.EMPTY_COLOR
+ : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
@@ -1856,8 +1856,8 @@ namespace Krypton.Toolkit
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                        : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+ ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+ : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -1876,8 +1876,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -2650,8 +2650,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -2728,8 +2728,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3127,8 +3127,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3203,8 +3203,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueLightMode.cs
@@ -238,44 +238,38 @@ namespace Krypton.Toolkit
             Color.FromArgb(219, 231, 247), // RibbonQATMini2
             Color.FromArgb(195, 213, 236), // RibbonQATMini3
             Color.FromArgb(128, Color.White), // RibbonQATMini4
-            Color.FromArgb(72, Color.White), // RibbonQATMini5                                                       
+            Color.FromArgb(72, Color.White), // RibbonQATMini5
             Color.FromArgb(153, 176, 206), // RibbonQATMini1I
             Color.FromArgb(226, 233, 241), // RibbonQATMini2I
             Color.FromArgb(198, 210, 226), // RibbonQATMini3I
             Color.FromArgb(128, Color.White), // RibbonQATMini4I
-            Color.FromArgb(72, Color.White), // RibbonQATMini5I                                                      
-            Color.FromArgb(178, 205, 237), // RibbonQATFullbar1                                                      
-            Color.FromArgb(170, 197, 234), // RibbonQATFullbar2                                                      
-            Color.FromArgb(126, 161, 205), // RibbonQATFullbar3                                                      
-            Color.FromArgb(86, 125, 177), // RibbonQATButtonDark                                                      
-            Color.FromArgb(234, 242, 249), // RibbonQATButtonLight                                                      
-            Color.FromArgb(192, 220, 255), // RibbonQATOverflow1                                                      
-            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-            Color.FromArgb(140, 172,
-                211), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(248, 250,
-                252), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(192, 212,
-                241), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(200, 219,
-                238), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(155, 183,
-                224), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(117, 150,
-                191), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor                                                    
-            Color.FromArgb(230, 239, 249), // GridListNormal1                                                    
-            Color.FromArgb(209, 226, 244), // GridListNormal2                                                    
-            Color.FromArgb(209, 226, 244), // GridListPressed1                                                    
-            Color.FromArgb(252, 253, 255), // GridListPressed2                                                    
-            Color.FromArgb(168, 200, 234), // GridListSelected                                                    
-            Color.FromArgb(230, 239, 249), // GridSheetColNormal1                                                    
-            Color.FromArgb(209, 226, 244), // GridSheetColNormal2                                                    
-            Color.FromArgb(223, 226, 228), // GridSheetColPressed1                                                    
-            Color.FromArgb(188, 197, 210), // GridSheetColPressed2                                                    
+            Color.FromArgb(72, Color.White), // RibbonQATMini5I
+            Color.FromArgb(178, 205, 237), // RibbonQATFullbar1
+            Color.FromArgb(170, 197, 234), // RibbonQATFullbar2
+            Color.FromArgb(126, 161, 205), // RibbonQATFullbar3
+            Color.FromArgb(86, 125, 177), // RibbonQATButtonDark
+            Color.FromArgb(234, 242, 249), // RibbonQATButtonLight
+            Color.FromArgb(192, 220, 255), // RibbonQATOverflow1
+            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
+            Color.FromArgb(140, 172, 211), // RibbonGroupSeparatorDark
+            Color.FromArgb(248, 250, 252), // RibbonGroupSeparatorLight
+            Color.FromArgb(192, 212, 241), // ButtonClusterButtonBack1
+            Color.FromArgb(200, 219, 238), // ButtonClusterButtonBack2
+            Color.FromArgb(155, 183, 224), // ButtonClusterButtonBorder1
+            Color.FromArgb(117, 150, 191), // ButtonClusterButtonBorder2
+            Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor
+            Color.FromArgb(230, 239, 249), // GridListNormal1
+            Color.FromArgb(209, 226, 244), // GridListNormal2
+            Color.FromArgb(209, 226, 244), // GridListPressed1
+            Color.FromArgb(252, 253, 255), // GridListPressed2
+            Color.FromArgb(168, 200, 234), // GridListSelected
+            Color.FromArgb(230, 239, 249), // GridSheetColNormal1
+            Color.FromArgb(209, 226, 244), // GridSheetColNormal2
+            Color.FromArgb(223, 226, 228), // GridSheetColPressed1
+            Color.FromArgb(188, 197, 210), // GridSheetColPressed2
             Color.FromArgb(188, 213, 239), // GridSheetColSelected1
             Color.FromArgb(168, 200, 234), // GridSheetColSelected2
-            Color.FromArgb(228, 236, 247), // GridSheetRowNormal                                                   
+            Color.FromArgb(228, 236, 247), // GridSheetRowNormal
             Color.FromArgb(187, 196, 209), // GridSheetRowPressed
             Color.FromArgb(255, 213, 141), // GridSheetRowSelected
             Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -329,8 +323,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(198, 214, 231), // ButtonNavigatorPressed2
             Color.FromArgb(200, 219, 240), // ButtonNavigatorChecked1
             Color.FromArgb(177, 201, 228), // ButtonNavigatorChecked2
-            Color.FromArgb(201, 217,
-                239) // ToolTipBottom                                                                      
+            Color.FromArgb(201, 217, 239) // ToolTipBottom
         ];
 
         #endregion
@@ -398,42 +391,42 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
-                                                     PaletteButtonSpecStyle.FormClose => state switch
-                                                     {
-                                                         PaletteState.Tracking => _formCloseActive,
-                                                         PaletteState.Normal => _formCloseNormal,
-                                                         PaletteState.Pressed => _formClosePressed,
-                                                         _ => _formCloseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMin => state switch
-                                                     {
-                                                         PaletteState.Normal => _formMinimiseNormal,
-                                                         PaletteState.Tracking => _formMinimiseActive,
-                                                         PaletteState.Pressed => _formMinimisePressed,
-                                                         _ => _formMinimiseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMax => state switch
-                                                     {
-                                                         PaletteState.Normal => _formMaximiseNormal,
-                                                         PaletteState.Tracking => _formMaximiseActive,
-                                                         PaletteState.Pressed => _formMaximisePressed,
-                                                         _ => _formMaximiseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormRestore => state switch
-                                                     {
-                                                         PaletteState.Normal => _formRestoreNormal,
-                                                         PaletteState.Tracking => _formRestoreActive,
-                                                         PaletteState.Pressed => _formRestorePressed,
-                                                         _ => _formRestoreDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormHelp => state switch
-                                                     {
-                                                         PaletteState.Tracking => _formHelpActive,
-                                                         PaletteState.Pressed => _formHelpPressed,
-                                                         PaletteState.Normal => _formHelpNormal,
-                                                         _ => _formHelpDisabled
-                                                     },
-                                                     _ => base.GetButtonSpecImage(style, state)
+ PaletteButtonSpecStyle.FormClose => state switch
+ {
+  PaletteState.Tracking => _formCloseActive,
+  PaletteState.Normal => _formCloseNormal,
+  PaletteState.Pressed => _formClosePressed,
+  _ => _formCloseDisabled
+ },
+ PaletteButtonSpecStyle.FormMin => state switch
+ {
+  PaletteState.Normal => _formMinimiseNormal,
+  PaletteState.Tracking => _formMinimiseActive,
+  PaletteState.Pressed => _formMinimisePressed,
+  _ => _formMinimiseDisabled
+ },
+ PaletteButtonSpecStyle.FormMax => state switch
+ {
+  PaletteState.Normal => _formMaximiseNormal,
+  PaletteState.Tracking => _formMaximiseActive,
+  PaletteState.Pressed => _formMaximisePressed,
+  _ => _formMaximiseDisabled
+ },
+ PaletteButtonSpecStyle.FormRestore => state switch
+ {
+  PaletteState.Normal => _formRestoreNormal,
+  PaletteState.Tracking => _formRestoreActive,
+  PaletteState.Pressed => _formRestorePressed,
+  _ => _formRestoreDisabled
+ },
+ PaletteButtonSpecStyle.FormHelp => state switch
+ {
+  PaletteState.Tracking => _formHelpActive,
+  PaletteState.Pressed => _formHelpPressed,
+  PaletteState.Normal => _formHelpNormal,
+  _ => _formHelpDisabled
+ },
+ _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 
@@ -633,25 +626,25 @@ namespace Krypton.Toolkit
         private static readonly Color[] _buttonBorderColors =
         [
             Color.FromArgb(212, 212, 212), // Button, Disabled, Border
-                                                                Color.FromArgb(168, 200, 234), // Button, Tracking, Border 1
-                                                                Color.FromArgb(170, 210, 245), // Button, Tracking, Border 2
-                                                                Color.FromArgb(155, 205, 230), // Button, Pressed, Border 1
-                                                                Color.FromArgb(150, 200, 225), // Button, Pressed, Border 2
-                                                                Color.FromArgb(148, 197,  220), // Button, Checked, Border 1
-                                                                Color.FromArgb(160, 205, 240)  // Button, Checked, Border 2
+         Color.FromArgb(168, 200, 234), // Button, Tracking, Border 1
+         Color.FromArgb(170, 210, 245), // Button, Tracking, Border 2
+         Color.FromArgb(155, 205, 230), // Button, Pressed, Border 1
+         Color.FromArgb(150, 200, 225), // Button, Pressed, Border 2
+         Color.FromArgb(148, 197,  220), // Button, Checked, Border 1
+         Color.FromArgb(160, 205, 240)  // Button, Checked, Border 2
         ];
         private static readonly Color[] _buttonBackColors =
         [
             Color.FromArgb(221, 221, 221), // Button, Disabled, Back 1
-                                                                Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
-                                                                Color.FromArgb(188, 213, 239), // Button, Tracking, Back 1
-                                                                Color.FromArgb(168, 200, 234), // Button, Tracking, Back 2
-                                                                Color.FromArgb(209, 226, 244), // Button, Pressed, Back 1
-                                                                Color.FromArgb(188, 213, 239), // Button, Pressed, Back 2
-                                                                Color.FromArgb(189, 213, 233), // Button, Checked, Back 1
-                                                                Color.FromArgb(188, 213, 239), // Button, Checked, Back 2
-                                                                Color.FromArgb(209, 226, 244), // Button, Checked Tracking, Back 1
-                                                                Color.FromArgb(210, 226, 244)  // Button, Checked Tracking, Back 2
+         Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
+         Color.FromArgb(188, 213, 239), // Button, Tracking, Back 1
+         Color.FromArgb(168, 200, 234), // Button, Tracking, Back 2
+         Color.FromArgb(209, 226, 244), // Button, Pressed, Back 1
+         Color.FromArgb(188, 213, 239), // Button, Pressed, Back 2
+         Color.FromArgb(189, 213, 233), // Button, Checked, Back 1
+         Color.FromArgb(188, 213, 239), // Button, Checked, Back 2
+         Color.FromArgb(209, 226, 244), // Button, Checked Tracking, Back 1
+         Color.FromArgb(210, 226, 244)  // Button, Checked Tracking, Back 2
         ];
 
         #endregion
@@ -1360,8 +1353,8 @@ namespace Krypton.Toolkit
                         PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack1] : _buttonBackColors[1],
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2],
                         PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
-                                                                ? GlobalStaticValues.EMPTY_COLOR
-                                                                : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
+         ? GlobalStaticValues.EMPTY_COLOR
+         : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2] : _buttonBackColors[7],
                         PaletteState.Tracking => _buttonBackColors[3],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
@@ -1716,8 +1709,8 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                        : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+ ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+ : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
                                                 ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
@@ -1740,8 +1733,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -1763,8 +1756,8 @@ namespace Krypton.Toolkit
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2] : _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
-                                                        ? GlobalStaticValues.EMPTY_COLOR
-                                                        : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+ ? GlobalStaticValues.EMPTY_COLOR
+ : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
@@ -1846,8 +1839,8 @@ namespace Krypton.Toolkit
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -1866,8 +1859,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -2640,8 +2633,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -2718,8 +2711,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3117,8 +3110,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3193,8 +3186,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueLightMode.cs
@@ -391,42 +391,42 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
- PaletteButtonSpecStyle.FormClose => state switch
- {
-  PaletteState.Tracking => _formCloseActive,
-  PaletteState.Normal => _formCloseNormal,
-  PaletteState.Pressed => _formClosePressed,
-  _ => _formCloseDisabled
- },
- PaletteButtonSpecStyle.FormMin => state switch
- {
-  PaletteState.Normal => _formMinimiseNormal,
-  PaletteState.Tracking => _formMinimiseActive,
-  PaletteState.Pressed => _formMinimisePressed,
-  _ => _formMinimiseDisabled
- },
- PaletteButtonSpecStyle.FormMax => state switch
- {
-  PaletteState.Normal => _formMaximiseNormal,
-  PaletteState.Tracking => _formMaximiseActive,
-  PaletteState.Pressed => _formMaximisePressed,
-  _ => _formMaximiseDisabled
- },
- PaletteButtonSpecStyle.FormRestore => state switch
- {
-  PaletteState.Normal => _formRestoreNormal,
-  PaletteState.Tracking => _formRestoreActive,
-  PaletteState.Pressed => _formRestorePressed,
-  _ => _formRestoreDisabled
- },
- PaletteButtonSpecStyle.FormHelp => state switch
- {
-  PaletteState.Tracking => _formHelpActive,
-  PaletteState.Pressed => _formHelpPressed,
-  PaletteState.Normal => _formHelpNormal,
-  _ => _formHelpDisabled
- },
- _ => base.GetButtonSpecImage(style, state)
+                                                     PaletteButtonSpecStyle.FormClose => state switch
+                                                     {
+                                                         PaletteState.Tracking => _formCloseActive,
+                                                         PaletteState.Normal => _formCloseNormal,
+                                                         PaletteState.Pressed => _formClosePressed,
+                                                         _ => _formCloseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMin => state switch
+                                                     {
+                                                         PaletteState.Normal => _formMinimiseNormal,
+                                                         PaletteState.Tracking => _formMinimiseActive,
+                                                         PaletteState.Pressed => _formMinimisePressed,
+                                                         _ => _formMinimiseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMax => state switch
+                                                     {
+                                                         PaletteState.Normal => _formMaximiseNormal,
+                                                         PaletteState.Tracking => _formMaximiseActive,
+                                                         PaletteState.Pressed => _formMaximisePressed,
+                                                         _ => _formMaximiseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormRestore => state switch
+                                                     {
+                                                         PaletteState.Normal => _formRestoreNormal,
+                                                         PaletteState.Tracking => _formRestoreActive,
+                                                         PaletteState.Pressed => _formRestorePressed,
+                                                         _ => _formRestoreDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormHelp => state switch
+                                                     {
+                                                         PaletteState.Tracking => _formHelpActive,
+                                                         PaletteState.Pressed => _formHelpPressed,
+                                                         PaletteState.Normal => _formHelpNormal,
+                                                         _ => _formHelpDisabled
+                                                     },
+                                                     _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 
@@ -626,25 +626,25 @@ namespace Krypton.Toolkit
         private static readonly Color[] _buttonBorderColors =
         [
             Color.FromArgb(212, 212, 212), // Button, Disabled, Border
-         Color.FromArgb(168, 200, 234), // Button, Tracking, Border 1
-         Color.FromArgb(170, 210, 245), // Button, Tracking, Border 2
-         Color.FromArgb(155, 205, 230), // Button, Pressed, Border 1
-         Color.FromArgb(150, 200, 225), // Button, Pressed, Border 2
-         Color.FromArgb(148, 197,  220), // Button, Checked, Border 1
-         Color.FromArgb(160, 205, 240)  // Button, Checked, Border 2
+                                                                Color.FromArgb(168, 200, 234), // Button, Tracking, Border 1
+                                                                Color.FromArgb(170, 210, 245), // Button, Tracking, Border 2
+                                                                Color.FromArgb(155, 205, 230), // Button, Pressed, Border 1
+                                                                Color.FromArgb(150, 200, 225), // Button, Pressed, Border 2
+                                                                Color.FromArgb(148, 197,  220), // Button, Checked, Border 1
+                                                                Color.FromArgb(160, 205, 240)  // Button, Checked, Border 2
         ];
         private static readonly Color[] _buttonBackColors =
         [
             Color.FromArgb(221, 221, 221), // Button, Disabled, Back 1
-         Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
-         Color.FromArgb(188, 213, 239), // Button, Tracking, Back 1
-         Color.FromArgb(168, 200, 234), // Button, Tracking, Back 2
-         Color.FromArgb(209, 226, 244), // Button, Pressed, Back 1
-         Color.FromArgb(188, 213, 239), // Button, Pressed, Back 2
-         Color.FromArgb(189, 213, 233), // Button, Checked, Back 1
-         Color.FromArgb(188, 213, 239), // Button, Checked, Back 2
-         Color.FromArgb(209, 226, 244), // Button, Checked Tracking, Back 1
-         Color.FromArgb(210, 226, 244)  // Button, Checked Tracking, Back 2
+                                                                Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
+                                                                Color.FromArgb(188, 213, 239), // Button, Tracking, Back 1
+                                                                Color.FromArgb(168, 200, 234), // Button, Tracking, Back 2
+                                                                Color.FromArgb(209, 226, 244), // Button, Pressed, Back 1
+                                                                Color.FromArgb(188, 213, 239), // Button, Pressed, Back 2
+                                                                Color.FromArgb(189, 213, 233), // Button, Checked, Back 1
+                                                                Color.FromArgb(188, 213, 239), // Button, Checked, Back 2
+                                                                Color.FromArgb(209, 226, 244), // Button, Checked Tracking, Back 1
+                                                                Color.FromArgb(210, 226, 244)  // Button, Checked Tracking, Back 2
         ];
 
         #endregion
@@ -1353,8 +1353,8 @@ namespace Krypton.Toolkit
                         PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack1] : _buttonBackColors[1],
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2],
                         PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
-         ? GlobalStaticValues.EMPTY_COLOR
-         : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
+                                                                ? GlobalStaticValues.EMPTY_COLOR
+                                                                : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2] : _buttonBackColors[7],
                         PaletteState.Tracking => _buttonBackColors[3],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
@@ -1709,8 +1709,8 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
- ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
- : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                        ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                        : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
                                                 ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
@@ -1733,8 +1733,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -1756,8 +1756,8 @@ namespace Krypton.Toolkit
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2] : _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
- ? GlobalStaticValues.EMPTY_COLOR
- : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+                                                        ? GlobalStaticValues.EMPTY_COLOR
+                                                        : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
@@ -1839,8 +1839,8 @@ namespace Krypton.Toolkit
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -1859,8 +1859,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -2633,8 +2633,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -2711,8 +2711,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3110,8 +3110,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3186,8 +3186,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverDarkMode.cs
@@ -388,42 +388,42 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
- PaletteButtonSpecStyle.FormClose => state switch
- {
-  PaletteState.Tracking => _formCloseActive,
-  PaletteState.Normal => _formCloseNormal,
-  PaletteState.Pressed => _formClosePressed,
-  _ => _formCloseDisabled
- },
- PaletteButtonSpecStyle.FormMin => state switch
- {
-  PaletteState.Normal => _formMinimiseNormal,
-  PaletteState.Tracking => _formMinimiseActive,
-  PaletteState.Pressed => _formMinimisePressed,
-  _ => _formMinimiseDisabled
- },
- PaletteButtonSpecStyle.FormMax => state switch
- {
-  PaletteState.Normal => _formMaximiseNormal,
-  PaletteState.Tracking => _formMaximiseActive,
-  PaletteState.Pressed => _formMaximisePressed,
-  _ => _formMaximiseDisabled
- },
- PaletteButtonSpecStyle.FormRestore => state switch
- {
-  PaletteState.Normal => _formRestoreNormal,
-  PaletteState.Tracking => _formRestoreActive,
-  PaletteState.Pressed => _formRestorePressed,
-  _ => _formRestoreDisabled
- },
- PaletteButtonSpecStyle.FormHelp => state switch
- {
-  PaletteState.Tracking => _formHelpActive,
-  PaletteState.Pressed => _formHelpPressed,
-  PaletteState.Normal => _formHelpNormal,
-  _ => _formHelpDisabled
- },
- _ => base.GetButtonSpecImage(style, state)
+                                                     PaletteButtonSpecStyle.FormClose => state switch
+                                                     {
+                                                         PaletteState.Tracking => _formCloseActive,
+                                                         PaletteState.Normal => _formCloseNormal,
+                                                         PaletteState.Pressed => _formClosePressed,
+                                                         _ => _formCloseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMin => state switch
+                                                     {
+                                                         PaletteState.Normal => _formMinimiseNormal,
+                                                         PaletteState.Tracking => _formMinimiseActive,
+                                                         PaletteState.Pressed => _formMinimisePressed,
+                                                         _ => _formMinimiseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMax => state switch
+                                                     {
+                                                         PaletteState.Normal => _formMaximiseNormal,
+                                                         PaletteState.Tracking => _formMaximiseActive,
+                                                         PaletteState.Pressed => _formMaximisePressed,
+                                                         _ => _formMaximiseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormRestore => state switch
+                                                     {
+                                                         PaletteState.Normal => _formRestoreNormal,
+                                                         PaletteState.Tracking => _formRestoreActive,
+                                                         PaletteState.Pressed => _formRestorePressed,
+                                                         _ => _formRestoreDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormHelp => state switch
+                                                     {
+                                                         PaletteState.Tracking => _formHelpActive,
+                                                         PaletteState.Pressed => _formHelpPressed,
+                                                         PaletteState.Normal => _formHelpNormal,
+                                                         _ => _formHelpDisabled
+                                                     },
+                                                     _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 
@@ -1352,8 +1352,8 @@ namespace Krypton.Toolkit
                         PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack1] : _buttonBackColors[1],
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2],
                         PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
-     ? GlobalStaticValues.EMPTY_COLOR
-     : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
+                                                            ? GlobalStaticValues.EMPTY_COLOR
+                                                            : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2] : _buttonBackColors[7],
                         PaletteState.Tracking => _buttonBackColors[3],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
@@ -1708,8 +1708,8 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
                                                 ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
@@ -1723,8 +1723,8 @@ namespace Krypton.Toolkit
                 },
                 PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
                 PaletteBorderStyle.InputControlStandalone or PaletteBorderStyle.InputControlRibbon or PaletteBorderStyle.InputControlCustom1 or PaletteBorderStyle.InputControlCustom2 or PaletteBorderStyle.InputControlCustom3 => state == PaletteState.Disabled
- ? _ribbonColours[(int)SchemeOfficeColors.InputControlBorderDisabled]
- : _ribbonColours[(int)SchemeOfficeColors.InputControlBorderNormal],
+                                                        ? _ribbonColours[(int)SchemeOfficeColors.InputControlBorderDisabled]
+                                                        : _ribbonColours[(int)SchemeOfficeColors.InputControlBorderNormal],
                 PaletteBorderStyle.GridDataCellList or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1 or PaletteBorderStyle.GridDataCellCustom2 or PaletteBorderStyle.GridDataCellCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.GridDataCellBorder],
                 PaletteBorderStyle.ControlRibbon => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.RibbonGroupsArea1],
                 PaletteBorderStyle.ControlRibbonAppMenu => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.AppButtonBorder],
@@ -1732,8 +1732,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -1755,8 +1755,8 @@ namespace Krypton.Toolkit
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2] : _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
- ? GlobalStaticValues.EMPTY_COLOR
- : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+                                                        ? GlobalStaticValues.EMPTY_COLOR
+                                                        : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
@@ -1838,8 +1838,8 @@ namespace Krypton.Toolkit
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -1849,8 +1849,8 @@ namespace Krypton.Toolkit
                 },
                 PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
                 PaletteBorderStyle.InputControlStandalone or PaletteBorderStyle.InputControlRibbon or PaletteBorderStyle.InputControlCustom1 or PaletteBorderStyle.InputControlCustom2 or PaletteBorderStyle.InputControlCustom3 => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.InputControlBorderDisabled]
-: _ribbonColours[(int)SchemeOfficeColors.InputControlBorderNormal],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.InputControlBorderDisabled]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.InputControlBorderNormal],
                 PaletteBorderStyle.GridDataCellList or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1 or PaletteBorderStyle.GridDataCellCustom2 or PaletteBorderStyle.GridDataCellCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.GridDataCellBorder],
                 PaletteBorderStyle.ControlRibbon => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.RibbonGroupsArea1],
                 PaletteBorderStyle.ControlRibbonAppMenu => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.AppButtonBorder],
@@ -1858,8 +1858,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverDarkMode.cs
@@ -233,38 +233,38 @@ namespace Krypton.Toolkit
             Color.FromArgb(210, 215, 221), // RibbonQATMini2
             Color.FromArgb(195, 200, 206), // RibbonQATMini3
             Color.FromArgb(10, Color.White), // RibbonQATMini4
-            Color.FromArgb(32, Color.White), // RibbonQATMini5                                                       
+            Color.FromArgb(32, Color.White), // RibbonQATMini5
             Color.FromArgb(200, 200, 200), // RibbonQATMini1I
             Color.FromArgb(233, 234, 238), // RibbonQATMini2I
             Color.FromArgb(223, 224, 228), // RibbonQATMini3I
             Color.FromArgb(10, Color.White), // RibbonQATMini4I
-            Color.FromArgb(32, Color.White), // RibbonQATMini5I                                                       
-            Color.FromArgb(217, 222, 230), // RibbonQATFullbar1                                                      
-            Color.FromArgb(214, 219, 227), // RibbonQATFullbar2                                                      
-            Color.FromArgb(194, 201, 212), // RibbonQATFullbar3                                                      
-            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark                                                      
-            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
-            Color.FromArgb(219, 218, 228), // RibbonQATOverflow1                                                      
-            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-            Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor                                                    
-            Color.FromArgb(119, 132, 161), // GridListNormal1                                                    
-            Color.FromArgb(83, 99, 136), // GridListNormal2                                                    
-            Color.FromArgb(83, 99, 136), // GridListPressed1                                                    
-            Color.FromArgb(252, 253, 253), // GridListPressed2                                                    
-            Color.FromArgb(83, 99, 136), // GridListSelected                                                    
-            Color.FromArgb(119, 132, 161), // GridSheetColNormal1                                                    
-            Color.FromArgb(83, 99, 136), // GridSheetColNormal2                                                    
-            Color.FromArgb(208, 208, 208), // GridSheetColPressed1                                                    
-            Color.FromArgb(166, 166, 166), // GridSheetColPressed2                                                    
+            Color.FromArgb(32, Color.White), // RibbonQATMini5I
+            Color.FromArgb(217, 222, 230), // RibbonQATFullbar1
+            Color.FromArgb(214, 219, 227), // RibbonQATFullbar2
+            Color.FromArgb(194, 201, 212), // RibbonQATFullbar3
+            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark
+            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight
+            Color.FromArgb(219, 218, 228), // RibbonQATOverflow1
+            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
+            Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark
+            Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight
+            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1
+            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2
+            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1
+            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2
+            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor
+            Color.FromArgb(119, 132, 161), // GridListNormal1
+            Color.FromArgb(83, 99, 136), // GridListNormal2
+            Color.FromArgb(83, 99, 136), // GridListPressed1
+            Color.FromArgb(252, 253, 253), // GridListPressed2
+            Color.FromArgb(83, 99, 136), // GridListSelected
+            Color.FromArgb(119, 132, 161), // GridSheetColNormal1
+            Color.FromArgb(83, 99, 136), // GridSheetColNormal2
+            Color.FromArgb(208, 208, 208), // GridSheetColPressed1
+            Color.FromArgb(166, 166, 166), // GridSheetColPressed2
             Color.FromArgb(54, 64, 88), // GridSheetColSelected1
             Color.FromArgb(83, 99, 136), // GridSheetColSelected2
-            Color.FromArgb(231, 231, 231), // GridSheetRowNormal                                                   
+            Color.FromArgb(231, 231, 231), // GridSheetRowNormal
             Color.FromArgb(184, 191, 196), // GridSheetRowPressed
             Color.FromArgb(245, 199, 149), // GridSheetRowSelected
             Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -320,7 +320,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(225, 226, 230), // ButtonNavigatorPressed2
             Color.FromArgb(222, 227, 234), // ButtonNavigatorChecked1
             Color.FromArgb(206, 214, 221), // ButtonNavigatorChecked2
-            Color.FromArgb(221, 221, 221) // ToolTipBottom                                                                      
+            Color.FromArgb(221, 221, 221) // ToolTipBottom               
         ];
 
         #endregion
@@ -388,42 +388,42 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
-                                                     PaletteButtonSpecStyle.FormClose => state switch
-                                                     {
-                                                         PaletteState.Tracking => _formCloseActive,
-                                                         PaletteState.Normal => _formCloseNormal,
-                                                         PaletteState.Pressed => _formClosePressed,
-                                                         _ => _formCloseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMin => state switch
-                                                     {
-                                                         PaletteState.Normal => _formMinimiseNormal,
-                                                         PaletteState.Tracking => _formMinimiseActive,
-                                                         PaletteState.Pressed => _formMinimisePressed,
-                                                         _ => _formMinimiseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMax => state switch
-                                                     {
-                                                         PaletteState.Normal => _formMaximiseNormal,
-                                                         PaletteState.Tracking => _formMaximiseActive,
-                                                         PaletteState.Pressed => _formMaximisePressed,
-                                                         _ => _formMaximiseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormRestore => state switch
-                                                     {
-                                                         PaletteState.Normal => _formRestoreNormal,
-                                                         PaletteState.Tracking => _formRestoreActive,
-                                                         PaletteState.Pressed => _formRestorePressed,
-                                                         _ => _formRestoreDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormHelp => state switch
-                                                     {
-                                                         PaletteState.Tracking => _formHelpActive,
-                                                         PaletteState.Pressed => _formHelpPressed,
-                                                         PaletteState.Normal => _formHelpNormal,
-                                                         _ => _formHelpDisabled
-                                                     },
-                                                     _ => base.GetButtonSpecImage(style, state)
+ PaletteButtonSpecStyle.FormClose => state switch
+ {
+  PaletteState.Tracking => _formCloseActive,
+  PaletteState.Normal => _formCloseNormal,
+  PaletteState.Pressed => _formClosePressed,
+  _ => _formCloseDisabled
+ },
+ PaletteButtonSpecStyle.FormMin => state switch
+ {
+  PaletteState.Normal => _formMinimiseNormal,
+  PaletteState.Tracking => _formMinimiseActive,
+  PaletteState.Pressed => _formMinimisePressed,
+  _ => _formMinimiseDisabled
+ },
+ PaletteButtonSpecStyle.FormMax => state switch
+ {
+  PaletteState.Normal => _formMaximiseNormal,
+  PaletteState.Tracking => _formMaximiseActive,
+  PaletteState.Pressed => _formMaximisePressed,
+  _ => _formMaximiseDisabled
+ },
+ PaletteButtonSpecStyle.FormRestore => state switch
+ {
+  PaletteState.Normal => _formRestoreNormal,
+  PaletteState.Tracking => _formRestoreActive,
+  PaletteState.Pressed => _formRestorePressed,
+  _ => _formRestoreDisabled
+ },
+ PaletteButtonSpecStyle.FormHelp => state switch
+ {
+  PaletteState.Tracking => _formHelpActive,
+  PaletteState.Pressed => _formHelpPressed,
+  PaletteState.Normal => _formHelpNormal,
+  _ => _formHelpDisabled
+ },
+ _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 
@@ -1352,8 +1352,8 @@ namespace Krypton.Toolkit
                         PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack1] : _buttonBackColors[1],
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2],
                         PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
-                                                            ? GlobalStaticValues.EMPTY_COLOR
-                                                            : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
+     ? GlobalStaticValues.EMPTY_COLOR
+     : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2] : _buttonBackColors[7],
                         PaletteState.Tracking => _buttonBackColors[3],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
@@ -1708,8 +1708,8 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
                                                 ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
@@ -1723,8 +1723,8 @@ namespace Krypton.Toolkit
                 },
                 PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
                 PaletteBorderStyle.InputControlStandalone or PaletteBorderStyle.InputControlRibbon or PaletteBorderStyle.InputControlCustom1 or PaletteBorderStyle.InputControlCustom2 or PaletteBorderStyle.InputControlCustom3 => state == PaletteState.Disabled
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.InputControlBorderDisabled]
-                                                        : _ribbonColours[(int)SchemeOfficeColors.InputControlBorderNormal],
+ ? _ribbonColours[(int)SchemeOfficeColors.InputControlBorderDisabled]
+ : _ribbonColours[(int)SchemeOfficeColors.InputControlBorderNormal],
                 PaletteBorderStyle.GridDataCellList or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1 or PaletteBorderStyle.GridDataCellCustom2 or PaletteBorderStyle.GridDataCellCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.GridDataCellBorder],
                 PaletteBorderStyle.ControlRibbon => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.RibbonGroupsArea1],
                 PaletteBorderStyle.ControlRibbonAppMenu => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.AppButtonBorder],
@@ -1732,8 +1732,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -1755,8 +1755,8 @@ namespace Krypton.Toolkit
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2] : _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
-                                                        ? GlobalStaticValues.EMPTY_COLOR
-                                                        : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+ ? GlobalStaticValues.EMPTY_COLOR
+ : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
@@ -1838,8 +1838,8 @@ namespace Krypton.Toolkit
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -1849,8 +1849,8 @@ namespace Krypton.Toolkit
                 },
                 PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
                 PaletteBorderStyle.InputControlStandalone or PaletteBorderStyle.InputControlRibbon or PaletteBorderStyle.InputControlCustom1 or PaletteBorderStyle.InputControlCustom2 or PaletteBorderStyle.InputControlCustom3 => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.InputControlBorderDisabled]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.InputControlBorderNormal],
+? _ribbonColours[(int)SchemeOfficeColors.InputControlBorderDisabled]
+: _ribbonColours[(int)SchemeOfficeColors.InputControlBorderNormal],
                 PaletteBorderStyle.GridDataCellList or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1 or PaletteBorderStyle.GridDataCellCustom2 or PaletteBorderStyle.GridDataCellCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.GridDataCellBorder],
                 PaletteBorderStyle.ControlRibbon => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.RibbonGroupsArea1],
                 PaletteBorderStyle.ControlRibbonAppMenu => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.AppButtonBorder],
@@ -1858,8 +1858,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverLightMode.cs
@@ -233,44 +233,38 @@ namespace Krypton.Toolkit
             Color.FromArgb(210, 215, 221), // RibbonQATMini2
             Color.FromArgb(195, 200, 206), // RibbonQATMini3
             Color.FromArgb(10, Color.White), // RibbonQATMini4
-            Color.FromArgb(32, Color.White), // RibbonQATMini5                                                       
+            Color.FromArgb(32, Color.White), // RibbonQATMini5
             Color.FromArgb(200, 200, 200), // RibbonQATMini1I
             Color.FromArgb(233, 234, 238), // RibbonQATMini2I
             Color.FromArgb(223, 224, 228), // RibbonQATMini3I
             Color.FromArgb(10, Color.White), // RibbonQATMini4I
-            Color.FromArgb(32, Color.White), // RibbonQATMini5I                                                       
-            Color.FromArgb(217, 222, 230), // RibbonQATFullbar1                                                      
-            Color.FromArgb(214, 219, 227), // RibbonQATFullbar2                                                      
-            Color.FromArgb(194, 201, 212), // RibbonQATFullbar3                                                      
-            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark                                                      
-            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
-            Color.FromArgb(219, 218, 228), // RibbonQATOverflow1                                                      
-            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-            Color.FromArgb(173, 177,
-                181), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(232, 235,
-                237), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(231, 234,
-                238), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(241, 243,
-                243), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(197, 198,
-                199), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(157, 158,
-                159), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor                                                    
-            Color.FromArgb(224, 225, 231), // GridListNormal1                                                    
-            Color.FromArgb(195, 198, 209), // GridListNormal2                                                    
-            Color.FromArgb(195, 198, 209), // GridListPressed1                                                    
-            Color.FromArgb(252, 253, 253), // GridListPressed2                                                    
-            Color.FromArgb(195, 198, 209), // GridListSelected                                                    
-            Color.FromArgb(224, 225, 231), // GridSheetColNormal1                                                    
-            Color.FromArgb(195, 198, 209), // GridSheetColNormal2                                                    
-            Color.FromArgb(208, 208, 208), // GridSheetColPressed1                                                    
-            Color.FromArgb(166, 166, 166), // GridSheetColPressed2                                                    
+            Color.FromArgb(32, Color.White), // RibbonQATMini5I
+            Color.FromArgb(217, 222, 230), // RibbonQATFullbar1
+            Color.FromArgb(214, 219, 227), // RibbonQATFullbar2
+            Color.FromArgb(194, 201, 212), // RibbonQATFullbar3
+            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark
+            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight
+            Color.FromArgb(219, 218, 228), // RibbonQATOverflow1
+            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
+            Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark
+            Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight
+            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1
+            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2
+            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1
+            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2
+            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor
+            Color.FromArgb(224, 225, 231), // GridListNormal1
+            Color.FromArgb(195, 198, 209), // GridListNormal2
+            Color.FromArgb(195, 198, 209), // GridListPressed1
+            Color.FromArgb(252, 253, 253), // GridListPressed2
+            Color.FromArgb(195, 198, 209), // GridListSelected
+            Color.FromArgb(224, 225, 231), // GridSheetColNormal1
+            Color.FromArgb(195, 198, 209), // GridSheetColNormal2
+            Color.FromArgb(208, 208, 208), // GridSheetColPressed1
+            Color.FromArgb(166, 166, 166), // GridSheetColPressed2
             Color.FromArgb(54, 64, 88), // GridSheetColSelected1
             Color.FromArgb(195, 198, 209), // GridSheetColSelected2
-            Color.FromArgb(231, 231, 231), // GridSheetRowNormal                                                   
+            Color.FromArgb(231, 231, 231), // GridSheetRowNormal
             Color.FromArgb(184, 191, 196), // GridSheetRowPressed
             Color.FromArgb(245, 199, 149), // GridSheetRowSelected
             Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -324,7 +318,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(225, 226, 230), // ButtonNavigatorPressed2
             Color.FromArgb(222, 227, 234), // ButtonNavigatorChecked1
             Color.FromArgb(206, 214, 221), // ButtonNavigatorChecked2
-            Color.FromArgb(221, 221, 221) // ToolTipBottom - 221, 221, 221                                                                      
+            Color.FromArgb(221, 221, 221) // ToolTipBottom - 221, 221, 221
         ];
 
         #endregion
@@ -392,42 +386,42 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
-                                                     PaletteButtonSpecStyle.FormClose => state switch
-                                                     {
-                                                         PaletteState.Tracking => _formCloseActive,
-                                                         PaletteState.Normal => _formCloseNormal,
-                                                         PaletteState.Pressed => _formClosePressed,
-                                                         _ => _formCloseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMin => state switch
-                                                     {
-                                                         PaletteState.Normal => _formMinimiseNormal,
-                                                         PaletteState.Tracking => _formMinimiseActive,
-                                                         PaletteState.Pressed => _formMinimisePressed,
-                                                         _ => _formMinimiseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMax => state switch
-                                                     {
-                                                         PaletteState.Normal => _formMaximiseNormal,
-                                                         PaletteState.Tracking => _formMaximiseActive,
-                                                         PaletteState.Pressed => _formMaximisePressed,
-                                                         _ => _formMaximiseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormRestore => state switch
-                                                     {
-                                                         PaletteState.Normal => _formRestoreNormal,
-                                                         PaletteState.Tracking => _formRestoreActive,
-                                                         PaletteState.Pressed => _formRestorePressed,
-                                                         _ => _formRestoreDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormHelp => state switch
-                                                     {
-                                                         PaletteState.Tracking => _formHelpActive,
-                                                         PaletteState.Pressed => _formHelpPressed,
-                                                         PaletteState.Normal => _formHelpNormal,
-                                                         _ => _formHelpDisabled
-                                                     },
-                                                     _ => base.GetButtonSpecImage(style, state)
+ PaletteButtonSpecStyle.FormClose => state switch
+ {
+  PaletteState.Tracking => _formCloseActive,
+  PaletteState.Normal => _formCloseNormal,
+  PaletteState.Pressed => _formClosePressed,
+  _ => _formCloseDisabled
+ },
+ PaletteButtonSpecStyle.FormMin => state switch
+ {
+  PaletteState.Normal => _formMinimiseNormal,
+  PaletteState.Tracking => _formMinimiseActive,
+  PaletteState.Pressed => _formMinimisePressed,
+  _ => _formMinimiseDisabled
+ },
+ PaletteButtonSpecStyle.FormMax => state switch
+ {
+  PaletteState.Normal => _formMaximiseNormal,
+  PaletteState.Tracking => _formMaximiseActive,
+  PaletteState.Pressed => _formMaximisePressed,
+  _ => _formMaximiseDisabled
+ },
+ PaletteButtonSpecStyle.FormRestore => state switch
+ {
+  PaletteState.Normal => _formRestoreNormal,
+  PaletteState.Tracking => _formRestoreActive,
+  PaletteState.Pressed => _formRestorePressed,
+  _ => _formRestoreDisabled
+ },
+ PaletteButtonSpecStyle.FormHelp => state switch
+ {
+  PaletteState.Tracking => _formHelpActive,
+  PaletteState.Pressed => _formHelpPressed,
+  PaletteState.Normal => _formHelpNormal,
+  _ => _formHelpDisabled
+ },
+ _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 
@@ -1379,8 +1373,8 @@ namespace Krypton.Toolkit
                         PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack1] : _buttonBackColors[1],
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2],
                         PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
-                                                                ? GlobalStaticValues.EMPTY_COLOR
-                                                                : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
+         ? GlobalStaticValues.EMPTY_COLOR
+         : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2] : _buttonBackColors[7],
                         PaletteState.Tracking => _buttonBackColors[3],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
@@ -1735,8 +1729,8 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
                                                 ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
@@ -1750,8 +1744,8 @@ namespace Krypton.Toolkit
                 },
                 PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
                 PaletteBorderStyle.InputControlStandalone or PaletteBorderStyle.InputControlRibbon or PaletteBorderStyle.InputControlCustom1 or PaletteBorderStyle.InputControlCustom2 or PaletteBorderStyle.InputControlCustom3 => state == PaletteState.Disabled
-                                                            ? _ribbonColours[(int)SchemeOfficeColors.InputControlBorderDisabled]
-                                                            : _ribbonColours[(int)SchemeOfficeColors.InputControlBorderNormal],
+     ? _ribbonColours[(int)SchemeOfficeColors.InputControlBorderDisabled]
+     : _ribbonColours[(int)SchemeOfficeColors.InputControlBorderNormal],
                 PaletteBorderStyle.GridDataCellList or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1 or PaletteBorderStyle.GridDataCellCustom2 or PaletteBorderStyle.GridDataCellCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.GridDataCellBorder],
                 PaletteBorderStyle.ControlRibbon => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.RibbonGroupsArea1],
                 PaletteBorderStyle.ControlRibbonAppMenu => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.AppButtonBorder],
@@ -1759,8 +1753,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -1782,8 +1776,8 @@ namespace Krypton.Toolkit
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2] : _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
-                                                            ? GlobalStaticValues.EMPTY_COLOR
-                                                            : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+     ? GlobalStaticValues.EMPTY_COLOR
+     : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
@@ -1861,12 +1855,12 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
+? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
+: _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -1876,8 +1870,8 @@ namespace Krypton.Toolkit
                 },
                 PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
                 PaletteBorderStyle.InputControlStandalone or PaletteBorderStyle.InputControlRibbon or PaletteBorderStyle.InputControlCustom1 or PaletteBorderStyle.InputControlCustom2 or PaletteBorderStyle.InputControlCustom3 => state == PaletteState.Disabled
-                                                        ? _ribbonColours[(int)SchemeOfficeColors.InputControlBorderDisabled]
-                                                        : _ribbonColours[(int)SchemeOfficeColors.InputControlBorderNormal],
+ ? _ribbonColours[(int)SchemeOfficeColors.InputControlBorderDisabled]
+ : _ribbonColours[(int)SchemeOfficeColors.InputControlBorderNormal],
                 PaletteBorderStyle.GridDataCellList or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1 or PaletteBorderStyle.GridDataCellCustom2 or PaletteBorderStyle.GridDataCellCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.GridDataCellBorder],
                 PaletteBorderStyle.ControlRibbon => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.RibbonGroupsArea1],
                 PaletteBorderStyle.ControlRibbonAppMenu => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.AppButtonBorder],
@@ -2659,8 +2653,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -2737,8 +2731,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3136,8 +3130,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3212,8 +3206,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverLightMode.cs
@@ -386,42 +386,42 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
- PaletteButtonSpecStyle.FormClose => state switch
- {
-  PaletteState.Tracking => _formCloseActive,
-  PaletteState.Normal => _formCloseNormal,
-  PaletteState.Pressed => _formClosePressed,
-  _ => _formCloseDisabled
- },
- PaletteButtonSpecStyle.FormMin => state switch
- {
-  PaletteState.Normal => _formMinimiseNormal,
-  PaletteState.Tracking => _formMinimiseActive,
-  PaletteState.Pressed => _formMinimisePressed,
-  _ => _formMinimiseDisabled
- },
- PaletteButtonSpecStyle.FormMax => state switch
- {
-  PaletteState.Normal => _formMaximiseNormal,
-  PaletteState.Tracking => _formMaximiseActive,
-  PaletteState.Pressed => _formMaximisePressed,
-  _ => _formMaximiseDisabled
- },
- PaletteButtonSpecStyle.FormRestore => state switch
- {
-  PaletteState.Normal => _formRestoreNormal,
-  PaletteState.Tracking => _formRestoreActive,
-  PaletteState.Pressed => _formRestorePressed,
-  _ => _formRestoreDisabled
- },
- PaletteButtonSpecStyle.FormHelp => state switch
- {
-  PaletteState.Tracking => _formHelpActive,
-  PaletteState.Pressed => _formHelpPressed,
-  PaletteState.Normal => _formHelpNormal,
-  _ => _formHelpDisabled
- },
- _ => base.GetButtonSpecImage(style, state)
+                                                     PaletteButtonSpecStyle.FormClose => state switch
+                                                     {
+                                                         PaletteState.Tracking => _formCloseActive,
+                                                         PaletteState.Normal => _formCloseNormal,
+                                                         PaletteState.Pressed => _formClosePressed,
+                                                         _ => _formCloseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMin => state switch
+                                                     {
+                                                         PaletteState.Normal => _formMinimiseNormal,
+                                                         PaletteState.Tracking => _formMinimiseActive,
+                                                         PaletteState.Pressed => _formMinimisePressed,
+                                                         _ => _formMinimiseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMax => state switch
+                                                     {
+                                                         PaletteState.Normal => _formMaximiseNormal,
+                                                         PaletteState.Tracking => _formMaximiseActive,
+                                                         PaletteState.Pressed => _formMaximisePressed,
+                                                         _ => _formMaximiseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormRestore => state switch
+                                                     {
+                                                         PaletteState.Normal => _formRestoreNormal,
+                                                         PaletteState.Tracking => _formRestoreActive,
+                                                         PaletteState.Pressed => _formRestorePressed,
+                                                         _ => _formRestoreDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormHelp => state switch
+                                                     {
+                                                         PaletteState.Tracking => _formHelpActive,
+                                                         PaletteState.Pressed => _formHelpPressed,
+                                                         PaletteState.Normal => _formHelpNormal,
+                                                         _ => _formHelpDisabled
+                                                     },
+                                                     _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 
@@ -1373,8 +1373,8 @@ namespace Krypton.Toolkit
                         PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack1] : _buttonBackColors[1],
                         PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2],
                         PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
-         ? GlobalStaticValues.EMPTY_COLOR
-         : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
+                                                                ? GlobalStaticValues.EMPTY_COLOR
+                                                                : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBack2] : _buttonBackColors[7],
                         PaletteState.Tracking => _buttonBackColors[3],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
@@ -1729,8 +1729,8 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
                                                 ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
                                                 : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
@@ -1744,8 +1744,8 @@ namespace Krypton.Toolkit
                 },
                 PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
                 PaletteBorderStyle.InputControlStandalone or PaletteBorderStyle.InputControlRibbon or PaletteBorderStyle.InputControlCustom1 or PaletteBorderStyle.InputControlCustom2 or PaletteBorderStyle.InputControlCustom3 => state == PaletteState.Disabled
-     ? _ribbonColours[(int)SchemeOfficeColors.InputControlBorderDisabled]
-     : _ribbonColours[(int)SchemeOfficeColors.InputControlBorderNormal],
+                                                            ? _ribbonColours[(int)SchemeOfficeColors.InputControlBorderDisabled]
+                                                            : _ribbonColours[(int)SchemeOfficeColors.InputControlBorderNormal],
                 PaletteBorderStyle.GridDataCellList or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1 or PaletteBorderStyle.GridDataCellCustom2 or PaletteBorderStyle.GridDataCellCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.GridDataCellBorder],
                 PaletteBorderStyle.ControlRibbon => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.RibbonGroupsArea1],
                 PaletteBorderStyle.ControlRibbonAppMenu => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.AppButtonBorder],
@@ -1753,8 +1753,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
-: _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderInactive]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -1776,8 +1776,8 @@ namespace Krypton.Toolkit
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? _ribbonColours[(int)SchemeOfficeColors.RibbonGalleryBack2] : _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColours[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
-     ? GlobalStaticValues.EMPTY_COLOR
-     : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+                                                            ? GlobalStaticValues.EMPTY_COLOR
+                                                            : _ribbonColours[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
@@ -1855,12 +1855,12 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
-: _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderInactive]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-: _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                    ? _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                    : _ribbonColours[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -1870,8 +1870,8 @@ namespace Krypton.Toolkit
                 },
                 PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
                 PaletteBorderStyle.InputControlStandalone or PaletteBorderStyle.InputControlRibbon or PaletteBorderStyle.InputControlCustom1 or PaletteBorderStyle.InputControlCustom2 or PaletteBorderStyle.InputControlCustom3 => state == PaletteState.Disabled
- ? _ribbonColours[(int)SchemeOfficeColors.InputControlBorderDisabled]
- : _ribbonColours[(int)SchemeOfficeColors.InputControlBorderNormal],
+                                                        ? _ribbonColours[(int)SchemeOfficeColors.InputControlBorderDisabled]
+                                                        : _ribbonColours[(int)SchemeOfficeColors.InputControlBorderNormal],
                 PaletteBorderStyle.GridDataCellList or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1 or PaletteBorderStyle.GridDataCellCustom2 or PaletteBorderStyle.GridDataCellCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.GridDataCellBorder],
                 PaletteBorderStyle.ControlRibbon => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.RibbonGroupsArea1],
                 PaletteBorderStyle.ControlRibbonAppMenu => state == PaletteState.Disabled ? _disabledBorder : _ribbonColours[(int)SchemeOfficeColors.AppButtonBorder],
@@ -2653,8 +2653,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -2731,8 +2731,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3130,8 +3130,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3206,8 +3206,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColours[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColours[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColours[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColours[(int)SchemeOfficeColors.TextButtonNormal]
                 },

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Non Official Themes/PaletteOffice2010DarkGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Non Official Themes/PaletteOffice2010DarkGray.cs
@@ -382,42 +382,42 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
- PaletteButtonSpecStyle.FormClose => state switch
- {
-  PaletteState.Tracking => _formCloseActive,
-  PaletteState.Normal => _formCloseNormal,
-  PaletteState.Pressed => _formClosePressed,
-  _ => _formCloseDisabled
- },
- PaletteButtonSpecStyle.FormMin => state switch
- {
-  PaletteState.Normal => _formMinimiseNormal,
-  PaletteState.Tracking => _formMinimiseActive,
-  PaletteState.Pressed => _formMinimisePressed,
-  _ => _formMinimiseDisabled
- },
- PaletteButtonSpecStyle.FormMax => state switch
- {
-  PaletteState.Normal => _formMaximiseNormal,
-  PaletteState.Tracking => _formMaximiseActive,
-  PaletteState.Pressed => _formMaximisePressed,
-  _ => _formMaximiseDisabled
- },
- PaletteButtonSpecStyle.FormRestore => state switch
- {
-  PaletteState.Normal => _formRestoreNormal,
-  PaletteState.Tracking => _formRestoreActive,
-  PaletteState.Pressed => _formRestorePressed,
-  _ => _formRestoreDisabled
- },
- PaletteButtonSpecStyle.FormHelp => state switch
- {
-  PaletteState.Tracking => _formHelpActive,
-  PaletteState.Pressed => _formHelpPressed,
-  PaletteState.Normal => _formHelpNormal,
-  _ => _formHelpDisabled
- },
- _ => base.GetButtonSpecImage(style, state)
+                                                     PaletteButtonSpecStyle.FormClose => state switch
+                                                     {
+                                                         PaletteState.Tracking => _formCloseActive,
+                                                         PaletteState.Normal => _formCloseNormal,
+                                                         PaletteState.Pressed => _formClosePressed,
+                                                         _ => _formCloseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMin => state switch
+                                                     {
+                                                         PaletteState.Normal => _formMinimiseNormal,
+                                                         PaletteState.Tracking => _formMinimiseActive,
+                                                         PaletteState.Pressed => _formMinimisePressed,
+                                                         _ => _formMinimiseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMax => state switch
+                                                     {
+                                                         PaletteState.Normal => _formMaximiseNormal,
+                                                         PaletteState.Tracking => _formMaximiseActive,
+                                                         PaletteState.Pressed => _formMaximisePressed,
+                                                         _ => _formMaximiseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormRestore => state switch
+                                                     {
+                                                         PaletteState.Normal => _formRestoreNormal,
+                                                         PaletteState.Tracking => _formRestoreActive,
+                                                         PaletteState.Pressed => _formRestorePressed,
+                                                         _ => _formRestoreDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormHelp => state switch
+                                                     {
+                                                         PaletteState.Tracking => _formHelpActive,
+                                                         PaletteState.Pressed => _formHelpPressed,
+                                                         PaletteState.Normal => _formHelpNormal,
+                                                         _ => _formHelpDisabled
+                                                     },
+                                                     _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Non Official Themes/PaletteOffice2010DarkGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Non Official Themes/PaletteOffice2010DarkGray.cs
@@ -215,7 +215,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(226, 229, 234), // RibbonGroupFrameInside2
             Color.FromArgb(220, 224, 231), // RibbonGroupFrameInside3
             Color.FromArgb(232, 234, 238), // RibbonGroupFrameInside4
-            Color.FromArgb(68, 68, 68), // RibbonGroupCollapsedText         
+            Color.FromArgb(68, 68, 68), // RibbonGroupCollapsedText
             Color.FromArgb(179, 185, 195), // AlternatePressedBack1
             Color.FromArgb(216, 224, 224), // AlternatePressedBack2
             Color.FromArgb(125, 125, 125), // AlternatePressedBorder1
@@ -229,38 +229,38 @@ namespace Krypton.Toolkit
             Color.FromArgb(210, 215, 221), // RibbonQATMini2
             Color.FromArgb(195, 200, 206), // RibbonQATMini3
             Color.FromArgb(10, Color.White), // RibbonQATMini4
-            Color.FromArgb(32, Color.White), // RibbonQATMini5                                                       
+            Color.FromArgb(32, Color.White), // RibbonQATMini5
             Color.FromArgb(200, 200, 200), // RibbonQATMini1I
             Color.FromArgb(233, 234, 238), // RibbonQATMini2I
             Color.FromArgb(223, 224, 228), // RibbonQATMini3I
             Color.FromArgb(10, Color.White), // RibbonQATMini4I
-            Color.FromArgb(32, Color.White), // RibbonQATMini5I                                                       
-            Color.FromArgb(217, 222, 230), // RibbonQATFullbar1                                                      
-            Color.FromArgb(214, 219, 227), // RibbonQATFullbar2                                                      
-            Color.FromArgb(194, 201, 212), // RibbonQATFullbar3                                                      
-            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark                                                      
-            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
-            Color.FromArgb(219, 218, 228), // RibbonQATOverflow1                                                      
-            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-            Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor                                                    
-            Color.White, // GridListNormal1                                                    
-            Color.FromArgb(212, 215, 219), // GridListNormal2                                                    
-            Color.FromArgb(210, 213, 218), // GridListPressed1                                                    
-            Color.FromArgb(252, 253, 253), // GridListPressed2                                                    
-            Color.FromArgb(186, 189, 194), // GridListSelected                                                    
-            Color.FromArgb(241, 243, 243), // GridSheetColNormal1                                                    
-            Color.FromArgb(200, 201, 202), // GridSheetColNormal2                                                    
-            Color.FromArgb(208, 208, 208), // GridSheetColPressed1                                                    
-            Color.FromArgb(166, 166, 166), // GridSheetColPressed2                                                    
+            Color.FromArgb(32, Color.White), // RibbonQATMini5I
+            Color.FromArgb(217, 222, 230), // RibbonQATFullbar1
+            Color.FromArgb(214, 219, 227), // RibbonQATFullbar2
+            Color.FromArgb(194, 201, 212), // RibbonQATFullbar3
+            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark
+            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight
+            Color.FromArgb(219, 218, 228), // RibbonQATOverflow1
+            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
+            Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark
+            Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight
+            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1
+            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2
+            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1
+            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2
+            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor
+            Color.White, // GridListNormal1
+            Color.FromArgb(212, 215, 219), // GridListNormal2
+            Color.FromArgb(210, 213, 218), // GridListPressed1
+            Color.FromArgb(252, 253, 253), // GridListPressed2
+            Color.FromArgb(186, 189, 194), // GridListSelected
+            Color.FromArgb(241, 243, 243), // GridSheetColNormal1
+            Color.FromArgb(200, 201, 202), // GridSheetColNormal2
+            Color.FromArgb(208, 208, 208), // GridSheetColPressed1
+            Color.FromArgb(166, 166, 166), // GridSheetColPressed2
             Color.FromArgb(255, 204, 153), // GridSheetColSelected1
             Color.FromArgb(255, 155, 104), // GridSheetColSelected2
-            Color.FromArgb(231, 231, 231), // GridSheetRowNormal                                                   
+            Color.FromArgb(231, 231, 231), // GridSheetRowNormal
             Color.FromArgb(184, 191, 196), // GridSheetRowPressed
             Color.FromArgb(245, 199, 149), // GridSheetRowSelected
             Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -300,6 +300,8 @@ namespace Krypton.Toolkit
             GlobalStaticValues.EMPTY_COLOR, // RibbonTabTracking4
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder3
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder4
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder5
+            Color.FromArgb(119, 119, 119), // RibbonGroupTitleText
             GlobalStaticValues.EMPTY_COLOR, // RibbonDropArrowLight
             GlobalStaticValues.EMPTY_COLOR, // RibbonDropArrowDark
             Color.FromArgb(237, 242, 248), // HeaderDockInactiveBack1
@@ -312,7 +314,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(225, 226, 230), // ButtonNavigatorPressed2
             Color.FromArgb(222, 227, 234), // ButtonNavigatorChecked1
             Color.FromArgb(206, 214, 221), // ButtonNavigatorChecked2
-            Color.FromArgb(221, 221, 221) // ToolTipBottom                                                                      
+            Color.FromArgb(221, 221, 221) // ToolTipBottom
         ];
 
         #endregion
@@ -380,42 +382,42 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
-                                                     PaletteButtonSpecStyle.FormClose => state switch
-                                                     {
-                                                         PaletteState.Tracking => _formCloseActive,
-                                                         PaletteState.Normal => _formCloseNormal,
-                                                         PaletteState.Pressed => _formClosePressed,
-                                                         _ => _formCloseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMin => state switch
-                                                     {
-                                                         PaletteState.Normal => _formMinimiseNormal,
-                                                         PaletteState.Tracking => _formMinimiseActive,
-                                                         PaletteState.Pressed => _formMinimisePressed,
-                                                         _ => _formMinimiseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMax => state switch
-                                                     {
-                                                         PaletteState.Normal => _formMaximiseNormal,
-                                                         PaletteState.Tracking => _formMaximiseActive,
-                                                         PaletteState.Pressed => _formMaximisePressed,
-                                                         _ => _formMaximiseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormRestore => state switch
-                                                     {
-                                                         PaletteState.Normal => _formRestoreNormal,
-                                                         PaletteState.Tracking => _formRestoreActive,
-                                                         PaletteState.Pressed => _formRestorePressed,
-                                                         _ => _formRestoreDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormHelp => state switch
-                                                     {
-                                                         PaletteState.Tracking => _formHelpActive,
-                                                         PaletteState.Pressed => _formHelpPressed,
-                                                         PaletteState.Normal => _formHelpNormal,
-                                                         _ => _formHelpDisabled
-                                                     },
-                                                     _ => base.GetButtonSpecImage(style, state)
+ PaletteButtonSpecStyle.FormClose => state switch
+ {
+  PaletteState.Tracking => _formCloseActive,
+  PaletteState.Normal => _formCloseNormal,
+  PaletteState.Pressed => _formClosePressed,
+  _ => _formCloseDisabled
+ },
+ PaletteButtonSpecStyle.FormMin => state switch
+ {
+  PaletteState.Normal => _formMinimiseNormal,
+  PaletteState.Tracking => _formMinimiseActive,
+  PaletteState.Pressed => _formMinimisePressed,
+  _ => _formMinimiseDisabled
+ },
+ PaletteButtonSpecStyle.FormMax => state switch
+ {
+  PaletteState.Normal => _formMaximiseNormal,
+  PaletteState.Tracking => _formMaximiseActive,
+  PaletteState.Pressed => _formMaximisePressed,
+  _ => _formMaximiseDisabled
+ },
+ PaletteButtonSpecStyle.FormRestore => state switch
+ {
+  PaletteState.Normal => _formRestoreNormal,
+  PaletteState.Tracking => _formRestoreActive,
+  PaletteState.Pressed => _formRestorePressed,
+  _ => _formRestoreDisabled
+ },
+ PaletteButtonSpecStyle.FormHelp => state switch
+ {
+  PaletteState.Tracking => _formHelpActive,
+  PaletteState.Pressed => _formHelpPressed,
+  PaletteState.Normal => _formHelpNormal,
+  _ => _formHelpDisabled
+ },
+ _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Official Themes/PaletteOffice2010Black.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Official Themes/PaletteOffice2010Black.cs
@@ -237,7 +237,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(167, 167, 168), // RibbonGroupFrameInside2
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupFrameInside3
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupFrameInside4
-            Color.FromArgb(59, 59, 59), // RibbonGroupCollapsedText         
+            Color.FromArgb(59, 59, 59), // RibbonGroupCollapsedText
             Color.FromArgb(158, 163, 172), // AlternatePressedBack1
             Color.FromArgb(212, 215, 216), // AlternatePressedBack2
             Color.FromArgb(124, 125, 125), // AlternatePressedBorder1
@@ -257,43 +257,36 @@ namespace Krypton.Toolkit
             Color.FromArgb(140, 140, 140), // RibbonQATMini3I
             Color.FromArgb(12, Color.White), // RibbonQATMini4I
             Color.FromArgb(14, Color.White), // RibbonQATMini5I
-            Color.FromArgb(132, 132, 132), // RibbonQATFullbar1                                                      
-            Color.FromArgb(121, 121, 121), // RibbonQATFullbar2                                                      
-            Color.FromArgb(50, 49, 49), // RibbonQATFullbar3                                                      
-            Color.FromArgb(90, 90, 90), // RibbonQATButtonDark                                                      
-            Color.FromArgb(174, 174, 175), // RibbonQATButtonLight                                                      
-            Color.FromArgb(161, 161, 161), // RibbonQATOverflow1                                                      
-            Color.FromArgb(68, 68, 68), // RibbonQATOverflow2                                                      
-            Color.FromArgb(82, 82,
-                82), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(190, 190,
-                190), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(210, 217,
-                219), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(214, 222,
-                223), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(179, 188,
-                191), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(145, 156,
-                159), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(235, 235, 235), // NavigatorMiniBackColor                                                    
-            Color.FromArgb(205, 205, 205), // GridListNormal1                                                    
-            Color.FromArgb(166, 166, 166), // GridListNormal2                                                    
-            Color.FromArgb(166, 166, 166), // GridListPressed1                                                    
-            Color.FromArgb(205, 205, 205), // GridListPressed2                                                    
-            Color.FromArgb(150, 150, 150), // GridListSelected                                                    
-            Color.FromArgb(220, 220, 220), // GridSheetColNormal1                                                    
-            Color.FromArgb(200, 200, 200), // GridSheetColNormal2                                                    
-            Color.FromArgb(255, 223, 107), // GridSheetColPressed1                                                    
-            Color.FromArgb(255, 252, 230), // GridSheetColPressed2                                                    
+            Color.FromArgb(132, 132, 132), // RibbonQATFullbar1
+            Color.FromArgb(121, 121, 121), // RibbonQATFullbar2
+            Color.FromArgb(50, 49, 49), // RibbonQATFullbar3
+            Color.FromArgb(90, 90, 90), // RibbonQATButtonDark
+            Color.FromArgb(174, 174, 175), // RibbonQATButtonLight
+            Color.FromArgb(161, 161, 161), // RibbonQATOverflow1
+            Color.FromArgb(68, 68, 68), // RibbonQATOverflow2
+            Color.FromArgb(82, 82, 82), // RibbonGroupSeparatorDark
+            Color.FromArgb(190, 190, 190), // RibbonGroupSeparatorLight
+            Color.FromArgb(210, 217, 219), // ButtonClusterButtonBack1
+            Color.FromArgb(214, 222, 223), // ButtonClusterButtonBack2
+            Color.FromArgb(179, 188, 191), // ButtonClusterButtonBorder1
+            Color.FromArgb(145, 156, 159), // ButtonClusterButtonBorder2
+            Color.FromArgb(235, 235, 235), // NavigatorMiniBackColor
+            Color.FromArgb(205, 205, 205), // GridListNormal1
+            Color.FromArgb(166, 166, 166), // GridListNormal2
+            Color.FromArgb(166, 166, 166), // GridListPressed1
+            Color.FromArgb(205, 205, 205), // GridListPressed2
+            Color.FromArgb(150, 150, 150), // GridListSelected
+            Color.FromArgb(220, 220, 220), // GridSheetColNormal1
+            Color.FromArgb(200, 200, 200), // GridSheetColNormal2
+            Color.FromArgb(255, 223, 107), // GridSheetColPressed1
+            Color.FromArgb(255, 252, 230), // GridSheetColPressed2
             Color.FromArgb(255, 211, 89), // GridSheetColSelected1
             Color.FromArgb(255, 239, 113), // GridSheetColSelected2
-            Color.FromArgb(205, 205, 205), // GridSheetRowNormal                                                   
+            Color.FromArgb(205, 205, 205), // GridSheetRowNormal
             Color.FromArgb(255, 223, 107), // GridSheetRowPressed
             Color.FromArgb(245, 210, 87), // GridSheetRowSelected
             Color.FromArgb(218, 220, 221), // GridDataCellBorder
-            Color.FromArgb(183, 219, 255), // GridDataCellSelected
-            //Color.Black,    
+            Color.FromArgb(183, 219, 255), // GridDataCellSelected  //Color.Black,    
             Color.FromArgb(70, 70, 70), // InputControlTextNormal
             Color.FromArgb(168, 168, 168), // InputControlTextDisabled
             Color.FromArgb(132, 132, 132), // InputControlBorderNormal
@@ -343,7 +336,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(148, 148, 143), // ButtonNavigatorPressed2
             Color.FromArgb(91, 91, 91), // ButtonNavigatorChecked1
             Color.FromArgb(73, 73, 73), // ButtonNavigatorChecked2
-            Color.FromArgb(201, 201, 201) // ToolTipBottom                                                                      
+            Color.FromArgb(201, 201, 201) // ToolTipBottom
         ];
 
         #endregion
@@ -1366,8 +1359,8 @@ namespace Krypton.Toolkit
                         PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColors[(int)SchemeOfficeColors.RibbonGalleryBack1] : _buttonBackColors[1],
                         PaletteState.Normal => _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBack2],
                         PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
-                                                            ? GlobalStaticValues.EMPTY_COLOR
-                                                            : _ribbonColors[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
+     ? GlobalStaticValues.EMPTY_COLOR
+     : _ribbonColors[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBack2] : _buttonBackColors[7],
                         PaletteState.Tracking => _buttonBackColors[3],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
@@ -1722,11 +1715,11 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                    ? _ribbonColors[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                    : _ribbonColors[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+? _ribbonColors[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+: _ribbonColors[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
-                                                    ? _ribbonColors[(int)SchemeOfficeColors.FormBorderHeaderInactive]
-                                                    : _ribbonColors[(int)SchemeOfficeColors.FormBorderHeaderActive],
+? _ribbonColors[(int)SchemeOfficeColors.FormBorderHeaderInactive]
+: _ribbonColors[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColors[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
@@ -1737,8 +1730,8 @@ namespace Krypton.Toolkit
                 },
                 PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
                 PaletteBorderStyle.InputControlStandalone or PaletteBorderStyle.InputControlRibbon or PaletteBorderStyle.InputControlCustom1 or PaletteBorderStyle.InputControlCustom2 or PaletteBorderStyle.InputControlCustom3 => state == PaletteState.Disabled
-                                                        ? _ribbonColors[(int)SchemeOfficeColors.InputControlBorderDisabled]
-                                                        : _ribbonColors[(int)SchemeOfficeColors.InputControlBorderNormal],
+ ? _ribbonColors[(int)SchemeOfficeColors.InputControlBorderDisabled]
+ : _ribbonColors[(int)SchemeOfficeColors.InputControlBorderNormal],
                 PaletteBorderStyle.GridDataCellList or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1 or PaletteBorderStyle.GridDataCellCustom2 or PaletteBorderStyle.GridDataCellCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColors[(int)SchemeOfficeColors.GridDataCellBorder],
                 PaletteBorderStyle.ControlRibbon => state == PaletteState.Disabled ? _disabledBorder : _ribbonColors[(int)SchemeOfficeColors.RibbonGroupsArea1],
                 PaletteBorderStyle.ControlRibbonAppMenu => state == PaletteState.Disabled ? _disabledBorder : _ribbonColors[(int)SchemeOfficeColors.AppButtonBorder],
@@ -1746,8 +1739,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-                                                    ? _ribbonColors[(int)SchemeOfficeColors.FormBorderInactive]
-                                                    : _ribbonColors[(int)SchemeOfficeColors.FormBorderActive],
+? _ribbonColors[(int)SchemeOfficeColors.FormBorderInactive]
+: _ribbonColors[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -1769,8 +1762,8 @@ namespace Krypton.Toolkit
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? _ribbonColors[(int)SchemeOfficeColors.RibbonGalleryBack2] : _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
-                                                            ? GlobalStaticValues.EMPTY_COLOR
-                                                            : _ribbonColors[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+     ? GlobalStaticValues.EMPTY_COLOR
+     : _ribbonColors[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
@@ -1852,8 +1845,8 @@ namespace Krypton.Toolkit
                                                 : _ribbonColors[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColors[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-                                                    ? _ribbonColors[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-                                                    : _ribbonColors[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+? _ribbonColors[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+: _ribbonColors[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -1872,8 +1865,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-                                                    ? _ribbonColors[(int)SchemeOfficeColors.FormBorderInactive]
-                                                    : _ribbonColors[(int)SchemeOfficeColors.FormBorderActive],
+? _ribbonColors[(int)SchemeOfficeColors.FormBorderInactive]
+: _ribbonColors[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -2755,8 +2748,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3154,8 +3147,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3230,8 +3223,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal]
                 },

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Official Themes/PaletteOffice2010Black.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Official Themes/PaletteOffice2010Black.cs
@@ -1359,8 +1359,8 @@ namespace Krypton.Toolkit
                         PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColors[(int)SchemeOfficeColors.RibbonGalleryBack1] : _buttonBackColors[1],
                         PaletteState.Normal => _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBack2],
                         PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
-     ? GlobalStaticValues.EMPTY_COLOR
-     : _ribbonColors[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
+                                                            ? GlobalStaticValues.EMPTY_COLOR
+                                                            : _ribbonColors[(int)SchemeOfficeColors.ButtonNormalDefaultBack2],
                         PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBack2] : _buttonBackColors[7],
                         PaletteState.Tracking => _buttonBackColors[3],
                         PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
@@ -1715,11 +1715,11 @@ namespace Krypton.Toolkit
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 },
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-? _ribbonColors[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-: _ribbonColors[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                    ? _ribbonColors[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                    : _ribbonColors[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
-? _ribbonColors[(int)SchemeOfficeColors.FormBorderHeaderInactive]
-: _ribbonColors[(int)SchemeOfficeColors.FormBorderHeaderActive],
+                                                    ? _ribbonColors[(int)SchemeOfficeColors.FormBorderHeaderInactive]
+                                                    : _ribbonColors[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColors[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
@@ -1730,8 +1730,8 @@ namespace Krypton.Toolkit
                 },
                 PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
                 PaletteBorderStyle.InputControlStandalone or PaletteBorderStyle.InputControlRibbon or PaletteBorderStyle.InputControlCustom1 or PaletteBorderStyle.InputControlCustom2 or PaletteBorderStyle.InputControlCustom3 => state == PaletteState.Disabled
- ? _ribbonColors[(int)SchemeOfficeColors.InputControlBorderDisabled]
- : _ribbonColors[(int)SchemeOfficeColors.InputControlBorderNormal],
+                                                        ? _ribbonColors[(int)SchemeOfficeColors.InputControlBorderDisabled]
+                                                        : _ribbonColors[(int)SchemeOfficeColors.InputControlBorderNormal],
                 PaletteBorderStyle.GridDataCellList or PaletteBorderStyle.GridDataCellSheet or PaletteBorderStyle.GridDataCellCustom1 or PaletteBorderStyle.GridDataCellCustom2 or PaletteBorderStyle.GridDataCellCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColors[(int)SchemeOfficeColors.GridDataCellBorder],
                 PaletteBorderStyle.ControlRibbon => state == PaletteState.Disabled ? _disabledBorder : _ribbonColors[(int)SchemeOfficeColors.RibbonGroupsArea1],
                 PaletteBorderStyle.ControlRibbonAppMenu => state == PaletteState.Disabled ? _disabledBorder : _ribbonColors[(int)SchemeOfficeColors.AppButtonBorder],
@@ -1739,8 +1739,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-? _ribbonColors[(int)SchemeOfficeColors.FormBorderInactive]
-: _ribbonColors[(int)SchemeOfficeColors.FormBorderActive],
+                                                    ? _ribbonColors[(int)SchemeOfficeColors.FormBorderInactive]
+                                                    : _ribbonColors[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -1762,8 +1762,8 @@ namespace Krypton.Toolkit
                     PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? _ribbonColors[(int)SchemeOfficeColors.RibbonGalleryBack2] : _buttonBorderColors[0],
                     PaletteState.Normal => _ribbonColors[(int)SchemeOfficeColors.ButtonNormalBorder],
                     PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
-     ? GlobalStaticValues.EMPTY_COLOR
-     : _ribbonColors[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
+                                                            ? GlobalStaticValues.EMPTY_COLOR
+                                                            : _ribbonColors[(int)SchemeOfficeColors.ButtonNormalDefaultBorder],
                     PaletteState.CheckedNormal => _buttonBorderColors[5],
                     PaletteState.Tracking => _buttonBorderColors[1],
                     PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
@@ -1845,8 +1845,8 @@ namespace Krypton.Toolkit
                                                 : _ribbonColors[(int)SchemeOfficeColors.FormBorderHeaderActive],
                 PaletteBorderStyle.SeparatorLowProfile or PaletteBorderStyle.SeparatorHighInternalProfile or PaletteBorderStyle.SeparatorHighProfile or PaletteBorderStyle.SeparatorCustom1 or PaletteBorderStyle.SeparatorCustom2 or PaletteBorderStyle.SeparatorCustom3 or PaletteBorderStyle.HeaderPrimary or PaletteBorderStyle.HeaderDockInactive or PaletteBorderStyle.HeaderDockActive or PaletteBorderStyle.HeaderSecondary or PaletteBorderStyle.HeaderCustom1 or PaletteBorderStyle.HeaderCustom2 or PaletteBorderStyle.HeaderCustom3 or PaletteBorderStyle.ControlClient or PaletteBorderStyle.ControlAlternate or PaletteBorderStyle.ControlGroupBox or PaletteBorderStyle.ControlCustom1 or PaletteBorderStyle.ControlCustom2 or PaletteBorderStyle.ControlCustom3 or PaletteBorderStyle.GridHeaderColumnList or PaletteBorderStyle.GridHeaderColumnSheet or PaletteBorderStyle.GridHeaderColumnCustom1 or PaletteBorderStyle.GridHeaderColumnCustom2 or PaletteBorderStyle.GridHeaderColumnCustom3 or PaletteBorderStyle.GridHeaderRowList or PaletteBorderStyle.GridHeaderRowSheet or PaletteBorderStyle.GridHeaderRowCustom1 or PaletteBorderStyle.GridHeaderRowCustom2 or PaletteBorderStyle.GridHeaderRowCustom3 => state == PaletteState.Disabled ? _disabledBorder : _ribbonColors[(int)SchemeOfficeColors.ControlBorder],
                 PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
-? _ribbonColors[(int)SchemeOfficeColors.HeaderPrimaryBack1]
-: _ribbonColors[(int)SchemeOfficeColors.HeaderPrimaryBack2],
+                                                    ? _ribbonColors[(int)SchemeOfficeColors.HeaderPrimaryBack1]
+                                                    : _ribbonColors[(int)SchemeOfficeColors.HeaderPrimaryBack2],
                 PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
                 PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
                 {
@@ -1865,8 +1865,8 @@ namespace Krypton.Toolkit
                 PaletteBorderStyle.ContextMenuInner => _contextMenuBack,
                 PaletteBorderStyle.ControlToolTip => state == PaletteState.Disabled ? _disabledBorder : _toolTipBorder,
                 PaletteBorderStyle.FormMain or PaletteBorderStyle.FormCustom1 or PaletteBorderStyle.FormCustom2 or PaletteBorderStyle.FormCustom3 => state == PaletteState.Disabled
-? _ribbonColors[(int)SchemeOfficeColors.FormBorderInactive]
-: _ribbonColors[(int)SchemeOfficeColors.FormBorderActive],
+                                                    ? _ribbonColors[(int)SchemeOfficeColors.FormBorderInactive]
+                                                    : _ribbonColors[(int)SchemeOfficeColors.FormBorderActive],
                 PaletteBorderStyle.ButtonForm => state switch
                 {
                     PaletteState.Disabled or PaletteState.Normal or PaletteState.NormalDefaultOverride => GlobalStaticValues.EMPTY_COLOR,
@@ -2748,8 +2748,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3147,8 +3147,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3223,8 +3223,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal]
                 },

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Official Themes/PaletteOffice2010Blue.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Official Themes/PaletteOffice2010Blue.cs
@@ -384,42 +384,42 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
- PaletteButtonSpecStyle.FormClose => state switch
- {
-  PaletteState.Tracking => _formCloseActive,
-  PaletteState.Normal => _formCloseNormal,
-  PaletteState.Pressed => _formClosePressed,
-  _ => _formCloseDisabled
- },
- PaletteButtonSpecStyle.FormMin => state switch
- {
-  PaletteState.Normal => _formMinimiseNormal,
-  PaletteState.Tracking => _formMinimiseActive,
-  PaletteState.Pressed => _formMinimisePressed,
-  _ => _formMinimiseDisabled
- },
- PaletteButtonSpecStyle.FormMax => state switch
- {
-  PaletteState.Normal => _formMaximiseNormal,
-  PaletteState.Tracking => _formMaximiseActive,
-  PaletteState.Pressed => _formMaximisePressed,
-  _ => _formMaximiseDisabled
- },
- PaletteButtonSpecStyle.FormRestore => state switch
- {
-  PaletteState.Normal => _formRestoreNormal,
-  PaletteState.Tracking => _formRestoreActive,
-  PaletteState.Pressed => _formRestorePressed,
-  _ => _formRestoreDisabled
- },
- PaletteButtonSpecStyle.FormHelp => state switch
- {
-  PaletteState.Tracking => _formHelpActive,
-  PaletteState.Pressed => _formHelpPressed,
-  PaletteState.Normal => _formHelpNormal,
-  _ => _formHelpDisabled
- },
- _ => base.GetButtonSpecImage(style, state)
+                                                     PaletteButtonSpecStyle.FormClose => state switch
+                                                     {
+                                                         PaletteState.Tracking => _formCloseActive,
+                                                         PaletteState.Normal => _formCloseNormal,
+                                                         PaletteState.Pressed => _formClosePressed,
+                                                         _ => _formCloseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMin => state switch
+                                                     {
+                                                         PaletteState.Normal => _formMinimiseNormal,
+                                                         PaletteState.Tracking => _formMinimiseActive,
+                                                         PaletteState.Pressed => _formMinimisePressed,
+                                                         _ => _formMinimiseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMax => state switch
+                                                     {
+                                                         PaletteState.Normal => _formMaximiseNormal,
+                                                         PaletteState.Tracking => _formMaximiseActive,
+                                                         PaletteState.Pressed => _formMaximisePressed,
+                                                         _ => _formMaximiseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormRestore => state switch
+                                                     {
+                                                         PaletteState.Normal => _formRestoreNormal,
+                                                         PaletteState.Tracking => _formRestoreActive,
+                                                         PaletteState.Pressed => _formRestorePressed,
+                                                         _ => _formRestoreDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormHelp => state switch
+                                                     {
+                                                         PaletteState.Tracking => _formHelpActive,
+                                                         PaletteState.Pressed => _formHelpPressed,
+                                                         PaletteState.Normal => _formHelpNormal,
+                                                         _ => _formHelpDisabled
+                                                     },
+                                                     _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Official Themes/PaletteOffice2010Blue.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Official Themes/PaletteOffice2010Blue.cs
@@ -232,44 +232,38 @@ namespace Krypton.Toolkit
             Color.FromArgb(219, 231, 247), // RibbonQATMini2
             Color.FromArgb(195, 213, 236), // RibbonQATMini3
             Color.FromArgb(128, Color.White), // RibbonQATMini4
-            Color.FromArgb(72, Color.White), // RibbonQATMini5                                                       
+            Color.FromArgb(72, Color.White), // RibbonQATMini5
             Color.FromArgb(153, 176, 206), // RibbonQATMini1I
             Color.FromArgb(226, 233, 241), // RibbonQATMini2I
             Color.FromArgb(198, 210, 226), // RibbonQATMini3I
             Color.FromArgb(128, Color.White), // RibbonQATMini4I
-            Color.FromArgb(72, Color.White), // RibbonQATMini5I                                                      
-            Color.FromArgb(213, 232, 254), // RibbonQATFullbar1                                                      
-            Color.FromArgb(205, 223, 245), // RibbonQATFullbar2                                                      
-            Color.FromArgb(114, 142, 173), // RibbonQATFullbar3                                                      
-            Color.FromArgb(90, 90, 90), // RibbonQATButtonDark                                                      
-            Color.FromArgb(207, 214, 224), // RibbonQATButtonLight                                                      
-            Color.FromArgb(222, 236, 252), // RibbonQATOverflow1                                                      
-            Color.FromArgb(123, 139, 156), // RibbonQATOverflow2                                                      
-            Color.FromArgb(145, 166,
-                194), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(239, 245,
-                250), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(192, 212,
-                241), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(200, 219,
-                238), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(155, 183,
-                224), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(117, 150,
-                191), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor                                                    
-            Color.FromArgb(244, 249, 255), // GridListNormal1                                                    
-            Color.FromArgb(218, 231, 245), // GridListNormal2                                                    
-            Color.FromArgb(198, 211, 225), // GridListPressed1                                                    
-            Color.FromArgb(244, 249, 255), // GridListPressed2                                                    
-            Color.FromArgb(160, 185, 230), // GridListSelected                                                    
-            Color.FromArgb(233, 246, 255), // GridSheetColNormal1                                                    
-            Color.FromArgb(213, 226, 240), // GridSheetColNormal2                                                    
-            Color.FromArgb(255, 223, 107), // GridSheetColPressed1                                                    
-            Color.FromArgb(255, 252, 230), // GridSheetColPressed2                                                    
+            Color.FromArgb(72, Color.White), // RibbonQATMini5I
+            Color.FromArgb(213, 232, 254), // RibbonQATFullbar1
+            Color.FromArgb(205, 223, 245), // RibbonQATFullbar2
+            Color.FromArgb(114, 142, 173), // RibbonQATFullbar3
+            Color.FromArgb(90, 90, 90), // RibbonQATButtonDark
+            Color.FromArgb(207, 214, 224), // RibbonQATButtonLight
+            Color.FromArgb(222, 236, 252), // RibbonQATOverflow1
+            Color.FromArgb(123, 139, 156), // RibbonQATOverflow2
+            Color.FromArgb(145, 166, 194), // RibbonGroupSeparatorDark
+            Color.FromArgb(239, 245, 250), // RibbonGroupSeparatorLight
+            Color.FromArgb(192, 212, 241), // ButtonClusterButtonBack1
+            Color.FromArgb(200, 219, 238), // ButtonClusterButtonBack2
+            Color.FromArgb(155, 183, 224), // ButtonClusterButtonBorder1
+            Color.FromArgb(117, 150, 191), // ButtonClusterButtonBorder2
+            Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor
+            Color.FromArgb(244, 249, 255), // GridListNormal1
+            Color.FromArgb(218, 231, 245), // GridListNormal2
+            Color.FromArgb(198, 211, 225), // GridListPressed1
+            Color.FromArgb(244, 249, 255), // GridListPressed2
+            Color.FromArgb(160, 185, 230), // GridListSelected
+            Color.FromArgb(233, 246, 255), // GridSheetColNormal1
+            Color.FromArgb(213, 226, 240), // GridSheetColNormal2
+            Color.FromArgb(255, 223, 107), // GridSheetColPressed1
+            Color.FromArgb(255, 252, 230), // GridSheetColPressed2
             Color.FromArgb(255, 211, 89), // GridSheetColSelected1
             Color.FromArgb(255, 239, 113), // GridSheetColSelected2
-            Color.FromArgb(218, 231, 245), // GridSheetRowNormal                                                   
+            Color.FromArgb(218, 231, 245), // GridSheetRowNormal
             Color.FromArgb(255, 223, 107), // GridSheetRowPressed
             Color.FromArgb(245, 210, 87), // GridSheetRowSelected
             Color.FromArgb(218, 220, 221), // GridDataCellBorder
@@ -323,7 +317,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(198, 214, 231), // ButtonNavigatorPressed2
             Color.FromArgb(200, 219, 240), // ButtonNavigatorChecked1
             Color.FromArgb(177, 201, 228), // ButtonNavigatorChecked2
-            Color.FromArgb(201, 217, 239) // ToolTipBottom                                                                      
+            Color.FromArgb(201, 217, 239) // ToolTipBottom
         ];
 
         #endregion
@@ -390,42 +384,42 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
-                                                     PaletteButtonSpecStyle.FormClose => state switch
-                                                     {
-                                                         PaletteState.Tracking => _formCloseActive,
-                                                         PaletteState.Normal => _formCloseNormal,
-                                                         PaletteState.Pressed => _formClosePressed,
-                                                         _ => _formCloseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMin => state switch
-                                                     {
-                                                         PaletteState.Normal => _formMinimiseNormal,
-                                                         PaletteState.Tracking => _formMinimiseActive,
-                                                         PaletteState.Pressed => _formMinimisePressed,
-                                                         _ => _formMinimiseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMax => state switch
-                                                     {
-                                                         PaletteState.Normal => _formMaximiseNormal,
-                                                         PaletteState.Tracking => _formMaximiseActive,
-                                                         PaletteState.Pressed => _formMaximisePressed,
-                                                         _ => _formMaximiseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormRestore => state switch
-                                                     {
-                                                         PaletteState.Normal => _formRestoreNormal,
-                                                         PaletteState.Tracking => _formRestoreActive,
-                                                         PaletteState.Pressed => _formRestorePressed,
-                                                         _ => _formRestoreDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormHelp => state switch
-                                                     {
-                                                         PaletteState.Tracking => _formHelpActive,
-                                                         PaletteState.Pressed => _formHelpPressed,
-                                                         PaletteState.Normal => _formHelpNormal,
-                                                         _ => _formHelpDisabled
-                                                     },
-                                                     _ => base.GetButtonSpecImage(style, state)
+ PaletteButtonSpecStyle.FormClose => state switch
+ {
+  PaletteState.Tracking => _formCloseActive,
+  PaletteState.Normal => _formCloseNormal,
+  PaletteState.Pressed => _formClosePressed,
+  _ => _formCloseDisabled
+ },
+ PaletteButtonSpecStyle.FormMin => state switch
+ {
+  PaletteState.Normal => _formMinimiseNormal,
+  PaletteState.Tracking => _formMinimiseActive,
+  PaletteState.Pressed => _formMinimisePressed,
+  _ => _formMinimiseDisabled
+ },
+ PaletteButtonSpecStyle.FormMax => state switch
+ {
+  PaletteState.Normal => _formMaximiseNormal,
+  PaletteState.Tracking => _formMaximiseActive,
+  PaletteState.Pressed => _formMaximisePressed,
+  _ => _formMaximiseDisabled
+ },
+ PaletteButtonSpecStyle.FormRestore => state switch
+ {
+  PaletteState.Normal => _formRestoreNormal,
+  PaletteState.Tracking => _formRestoreActive,
+  PaletteState.Pressed => _formRestorePressed,
+  _ => _formRestoreDisabled
+ },
+ PaletteButtonSpecStyle.FormHelp => state switch
+ {
+  PaletteState.Tracking => _formHelpActive,
+  PaletteState.Pressed => _formHelpPressed,
+  PaletteState.Normal => _formHelpNormal,
+  _ => _formHelpDisabled
+ },
+ _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Official Themes/PaletteOffice2010Silver.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Official Themes/PaletteOffice2010Silver.cs
@@ -231,38 +231,38 @@ namespace Krypton.Toolkit
             Color.FromArgb(210, 215, 221),    // RibbonQATMini2
             Color.FromArgb(195, 200, 206),    // RibbonQATMini3
             Color.FromArgb(10, Color.White),  // RibbonQATMini4
-            Color.FromArgb(32, Color.White),  // RibbonQATMini5                                                       
+            Color.FromArgb(32, Color.White),  // RibbonQATMini5
             Color.FromArgb(200, 200, 200),    // RibbonQATMini1I
             Color.FromArgb(233, 234, 238),    // RibbonQATMini2I
             Color.FromArgb(223, 224, 228),    // RibbonQATMini3I
             Color.FromArgb(10, Color.White),  // RibbonQATMini4I
-            Color.FromArgb(32, Color.White),  // RibbonQATMini5I                                                       
-            Color.FromArgb(223, 227, 234),    // RibbonQATFullbar1                                                      
-            Color.FromArgb(213, 217, 222),    // RibbonQATFullbar2                                                      
-            Color.FromArgb(135, 140, 146),    // RibbonQATFullbar3                                                      
-            Color.FromArgb( 90,  90,  90),    // RibbonQATButtonDark                                                      
-            Color.FromArgb(210, 212, 215),    // RibbonQATButtonLight                                                      
-            Color.FromArgb(233, 237, 241),    // RibbonQATOverflow1                                                      
-            Color.FromArgb(138, 144, 150),    // RibbonQATOverflow2                                                      
-            Color.FromArgb(191, 195, 199),    // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(255, 255, 255),    // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(231, 234, 238),    // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(241, 243, 243),    // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(197, 198, 199),    // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(157, 158, 159),    // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(238, 238, 244),    // NavigatorMiniBackColor                                                    
-            Color.FromArgb(248, 252, 255),    // GridListNormal1                                                    
-            Color.FromArgb(223, 227, 232),    // GridListNormal2                                                    
-            Color.FromArgb(203, 207, 212),    // GridListPressed1                                                    
-            Color.White,                      // GridListPressed2                                                    
-            Color.FromArgb(186, 189, 194),    // GridListSelected                                                    
-            Color.FromArgb(238, 241, 247),    // GridSheetColNormal1                                                    
-            Color.FromArgb(218, 222, 227),    // GridSheetColNormal2                                                    
-            Color.FromArgb(255, 223, 107),    // GridSheetColPressed1                                                    
-            Color.FromArgb(255, 252, 230),    // GridSheetColPressed2                                                    
+            Color.FromArgb(32, Color.White),  // RibbonQATMini5I
+            Color.FromArgb(223, 227, 234),    // RibbonQATFullbar1
+            Color.FromArgb(213, 217, 222),    // RibbonQATFullbar2
+            Color.FromArgb(135, 140, 146),    // RibbonQATFullbar3
+            Color.FromArgb( 90,  90,  90),    // RibbonQATButtonDark
+            Color.FromArgb(210, 212, 215),    // RibbonQATButtonLight
+            Color.FromArgb(233, 237, 241),    // RibbonQATOverflow1
+            Color.FromArgb(138, 144, 150),    // RibbonQATOverflow2
+            Color.FromArgb(191, 195, 199),    // RibbonGroupSeparatorDark
+            Color.FromArgb(255, 255, 255),    // RibbonGroupSeparatorLight
+            Color.FromArgb(231, 234, 238),    // ButtonClusterButtonBack1
+            Color.FromArgb(241, 243, 243),    // ButtonClusterButtonBack2
+            Color.FromArgb(197, 198, 199),    // ButtonClusterButtonBorder1
+            Color.FromArgb(157, 158, 159),    // ButtonClusterButtonBorder2
+            Color.FromArgb(238, 238, 244),    // NavigatorMiniBackColor
+            Color.FromArgb(248, 252, 255),    // GridListNormal1
+            Color.FromArgb(223, 227, 232),    // GridListNormal2
+            Color.FromArgb(203, 207, 212),    // GridListPressed1
+            Color.White,                      // GridListPressed2
+            Color.FromArgb(186, 189, 194),    // GridListSelected
+            Color.FromArgb(238, 241, 247),    // GridSheetColNormal1
+            Color.FromArgb(218, 222, 227),    // GridSheetColNormal2
+            Color.FromArgb(255, 223, 107),    // GridSheetColPressed1
+            Color.FromArgb(255, 252, 230),    // GridSheetColPressed2
             Color.FromArgb(255, 211,  89),    // GridSheetColSelected1
             Color.FromArgb(255, 239, 113),    // GridSheetColSelected2
-            Color.FromArgb(223, 227, 232),    // GridSheetRowNormal                                                   
+            Color.FromArgb(223, 227, 232),    // GridSheetRowNormal
             Color.FromArgb(255, 223, 107),    // GridSheetRowPressed
             Color.FromArgb(245, 210,  87),    // GridSheetRowSelected
             Color.FromArgb(218, 220, 221),    // GridDataCellBorder
@@ -297,7 +297,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(255, 255, 255),    // RibbonGalleryBackNormal
             Color.FromArgb(255, 255, 255),    // RibbonGalleryBackTracking
             Color.FromArgb(250, 250, 250),    // RibbonGalleryBack1
-            Color.FromArgb(228, 231, 235),    // RibbonGalleryBack2                                                                                                                                      Color.FromArgb(177, 181, 186),    // RibbonTabTracking1
+            Color.FromArgb(228, 231, 235),    // RibbonGalleryBack2                        Color.FromArgb(177, 181, 186),    // RibbonTabTracking1
             Color.FromArgb(229, 231, 235),    // RibbonTabTracking3
             Color.FromArgb(231, 233, 235),    // RibbonTabTracking4
             Color.FromArgb(176, 182, 188),    // RibbonGroupBorder3
@@ -316,7 +316,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(225, 226, 230),    // ButtonNavigatorPressed2
             Color.FromArgb(222, 227, 234),    // ButtonNavigatorChecked1
             Color.FromArgb(206, 214, 221),    // ButtonNavigatorChecked2
-            Color.FromArgb(221, 221, 221) // ToolTipBottom                                                                      
+            Color.FromArgb(221, 221, 221) // ToolTipBottom               
         ];
 
         #endregion
@@ -383,42 +383,42 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
-                                                     PaletteButtonSpecStyle.FormClose => state switch
-                                                     {
-                                                         PaletteState.Tracking => _formCloseActive,
-                                                         PaletteState.Normal => _formCloseNormal,
-                                                         PaletteState.Pressed => _formClosePressed,
-                                                         _ => _formCloseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMin => state switch
-                                                     {
-                                                         PaletteState.Normal => _formMinimiseNormal,
-                                                         PaletteState.Tracking => _formMinimiseActive,
-                                                         PaletteState.Pressed => _formMinimisePressed,
-                                                         _ => _formMinimiseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMax => state switch
-                                                     {
-                                                         PaletteState.Normal => _formMaximiseNormal,
-                                                         PaletteState.Tracking => _formMaximiseActive,
-                                                         PaletteState.Pressed => _formMaximisePressed,
-                                                         _ => _formMaximiseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormRestore => state switch
-                                                     {
-                                                         PaletteState.Normal => _formRestoreNormal,
-                                                         PaletteState.Tracking => _formRestoreActive,
-                                                         PaletteState.Pressed => _formRestorePressed,
-                                                         _ => _formRestoreDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormHelp => state switch
-                                                     {
-                                                         PaletteState.Tracking => _formHelpActive,
-                                                         PaletteState.Pressed => _formHelpPressed,
-                                                         PaletteState.Normal => _formHelpNormal,
-                                                         _ => _formHelpDisabled
-                                                     },
-                                                     _ => base.GetButtonSpecImage(style, state)
+ PaletteButtonSpecStyle.FormClose => state switch
+ {
+  PaletteState.Tracking => _formCloseActive,
+  PaletteState.Normal => _formCloseNormal,
+  PaletteState.Pressed => _formClosePressed,
+  _ => _formCloseDisabled
+ },
+ PaletteButtonSpecStyle.FormMin => state switch
+ {
+  PaletteState.Normal => _formMinimiseNormal,
+  PaletteState.Tracking => _formMinimiseActive,
+  PaletteState.Pressed => _formMinimisePressed,
+  _ => _formMinimiseDisabled
+ },
+ PaletteButtonSpecStyle.FormMax => state switch
+ {
+  PaletteState.Normal => _formMaximiseNormal,
+  PaletteState.Tracking => _formMaximiseActive,
+  PaletteState.Pressed => _formMaximisePressed,
+  _ => _formMaximiseDisabled
+ },
+ PaletteButtonSpecStyle.FormRestore => state switch
+ {
+  PaletteState.Normal => _formRestoreNormal,
+  PaletteState.Tracking => _formRestoreActive,
+  PaletteState.Pressed => _formRestorePressed,
+  _ => _formRestoreDisabled
+ },
+ PaletteButtonSpecStyle.FormHelp => state switch
+ {
+  PaletteState.Tracking => _formHelpActive,
+  PaletteState.Pressed => _formHelpPressed,
+  PaletteState.Normal => _formHelpNormal,
+  _ => _formHelpDisabled
+ },
+ _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Official Themes/PaletteOffice2010Silver.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Official Themes/PaletteOffice2010Silver.cs
@@ -383,42 +383,42 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
- PaletteButtonSpecStyle.FormClose => state switch
- {
-  PaletteState.Tracking => _formCloseActive,
-  PaletteState.Normal => _formCloseNormal,
-  PaletteState.Pressed => _formClosePressed,
-  _ => _formCloseDisabled
- },
- PaletteButtonSpecStyle.FormMin => state switch
- {
-  PaletteState.Normal => _formMinimiseNormal,
-  PaletteState.Tracking => _formMinimiseActive,
-  PaletteState.Pressed => _formMinimisePressed,
-  _ => _formMinimiseDisabled
- },
- PaletteButtonSpecStyle.FormMax => state switch
- {
-  PaletteState.Normal => _formMaximiseNormal,
-  PaletteState.Tracking => _formMaximiseActive,
-  PaletteState.Pressed => _formMaximisePressed,
-  _ => _formMaximiseDisabled
- },
- PaletteButtonSpecStyle.FormRestore => state switch
- {
-  PaletteState.Normal => _formRestoreNormal,
-  PaletteState.Tracking => _formRestoreActive,
-  PaletteState.Pressed => _formRestorePressed,
-  _ => _formRestoreDisabled
- },
- PaletteButtonSpecStyle.FormHelp => state switch
- {
-  PaletteState.Tracking => _formHelpActive,
-  PaletteState.Pressed => _formHelpPressed,
-  PaletteState.Normal => _formHelpNormal,
-  _ => _formHelpDisabled
- },
- _ => base.GetButtonSpecImage(style, state)
+                                                     PaletteButtonSpecStyle.FormClose => state switch
+                                                     {
+                                                         PaletteState.Tracking => _formCloseActive,
+                                                         PaletteState.Normal => _formCloseNormal,
+                                                         PaletteState.Pressed => _formClosePressed,
+                                                         _ => _formCloseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMin => state switch
+                                                     {
+                                                         PaletteState.Normal => _formMinimiseNormal,
+                                                         PaletteState.Tracking => _formMinimiseActive,
+                                                         PaletteState.Pressed => _formMinimisePressed,
+                                                         _ => _formMinimiseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMax => state switch
+                                                     {
+                                                         PaletteState.Normal => _formMaximiseNormal,
+                                                         PaletteState.Tracking => _formMaximiseActive,
+                                                         PaletteState.Pressed => _formMaximisePressed,
+                                                         _ => _formMaximiseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormRestore => state switch
+                                                     {
+                                                         PaletteState.Normal => _formRestoreNormal,
+                                                         PaletteState.Tracking => _formRestoreActive,
+                                                         PaletteState.Pressed => _formRestorePressed,
+                                                         _ => _formRestoreDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormHelp => state switch
+                                                     {
+                                                         PaletteState.Tracking => _formHelpActive,
+                                                         PaletteState.Pressed => _formHelpPressed,
+                                                         PaletteState.Normal => _formHelpNormal,
+                                                         _ => _formHelpDisabled
+                                                     },
+                                                     _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013DarkGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013DarkGray.cs
@@ -210,7 +210,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(226, 229, 234), // RibbonGroupFrameInside2
             Color.FromArgb(220, 224, 231), // RibbonGroupFrameInside3
             Color.FromArgb(232, 234, 238), // RibbonGroupFrameInside4
-            Color.FromArgb(68, 68, 68), // RibbonGroupCollapsedText         
+            Color.FromArgb(68, 68, 68), // RibbonGroupCollapsedText
             Color.FromArgb(179, 185, 195), // AlternatePressedBack1
             Color.FromArgb(216, 224, 224), // AlternatePressedBack2
             Color.FromArgb(125, 125, 125), // AlternatePressedBorder1
@@ -224,38 +224,38 @@ namespace Krypton.Toolkit
             Color.FromArgb(210, 215, 221), // RibbonQATMini2
             Color.FromArgb(195, 200, 206), // RibbonQATMini3
             Color.FromArgb(10, Color.White), // RibbonQATMini4
-            Color.FromArgb(32, Color.White), // RibbonQATMini5                                                       
+            Color.FromArgb(32, Color.White), // RibbonQATMini5
             Color.FromArgb(200, 200, 200), // RibbonQATMini1I
             Color.FromArgb(233, 234, 238), // RibbonQATMini2I
             Color.FromArgb(223, 224, 228), // RibbonQATMini3I
             Color.FromArgb(10, Color.White), // RibbonQATMini4I
-            Color.FromArgb(32, Color.White), // RibbonQATMini5I                                                       
-            Color.FromArgb(217, 222, 230), // RibbonQATFullbar1                                                      
-            Color.FromArgb(214, 219, 227), // RibbonQATFullbar2                                                      
-            Color.FromArgb(194, 201, 212), // RibbonQATFullbar3                                                      
-            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark                                                      
-            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
-            Color.FromArgb(219, 218, 228), // RibbonQATOverflow1                                                      
-            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-            Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor                                                    
-            Color.White, // GridListNormal1                                                    
-            Color.FromArgb(212, 215, 219), // GridListNormal2                                                    
-            Color.FromArgb(210, 213, 218), // GridListPressed1                                                    
-            Color.FromArgb(252, 253, 253), // GridListPressed2                                                    
-            Color.FromArgb(186, 189, 194), // GridListSelected                                                    
-            Color.FromArgb(241, 243, 243), // GridSheetColNormal1                                                    
-            Color.FromArgb(200, 201, 202), // GridSheetColNormal2                                                    
-            Color.FromArgb(208, 208, 208), // GridSheetColPressed1                                                    
-            Color.FromArgb(166, 166, 166), // GridSheetColPressed2                                                    
+            Color.FromArgb(32, Color.White), // RibbonQATMini5I
+            Color.FromArgb(217, 222, 230), // RibbonQATFullbar1
+            Color.FromArgb(214, 219, 227), // RibbonQATFullbar2
+            Color.FromArgb(194, 201, 212), // RibbonQATFullbar3
+            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark
+            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight
+            Color.FromArgb(219, 218, 228), // RibbonQATOverflow1
+            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
+            Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark
+            Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight
+            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1
+            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2
+            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1
+            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2
+            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor
+            Color.White, // GridListNormal1
+            Color.FromArgb(212, 215, 219), // GridListNormal2
+            Color.FromArgb(210, 213, 218), // GridListPressed1
+            Color.FromArgb(252, 253, 253), // GridListPressed2
+            Color.FromArgb(186, 189, 194), // GridListSelected
+            Color.FromArgb(241, 243, 243), // GridSheetColNormal1
+            Color.FromArgb(200, 201, 202), // GridSheetColNormal2
+            Color.FromArgb(208, 208, 208), // GridSheetColPressed1
+            Color.FromArgb(166, 166, 166), // GridSheetColPressed2
             Color.FromArgb(255, 204, 153), // GridSheetColSelected1
             Color.FromArgb(255, 155, 104), // GridSheetColSelected2
-            Color.FromArgb(231, 231, 231), // GridSheetRowNormal                                                   
+            Color.FromArgb(231, 231, 231), // GridSheetRowNormal
             Color.FromArgb(184, 191, 196), // GridSheetRowPressed
             Color.FromArgb(245, 199, 149), // GridSheetRowSelected
             Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -295,6 +295,8 @@ namespace Krypton.Toolkit
             GlobalStaticValues.EMPTY_COLOR, // RibbonTabTracking4
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder3
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder4
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder5
+            Color.FromArgb(119, 119, 119), // RibbonGroupTitleText
             GlobalStaticValues.EMPTY_COLOR, // RibbonDropArrowLight
             GlobalStaticValues.EMPTY_COLOR, // RibbonDropArrowDark
             Color.FromArgb(237, 242, 248), // HeaderDockInactiveBack1
@@ -307,7 +309,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(225, 226, 230), // ButtonNavigatorPressed2
             Color.FromArgb(222, 227, 234), // ButtonNavigatorChecked1
             Color.FromArgb(206, 214, 221), // ButtonNavigatorChecked2
-            Color.FromArgb(221, 221, 221) // ToolTipBottom                                                                      
+            Color.FromArgb(221, 221, 221) // ToolTipBottom
         ];
 
         #endregion
@@ -375,42 +377,42 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
-                                                     PaletteButtonSpecStyle.FormClose => state switch
-                                                     {
-                                                         PaletteState.Tracking => _formCloseActive,
-                                                         PaletteState.Normal => _formCloseNormal,
-                                                         PaletteState.Pressed => _formClosePressed,
-                                                         _ => _formCloseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMin => state switch
-                                                     {
-                                                         PaletteState.Normal => _formMinimiseNormal,
-                                                         PaletteState.Tracking => _formMinimiseActive,
-                                                         PaletteState.Pressed => _formMinimisePressed,
-                                                         _ => _formMinimiseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMax => state switch
-                                                     {
-                                                         PaletteState.Normal => _formMaximiseNormal,
-                                                         PaletteState.Tracking => _formMaximiseActive,
-                                                         PaletteState.Pressed => _formMaximisePressed,
-                                                         _ => _formMaximiseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormRestore => state switch
-                                                     {
-                                                         PaletteState.Normal => _formRestoreNormal,
-                                                         PaletteState.Tracking => _formRestoreActive,
-                                                         PaletteState.Pressed => _formRestorePressed,
-                                                         _ => _formRestoreDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormHelp => state switch
-                                                     {
-                                                         PaletteState.Tracking => _formHelpActive,
-                                                         PaletteState.Pressed => _formHelpPressed,
-                                                         PaletteState.Normal => _formHelpNormal,
-                                                         _ => _formHelpDisabled
-                                                     },
-                                                     _ => base.GetButtonSpecImage(style, state)
+ PaletteButtonSpecStyle.FormClose => state switch
+ {
+  PaletteState.Tracking => _formCloseActive,
+  PaletteState.Normal => _formCloseNormal,
+  PaletteState.Pressed => _formClosePressed,
+  _ => _formCloseDisabled
+ },
+ PaletteButtonSpecStyle.FormMin => state switch
+ {
+  PaletteState.Normal => _formMinimiseNormal,
+  PaletteState.Tracking => _formMinimiseActive,
+  PaletteState.Pressed => _formMinimisePressed,
+  _ => _formMinimiseDisabled
+ },
+ PaletteButtonSpecStyle.FormMax => state switch
+ {
+  PaletteState.Normal => _formMaximiseNormal,
+  PaletteState.Tracking => _formMaximiseActive,
+  PaletteState.Pressed => _formMaximisePressed,
+  _ => _formMaximiseDisabled
+ },
+ PaletteButtonSpecStyle.FormRestore => state switch
+ {
+  PaletteState.Normal => _formRestoreNormal,
+  PaletteState.Tracking => _formRestoreActive,
+  PaletteState.Pressed => _formRestorePressed,
+  _ => _formRestoreDisabled
+ },
+ PaletteButtonSpecStyle.FormHelp => state switch
+ {
+  PaletteState.Tracking => _formHelpActive,
+  PaletteState.Pressed => _formHelpPressed,
+  PaletteState.Normal => _formHelpNormal,
+  _ => _formHelpDisabled
+ },
+ _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013DarkGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013DarkGray.cs
@@ -377,42 +377,42 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
- PaletteButtonSpecStyle.FormClose => state switch
- {
-  PaletteState.Tracking => _formCloseActive,
-  PaletteState.Normal => _formCloseNormal,
-  PaletteState.Pressed => _formClosePressed,
-  _ => _formCloseDisabled
- },
- PaletteButtonSpecStyle.FormMin => state switch
- {
-  PaletteState.Normal => _formMinimiseNormal,
-  PaletteState.Tracking => _formMinimiseActive,
-  PaletteState.Pressed => _formMinimisePressed,
-  _ => _formMinimiseDisabled
- },
- PaletteButtonSpecStyle.FormMax => state switch
- {
-  PaletteState.Normal => _formMaximiseNormal,
-  PaletteState.Tracking => _formMaximiseActive,
-  PaletteState.Pressed => _formMaximisePressed,
-  _ => _formMaximiseDisabled
- },
- PaletteButtonSpecStyle.FormRestore => state switch
- {
-  PaletteState.Normal => _formRestoreNormal,
-  PaletteState.Tracking => _formRestoreActive,
-  PaletteState.Pressed => _formRestorePressed,
-  _ => _formRestoreDisabled
- },
- PaletteButtonSpecStyle.FormHelp => state switch
- {
-  PaletteState.Tracking => _formHelpActive,
-  PaletteState.Pressed => _formHelpPressed,
-  PaletteState.Normal => _formHelpNormal,
-  _ => _formHelpDisabled
- },
- _ => base.GetButtonSpecImage(style, state)
+                                                     PaletteButtonSpecStyle.FormClose => state switch
+                                                     {
+                                                         PaletteState.Tracking => _formCloseActive,
+                                                         PaletteState.Normal => _formCloseNormal,
+                                                         PaletteState.Pressed => _formClosePressed,
+                                                         _ => _formCloseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMin => state switch
+                                                     {
+                                                         PaletteState.Normal => _formMinimiseNormal,
+                                                         PaletteState.Tracking => _formMinimiseActive,
+                                                         PaletteState.Pressed => _formMinimisePressed,
+                                                         _ => _formMinimiseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMax => state switch
+                                                     {
+                                                         PaletteState.Normal => _formMaximiseNormal,
+                                                         PaletteState.Tracking => _formMaximiseActive,
+                                                         PaletteState.Pressed => _formMaximisePressed,
+                                                         _ => _formMaximiseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormRestore => state switch
+                                                     {
+                                                         PaletteState.Normal => _formRestoreNormal,
+                                                         PaletteState.Tracking => _formRestoreActive,
+                                                         PaletteState.Pressed => _formRestorePressed,
+                                                         _ => _formRestoreDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormHelp => state switch
+                                                     {
+                                                         PaletteState.Tracking => _formHelpActive,
+                                                         PaletteState.Pressed => _formHelpPressed,
+                                                         PaletteState.Normal => _formHelpNormal,
+                                                         _ => _formHelpDisabled
+                                                     },
+                                                     _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013LightGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013LightGray.cs
@@ -210,7 +210,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(226, 229, 234), // RibbonGroupFrameInside2
             Color.FromArgb(220, 224, 231), // RibbonGroupFrameInside3
             Color.FromArgb(232, 234, 238), // RibbonGroupFrameInside4
-            Color.FromArgb(68, 68, 68), // RibbonGroupCollapsedText         
+            Color.FromArgb(68, 68, 68), // RibbonGroupCollapsedText
             Color.FromArgb(179, 185, 195), // AlternatePressedBack1
             Color.FromArgb(216, 224, 224), // AlternatePressedBack2
             Color.FromArgb(125, 125, 125), // AlternatePressedBorder1
@@ -224,38 +224,38 @@ namespace Krypton.Toolkit
             Color.FromArgb(210, 215, 221), // RibbonQATMini2
             Color.FromArgb(195, 200, 206), // RibbonQATMini3
             Color.FromArgb(10, Color.White), // RibbonQATMini4
-            Color.FromArgb(32, Color.White), // RibbonQATMini5                                                       
+            Color.FromArgb(32, Color.White), // RibbonQATMini5
             Color.FromArgb(200, 200, 200), // RibbonQATMini1I
             Color.FromArgb(233, 234, 238), // RibbonQATMini2I
             Color.FromArgb(223, 224, 228), // RibbonQATMini3I
             Color.FromArgb(10, Color.White), // RibbonQATMini4I
-            Color.FromArgb(32, Color.White), // RibbonQATMini5I                                                       
-            Color.FromArgb(217, 222, 230), // RibbonQATFullbar1                                                      
-            Color.FromArgb(214, 219, 227), // RibbonQATFullbar2                                                      
-            Color.FromArgb(194, 201, 212), // RibbonQATFullbar3                                                      
-            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark                                                      
-            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
-            Color.FromArgb(219, 218, 228), // RibbonQATOverflow1                                                      
-            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-            Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2                                                      
-            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor                                                    
-            Color.White, // GridListNormal1                                                    
-            Color.FromArgb(212, 215, 219), // GridListNormal2                                                    
-            Color.FromArgb(210, 213, 218), // GridListPressed1                                                    
-            Color.FromArgb(252, 253, 253), // GridListPressed2                                                    
-            Color.FromArgb(186, 189, 194), // GridListSelected                                                    
-            Color.FromArgb(241, 243, 243), // GridSheetColNormal1                                                    
-            Color.FromArgb(200, 201, 202), // GridSheetColNormal2                                                    
-            Color.FromArgb(208, 208, 208), // GridSheetColPressed1                                                    
-            Color.FromArgb(166, 166, 166), // GridSheetColPressed2                                                    
+            Color.FromArgb(32, Color.White), // RibbonQATMini5I
+            Color.FromArgb(217, 222, 230), // RibbonQATFullbar1
+            Color.FromArgb(214, 219, 227), // RibbonQATFullbar2
+            Color.FromArgb(194, 201, 212), // RibbonQATFullbar3
+            Color.FromArgb(103, 103, 103), // RibbonQATButtonDark
+            Color.FromArgb(225, 225, 225), // RibbonQATButtonLight
+            Color.FromArgb(219, 218, 228), // RibbonQATOverflow1
+            Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
+            Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark
+            Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight
+            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1
+            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2
+            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1
+            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2
+            Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor
+            Color.White, // GridListNormal1
+            Color.FromArgb(212, 215, 219), // GridListNormal2
+            Color.FromArgb(210, 213, 218), // GridListPressed1
+            Color.FromArgb(252, 253, 253), // GridListPressed2
+            Color.FromArgb(186, 189, 194), // GridListSelected
+            Color.FromArgb(241, 243, 243), // GridSheetColNormal1
+            Color.FromArgb(200, 201, 202), // GridSheetColNormal2
+            Color.FromArgb(208, 208, 208), // GridSheetColPressed1
+            Color.FromArgb(166, 166, 166), // GridSheetColPressed2
             Color.FromArgb(255, 204, 153), // GridSheetColSelected1
             Color.FromArgb(255, 155, 104), // GridSheetColSelected2
-            Color.FromArgb(231, 231, 231), // GridSheetRowNormal                                                   
+            Color.FromArgb(231, 231, 231), // GridSheetRowNormal
             Color.FromArgb(184, 191, 196), // GridSheetRowPressed
             Color.FromArgb(245, 199, 149), // GridSheetRowSelected
             Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -295,6 +295,8 @@ namespace Krypton.Toolkit
             GlobalStaticValues.EMPTY_COLOR, // RibbonTabTracking4
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder3
             GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder4
+            GlobalStaticValues.EMPTY_COLOR, // RibbonGroupBorder5
+            Color.FromArgb(119, 119, 119), // RibbonGroupTitleText
             GlobalStaticValues.EMPTY_COLOR, // RibbonDropArrowLight
             GlobalStaticValues.EMPTY_COLOR, // RibbonDropArrowDark
             Color.FromArgb(237, 242, 248), // HeaderDockInactiveBack1
@@ -307,7 +309,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(225, 226, 230), // ButtonNavigatorPressed2
             Color.FromArgb(222, 227, 234), // ButtonNavigatorChecked1
             Color.FromArgb(206, 214, 221), // ButtonNavigatorChecked2
-            Color.FromArgb(221, 221, 221) // ToolTipBottom                                                                      
+            Color.FromArgb(221, 221, 221) // ToolTipBottom
         ];
 
         #endregion
@@ -375,42 +377,42 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
-                                                     PaletteButtonSpecStyle.FormClose => state switch
-                                                     {
-                                                         PaletteState.Tracking => _formCloseActive,
-                                                         PaletteState.Normal => _formCloseNormal,
-                                                         PaletteState.Pressed => _formClosePressed,
-                                                         _ => _formCloseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMin => state switch
-                                                     {
-                                                         PaletteState.Normal => _formMinimiseNormal,
-                                                         PaletteState.Tracking => _formMinimiseActive,
-                                                         PaletteState.Pressed => _formMinimisePressed,
-                                                         _ => _formMinimiseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormMax => state switch
-                                                     {
-                                                         PaletteState.Normal => _formMaximiseNormal,
-                                                         PaletteState.Tracking => _formMaximiseActive,
-                                                         PaletteState.Pressed => _formMaximisePressed,
-                                                         _ => _formMaximiseDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormRestore => state switch
-                                                     {
-                                                         PaletteState.Normal => _formRestoreNormal,
-                                                         PaletteState.Tracking => _formRestoreActive,
-                                                         PaletteState.Pressed => _formRestorePressed,
-                                                         _ => _formRestoreDisabled
-                                                     },
-                                                     PaletteButtonSpecStyle.FormHelp => state switch
-                                                     {
-                                                         PaletteState.Tracking => _formHelpActive,
-                                                         PaletteState.Pressed => _formHelpPressed,
-                                                         PaletteState.Normal => _formHelpNormal,
-                                                         _ => _formHelpDisabled
-                                                     },
-                                                     _ => base.GetButtonSpecImage(style, state)
+ PaletteButtonSpecStyle.FormClose => state switch
+ {
+  PaletteState.Tracking => _formCloseActive,
+  PaletteState.Normal => _formCloseNormal,
+  PaletteState.Pressed => _formClosePressed,
+  _ => _formCloseDisabled
+ },
+ PaletteButtonSpecStyle.FormMin => state switch
+ {
+  PaletteState.Normal => _formMinimiseNormal,
+  PaletteState.Tracking => _formMinimiseActive,
+  PaletteState.Pressed => _formMinimisePressed,
+  _ => _formMinimiseDisabled
+ },
+ PaletteButtonSpecStyle.FormMax => state switch
+ {
+  PaletteState.Normal => _formMaximiseNormal,
+  PaletteState.Tracking => _formMaximiseActive,
+  PaletteState.Pressed => _formMaximisePressed,
+  _ => _formMaximiseDisabled
+ },
+ PaletteButtonSpecStyle.FormRestore => state switch
+ {
+  PaletteState.Normal => _formRestoreNormal,
+  PaletteState.Tracking => _formRestoreActive,
+  PaletteState.Pressed => _formRestorePressed,
+  _ => _formRestoreDisabled
+ },
+ PaletteButtonSpecStyle.FormHelp => state switch
+ {
+  PaletteState.Tracking => _formHelpActive,
+  PaletteState.Pressed => _formHelpPressed,
+  PaletteState.Normal => _formHelpNormal,
+  _ => _formHelpDisabled
+ },
+ _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013LightGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013LightGray.cs
@@ -377,42 +377,42 @@ namespace Krypton.Toolkit
         public override Image? GetButtonSpecImage(PaletteButtonSpecStyle style,
                                                  PaletteState state) => style switch
                                                  {
- PaletteButtonSpecStyle.FormClose => state switch
- {
-  PaletteState.Tracking => _formCloseActive,
-  PaletteState.Normal => _formCloseNormal,
-  PaletteState.Pressed => _formClosePressed,
-  _ => _formCloseDisabled
- },
- PaletteButtonSpecStyle.FormMin => state switch
- {
-  PaletteState.Normal => _formMinimiseNormal,
-  PaletteState.Tracking => _formMinimiseActive,
-  PaletteState.Pressed => _formMinimisePressed,
-  _ => _formMinimiseDisabled
- },
- PaletteButtonSpecStyle.FormMax => state switch
- {
-  PaletteState.Normal => _formMaximiseNormal,
-  PaletteState.Tracking => _formMaximiseActive,
-  PaletteState.Pressed => _formMaximisePressed,
-  _ => _formMaximiseDisabled
- },
- PaletteButtonSpecStyle.FormRestore => state switch
- {
-  PaletteState.Normal => _formRestoreNormal,
-  PaletteState.Tracking => _formRestoreActive,
-  PaletteState.Pressed => _formRestorePressed,
-  _ => _formRestoreDisabled
- },
- PaletteButtonSpecStyle.FormHelp => state switch
- {
-  PaletteState.Tracking => _formHelpActive,
-  PaletteState.Pressed => _formHelpPressed,
-  PaletteState.Normal => _formHelpNormal,
-  _ => _formHelpDisabled
- },
- _ => base.GetButtonSpecImage(style, state)
+                                                     PaletteButtonSpecStyle.FormClose => state switch
+                                                     {
+                                                         PaletteState.Tracking => _formCloseActive,
+                                                         PaletteState.Normal => _formCloseNormal,
+                                                         PaletteState.Pressed => _formClosePressed,
+                                                         _ => _formCloseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMin => state switch
+                                                     {
+                                                         PaletteState.Normal => _formMinimiseNormal,
+                                                         PaletteState.Tracking => _formMinimiseActive,
+                                                         PaletteState.Pressed => _formMinimisePressed,
+                                                         _ => _formMinimiseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormMax => state switch
+                                                     {
+                                                         PaletteState.Normal => _formMaximiseNormal,
+                                                         PaletteState.Tracking => _formMaximiseActive,
+                                                         PaletteState.Pressed => _formMaximisePressed,
+                                                         _ => _formMaximiseDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormRestore => state switch
+                                                     {
+                                                         PaletteState.Normal => _formRestoreNormal,
+                                                         PaletteState.Tracking => _formRestoreActive,
+                                                         PaletteState.Pressed => _formRestorePressed,
+                                                         _ => _formRestoreDisabled
+                                                     },
+                                                     PaletteButtonSpecStyle.FormHelp => state switch
+                                                     {
+                                                         PaletteState.Tracking => _formHelpActive,
+                                                         PaletteState.Pressed => _formHelpPressed,
+                                                         PaletteState.Normal => _formHelpNormal,
+                                                         _ => _formHelpDisabled
+                                                     },
+                                                     _ => base.GetButtonSpecImage(style, state)
                                                  };
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013White.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013White.cs
@@ -2482,8 +2482,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -2560,8 +2560,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -2959,8 +2959,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3035,8 +3035,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-                                                   ? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
-                                                   : _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
+? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
+: _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal]
                 },

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013White.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013White.cs
@@ -2482,8 +2482,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -2560,8 +2560,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonButtonSpec => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -2959,8 +2959,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal]
                 },
@@ -3035,8 +3035,8 @@ namespace Krypton.Toolkit
                 PaletteContentStyle.ButtonLowProfile or PaletteContentStyle.ButtonBreadCrumb or PaletteContentStyle.ButtonListItem or PaletteContentStyle.ButtonCommand or PaletteContentStyle.ButtonButtonSpec or PaletteContentStyle.ButtonCalendarDay => state switch
                 {
                     PaletteState.Normal => style == PaletteContentStyle.ButtonListItem
-? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
-: _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
+                                                   ? _ribbonColors[(int)SchemeOfficeColors.TextLabelControl]
+                                                   : _ribbonColors[(int)SchemeOfficeColors.TextLabelPanel],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeOfficeColors.TextButtonChecked],
                     _ => _ribbonColors[(int)SchemeOfficeColors.TextButtonNormal]
                 },


### PR DESCRIPTION
Resolve [[Bug]: Error in 'GroupBackStyle = Control - ToolTip' of KGroupBox (System.IndexOutRangeException) #2277](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2277)

Added colors `RibbonGroupBorder5`(index 211) and `RibbonGroupTitleText`(index 212) in the `Color[] _schemeOfficeColors` of the themes:
Office 2010 
Office 2013
Office 2013
Microsoft 365

<img width="859" height="242" alt="image" src="https://github.com/user-attachments/assets/bb545223-cb3e-484a-84f6-4da1330a96a8" />


<img width="662" height="195" alt="image" src="https://github.com/user-attachments/assets/f881f130-c08d-4c8a-a32b-746d2d39ac31" />
