### PR TITLE
2277 v85 added colors to the _schemeOfficeColors

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2025-08-25 - Build 2508 (Patch 8) - August 2025
+* Resolved [#2277](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2277), Added colors in the `Color[] _schemeOfficeColors`.
 * Resolved [#2235](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2235), `OSUtilities` Adds OsVersionInfo to the properties.
 * Resolved [#2264](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2264), Implementation of style: `PaletteBackStyle.Control`, `PaletteContentStyle.LabelAlternateControl` and `PaletteContentStyle.LabelAlternatePanel` in all themes.
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkMode.cs
@@ -279,18 +279,12 @@ namespace Krypton.Toolkit
             Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
             Color.FromArgb(118, 128, 142), // RibbonQATOverflow1                                                      
             Color.FromArgb(55, 60, 67), // RibbonQATOverflow2                                                      
-            Color.FromArgb(163, 168,
-                170), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(230, 233,
-                235), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(210, 217,
-                219), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(214, 222,
-                223), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(179, 188,
-                191), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(145, 156,
-                159), // ButtonClusterButtonBorder2                                                      
+            Color.FromArgb(163, 168, 170), // RibbonGroupSeparatorDark                                                      
+            Color.FromArgb(230, 233, 235), // RibbonGroupSeparatorLight                                                      
+            Color.FromArgb(210, 217, 219), // ButtonClusterButtonBack1                                                      
+            Color.FromArgb(214, 222, 223), // ButtonClusterButtonBack2                                                      
+            Color.FromArgb(179, 188, 191), // ButtonClusterButtonBorder1                                                      
+            Color.FromArgb(145, 156, 159), // ButtonClusterButtonBorder2                                                      
             Color.FromArgb(235, 235, 235), // NavigatorMiniBackColor                                                    
             Color.FromArgb(10, 10, 10), // GridListNormal1                                                    
             Color.FromArgb(41, 41, 41), // GridListNormal2                                                    
@@ -343,6 +337,8 @@ namespace Krypton.Toolkit
             Color.Empty, // RibbonTabTracking4
             Color.Empty, // RibbonGroupBorder3
             Color.Empty, // RibbonGroupBorder4
+            Color.Empty, // RibbonGroupBorder5
+            Color.FromArgb(255, 255, 255), // RibbonGroupTitleText
             Color.FromArgb(225, 225, 225), // RibbonDropArrowLight
             Color.FromArgb(103, 103, 103), // RibbonDropArrowDark
             Color.FromArgb(137, 137, 137), // HeaderDockInactiveBack1

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueDarkMode.cs
@@ -277,18 +277,12 @@ namespace Krypton.Toolkit
             Color.FromArgb(234, 242, 249), // RibbonQATButtonLight                                                      
             Color.FromArgb(192, 220, 255), // RibbonQATOverflow1                                                      
             Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-            Color.FromArgb(140, 172,
-                211), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(248, 250,
-                252), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(192, 212,
-                241), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(200, 219,
-                238), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(155, 183,
-                224), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(117, 150,
-                191), // ButtonClusterButtonBorder2                                                      
+            Color.FromArgb(140, 172, 211), // RibbonGroupSeparatorDark                                                      
+            Color.FromArgb(248, 250, 252), // RibbonGroupSeparatorLight                                                      
+            Color.FromArgb(192, 212, 241), // ButtonClusterButtonBack1                                                      
+            Color.FromArgb(200, 219, 238), // ButtonClusterButtonBack2                                                      
+            Color.FromArgb(155, 183, 224), // ButtonClusterButtonBorder1                                                      
+            Color.FromArgb(117, 150, 191), // ButtonClusterButtonBorder2                                                      
             Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor                                                    
             Color.FromArgb(134, 179, 236), // GridListNormal1                                                    
             Color.FromArgb(63, 122, 197), // GridListNormal2                                                    
@@ -341,6 +335,8 @@ namespace Krypton.Toolkit
             Color.Empty, // RibbonTabTracking4
             Color.Empty, // RibbonGroupBorder3
             Color.Empty, // RibbonGroupBorder4
+            Color.Empty, // RibbonGroupBorder5
+            Color.FromArgb(0, 21, 110), // RibbonGroupTitleText
             Color.Empty, // RibbonDropArrowLight
             Color.Empty, // RibbonDropArrowDark
             Color.FromArgb(208, 226, 248), // HeaderDockInactiveBack1
@@ -353,8 +349,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(198, 214, 231), // ButtonNavigatorPressed2
             Color.FromArgb(200, 219, 240), // ButtonNavigatorChecked1
             Color.FromArgb(177, 201, 228), // ButtonNavigatorChecked2
-            Color.FromArgb(201, 217,
-                239) // ToolTipBottom                                                                      
+            Color.FromArgb(201, 217, 239) // ToolTipBottom                                                                      
         };
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueLightMode.cs
@@ -339,6 +339,8 @@ namespace Krypton.Toolkit
                                                                 Color.Empty,                      // RibbonTabTracking4
                                                                 Color.Empty,                      // RibbonGroupBorder3
                                                                 Color.Empty,                      // RibbonGroupBorder4
+                                                                Color.Empty, // RibbonGroupBorder5
+                                                                Color.FromArgb(0, 21, 110), // RibbonGroupTitleText
                                                                 Color.Empty,                      // RibbonDropArrowLight
                                                                 Color.Empty,                      // RibbonDropArrowDark
                                                                 Color.FromArgb(208, 226, 248),    // HeaderDockInactiveBack1

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverDarkMode.cs
@@ -280,18 +280,12 @@ namespace Krypton.Toolkit
             Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
             Color.FromArgb(219, 218, 228), // RibbonQATOverflow1                                                      
             Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-            Color.FromArgb(173, 177,
-                181), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(232, 235,
-                237), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(231, 234,
-                238), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(241, 243,
-                243), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(197, 198,
-                199), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(157, 158,
-                159), // ButtonClusterButtonBorder2                                                      
+            Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark                                                      
+            Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight                                                      
+            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1                                                      
+            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2                                                      
+            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1                                                      
+            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2                                                      
             Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor                                                    
             Color.FromArgb(119, 132, 161), // GridListNormal1                                                    
             Color.FromArgb(83, 99, 136), // GridListNormal2                                                    
@@ -344,6 +338,8 @@ namespace Krypton.Toolkit
             Color.Empty, // RibbonTabTracking4
             Color.Empty, // RibbonGroupBorder3
             Color.Empty, // RibbonGroupBorder4
+            Color.Empty, // RibbonGroupBorder5
+            Color.FromArgb(255, 255, 255), // RibbonGroupTitleText
             Color.Empty, // RibbonDropArrowLight
             Color.Empty, // RibbonDropArrowDark
             Color.FromArgb(237, 242, 248), // HeaderDockInactiveBack1

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverLightMode.cs
@@ -342,6 +342,8 @@ namespace Krypton.Toolkit
             Color.Empty, // RibbonTabTracking4
             Color.Empty, // RibbonGroupBorder3
             Color.Empty, // RibbonGroupBorder4
+            Color.Empty, // RibbonGroupBorder5
+            Color.FromArgb(76, 83, 92), // RibbonGroupTitleText
             Color.Empty, // RibbonDropArrowLight
             Color.Empty, // RibbonDropArrowDark
             Color.FromArgb(237, 242, 248), // HeaderDockInactiveBack1

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Non Official Themes/PaletteMicrosoft365Blue.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Non Official Themes/PaletteMicrosoft365Blue.cs
@@ -284,18 +284,12 @@ namespace Krypton.Toolkit
             Color.FromArgb(207, 214, 224), // RibbonQATButtonLight                                                      
             Color.FromArgb(222, 236, 252), // RibbonQATOverflow1                                                      
             Color.FromArgb(123, 139, 156), // RibbonQATOverflow2                                                      
-            Color.FromArgb(145, 166,
-                194), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(239, 245,
-                250), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(192, 212,
-                241), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(200, 219,
-                238), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(155, 183,
-                224), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(117, 150,
-                191), // ButtonClusterButtonBorder2                                                      
+            Color.FromArgb(145, 166, 194), // RibbonGroupSeparatorDark                                                      
+            Color.FromArgb(239, 245, 250), // RibbonGroupSeparatorLight                                                      
+            Color.FromArgb(192, 212, 241), // ButtonClusterButtonBack1                                                      
+            Color.FromArgb(200, 219, 238), // ButtonClusterButtonBack2                                                      
+            Color.FromArgb(155, 183, 224), // ButtonClusterButtonBorder1                                                      
+            Color.FromArgb(117, 150, 191), // ButtonClusterButtonBorder2                                                      
             Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor                                                    
             Color.FromArgb(244, 249, 255), // GridListNormal1                                                    
             Color.FromArgb(218, 231, 245), // GridListNormal2                                                    
@@ -362,8 +356,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(198, 214, 231), // ButtonNavigatorPressed2
             Color.FromArgb(200, 219, 240), // ButtonNavigatorChecked1
             Color.FromArgb(177, 201, 228), // ButtonNavigatorChecked2
-            Color.FromArgb(201, 217,
-                239) // ToolTipBottom                                                                      
+            Color.FromArgb(201, 217, 239) // ToolTipBottom                                                                      
         };
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Black.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Black.cs
@@ -293,18 +293,12 @@ namespace Krypton.Toolkit
             Color.FromArgb(174, 174, 175), // RibbonQATButtonLight                                                      
             Color.FromArgb(161, 161, 161), // RibbonQATOverflow1                                                      
             Color.FromArgb(68, 68, 68), // RibbonQATOverflow2                                                      
-            Color.FromArgb(82, 82,
-                82), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(190, 190,
-                190), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(210, 217,
-                219), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(214, 222,
-                223), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(179, 188,
-                191), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(145, 156,
-                159), // ButtonClusterButtonBorder2                                                      
+            Color.FromArgb(82, 82, 82), // RibbonGroupSeparatorDark                                                      
+            Color.FromArgb(190, 190, 190), // RibbonGroupSeparatorLight                                                      
+            Color.FromArgb(210, 217, 219), // ButtonClusterButtonBack1                                                      
+            Color.FromArgb(214, 222, 223), // ButtonClusterButtonBack2                                                      
+            Color.FromArgb(179, 188, 191), // ButtonClusterButtonBorder1                                                      
+            Color.FromArgb(145, 156, 159), // ButtonClusterButtonBorder2                                                      
             Color.FromArgb(235, 235, 235), // NavigatorMiniBackColor                                                    
             Color.FromArgb(205, 205, 205), // GridListNormal1                                                    
             Color.FromArgb(166, 166, 166), // GridListNormal2                                                    
@@ -371,8 +365,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(148, 148, 143), // ButtonNavigatorPressed2
             Color.FromArgb(91, 91, 91), // ButtonNavigatorChecked1
             Color.FromArgb(73, 73, 73), // ButtonNavigatorChecked2
-            Color.FromArgb(201, 201,
-                201) // ToolTipBottom                                                                      
+            Color.FromArgb(201, 201, 201) // ToolTipBottom                                                                      
         };
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365DarkGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365DarkGray.cs
@@ -336,6 +336,8 @@ namespace Krypton.Toolkit
             Color.Empty, // RibbonTabTracking4
             Color.Empty, // RibbonGroupBorder3
             Color.Empty, // RibbonGroupBorder4
+            Color.Empty, // RibbonGroupBorder5
+            Color.FromArgb(139, 136, 134), // RibbonGroupTitleText
             Color.Empty, // RibbonDropArrowLight
             Color.Empty, // RibbonDropArrowDark
             Color.FromArgb(237, 242, 248), // HeaderDockInactiveBack1

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Silver.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365Silver.cs
@@ -287,18 +287,12 @@ namespace Krypton.Toolkit
             Color.FromArgb(210, 212, 215), // RibbonQATButtonLight                                                      
             Color.FromArgb(233, 237, 241), // RibbonQATOverflow1                                                      
             Color.FromArgb(138, 144, 150), // RibbonQATOverflow2                                                      
-            Color.FromArgb(191, 195,
-                199), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(255, 255,
-                255), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(231, 234,
-                238), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(241, 243,
-                243), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(197, 198,
-                199), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(157, 158,
-                159), // ButtonClusterButtonBorder2                                                      
+            Color.FromArgb(191, 195, 199), // RibbonGroupSeparatorDark                                                      
+            Color.FromArgb(255, 255, 255), // RibbonGroupSeparatorLight                                                      
+            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1                                                      
+            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2                                                      
+            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1                                                      
+            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2                                                      
             Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor                                                    
             Color.FromArgb(248, 252, 255), // GridListNormal1                                                    
             Color.FromArgb(223, 227, 232), // GridListNormal2                                                    
@@ -346,8 +340,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(255, 255, 255), // RibbonGalleryBackNormal
             Color.FromArgb(255, 255, 255), // RibbonGalleryBackTracking
             Color.FromArgb(250, 250, 250), // RibbonGalleryBack1
-            Color.FromArgb(228, 231,
-                235), // RibbonGalleryBack2                                                                                                                                      Color.FromArgb(177, 181, 186),    // RibbonTabTracking1
+            Color.FromArgb(228, 231, 235), // RibbonGalleryBack2           Color.FromArgb(177, 181, 186),    // RibbonTabTracking1
             Color.FromArgb(229, 231, 235), // RibbonTabTracking3
             Color.FromArgb(231, 233, 235), // RibbonTabTracking4
             Color.FromArgb(176, 182, 188), // RibbonGroupBorder3
@@ -366,8 +359,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(225, 226, 230), // ButtonNavigatorPressed2
             Color.FromArgb(222, 227, 234), // ButtonNavigatorChecked1
             Color.FromArgb(206, 214, 221), // ButtonNavigatorChecked2
-            Color.FromArgb(221, 221,
-                221) // ToolTipBottom                                                                      
+            Color.FromArgb(221, 221, 221) // ToolTipBottom                                                                      
         };
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365White.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Official Themes/PaletteMicrosoft365White.cs
@@ -287,18 +287,12 @@ namespace Krypton.Toolkit
             Color.FromArgb(210, 212, 215), // RibbonQATButtonLight                                                      
             Color.FromArgb(233, 237, 241), // RibbonQATOverflow1                                                      
             Color.FromArgb(138, 144, 150), // RibbonQATOverflow2                                                      
-            Color.FromArgb(191, 195,
-                199), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(255, 255,
-                255), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(231, 234,
-                238), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(241, 243,
-                243), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(197, 198,
-                199), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(157, 158,
-                159), // ButtonClusterButtonBorder2                                                      
+            Color.FromArgb(191, 195, 199), // RibbonGroupSeparatorDark                                                      
+            Color.FromArgb(255, 255, 255), // RibbonGroupSeparatorLight                                                      
+            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1                                                      
+            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2                                                      
+            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1                                                      
+            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2                                                      
             Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor                                                    
             Color.White, // GridListNormal1                                                    
             Color.White, // GridListNormal2                                                    
@@ -346,8 +340,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(255, 255, 255), // RibbonGalleryBackNormal
             Color.FromArgb(255, 255, 255), // RibbonGalleryBackTracking
             Color.FromArgb(250, 250, 250), // RibbonGalleryBack1
-            Color.FromArgb(228, 231,
-                235), // RibbonGalleryBack2                                                                                                                                      Color.FromArgb(177, 181, 186),    // RibbonTabTracking1
+            Color.FromArgb(228, 231, 235), // RibbonGalleryBack2        Color.FromArgb(177, 181, 186),    // RibbonTabTracking1
             Color.FromArgb(229, 231, 235), // RibbonTabTracking3
             Color.FromArgb(231, 233, 235), // RibbonTabTracking4
             Color.FromArgb(176, 182, 188), // RibbonGroupBorder3
@@ -366,8 +359,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(225, 226, 230), // ButtonNavigatorPressed2
             Color.FromArgb(222, 227, 234), // ButtonNavigatorChecked1
             Color.FromArgb(206, 214, 221), // ButtonNavigatorChecked2
-            Color.FromArgb(221, 221,
-                221) // ToolTipBottom                                                                      
+            Color.FromArgb(221, 221, 221) // ToolTipBottom                                                                      
         };
 
         #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlackDarkMode.cs
@@ -216,18 +216,12 @@ namespace Krypton.Toolkit
             Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
             Color.FromArgb(118, 128, 142), // RibbonQATOverflow1                                                      
             Color.FromArgb(55, 60, 67), // RibbonQATOverflow2                                                      
-            Color.FromArgb(163, 168,
-                170), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(230, 233,
-                235), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(210, 217,
-                219), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(214, 222,
-                223), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(179, 188,
-                191), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(145, 156,
-                159), // ButtonClusterButtonBorder2                                                      
+            Color.FromArgb(163, 168, 170), // RibbonGroupSeparatorDark                                                      
+            Color.FromArgb(230, 233, 235), // RibbonGroupSeparatorLight                                                      
+            Color.FromArgb(210, 217, 219), // ButtonClusterButtonBack1                                                      
+            Color.FromArgb(214, 222, 223), // ButtonClusterButtonBack2                                                      
+            Color.FromArgb(179, 188, 191), // ButtonClusterButtonBorder1                                                      
+            Color.FromArgb(145, 156, 159), // ButtonClusterButtonBorder2                                                      
             Color.FromArgb(235, 235, 235), // NavigatorMiniBackColor                                                    
             Color.FromArgb(10, 10, 10), // GridListNormal1                                                    
             Color.FromArgb(41, 41, 41), // GridListNormal2                                                    
@@ -280,6 +274,8 @@ namespace Krypton.Toolkit
             Color.Empty, // RibbonTabTracking4
             Color.Empty, // RibbonGroupBorder3
             Color.Empty, // RibbonGroupBorder4
+            Color.Empty, // RibbonGroupBorder5
+            Color.FromArgb(255, 255, 255), // RibbonGroupTitleText
             Color.FromArgb(225, 225, 225), // RibbonDropArrowLight
             Color.FromArgb(103, 103, 103) // RibbonDropArrowDark
         };

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueDarkMode.cs
@@ -213,18 +213,12 @@ namespace Krypton.Toolkit
             Color.FromArgb(234, 242, 249), // RibbonQATButtonLight                                                      
             Color.FromArgb(192, 220, 255), // RibbonQATOverflow1                                                      
             Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-            Color.FromArgb(140, 172,
-                211), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(248, 250,
-                252), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(192, 212,
-                241), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(200, 219,
-                238), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(155, 183,
-                224), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(117, 150,
-                191), // ButtonClusterButtonBorder2                                                      
+            Color.FromArgb(140, 172, 211), // RibbonGroupSeparatorDark                                                      
+            Color.FromArgb(248, 250, 252), // RibbonGroupSeparatorLight                                                      
+            Color.FromArgb(192, 212, 241), // ButtonClusterButtonBack1                                                      
+            Color.FromArgb(200, 219, 238), // ButtonClusterButtonBack2                                                      
+            Color.FromArgb(155, 183, 224), // ButtonClusterButtonBorder1                                                      
+            Color.FromArgb(117, 150, 191), // ButtonClusterButtonBorder2                                                      
             Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor                                                    
             Color.FromArgb(134, 179, 236), // GridListNormal1                                                    
             Color.FromArgb(63, 122, 197), // GridListNormal2                                                    
@@ -277,6 +271,8 @@ namespace Krypton.Toolkit
             Color.Empty, // RibbonTabTracking4
             Color.Empty, // RibbonGroupBorder3
             Color.Empty, // RibbonGroupBorder4
+            Color.Empty, // RibbonGroupBorder5
+            Color.FromArgb(21, 66, 139), // RibbonGroupTitleText
             Color.Empty, // RibbonDropArrowLight
             Color.Empty // RibbonDropArrowDark
         };

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueLightMode.cs
@@ -270,6 +270,8 @@ namespace Krypton.Toolkit
                                                                 Color.Empty,                      // RibbonTabTracking4
                                                                 Color.Empty,                      // RibbonGroupBorder3
                                                                 Color.Empty,                      // RibbonGroupBorder4
+                                                                Color.Empty, // RibbonGroupBorder5
+                                                                Color.FromArgb(21, 66, 139), // RibbonGroupTitleText
                                                                 Color.Empty,                      // RibbonDropArrowLight
                                                                 Color.Empty // RibbonDropArrowDark
         };

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverDarkMode.cs
@@ -225,18 +225,12 @@ namespace Krypton.Toolkit
             Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
             Color.FromArgb(219, 218, 228), // RibbonQATOverflow1                                                      
             Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-            Color.FromArgb(173, 177,
-                181), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(232, 235,
-                237), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(231, 234,
-                238), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(241, 243,
-                243), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(197, 198,
-                199), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(157, 158,
-                159), // ButtonClusterButtonBorder2                                                      
+            Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark                                                      
+            Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight                                                      
+            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1                                                      
+            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2                                                      
+            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1                                                      
+            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2                                                      
             Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor                                                    
             Color.FromArgb(119, 132, 161), // GridListNormal1                                                    
             Color.FromArgb(83, 99, 136), // GridListNormal2                                                    
@@ -289,6 +283,8 @@ namespace Krypton.Toolkit
             Color.Empty, // RibbonTabTracking4
             Color.Empty, // RibbonGroupBorder3
             Color.Empty, // RibbonGroupBorder4
+            Color.Empty, // RibbonGroupBorder5
+            Color.FromArgb(24, 24, 24), // RibbonGroupTitleText
             Color.Empty, // RibbonDropArrowLight
             Color.Empty // RibbonDropArrowDark
         };

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverLightMode.cs
@@ -285,6 +285,8 @@ namespace Krypton.Toolkit
             Color.Empty, // RibbonTabTracking4
             Color.Empty, // RibbonGroupBorder3
             Color.Empty, // RibbonGroupBorder4
+            Color.Empty, // RibbonGroupBorder5
+            Color.FromArgb(24, 24, 24), // RibbonGroupTitleText
             Color.Empty, // RibbonDropArrowLight
             Color.Empty // RibbonDropArrowDark
         };

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Non Official Themes/PaletteOffice2007DarkGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Non Official Themes/PaletteOffice2007DarkGray.cs
@@ -281,6 +281,8 @@ namespace Krypton.Toolkit
             Color.Empty, // RibbonTabTracking4
             Color.Empty, // RibbonGroupBorder3
             Color.Empty, // RibbonGroupBorder4
+            Color.Empty, // RibbonGroupBorder5
+            Color.FromArgb(119, 119, 119), // RibbonGroupTitleText
             Color.Empty, // RibbonDropArrowLight
             Color.Empty // RibbonDropArrowDark
         };

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Non Official Themes/PaletteOffice2007White.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Non Official Themes/PaletteOffice2007White.cs
@@ -203,18 +203,12 @@ namespace Krypton.Toolkit
             Color.FromArgb(210, 212, 215), // RibbonQATButtonLight                                                      
             Color.FromArgb(233, 237, 241), // RibbonQATOverflow1                                                      
             Color.FromArgb(138, 144, 150), // RibbonQATOverflow2                                                      
-            Color.FromArgb(191, 195,
-                199), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(255, 255,
-                255), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(231, 234,
-                238), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(241, 243,
-                243), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(197, 198,
-                199), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(157, 158,
-                159), // ButtonClusterButtonBorder2                                                      
+            Color.FromArgb(191, 195, 199), // RibbonGroupSeparatorDark                                                      
+            Color.FromArgb(255, 255, 255), // RibbonGroupSeparatorLight                                                      
+            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1                                                      
+            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2                                                      
+            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1                                                      
+            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2                                                      
             Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor                                                    
             Color.White, // GridListNormal1                                                    
             Color.White, // GridListNormal2                                                    
@@ -262,8 +256,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(255, 255, 255), // RibbonGalleryBackNormal
             Color.FromArgb(255, 255, 255), // RibbonGalleryBackTracking
             Color.FromArgb(250, 250, 250), // RibbonGalleryBack1
-            Color.FromArgb(228, 231,
-                235), // RibbonGalleryBack2                                                                                                                                      Color.FromArgb(177, 181, 186),    // RibbonTabTracking1
+            Color.FromArgb(228, 231, 235), // RibbonGalleryBack2          Color.FromArgb(177, 181, 186),    // RibbonTabTracking1
             Color.FromArgb(229, 231, 235), // RibbonTabTracking3
             Color.FromArgb(231, 233, 235), // RibbonTabTracking4
             Color.FromArgb(176, 182, 188), // RibbonGroupBorder3
@@ -282,8 +275,7 @@ namespace Krypton.Toolkit
             Color.FromArgb(225, 226, 230), // ButtonNavigatorPressed2
             Color.FromArgb(222, 227, 234), // ButtonNavigatorChecked1
             Color.FromArgb(206, 214, 221), // ButtonNavigatorChecked2
-            Color.FromArgb(221, 221,
-                221) // ToolTipBottom                                                                      
+            Color.FromArgb(221, 221, 221) // ToolTipBottom                                                                      
         };
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Official Themes/PaletteOffice2007Black.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Official Themes/PaletteOffice2007Black.cs
@@ -228,18 +228,12 @@ namespace Krypton.Toolkit
             Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
             Color.FromArgb(118, 128, 142), // RibbonQATOverflow1                                                      
             Color.FromArgb(55, 60, 67), // RibbonQATOverflow2                                                      
-            Color.FromArgb(163, 168,
-                170), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(230, 233,
-                235), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(210, 217,
-                219), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(214, 222,
-                223), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(179, 188,
-                191), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(145, 156,
-                159), // ButtonClusterButtonBorder2                                                      
+            Color.FromArgb(163, 168, 170), // RibbonGroupSeparatorDark                                                      
+            Color.FromArgb(230, 233, 235), // RibbonGroupSeparatorLight                                                      
+            Color.FromArgb(210, 217, 219), // ButtonClusterButtonBack1                                                      
+            Color.FromArgb(214, 222, 223), // ButtonClusterButtonBack2                                                      
+            Color.FromArgb(179, 188, 191), // ButtonClusterButtonBorder1                                                      
+            Color.FromArgb(145, 156, 159), // ButtonClusterButtonBorder2                                                      
             Color.FromArgb(235, 235, 235), // NavigatorMiniBackColor                                                    
             Color.White, // GridListNormal1                                                    
             Color.FromArgb(212, 215, 219), // GridListNormal2                                                    
@@ -292,6 +286,8 @@ namespace Krypton.Toolkit
             Color.Empty, // RibbonTabTracking4
             Color.Empty, // RibbonGroupBorder3
             Color.Empty, // RibbonGroupBorder4
+            Color.Empty, // RibbonGroupBorder5
+            Color.FromArgb(255, 255, 255), // RibbonGroupTitleText
             Color.FromArgb(225, 225, 225), // RibbonDropArrowLight
             Color.FromArgb(103, 103, 103) // RibbonDropArrowDark
         };

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Official Themes/PaletteOffice2007Blue.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Official Themes/PaletteOffice2007Blue.cs
@@ -206,18 +206,12 @@ namespace Krypton.Toolkit
             Color.FromArgb(234, 242, 249), // RibbonQATButtonLight                                                      
             Color.FromArgb(192, 220, 255), // RibbonQATOverflow1                                                      
             Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-            Color.FromArgb(140, 172,
-                211), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(248, 250,
-                252), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(192, 212,
-                241), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(200, 219,
-                238), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(155, 183,
-                224), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(117, 150,
-                191), // ButtonClusterButtonBorder2                                                      
+            Color.FromArgb(140, 172, 211), // RibbonGroupSeparatorDark                                                      
+            Color.FromArgb(248, 250, 252), // RibbonGroupSeparatorLight                                                      
+            Color.FromArgb(192, 212, 241), // ButtonClusterButtonBack1                                                      
+            Color.FromArgb(200, 219, 238), // ButtonClusterButtonBack2                                                      
+            Color.FromArgb(155, 183, 224), // ButtonClusterButtonBorder1                                                      
+            Color.FromArgb(117, 150, 191), // ButtonClusterButtonBorder2                                                      
             Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor                                                    
             Color.White, // GridListNormal1                                                    
             Color.FromArgb(196, 221, 255), // GridListNormal2                                                    
@@ -270,6 +264,8 @@ namespace Krypton.Toolkit
             Color.Empty, // RibbonTabTracking4
             Color.Empty, // RibbonGroupBorder3
             Color.Empty, // RibbonGroupBorder4
+            Color.Empty, // RibbonGroupBorder5
+            Color.FromArgb(21, 66, 139), // RibbonGroupTitleText
             Color.Empty, // RibbonDropArrowLight
             Color.Empty // RibbonDropArrowDark
         };

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Official Themes/PaletteOffice2007Silver.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Official Themes/PaletteOffice2007Silver.cs
@@ -206,18 +206,12 @@ namespace Krypton.Toolkit
             Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
             Color.FromArgb(219, 218, 228), // RibbonQATOverflow1                                                      
             Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-            Color.FromArgb(173, 177,
-                181), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(232, 235,
-                237), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(231, 234,
-                238), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(241, 243,
-                243), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(197, 198,
-                199), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(157, 158,
-                159), // ButtonClusterButtonBorder2                                                      
+            Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark                                                      
+            Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight                                                      
+            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1                                                      
+            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2                                                      
+            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1                                                      
+            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2                                                      
             Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor                                                    
             Color.White, // GridListNormal1                                                    
             Color.FromArgb(212, 215, 219), // GridListNormal2                                                    
@@ -270,6 +264,8 @@ namespace Krypton.Toolkit
             Color.Empty, // RibbonTabTracking4
             Color.Empty, // RibbonGroupBorder3
             Color.Empty, // RibbonGroupBorder4
+            Color.Empty, // RibbonGroupBorder5
+            Color.FromArgb(56, 63, 70), // RibbonGroupTitleText
             Color.Empty, // RibbonDropArrowLight
             Color.Empty // RibbonDropArrowDark
         };

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlackDarkMode.cs
@@ -221,18 +221,12 @@ namespace Krypton.Toolkit
             Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
             Color.FromArgb(118, 128, 142), // RibbonQATOverflow1                                                      
             Color.FromArgb(55, 60, 67), // RibbonQATOverflow2                                                      
-            Color.FromArgb(163, 168,
-                170), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(230, 233,
-                235), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(210, 217,
-                219), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(214, 222,
-                223), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(179, 188,
-                191), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(145, 156,
-                159), // ButtonClusterButtonBorder2                                                      
+            Color.FromArgb(163, 168, 170), // RibbonGroupSeparatorDark                                                      
+            Color.FromArgb(230, 233, 235), // RibbonGroupSeparatorLight                                                      
+            Color.FromArgb(210, 217, 219), // ButtonClusterButtonBack1                                                      
+            Color.FromArgb(214, 222, 223), // ButtonClusterButtonBack2                                                      
+            Color.FromArgb(179, 188, 191), // ButtonClusterButtonBorder1                                                      
+            Color.FromArgb(145, 156, 159), // ButtonClusterButtonBorder2                                                      
             Color.FromArgb(235, 235, 235), // NavigatorMiniBackColor                                                    
             Color.FromArgb(10, 10, 10), // GridListNormal1                                                    
             Color.FromArgb(41, 41, 41), // GridListNormal2                                                    
@@ -285,6 +279,8 @@ namespace Krypton.Toolkit
             Color.Empty, // RibbonTabTracking4
             Color.Empty, // RibbonGroupBorder3
             Color.Empty, // RibbonGroupBorder4
+            Color.Empty, // RibbonGroupBorder5
+            Color.FromArgb(255, 255, 255), // RibbonGroupTitleText
             Color.FromArgb(225, 225, 225), // RibbonDropArrowLight
             Color.FromArgb(103, 103, 103), // RibbonDropArrowDark
             Color.FromArgb(137, 137, 137), // HeaderDockInactiveBack1

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueDarkMode.cs
@@ -275,6 +275,8 @@ namespace Krypton.Toolkit
                                                                 Color.Empty,                      // RibbonTabTracking4
                                                                 Color.Empty,                      // RibbonGroupBorder3
                                                                 Color.Empty,                      // RibbonGroupBorder4
+                                                                Color.Empty,// RibbonGroupBorder5
+                                                                Color.FromArgb(0, 21, 110), // RibbonGroupTitleText
                                                                 Color.Empty,                      // RibbonDropArrowLight
                                                                 Color.Empty, // RibbonDropArrowDark
                                                                 Color.FromArgb(208, 226, 248),    // HeaderDockInactiveBack1

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueLightMode.cs
@@ -281,6 +281,8 @@ namespace Krypton.Toolkit
                                                                 Color.Empty,                      // RibbonTabTracking4
                                                                 Color.Empty,                      // RibbonGroupBorder3
                                                                 Color.Empty,                      // RibbonGroupBorder4
+                                                                Color.Empty,// RibbonGroupBorder5
+                                                                Color.FromArgb(0, 21, 110), // RibbonGroupTitleText
                                                                 Color.Empty,                      // RibbonDropArrowLight
                                                                 Color.Empty,                      // RibbonDropArrowDark
                                                                 Color.FromArgb(208, 226, 248),    // HeaderDockInactiveBack1

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverDarkMode.cs
@@ -220,18 +220,12 @@ namespace Krypton.Toolkit
             Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
             Color.FromArgb(219, 218, 228), // RibbonQATOverflow1                                                      
             Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-            Color.FromArgb(173, 177,
-                181), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(232, 235,
-                237), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(231, 234,
-                238), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(241, 243,
-                243), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(197, 198,
-                199), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(157, 158,
-                159), // ButtonClusterButtonBorder2                                                      
+            Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark                                                      
+            Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight                                                      
+            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1                                                      
+            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2                                                      
+            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1                                                      
+            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2                                                      
             Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor                                                    
             Color.FromArgb(119, 132, 161), // GridListNormal1                                                    
             Color.FromArgb(83, 99, 136), // GridListNormal2                                                    
@@ -286,6 +280,8 @@ namespace Krypton.Toolkit
             Color.Empty, // RibbonTabTracking4
             Color.Empty, // RibbonGroupBorder3
             Color.Empty, // RibbonGroupBorder4
+            Color.Empty,// RibbonGroupBorder5
+            Color.FromArgb(255, 255, 255), // RibbonGroupTitleText
             Color.Empty, // RibbonDropArrowLight
             Color.Empty, // RibbonDropArrowDark
             Color.FromArgb(237, 242, 248), // HeaderDockInactiveBack1

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverLightMode.cs
@@ -222,18 +222,12 @@ namespace Krypton.Toolkit
             Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
             Color.FromArgb(219, 218, 228), // RibbonQATOverflow1                                                      
             Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-            Color.FromArgb(173, 177,
-                181), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(232, 235,
-                237), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(231, 234,
-                238), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(241, 243,
-                243), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(197, 198,
-                199), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(157, 158,
-                159), // ButtonClusterButtonBorder2                                                      
+            Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark                                                      
+            Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight                                                      
+            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1                                                      
+            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2                                                      
+            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1                                                      
+            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2                                                      
             Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor                                                    
             Color.FromArgb(224, 225, 231), // GridListNormal1                                                    
             Color.FromArgb(195, 198, 209), // GridListNormal2                                                    
@@ -286,6 +280,8 @@ namespace Krypton.Toolkit
             Color.Empty, // RibbonTabTracking4
             Color.Empty, // RibbonGroupBorder3
             Color.Empty, // RibbonGroupBorder4
+            Color.Empty,// RibbonGroupBorder5
+            Color.FromArgb(76, 83, 92), // RibbonGroupTitleText
             Color.Empty, // RibbonDropArrowLight
             Color.Empty, // RibbonDropArrowDark
             Color.FromArgb(237, 242, 248), // HeaderDockInactiveBack1

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Non Official Themes/PaletteOffice2010DarkGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Non Official Themes/PaletteOffice2010DarkGray.cs
@@ -276,6 +276,8 @@ namespace Krypton.Toolkit
             Color.Empty, // RibbonTabTracking4
             Color.Empty, // RibbonGroupBorder3
             Color.Empty, // RibbonGroupBorder4
+            Color.Empty,// RibbonGroupBorder5
+            Color.FromArgb(119, 119, 119), // RibbonGroupTitleText
             Color.Empty, // RibbonDropArrowLight
             Color.Empty, // RibbonDropArrowDark
             Color.FromArgb(237, 242, 248), // HeaderDockInactiveBack1

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Official Themes/PaletteOffice2010Black.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Official Themes/PaletteOffice2010Black.cs
@@ -233,18 +233,12 @@ namespace Krypton.Toolkit
             Color.FromArgb(174, 174, 175), // RibbonQATButtonLight                                                      
             Color.FromArgb(161, 161, 161), // RibbonQATOverflow1                                                      
             Color.FromArgb(68, 68, 68), // RibbonQATOverflow2                                                      
-            Color.FromArgb(82, 82,
-                82), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(190, 190,
-                190), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(210, 217,
-                219), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(214, 222,
-                223), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(179, 188,
-                191), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(145, 156,
-                159), // ButtonClusterButtonBorder2                                                      
+            Color.FromArgb(82, 82, 82), // RibbonGroupSeparatorDark                                                      
+            Color.FromArgb(190, 190, 190), // RibbonGroupSeparatorLight                                                      
+            Color.FromArgb(210, 217, 219), // ButtonClusterButtonBack1                                                      
+            Color.FromArgb(214, 222, 223), // ButtonClusterButtonBack2                                                      
+            Color.FromArgb(179, 188, 191), // ButtonClusterButtonBorder1                                                      
+            Color.FromArgb(145, 156, 159), // ButtonClusterButtonBorder2                                                      
             Color.FromArgb(235, 235, 235), // NavigatorMiniBackColor                                                    
             Color.FromArgb(205, 205, 205), // GridListNormal1                                                    
             Color.FromArgb(166, 166, 166), // GridListNormal2                                                    

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013DarkGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013DarkGray.cs
@@ -279,6 +279,8 @@ namespace Krypton.Toolkit
             Color.Empty, // RibbonTabTracking4
             Color.Empty, // RibbonGroupBorder3
             Color.Empty, // RibbonGroupBorder4
+            Color.Empty, // RibbonGroupBorder5
+            Color.FromArgb(119, 119, 119), // RibbonGroupTitleText
             Color.Empty, // RibbonDropArrowLight
             Color.Empty, // RibbonDropArrowDark
             Color.FromArgb(237, 242, 248), // HeaderDockInactiveBack1

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013LightGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013LightGray.cs
@@ -279,6 +279,8 @@ namespace Krypton.Toolkit
             Color.Empty, // RibbonTabTracking4
             Color.Empty, // RibbonGroupBorder3
             Color.Empty, // RibbonGroupBorder4
+            Color.Empty, // RibbonGroupBorder5
+            Color.FromArgb(119, 119, 119), // RibbonGroupTitleText
             Color.Empty, // RibbonDropArrowLight
             Color.Empty, // RibbonDropArrowDark
             Color.FromArgb(237, 242, 248), // HeaderDockInactiveBack1

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013White.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013White.cs
@@ -226,18 +226,12 @@ namespace Krypton.Toolkit
             Color.FromArgb(210, 212, 215), // RibbonQATButtonLight                                                      
             Color.FromArgb(233, 237, 241), // RibbonQATOverflow1                                                      
             Color.FromArgb(138, 144, 150), // RibbonQATOverflow2                                                      
-            Color.FromArgb(191, 195,
-                199), // RibbonGroupSeparatorDark                                                      
-            Color.FromArgb(255, 255,
-                255), // RibbonGroupSeparatorLight                                                      
-            Color.FromArgb(231, 234,
-                238), // ButtonClusterButtonBack1                                                      
-            Color.FromArgb(241, 243,
-                243), // ButtonClusterButtonBack2                                                      
-            Color.FromArgb(197, 198,
-                199), // ButtonClusterButtonBorder1                                                      
-            Color.FromArgb(157, 158,
-                159), // ButtonClusterButtonBorder2                                                      
+            Color.FromArgb(191, 195, 199), // RibbonGroupSeparatorDark                                                      
+            Color.FromArgb(255, 255, 255), // RibbonGroupSeparatorLight                                                      
+            Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1                                                      
+            Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2                                                      
+            Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1                                                      
+            Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2                                                      
             Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor                                                    
             Color.White, // GridListNormal1                                                    
             Color.White, // GridListNormal2                                                    


### PR DESCRIPTION
Resolve [[Bug]: Error in 'GroupBackStyle = Control - ToolTip' of KGroupBox (System.IndexOutRangeException) #2277](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2277)

Added colors in the `Color[] _schemeOfficeColors` of the themes:
Office 2010 
Office 2013
Office 2013
Microsoft 365

<img width="485" height="158" alt="image" src="https://github.com/user-attachments/assets/1ed7d553-5070-4f05-8208-23d0a08aecc9" />
