### PR TITLE
2305-V100-chore-trackBarColours

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Bases/PaletteMicrosoft365Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Bases/PaletteMicrosoft365Base.cs
@@ -246,7 +246,7 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
 
     private readonly Color[] _ribbonColors;
 
-    private readonly Color[] _trackBarColours;
+    private readonly Color[] _trackBarColors;
     private readonly ImageList _checkBoxList;
     private readonly ImageList _galleryButtonList;
     private readonly Image?[] _radioButtonArray;
@@ -293,7 +293,7 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
 
         if (trackBarColours != null)
         {
-            _trackBarColours = trackBarColours;
+            _trackBarColors = trackBarColours;
         }
 
         DefineFonts();
@@ -4185,14 +4185,14 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[1];
+                return _trackBarColors[1];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
                     PaletteState.Disabled => GlobalStaticValues.EMPTY_COLOR,
-                    _ => _trackBarColours[4]
+                    _ => _trackBarColors[4]
                 };
             default:
                 // Should never happen!
@@ -4220,9 +4220,9 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[2];
+                return _trackBarColors[2];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -4258,9 +4258,9 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -4299,14 +4299,14 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {
@@ -4347,14 +4347,14 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkMode.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
  *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *
  */
 #endregion
 
@@ -284,38 +284,38 @@ public class PaletteMicrosoft365BlackDarkMode : PaletteMicrosoft365BlackDarkMode
         Color.FromArgb(140, 140, 140), // RibbonQATMini3I
         Color.FromArgb(12, Color.White), // RibbonQATMini4I
         Color.FromArgb(14, Color.White), // RibbonQATMini5I
-        Color.FromArgb(141, 144, 147), // RibbonQATFullbar1                                                      
-        Color.FromArgb(133, 135, 137), // RibbonQATFullbar2                                                      
-        Color.FromArgb(93, 96, 100), // RibbonQATFullbar3                                                      
-        Color.FromArgb(103, 103, 103), // RibbonQATButtonDark                                                      
-        Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
-        Color.FromArgb(118, 128, 142), // RibbonQATOverflow1                                                      
-        Color.FromArgb(55, 60, 67), // RibbonQATOverflow2                                                      
+        Color.FromArgb(141, 144, 147), // RibbonQATFullbar1
+        Color.FromArgb(133, 135, 137), // RibbonQATFullbar2
+        Color.FromArgb(93, 96, 100), // RibbonQATFullbar3
+        Color.FromArgb(103, 103, 103), // RibbonQATButtonDark
+        Color.FromArgb(225, 225, 225), // RibbonQATButtonLight
+        Color.FromArgb(118, 128, 142), // RibbonQATOverflow1
+        Color.FromArgb(55, 60, 67), // RibbonQATOverflow2
         Color.FromArgb(163, 168,
-            170), // RibbonGroupSeparatorDark                                                      
+            170), // RibbonGroupSeparatorDark
         Color.FromArgb(230, 233,
-            235), // RibbonGroupSeparatorLight                                                      
+            235), // RibbonGroupSeparatorLight
         Color.FromArgb(210, 217,
-            219), // ButtonClusterButtonBack1                                                      
+            219), // ButtonClusterButtonBack1
         Color.FromArgb(214, 222,
-            223), // ButtonClusterButtonBack2                                                      
+            223), // ButtonClusterButtonBack2
         Color.FromArgb(179, 188,
-            191), // ButtonClusterButtonBorder1                                                      
+            191), // ButtonClusterButtonBorder1
         Color.FromArgb(145, 156,
-            159), // ButtonClusterButtonBorder2                                                      
-        Color.FromArgb(235, 235, 235), // NavigatorMiniBackColor                                                    
-        Color.FromArgb(10, 10, 10), // GridListNormal1                                                    
-        Color.FromArgb(41, 41, 41), // GridListNormal2                                                    
-        Color.FromArgb(41, 41, 41), // GridListPressed1                                                    
-        Color.FromArgb(61, 61, 61), // GridListPressed2                                                    
-        Color.FromArgb(33, 33, 33), // GridListSelected                                                    
-        Color.FromArgb(10, 10, 10), // GridSheetColNormal1                                                    
-        Color.FromArgb(41, 41, 41), // GridSheetColNormal2                                                    
-        Color.FromArgb(224, 224, 224), // GridSheetColPressed1                                                    
-        Color.FromArgb(195, 195, 195), // GridSheetColPressed2                                                    
+            159), // ButtonClusterButtonBorder2
+        Color.FromArgb(235, 235, 235), // NavigatorMiniBackColor
+        Color.FromArgb(10, 10, 10), // GridListNormal1
+        Color.FromArgb(41, 41, 41), // GridListNormal2
+        Color.FromArgb(41, 41, 41), // GridListPressed1
+        Color.FromArgb(61, 61, 61), // GridListPressed2
+        Color.FromArgb(33, 33, 33), // GridListSelected
+        Color.FromArgb(10, 10, 10), // GridSheetColNormal1
+        Color.FromArgb(41, 41, 41), // GridSheetColNormal2
+        Color.FromArgb(224, 224, 224), // GridSheetColPressed1
+        Color.FromArgb(195, 195, 195), // GridSheetColPressed2
         Color.FromArgb(91, 91, 91), // GridSheetColSelected1
         Color.FromArgb(33, 33, 33), // GridSheetColSelected2
-        Color.FromArgb(237, 237, 237), // GridSheetRowNormal                                                   
+        Color.FromArgb(237, 237, 237), // GridSheetRowNormal
         Color.FromArgb(196, 196, 196), // GridSheetRowPressed
         Color.FromArgb(61, 61, 61), // GridSheetRowSelected
         Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -418,7 +418,7 @@ public class PaletteMicrosoft365BlackDarkMode : PaletteMicrosoft365BlackDarkMode
     }
     #endregion
 
-    #region Images        
+    #region Images
 
     /// <summary>
     /// Gets an image indicating a sub-menu on a context menu item.
@@ -430,7 +430,7 @@ public class PaletteMicrosoft365BlackDarkMode : PaletteMicrosoft365BlackDarkMode
 
     #endregion
 
-    #region ButtonSpec        
+    #region ButtonSpec
     /// <summary>
     /// Gets the image to display for the button.
     /// </summary>
@@ -622,7 +622,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
     private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
     private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
     private static readonly Padding _contentPaddingCalendar = new Padding(2);
-    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
+    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);
     private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
     private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
     private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -817,13 +817,13 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
 
     private readonly Color[] _ribbonColours;
 
-    private readonly Color[] _trackBarColours;
+    private readonly Color[] _trackBarColors;
     private readonly ImageList _checkBoxList;
     private readonly ImageList _galleryButtonList;
     private readonly Image?[] _radioButtonArray;
     #endregion
 
-    #region Constructor        
+    #region Constructor
     /// <summary>
     /// Initializes a new instance of the <see cref="PaletteMicrosoft365BlackDarkModeBase"/> class.
     /// </summary>
@@ -864,14 +864,14 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
 
         if (trackBarColours != null)
         {
-            _trackBarColours = trackBarColours;
+            _trackBarColors = trackBarColours;
         }
 
         DefineFonts();
     }
     #endregion
 
-    #region Renderer        
+    #region Renderer
     /// <summary>
     /// Gets the renderer to use for this palette.
     /// </summary>
@@ -4815,14 +4815,14 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[1];
+                return _trackBarColors[1];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
                     PaletteState.Disabled => GlobalStaticValues.EMPTY_COLOR,
-                    _ => _trackBarColours[4]
+                    _ => _trackBarColors[4]
                 };
             default:
                 // Should never happen!
@@ -4850,9 +4850,9 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[2];
+                return _trackBarColors[2];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -4888,9 +4888,9 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -4928,14 +4928,14 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
-                return _trackBarColours[0];
+                return _trackBarColors[0];
 
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
-                return _trackBarColours[3];
+                return _trackBarColors[3];
 
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
@@ -4977,14 +4977,14 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkModeAlternate.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlackDarkModeAlternate.cs
@@ -286,38 +286,38 @@ public class PaletteMicrosoft365BlackDarkModeAlternate : PaletteMicrosoft365Blac
         Color.FromArgb(140, 140, 140), // RibbonQATMini3I
         Color.FromArgb(12, Color.White), // RibbonQATMini4I
         Color.FromArgb(14, Color.White), // RibbonQATMini5I
-        Color.FromArgb(141, 144, 147), // RibbonQATFullbar1                                                      
-        Color.FromArgb(133, 135, 137), // RibbonQATFullbar2                                                      
-        Color.FromArgb(93, 96, 100), // RibbonQATFullbar3                                                      
-        Color.FromArgb(103, 103, 103), // RibbonQATButtonDark                                                      
-        Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
-        Color.FromArgb(118, 128, 142), // RibbonQATOverflow1                                                      
-        Color.FromArgb(55, 60, 67), // RibbonQATOverflow2                                                      
+        Color.FromArgb(141, 144, 147), // RibbonQATFullbar1
+        Color.FromArgb(133, 135, 137), // RibbonQATFullbar2
+        Color.FromArgb(93, 96, 100), // RibbonQATFullbar3
+        Color.FromArgb(103, 103, 103), // RibbonQATButtonDark
+        Color.FromArgb(225, 225, 225), // RibbonQATButtonLight
+        Color.FromArgb(118, 128, 142), // RibbonQATOverflow1
+        Color.FromArgb(55, 60, 67), // RibbonQATOverflow2
         Color.FromArgb(163, 168,
-            170), // RibbonGroupSeparatorDark                                                      
+            170), // RibbonGroupSeparatorDark
         Color.FromArgb(230, 233,
-            235), // RibbonGroupSeparatorLight                                                      
+            235), // RibbonGroupSeparatorLight
         Color.FromArgb(210, 217,
-            219), // ButtonClusterButtonBack1                                                      
+            219), // ButtonClusterButtonBack1
         Color.FromArgb(214, 222,
-            223), // ButtonClusterButtonBack2                                                      
+            223), // ButtonClusterButtonBack2
         Color.FromArgb(179, 188,
-            191), // ButtonClusterButtonBorder1                                                      
+            191), // ButtonClusterButtonBorder1
         Color.FromArgb(145, 156,
-            159), // ButtonClusterButtonBorder2                                                      
-        Color.FromArgb(235, 235, 235), // NavigatorMiniBackColor                                                    
-        Color.FromArgb(31, 31, 31), // GridListNormal1                                                    
-        Color.FromArgb(15, 15, 15), // GridListNormal2                                                    
-        Color.FromArgb(15, 15, 15), // GridListPressed1                                                    
-        Color.FromArgb(15, 15, 15), // GridListPressed2                                                    
-        Color.FromArgb(33, 33, 33), // GridListSelected                                                    
-        Color.FromArgb(31, 31, 31), // GridSheetColNormal1                                                    
-        Color.FromArgb(15, 15, 15), // GridSheetColNormal2                                                    
-        Color.FromArgb(224, 224, 224), // GridSheetColPressed1                                                    
-        Color.FromArgb(195, 195, 195), // GridSheetColPressed2                                                    
+            159), // ButtonClusterButtonBorder2
+        Color.FromArgb(235, 235, 235), // NavigatorMiniBackColor
+        Color.FromArgb(31, 31, 31), // GridListNormal1
+        Color.FromArgb(15, 15, 15), // GridListNormal2
+        Color.FromArgb(15, 15, 15), // GridListPressed1
+        Color.FromArgb(15, 15, 15), // GridListPressed2
+        Color.FromArgb(33, 33, 33), // GridListSelected
+        Color.FromArgb(31, 31, 31), // GridSheetColNormal1
+        Color.FromArgb(15, 15, 15), // GridSheetColNormal2
+        Color.FromArgb(224, 224, 224), // GridSheetColPressed1
+        Color.FromArgb(195, 195, 195), // GridSheetColPressed2
         Color.FromArgb(91, 91, 91), // GridSheetColSelected1
         Color.FromArgb(33, 33, 33), // GridSheetColSelected2
-        Color.FromArgb(237, 237, 237), // GridSheetRowNormal                                                   
+        Color.FromArgb(237, 237, 237), // GridSheetRowNormal
         Color.FromArgb(196, 196, 196), // GridSheetRowPressed
         Color.FromArgb(15, 15, 15), // GridSheetRowSelected
         Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -420,7 +420,7 @@ public class PaletteMicrosoft365BlackDarkModeAlternate : PaletteMicrosoft365Blac
     }
     #endregion
 
-    #region Images        
+    #region Images
     /// <summary>
     /// Gets an image indicating a sub-menu on a context menu item.
     /// </summary>
@@ -431,7 +431,7 @@ public class PaletteMicrosoft365BlackDarkModeAlternate : PaletteMicrosoft365Blac
 
     #endregion
 
-    #region ButtonSpec        
+    #region ButtonSpec
     /// <summary>
     /// Gets the image to display for the button.
     /// </summary>
@@ -622,7 +622,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
     private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
     private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
     private static readonly Padding _contentPaddingCalendar = new Padding(2);
-    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
+    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);
     private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
     private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
     private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -817,13 +817,13 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
 
     private readonly Color[] _ribbonColours;
 
-    private readonly Color[] _trackBarColours;
+    private readonly Color[] _trackBarColors;
     private readonly ImageList _checkBoxList;
     private readonly ImageList _galleryButtonList;
     private readonly Image?[] _radioButtonArray;
     #endregion
 
-    #region Constructor        
+    #region Constructor
     /// <summary>
     /// Initializes a new instance of the <see cref="PaletteMicrosoft365BlackDarkModeAlternateBase"/> class.
     /// </summary>
@@ -864,14 +864,14 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
 
         if (trackBarColours != null)
         {
-            _trackBarColours = trackBarColours;
+            _trackBarColors = trackBarColours;
         }
 
         DefineFonts();
     }
     #endregion
 
-    #region Renderer        
+    #region Renderer
     /// <summary>
     /// Gets the renderer to use for this palette.
     /// </summary>
@@ -4742,14 +4742,14 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[1];
+                return _trackBarColors[1];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
                     PaletteState.Disabled => GlobalStaticValues.EMPTY_COLOR,
-                    _ => _trackBarColours[4]
+                    _ => _trackBarColors[4]
                 };
             default:
                 // Should never happen!
@@ -4777,9 +4777,9 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[2];
+                return _trackBarColors[2];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -4815,9 +4815,9 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -4855,14 +4855,14 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
-                return _trackBarColours[0];
+                return _trackBarColors[0];
 
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
-                return _trackBarColours[3];
+                return _trackBarColors[3];
 
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
@@ -4904,14 +4904,14 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueDarkMode.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
  *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *
  */
 #endregion
 
@@ -282,38 +282,38 @@ public class PaletteMicrosoft365BlueDarkMode : PaletteMicrosoft365BlueDarkModeBa
         Color.FromArgb(219, 231, 247), // RibbonQATMini2
         Color.FromArgb(195, 213, 236), // RibbonQATMini3
         Color.FromArgb(128, Color.White), // RibbonQATMini4
-        Color.FromArgb(72, Color.White), // RibbonQATMini5                                                       
+        Color.FromArgb(72, Color.White), // RibbonQATMini5
         Color.FromArgb(153, 176, 206), // RibbonQATMini1I
         Color.FromArgb(226, 233, 241), // RibbonQATMini2I
         Color.FromArgb(198, 210, 226), // RibbonQATMini3I
         Color.FromArgb(128, Color.White), // RibbonQATMini4I
-        Color.FromArgb(72, Color.White), // RibbonQATMini5I                                                      
-        Color.FromArgb(178, 205, 237), // RibbonQATFullbar1                                                      
-        Color.FromArgb(170, 197, 234), // RibbonQATFullbar2                                                      
-        Color.FromArgb(126, 161, 205), // RibbonQATFullbar3                                                      
-        Color.FromArgb(86, 125, 177), // RibbonQATButtonDark                                                      
-        Color.FromArgb(234, 242, 249), // RibbonQATButtonLight                                                      
-        Color.FromArgb(192, 220, 255), // RibbonQATOverflow1                                                      
-        Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-        Color.FromArgb(140, 172, 211), // RibbonGroupSeparatorDark                                                      
-        Color.FromArgb(248, 250, 252), // RibbonGroupSeparatorLight                                                      
-        Color.FromArgb(192, 212, 241), // ButtonClusterButtonBack1                                                      
-        Color.FromArgb(200, 219, 238), // ButtonClusterButtonBack2                                                      
-        Color.FromArgb(155, 183, 224), // ButtonClusterButtonBorder1                                                      
-        Color.FromArgb(117, 150, 191), // ButtonClusterButtonBorder2                                                      
-        Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor                                                    
-        Color.FromArgb(134, 179, 236), // GridListNormal1                                                    
-        Color.FromArgb(63, 122, 197), // GridListNormal2                                                    
-        Color.FromArgb(63, 122, 197), // GridListPressed1                                                    
-        Color.FromArgb(252, 253, 255), // GridListPressed2                                                    
-        Color.FromArgb(170, 195, 240), // GridListSelected                                                    
-        Color.FromArgb(134, 179, 236), // GridSheetColNormal1                                                    
-        Color.FromArgb(63, 122, 197), // GridSheetColNormal2                                                    
-        Color.FromArgb(223, 226, 228), // GridSheetColPressed1                                                    
-        Color.FromArgb(188, 197, 210), // GridSheetColPressed2                                                    
+        Color.FromArgb(72, Color.White), // RibbonQATMini5I
+        Color.FromArgb(178, 205, 237), // RibbonQATFullbar1
+        Color.FromArgb(170, 197, 234), // RibbonQATFullbar2
+        Color.FromArgb(126, 161, 205), // RibbonQATFullbar3
+        Color.FromArgb(86, 125, 177), // RibbonQATButtonDark
+        Color.FromArgb(234, 242, 249), // RibbonQATButtonLight
+        Color.FromArgb(192, 220, 255), // RibbonQATOverflow1
+        Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
+        Color.FromArgb(140, 172, 211), // RibbonGroupSeparatorDark
+        Color.FromArgb(248, 250, 252), // RibbonGroupSeparatorLight
+        Color.FromArgb(192, 212, 241), // ButtonClusterButtonBack1
+        Color.FromArgb(200, 219, 238), // ButtonClusterButtonBack2
+        Color.FromArgb(155, 183, 224), // ButtonClusterButtonBorder1
+        Color.FromArgb(117, 150, 191), // ButtonClusterButtonBorder2
+        Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor
+        Color.FromArgb(134, 179, 236), // GridListNormal1
+        Color.FromArgb(63, 122, 197), // GridListNormal2
+        Color.FromArgb(63, 122, 197), // GridListPressed1
+        Color.FromArgb(252, 253, 255), // GridListPressed2
+        Color.FromArgb(170, 195, 240), // GridListSelected
+        Color.FromArgb(134, 179, 236), // GridSheetColNormal1
+        Color.FromArgb(63, 122, 197), // GridSheetColNormal2
+        Color.FromArgb(223, 226, 228), // GridSheetColPressed1
+        Color.FromArgb(188, 197, 210), // GridSheetColPressed2
         Color.FromArgb(249, 217, 159), // GridSheetColSelected1
         Color.FromArgb(241, 193, 95), // GridSheetColSelected2
-        Color.FromArgb(228, 236, 247), // GridSheetRowNormal                                                   
+        Color.FromArgb(228, 236, 247), // GridSheetRowNormal
         Color.FromArgb(187, 196, 209), // GridSheetRowPressed
         Color.FromArgb(255, 213, 141), // GridSheetRowSelected
         Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -368,7 +368,7 @@ public class PaletteMicrosoft365BlueDarkMode : PaletteMicrosoft365BlueDarkModeBa
         Color.FromArgb(200, 219, 240), // ButtonNavigatorChecked1
         Color.FromArgb(177, 201, 228), // ButtonNavigatorChecked2
         Color.FromArgb(201, 217,
-            239) // ToolTipBottom                                                                      
+            239) // ToolTipBottom
     ];
 
     #endregion
@@ -413,7 +413,7 @@ public class PaletteMicrosoft365BlueDarkMode : PaletteMicrosoft365BlueDarkModeBa
     }
     #endregion
 
-    #region Images        
+    #region Images
     /// <summary>
     /// Gets an image indicating a sub-menu on a context menu item.
     /// </summary>
@@ -424,7 +424,7 @@ public class PaletteMicrosoft365BlueDarkMode : PaletteMicrosoft365BlueDarkModeBa
 
     #endregion
 
-    #region ButtonSpec        
+    #region ButtonSpec
     /// <summary>
     /// Gets the image to display for the button.
     /// </summary>
@@ -611,7 +611,7 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
     private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
     private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
     private static readonly Padding _contentPaddingCalendar = new Padding(2);
-    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
+    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);
     private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
     private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
     private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -807,13 +807,13 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
 
     private readonly Color[] _ribbonColours;
 
-    private readonly Color[] _trackBarColours;
+    private readonly Color[] _trackBarColors;
     private readonly ImageList _checkBoxList;
     private readonly ImageList _galleryButtonList;
     private readonly Image?[] _radioButtonArray;
     #endregion
 
-    #region Constructor        
+    #region Constructor
     /// <summary>
     /// Initializes a new instance of the <see cref="PaletteMicrosoft365BlueDarkModeBase"/> class.
     /// </summary>
@@ -854,7 +854,7 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
 
         //if (trackBarColours != null)
         {
-            _trackBarColours = trackBarColours;
+            _trackBarColors = trackBarColours;
         }
 
         DefineFonts();
@@ -862,7 +862,7 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
     #endregion
 
 
-    #region Renderer        
+    #region Renderer
     /// <summary>
     /// Gets the renderer to use for this palette.
     /// </summary>
@@ -3863,7 +3863,7 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
             case PaletteButtonSpecStyle.QuickPrint:
                 return _integratedToolbarQuickPrintNormal;
             case PaletteButtonSpecStyle.Generic:
-                return null!;   // TODO: Work out why is this is allowed to be null 
+                return null!;   // TODO: Work out why is this is allowed to be null
             default:
                 // Should never happen!
                 Debug.Assert(false);
@@ -4675,14 +4675,14 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[1];
+                return _trackBarColors[1];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
                     PaletteState.Disabled => GlobalStaticValues.EMPTY_COLOR,
-                    _ => _trackBarColours[4]
+                    _ => _trackBarColors[4]
                 };
             default:
                 // Should never happen!
@@ -4710,9 +4710,9 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[2];
+                return _trackBarColors[2];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -4748,9 +4748,9 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -4789,14 +4789,14 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {
@@ -4837,14 +4837,14 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365BlueLightMode.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
  *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *
  */
 #endregion
 
@@ -288,44 +288,44 @@ public class PaletteMicrosoft365BlueLightMode : PaletteMicrosoft365BlueLightMode
         Color.FromArgb(219, 231, 247), // RibbonQATMini2
         Color.FromArgb(195, 213, 236), // RibbonQATMini3
         Color.FromArgb(128, Color.White), // RibbonQATMini4
-        Color.FromArgb(72, Color.White), // RibbonQATMini5                                                       
+        Color.FromArgb(72, Color.White), // RibbonQATMini5
         Color.FromArgb(153, 176, 206), // RibbonQATMini1I
         Color.FromArgb(226, 233, 241), // RibbonQATMini2I
         Color.FromArgb(198, 210, 226), // RibbonQATMini3I
         Color.FromArgb(128, Color.White), // RibbonQATMini4I
-        Color.FromArgb(72, Color.White), // RibbonQATMini5I                                                      
-        Color.FromArgb(178, 205, 237), // RibbonQATFullbar1                                                      
-        Color.FromArgb(170, 197, 234), // RibbonQATFullbar2                                                      
-        Color.FromArgb(126, 161, 205), // RibbonQATFullbar3                                                      
-        Color.FromArgb(86, 125, 177), // RibbonQATButtonDark                                                      
-        Color.FromArgb(234, 242, 249), // RibbonQATButtonLight                                                      
-        Color.FromArgb(192, 220, 255), // RibbonQATOverflow1                                                      
-        Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
+        Color.FromArgb(72, Color.White), // RibbonQATMini5I
+        Color.FromArgb(178, 205, 237), // RibbonQATFullbar1
+        Color.FromArgb(170, 197, 234), // RibbonQATFullbar2
+        Color.FromArgb(126, 161, 205), // RibbonQATFullbar3
+        Color.FromArgb(86, 125, 177), // RibbonQATButtonDark
+        Color.FromArgb(234, 242, 249), // RibbonQATButtonLight
+        Color.FromArgb(192, 220, 255), // RibbonQATOverflow1
+        Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
         Color.FromArgb(140, 172,
-            211), // RibbonGroupSeparatorDark                                                      
+            211), // RibbonGroupSeparatorDark
         Color.FromArgb(248, 250,
-            252), // RibbonGroupSeparatorLight                                                      
+            252), // RibbonGroupSeparatorLight
         Color.FromArgb(192, 212,
-            241), // ButtonClusterButtonBack1                                                      
+            241), // ButtonClusterButtonBack1
         Color.FromArgb(200, 219,
-            238), // ButtonClusterButtonBack2                                                      
+            238), // ButtonClusterButtonBack2
         Color.FromArgb(155, 183,
-            224), // ButtonClusterButtonBorder1                                                      
+            224), // ButtonClusterButtonBorder1
         Color.FromArgb(117, 150,
-            191), // ButtonClusterButtonBorder2                                                      
-        Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor                                                    
-        Color.FromArgb(230, 239, 249), // GridListNormal1                                                    
-        Color.FromArgb(209, 226, 244), // GridListNormal2                                                    
-        Color.FromArgb(209, 226, 244), // GridListPressed1                                                    
-        Color.FromArgb(252, 253, 255), // GridListPressed2                                                    
-        Color.FromArgb(168, 200, 234), // GridListSelected                                                    
-        Color.FromArgb(230, 239, 249), // GridSheetColNormal1                                                    
-        Color.FromArgb(209, 226, 244), // GridSheetColNormal2                                                    
-        Color.FromArgb(223, 226, 228), // GridSheetColPressed1                                                    
-        Color.FromArgb(188, 197, 210), // GridSheetColPressed2                                                    
+            191), // ButtonClusterButtonBorder2
+        Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor
+        Color.FromArgb(230, 239, 249), // GridListNormal1
+        Color.FromArgb(209, 226, 244), // GridListNormal2
+        Color.FromArgb(209, 226, 244), // GridListPressed1
+        Color.FromArgb(252, 253, 255), // GridListPressed2
+        Color.FromArgb(168, 200, 234), // GridListSelected
+        Color.FromArgb(230, 239, 249), // GridSheetColNormal1
+        Color.FromArgb(209, 226, 244), // GridSheetColNormal2
+        Color.FromArgb(223, 226, 228), // GridSheetColPressed1
+        Color.FromArgb(188, 197, 210), // GridSheetColPressed2
         Color.FromArgb(188, 213, 239), // GridSheetColSelected1
         Color.FromArgb(168, 200, 234), // GridSheetColSelected2
-        Color.FromArgb(228, 236, 247), // GridSheetRowNormal                                                   
+        Color.FromArgb(228, 236, 247), // GridSheetRowNormal
         Color.FromArgb(187, 196, 209), // GridSheetRowPressed
         Color.FromArgb(255, 213, 141), // GridSheetRowSelected
         Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -380,7 +380,7 @@ public class PaletteMicrosoft365BlueLightMode : PaletteMicrosoft365BlueLightMode
         Color.FromArgb(200, 219, 240), // ButtonNavigatorChecked1
         Color.FromArgb(177, 201, 228), // ButtonNavigatorChecked2
         Color.FromArgb(201, 217,
-            239) // ToolTipBottom                                                                      
+            239) // ToolTipBottom
     ];
 
     #endregion
@@ -425,7 +425,7 @@ public class PaletteMicrosoft365BlueLightMode : PaletteMicrosoft365BlueLightMode
     }
     #endregion
 
-    #region Images        
+    #region Images
     /// <summary>
     /// Gets an image indicating a sub-menu on a context menu item.
     /// </summary>
@@ -436,7 +436,7 @@ public class PaletteMicrosoft365BlueLightMode : PaletteMicrosoft365BlueLightMode
 
     #endregion
 
-    #region ButtonSpec        
+    #region ButtonSpec
     /// <summary>
     /// Gets the image to display for the button.
     /// </summary>
@@ -623,7 +623,7 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
     private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
     private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
     private static readonly Padding _contentPaddingCalendar = new Padding(2);
-    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
+    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);
     private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
     private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
     private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -819,13 +819,13 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
 
     private readonly Color[] _ribbonColours;
 
-    private readonly Color[] _trackBarColours;
+    private readonly Color[] _trackBarColors;
     private readonly ImageList _checkBoxList;
     private readonly ImageList _galleryButtonList;
     private readonly Image?[] _radioButtonArray;
     #endregion
 
-    #region Constructor        
+    #region Constructor
     /// <summary>
     /// Initializes a new instance of the <see cref="PaletteMicrosoft365BlueLightModeBase"/> class.
     /// </summary>
@@ -866,14 +866,14 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
 
         if (trackBarColours != null)
         {
-            _trackBarColours = trackBarColours;
+            _trackBarColors = trackBarColours;
         }
 
         DefineFonts();
     }
     #endregion
 
-    #region Renderer        
+    #region Renderer
     /// <summary>
     /// Gets the renderer to use for this palette.
     /// </summary>
@@ -4739,14 +4739,14 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[1];
+                return _trackBarColors[1];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
                     PaletteState.Disabled => GlobalStaticValues.EMPTY_COLOR,
-                    _ => _trackBarColours[4]
+                    _ => _trackBarColors[4]
                 };
             default:
                 // Should never happen!
@@ -4774,9 +4774,9 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[2];
+                return _trackBarColors[2];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -4812,9 +4812,9 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -4853,14 +4853,14 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {
@@ -4901,13 +4901,13 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
-                return _trackBarColours[3];
+                return _trackBarColors[3];
 
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverDarkMode.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
  *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *
  */
 #endregion
 
@@ -283,38 +283,38 @@ public class PaletteMicrosoft365SilverDarkMode : PaletteMicrosoft365SilverDarkMo
         Color.FromArgb(210, 215, 221), // RibbonQATMini2
         Color.FromArgb(195, 200, 206), // RibbonQATMini3
         Color.FromArgb(10, Color.White), // RibbonQATMini4
-        Color.FromArgb(32, Color.White), // RibbonQATMini5                                                       
+        Color.FromArgb(32, Color.White), // RibbonQATMini5
         Color.FromArgb(200, 200, 200), // RibbonQATMini1I
         Color.FromArgb(233, 234, 238), // RibbonQATMini2I
         Color.FromArgb(223, 224, 228), // RibbonQATMini3I
         Color.FromArgb(10, Color.White), // RibbonQATMini4I
-        Color.FromArgb(32, Color.White), // RibbonQATMini5I                                                       
-        Color.FromArgb(217, 222, 230), // RibbonQATFullbar1                                                      
-        Color.FromArgb(214, 219, 227), // RibbonQATFullbar2                                                      
-        Color.FromArgb(194, 201, 212), // RibbonQATFullbar3                                                      
-        Color.FromArgb(103, 103, 103), // RibbonQATButtonDark                                                      
-        Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
-        Color.FromArgb(219, 218, 228), // RibbonQATOverflow1                                                      
-        Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-        Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark                                                      
-        Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight                                                      
-        Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1                                                      
-        Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2                                                      
-        Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1                                                      
-        Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2                                                      
-        Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor                                                    
-        Color.FromArgb(119, 132, 161), // GridListNormal1                                                    
-        Color.FromArgb(83, 99, 136), // GridListNormal2                                                    
-        Color.FromArgb(83, 99, 136), // GridListPressed1                                                    
-        Color.FromArgb(252, 253, 253), // GridListPressed2                                                    
-        Color.FromArgb(83, 99, 136), // GridListSelected                                                    
-        Color.FromArgb(119, 132, 161), // GridSheetColNormal1                                                    
-        Color.FromArgb(83, 99, 136), // GridSheetColNormal2                                                    
-        Color.FromArgb(208, 208, 208), // GridSheetColPressed1                                                    
-        Color.FromArgb(166, 166, 166), // GridSheetColPressed2                                                    
+        Color.FromArgb(32, Color.White), // RibbonQATMini5I
+        Color.FromArgb(217, 222, 230), // RibbonQATFullbar1
+        Color.FromArgb(214, 219, 227), // RibbonQATFullbar2
+        Color.FromArgb(194, 201, 212), // RibbonQATFullbar3
+        Color.FromArgb(103, 103, 103), // RibbonQATButtonDark
+        Color.FromArgb(225, 225, 225), // RibbonQATButtonLight
+        Color.FromArgb(219, 218, 228), // RibbonQATOverflow1
+        Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
+        Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark
+        Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight
+        Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1
+        Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2
+        Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1
+        Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2
+        Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor
+        Color.FromArgb(119, 132, 161), // GridListNormal1
+        Color.FromArgb(83, 99, 136), // GridListNormal2
+        Color.FromArgb(83, 99, 136), // GridListPressed1
+        Color.FromArgb(252, 253, 253), // GridListPressed2
+        Color.FromArgb(83, 99, 136), // GridListSelected
+        Color.FromArgb(119, 132, 161), // GridSheetColNormal1
+        Color.FromArgb(83, 99, 136), // GridSheetColNormal2
+        Color.FromArgb(208, 208, 208), // GridSheetColPressed1
+        Color.FromArgb(166, 166, 166), // GridSheetColPressed2
         Color.FromArgb(54, 64, 88), // GridSheetColSelected1
         Color.FromArgb(83, 99, 136), // GridSheetColSelected2
-        Color.FromArgb(231, 231, 231), // GridSheetRowNormal                                                   
+        Color.FromArgb(231, 231, 231), // GridSheetRowNormal
         Color.FromArgb(184, 191, 196), // GridSheetRowPressed
         Color.FromArgb(245, 199, 149), // GridSheetRowSelected
         Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -368,7 +368,7 @@ public class PaletteMicrosoft365SilverDarkMode : PaletteMicrosoft365SilverDarkMo
         Color.FromArgb(225, 226, 230), // ButtonNavigatorPressed2
         Color.FromArgb(222, 227, 234), // ButtonNavigatorChecked1
         Color.FromArgb(206, 214, 221), // ButtonNavigatorChecked2
-        Color.FromArgb(221, 221, 221) // ToolTipBottom                                                                      
+        Color.FromArgb(221, 221, 221) // ToolTipBottom
     ];
 
     #endregion
@@ -413,7 +413,7 @@ public class PaletteMicrosoft365SilverDarkMode : PaletteMicrosoft365SilverDarkMo
     }
     #endregion
 
-    #region Images        
+    #region Images
     /// <summary>
     /// Gets an image indicating a sub-menu on a context menu item.
     /// </summary>
@@ -424,7 +424,7 @@ public class PaletteMicrosoft365SilverDarkMode : PaletteMicrosoft365SilverDarkMo
 
     #endregion
 
-    #region ButtonSpec        
+    #region ButtonSpec
     /// <summary>
     /// Gets the image to display for the button.
     /// </summary>
@@ -611,7 +611,7 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
     private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
     private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
     private static readonly Padding _contentPaddingCalendar = new Padding(2);
-    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
+    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);
     private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
     private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
     private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -808,13 +808,13 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
 
     private readonly Color[] _ribbonColours;
 
-    private readonly Color[] _trackBarColours;
+    private readonly Color[] _trackBarColors;
     private readonly ImageList _checkBoxList;
     private readonly ImageList _galleryButtonList;
     private readonly Image?[] _radioButtonArray;
     #endregion
 
-    #region Constructor        
+    #region Constructor
     /// <summary>
     /// Initializes a new instance of the <see cref="PaletteMicrosoft365SilverDarkModeBase"/> class.
     /// </summary>
@@ -856,14 +856,14 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
 
         if (trackBarColours != null)
         {
-            _trackBarColours = trackBarColours;
+            _trackBarColors = trackBarColours;
         }
 
         DefineFonts();
     }
     #endregion
 
-    #region Renderer        
+    #region Renderer
     /// <summary>
     /// Gets the renderer to use for this palette.
     /// </summary>
@@ -4714,14 +4714,14 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[1];
+                return _trackBarColors[1];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
                     PaletteState.Disabled => GlobalStaticValues.EMPTY_COLOR,
-                    _ => _trackBarColours[4]
+                    _ => _trackBarColors[4]
                 };
             default:
                 // Should never happen!
@@ -4749,9 +4749,9 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[2];
+                return _trackBarColors[2];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -4787,9 +4787,9 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -4828,14 +4828,14 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {
@@ -4876,14 +4876,14 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/PaletteMicrosoft365SilverLightMode.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
  *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *
  */
 #endregion
 
@@ -273,7 +273,7 @@ public class PaletteMicrosoft365SilverLightMode : PaletteMicrosoft365SilverLight
         Color.FromArgb(226, 229, 234), // RibbonGroupFrameInside2
         Color.FromArgb(220, 224, 231), // RibbonGroupFrameInside3
         Color.FromArgb(232, 234, 238), // RibbonGroupFrameInside4
-        Color.FromArgb(76, 83, 92), // RibbonGroupCollapsedText         
+        Color.FromArgb(76, 83, 92), // RibbonGroupCollapsedText
         Color.FromArgb(179, 185, 195), // AlternatePressedBack1
         Color.FromArgb(216, 224, 224), // AlternatePressedBack2
         Color.FromArgb(125, 125, 125), // AlternatePressedBorder1
@@ -287,38 +287,38 @@ public class PaletteMicrosoft365SilverLightMode : PaletteMicrosoft365SilverLight
         Color.FromArgb(210, 215, 221), // RibbonQATMini2
         Color.FromArgb(195, 200, 206), // RibbonQATMini3
         Color.FromArgb(10, Color.White), // RibbonQATMini4
-        Color.FromArgb(32, Color.White), // RibbonQATMini5                                                       
+        Color.FromArgb(32, Color.White), // RibbonQATMini5
         Color.FromArgb(200, 200, 200), // RibbonQATMini1I
         Color.FromArgb(233, 234, 238), // RibbonQATMini2I
         Color.FromArgb(223, 224, 228), // RibbonQATMini3I
         Color.FromArgb(10, Color.White), // RibbonQATMini4I
-        Color.FromArgb(32, Color.White), // RibbonQATMini5I                                                       
-        Color.FromArgb(217, 222, 230), // RibbonQATFullbar1                                                      
-        Color.FromArgb(214, 219, 227), // RibbonQATFullbar2                                                      
-        Color.FromArgb(194, 201, 212), // RibbonQATFullbar3                                                      
-        Color.FromArgb(103, 103, 103), // RibbonQATButtonDark                                                      
-        Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
-        Color.FromArgb(219, 218, 228), // RibbonQATOverflow1                                                      
-        Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-        Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark                                                      
-        Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight                                                      
-        Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1                                                      
-        Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2                                                      
-        Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1                                                      
-        Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2                                                      
-        Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor                                                    
-        Color.FromArgb(224, 225, 231), // GridListNormal1                                                    
-        Color.FromArgb(195, 198, 209), // GridListNormal2                                                    
-        Color.FromArgb(195, 198, 209), // GridListPressed1                                                    
-        Color.FromArgb(252, 253, 253), // GridListPressed2                                                    
-        Color.FromArgb(195, 198, 209), // GridListSelected                                                    
-        Color.FromArgb(224, 225, 231), // GridSheetColNormal1                                                    
-        Color.FromArgb(195, 198, 209), // GridSheetColNormal2                                                    
-        Color.FromArgb(208, 208, 208), // GridSheetColPressed1                                                    
-        Color.FromArgb(166, 166, 166), // GridSheetColPressed2                                                    
+        Color.FromArgb(32, Color.White), // RibbonQATMini5I
+        Color.FromArgb(217, 222, 230), // RibbonQATFullbar1
+        Color.FromArgb(214, 219, 227), // RibbonQATFullbar2
+        Color.FromArgb(194, 201, 212), // RibbonQATFullbar3
+        Color.FromArgb(103, 103, 103), // RibbonQATButtonDark
+        Color.FromArgb(225, 225, 225), // RibbonQATButtonLight
+        Color.FromArgb(219, 218, 228), // RibbonQATOverflow1
+        Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
+        Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark
+        Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight
+        Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1
+        Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2
+        Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1
+        Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2
+        Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor
+        Color.FromArgb(224, 225, 231), // GridListNormal1
+        Color.FromArgb(195, 198, 209), // GridListNormal2
+        Color.FromArgb(195, 198, 209), // GridListPressed1
+        Color.FromArgb(252, 253, 253), // GridListPressed2
+        Color.FromArgb(195, 198, 209), // GridListSelected
+        Color.FromArgb(224, 225, 231), // GridSheetColNormal1
+        Color.FromArgb(195, 198, 209), // GridSheetColNormal2
+        Color.FromArgb(208, 208, 208), // GridSheetColPressed1
+        Color.FromArgb(166, 166, 166), // GridSheetColPressed2
         Color.FromArgb(54, 64, 88), // GridSheetColSelected1
         Color.FromArgb(195, 198, 209), // GridSheetColSelected2
-        Color.FromArgb(231, 231, 231), // GridSheetRowNormal                                                   
+        Color.FromArgb(231, 231, 231), // GridSheetRowNormal
         Color.FromArgb(184, 191, 196), // GridSheetRowPressed
         Color.FromArgb(245, 199, 149), // GridSheetRowSelected
         Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -372,7 +372,7 @@ public class PaletteMicrosoft365SilverLightMode : PaletteMicrosoft365SilverLight
         Color.FromArgb(225, 226, 230), // ButtonNavigatorPressed2
         Color.FromArgb(222, 227, 234), // ButtonNavigatorChecked1
         Color.FromArgb(206, 214, 221), // ButtonNavigatorChecked2
-        Color.FromArgb(221, 221, 221) // ToolTipBottom                                                                      
+        Color.FromArgb(221, 221, 221) // ToolTipBottom
     ];
 
     #endregion
@@ -417,7 +417,7 @@ public class PaletteMicrosoft365SilverLightMode : PaletteMicrosoft365SilverLight
     }
     #endregion
 
-    #region Images        
+    #region Images
     /// <summary>
     /// Gets an image indicating a sub-menu on a context menu item.
     /// </summary>
@@ -428,7 +428,7 @@ public class PaletteMicrosoft365SilverLightMode : PaletteMicrosoft365SilverLight
 
     #endregion
 
-    #region ButtonSpec        
+    #region ButtonSpec
     /// <summary>
     /// Gets the image to display for the button.
     /// </summary>
@@ -615,7 +615,7 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
     private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
     private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
     private static readonly Padding _contentPaddingCalendar = new Padding(2);
-    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
+    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);
     private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
     private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
     private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -812,13 +812,13 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
 
     private readonly Color[] _ribbonColours;
 
-    private readonly Color[] _trackBarColours;
+    private readonly Color[] _trackBarColors;
     private readonly ImageList _checkBoxList;
     private readonly ImageList _galleryButtonList;
     private readonly Image?[] _radioButtonArray;
     #endregion
 
-    #region Constructor        
+    #region Constructor
     /// <summary>
     /// Initializes a new instance of the <see cref="PaletteMicrosoft365SilverLightModeBase"/> class.
     /// </summary>
@@ -859,14 +859,14 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
 
         if (trackBarColours != null)
         {
-            _trackBarColours = trackBarColours;
+            _trackBarColors = trackBarColours;
         }
 
         DefineFonts();
     }
     #endregion
 
-    #region Renderer        
+    #region Renderer
     /// <summary>
     /// Gets the renderer to use for this palette.
     /// </summary>
@@ -4730,14 +4730,14 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[1];
+                return _trackBarColors[1];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
                     PaletteState.Disabled => GlobalStaticValues.EMPTY_COLOR,
-                    _ => _trackBarColours[4]
+                    _ => _trackBarColors[4]
                 };
             default:
                 // Should never happen!
@@ -4765,9 +4765,9 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[2];
+                return _trackBarColors[2];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -4803,9 +4803,9 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -4844,14 +4844,14 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {
@@ -4893,14 +4893,14 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlackDarkMode.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
  *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *
  */
 #endregion
 
@@ -189,7 +189,7 @@ public class PaletteOffice2007BlackDarkMode : PaletteOffice2007BlackDarkModeBase
         Color.FromArgb(222, 225, 229), // RibbonGroupFrameInside2
         Color.FromArgb(214, 218, 223), // RibbonGroupFrameInside3
         Color.FromArgb(222, 225, 230), // RibbonGroupFrameInside4
-        Color.FromArgb(70, 70, 70), // RibbonGroupCollapsedText         
+        Color.FromArgb(70, 70, 70), // RibbonGroupCollapsedText
         Color.FromArgb(158, 163, 172), // AlternatePressedBack1
         Color.FromArgb(212, 215, 216), // AlternatePressedBack2
         Color.FromArgb(124, 125, 125), // AlternatePressedBorder1
@@ -209,38 +209,38 @@ public class PaletteOffice2007BlackDarkMode : PaletteOffice2007BlackDarkModeBase
         Color.FromArgb(140, 140, 140), // RibbonQATMini3I
         Color.FromArgb(12, Color.White), // RibbonQATMini4I
         Color.FromArgb(14, Color.White), // RibbonQATMini5I
-        Color.FromArgb(141, 144, 147), // RibbonQATFullbar1                                                      
-        Color.FromArgb(133, 135, 137), // RibbonQATFullbar2                                                      
-        Color.FromArgb(93, 96, 100), // RibbonQATFullbar3                                                      
-        Color.FromArgb(103, 103, 103), // RibbonQATButtonDark                                                      
-        Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
-        Color.FromArgb(118, 128, 142), // RibbonQATOverflow1                                                      
-        Color.FromArgb(55, 60, 67), // RibbonQATOverflow2                                                      
+        Color.FromArgb(141, 144, 147), // RibbonQATFullbar1
+        Color.FromArgb(133, 135, 137), // RibbonQATFullbar2
+        Color.FromArgb(93, 96, 100), // RibbonQATFullbar3
+        Color.FromArgb(103, 103, 103), // RibbonQATButtonDark
+        Color.FromArgb(225, 225, 225), // RibbonQATButtonLight
+        Color.FromArgb(118, 128, 142), // RibbonQATOverflow1
+        Color.FromArgb(55, 60, 67), // RibbonQATOverflow2
         Color.FromArgb(163, 168,
-            170), // RibbonGroupSeparatorDark                                                      
+            170), // RibbonGroupSeparatorDark
         Color.FromArgb(230, 233,
-            235), // RibbonGroupSeparatorLight                                                      
+            235), // RibbonGroupSeparatorLight
         Color.FromArgb(210, 217,
-            219), // ButtonClusterButtonBack1                                                      
+            219), // ButtonClusterButtonBack1
         Color.FromArgb(214, 222,
-            223), // ButtonClusterButtonBack2                                                      
+            223), // ButtonClusterButtonBack2
         Color.FromArgb(179, 188,
-            191), // ButtonClusterButtonBorder1                                                      
+            191), // ButtonClusterButtonBorder1
         Color.FromArgb(145, 156,
-            159), // ButtonClusterButtonBorder2                                                      
-        Color.FromArgb(235, 235, 235), // NavigatorMiniBackColor                                                    
-        Color.FromArgb(10, 10, 10), // GridListNormal1                                                    
-        Color.FromArgb(41, 41, 41), // GridListNormal2                                                    
-        Color.FromArgb(41, 41, 41), // GridListPressed1                                                    
-        Color.FromArgb(61, 61, 61), // GridListPressed2                                                    
-        Color.FromArgb(33, 33, 33), // GridListSelected                                                    
-        Color.FromArgb(10, 10, 10), // GridSheetColNormal1                                                    
-        Color.FromArgb(41, 41, 41), // GridSheetColNormal2                                                    
-        Color.FromArgb(224, 224, 224), // GridSheetColPressed1                                                    
-        Color.FromArgb(195, 195, 195), // GridSheetColPressed2                                                    
+            159), // ButtonClusterButtonBorder2
+        Color.FromArgb(235, 235, 235), // NavigatorMiniBackColor
+        Color.FromArgb(10, 10, 10), // GridListNormal1
+        Color.FromArgb(41, 41, 41), // GridListNormal2
+        Color.FromArgb(41, 41, 41), // GridListPressed1
+        Color.FromArgb(61, 61, 61), // GridListPressed2
+        Color.FromArgb(33, 33, 33), // GridListSelected
+        Color.FromArgb(10, 10, 10), // GridSheetColNormal1
+        Color.FromArgb(41, 41, 41), // GridSheetColNormal2
+        Color.FromArgb(224, 224, 224), // GridSheetColPressed1
+        Color.FromArgb(195, 195, 195), // GridSheetColPressed2
         Color.FromArgb(91, 91, 91), // GridSheetColSelected1
         Color.FromArgb(33, 33, 33), // GridSheetColSelected2
-        Color.FromArgb(237, 237, 237), // GridSheetRowNormal                                                   
+        Color.FromArgb(237, 237, 237), // GridSheetRowNormal
         Color.FromArgb(196, 196, 196), // GridSheetRowPressed
         Color.FromArgb(61, 61, 61), // GridSheetRowSelected
         Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -638,7 +638,7 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
     private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
     private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
     private static readonly Padding _contentPaddingCalendar = new Padding(2);
-    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
+    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);
     private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
     private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
     private static readonly Padding _contentPaddingButtonCalendar = new Padding(-1);
@@ -853,7 +853,7 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
     #region Instance Fields
     private KryptonColorTable2007BlackDarkMode? _table;
     private readonly Color[] _ribbonColours;
-    private readonly Color[] _trackBarColours;
+    private readonly Color[] _trackBarColors;
     private readonly ImageList _checkBoxList;
     private readonly ImageList _galleryButtonList;
     private readonly Image?[] _radioButtonArray;
@@ -904,7 +904,7 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
 
         if (trackBarColors != null)
         {
-            _trackBarColours = trackBarColors;
+            _trackBarColors = trackBarColors;
         }
 
         // Get the font settings from the system
@@ -5668,14 +5668,14 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[1];
+                return _trackBarColors[1];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
                     PaletteState.Disabled => GlobalStaticValues.EMPTY_COLOR,
-                    _ => _trackBarColours[4]
+                    _ => _trackBarColors[4]
                 };
             default:
                 // Should never happen!
@@ -5704,9 +5704,9 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[2];
+                return _trackBarColors[2];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -5744,9 +5744,9 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -5786,14 +5786,14 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {
@@ -5835,14 +5835,14 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueDarkMode.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
  *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *
  */
 #endregion
 
@@ -202,44 +202,44 @@ public class PaletteOffice2007BlueDarkMode : PaletteOffice2007BlueDarkModeBase
         Color.FromArgb(219, 231, 247), // RibbonQATMini2
         Color.FromArgb(195, 213, 236), // RibbonQATMini3
         Color.FromArgb(128, Color.White), // RibbonQATMini4
-        Color.FromArgb(72, Color.White), // RibbonQATMini5                                                       
+        Color.FromArgb(72, Color.White), // RibbonQATMini5
         Color.FromArgb(153, 176, 206), // RibbonQATMini1I
         Color.FromArgb(226, 233, 241), // RibbonQATMini2I
         Color.FromArgb(198, 210, 226), // RibbonQATMini3I
         Color.FromArgb(128, Color.White), // RibbonQATMini4I
-        Color.FromArgb(72, Color.White), // RibbonQATMini5I                                                      
-        Color.FromArgb(178, 205, 237), // RibbonQATFullbar1                                                      
-        Color.FromArgb(170, 197, 234), // RibbonQATFullbar2                                                      
-        Color.FromArgb(126, 161, 205), // RibbonQATFullbar3                                                      
-        Color.FromArgb(86, 125, 177), // RibbonQATButtonDark                                                      
-        Color.FromArgb(234, 242, 249), // RibbonQATButtonLight                                                      
-        Color.FromArgb(192, 220, 255), // RibbonQATOverflow1                                                      
-        Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
+        Color.FromArgb(72, Color.White), // RibbonQATMini5I
+        Color.FromArgb(178, 205, 237), // RibbonQATFullbar1
+        Color.FromArgb(170, 197, 234), // RibbonQATFullbar2
+        Color.FromArgb(126, 161, 205), // RibbonQATFullbar3
+        Color.FromArgb(86, 125, 177), // RibbonQATButtonDark
+        Color.FromArgb(234, 242, 249), // RibbonQATButtonLight
+        Color.FromArgb(192, 220, 255), // RibbonQATOverflow1
+        Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
         Color.FromArgb(140, 172,
-            211), // RibbonGroupSeparatorDark                                                      
+            211), // RibbonGroupSeparatorDark
         Color.FromArgb(248, 250,
-            252), // RibbonGroupSeparatorLight                                                      
+            252), // RibbonGroupSeparatorLight
         Color.FromArgb(192, 212,
-            241), // ButtonClusterButtonBack1                                                      
+            241), // ButtonClusterButtonBack1
         Color.FromArgb(200, 219,
-            238), // ButtonClusterButtonBack2                                                      
+            238), // ButtonClusterButtonBack2
         Color.FromArgb(155, 183,
-            224), // ButtonClusterButtonBorder1                                                      
+            224), // ButtonClusterButtonBorder1
         Color.FromArgb(117, 150,
-            191), // ButtonClusterButtonBorder2                                                      
-        Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor                                                    
-        Color.FromArgb(134, 179, 236), // GridListNormal1                                                    
-        Color.FromArgb(63, 122, 197), // GridListNormal2                                                    
-        Color.FromArgb(63, 122, 197), // GridListPressed1                                                    
-        Color.FromArgb(252, 253, 255), // GridListPressed2                                                    
-        Color.FromArgb(170, 195, 240), // GridListSelected                                                    
-        Color.FromArgb(134, 179, 236), // GridSheetColNormal1                                                    
-        Color.FromArgb(63, 122, 197), // GridSheetColNormal2                                                    
-        Color.FromArgb(223, 226, 228), // GridSheetColPressed1                                                    
-        Color.FromArgb(188, 197, 210), // GridSheetColPressed2                                                    
+            191), // ButtonClusterButtonBorder2
+        Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor
+        Color.FromArgb(134, 179, 236), // GridListNormal1
+        Color.FromArgb(63, 122, 197), // GridListNormal2
+        Color.FromArgb(63, 122, 197), // GridListPressed1
+        Color.FromArgb(252, 253, 255), // GridListPressed2
+        Color.FromArgb(170, 195, 240), // GridListSelected
+        Color.FromArgb(134, 179, 236), // GridSheetColNormal1
+        Color.FromArgb(63, 122, 197), // GridSheetColNormal2
+        Color.FromArgb(223, 226, 228), // GridSheetColPressed1
+        Color.FromArgb(188, 197, 210), // GridSheetColPressed2
         Color.FromArgb(249, 217, 159), // GridSheetColSelected1
         Color.FromArgb(241, 193, 95), // GridSheetColSelected2
-        Color.FromArgb(228, 236, 247), // GridSheetRowNormal                                                   
+        Color.FromArgb(228, 236, 247), // GridSheetRowNormal
         Color.FromArgb(187, 196, 209), // GridSheetRowPressed
         Color.FromArgb(255, 213, 141), // GridSheetRowSelected
         Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -483,7 +483,7 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
     private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
     private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
     private static readonly Padding _contentPaddingCalendar = new Padding(2);
-    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
+    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);
     private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
     private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
     private static readonly Padding _contentPaddingButtonCalendar = new Padding(-1);
@@ -701,7 +701,7 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
     #region Instance Fields
     private KryptonColorTable2007BlueDarkMode? _table;
     private readonly Color[] _ribbonColours;
-    private readonly Color[] _trackBarColours;
+    private readonly Color[] _trackBarColors;
     private readonly ImageList _checkBoxList;
     private readonly ImageList _galleryButtonList;
     private readonly Image?[] _radioButtonArray;
@@ -748,7 +748,7 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
         }
         if (trackBarColors != null)
         {
-            _trackBarColours = trackBarColors;
+            _trackBarColors = trackBarColors;
         }
 
         // Get the font settings from the system
@@ -4960,14 +4960,14 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[1];
+                return _trackBarColors[1];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
                     PaletteState.Disabled => GlobalStaticValues.EMPTY_COLOR,
-                    _ => _trackBarColours[4]
+                    _ => _trackBarColors[4]
                 };
             default:
                 // Should never happen!
@@ -4996,9 +4996,9 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[2];
+                return _trackBarColors[2];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -5036,9 +5036,9 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -5078,14 +5078,14 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {
@@ -5127,14 +5127,14 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueLightMode.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
  *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *
  */
 #endregion
 
@@ -204,44 +204,44 @@ public class PaletteOffice2007BlueLightMode : PaletteOffice2007BlueLightModeBase
         Color.FromArgb(219, 231, 247), // RibbonQATMini2
         Color.FromArgb(195, 213, 236), // RibbonQATMini3
         Color.FromArgb(128, Color.White), // RibbonQATMini4
-        Color.FromArgb(72, Color.White), // RibbonQATMini5                                                       
+        Color.FromArgb(72, Color.White), // RibbonQATMini5
         Color.FromArgb(153, 176, 206), // RibbonQATMini1I
         Color.FromArgb(226, 233, 241), // RibbonQATMini2I
         Color.FromArgb(198, 210, 226), // RibbonQATMini3I
         Color.FromArgb(128, Color.White), // RibbonQATMini4I
-        Color.FromArgb(72, Color.White), // RibbonQATMini5I                                                      
-        Color.FromArgb(178, 205, 237), // RibbonQATFullbar1                                                      
-        Color.FromArgb(170, 197, 234), // RibbonQATFullbar2                                                      
-        Color.FromArgb(126, 161, 205), // RibbonQATFullbar3                                                      
-        Color.FromArgb(86, 125, 177), // RibbonQATButtonDark                                                      
-        Color.FromArgb(234, 242, 249), // RibbonQATButtonLight                                                      
-        Color.FromArgb(192, 220, 255), // RibbonQATOverflow1                                                      
-        Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
+        Color.FromArgb(72, Color.White), // RibbonQATMini5I
+        Color.FromArgb(178, 205, 237), // RibbonQATFullbar1
+        Color.FromArgb(170, 197, 234), // RibbonQATFullbar2
+        Color.FromArgb(126, 161, 205), // RibbonQATFullbar3
+        Color.FromArgb(86, 125, 177), // RibbonQATButtonDark
+        Color.FromArgb(234, 242, 249), // RibbonQATButtonLight
+        Color.FromArgb(192, 220, 255), // RibbonQATOverflow1
+        Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
         Color.FromArgb(140, 172,
-            211), // RibbonGroupSeparatorDark                                                      
+            211), // RibbonGroupSeparatorDark
         Color.FromArgb(248, 250,
-            252), // RibbonGroupSeparatorLight                                                      
+            252), // RibbonGroupSeparatorLight
         Color.FromArgb(192, 212,
-            241), // ButtonClusterButtonBack1                                                      
+            241), // ButtonClusterButtonBack1
         Color.FromArgb(200, 219,
-            238), // ButtonClusterButtonBack2                                                      
+            238), // ButtonClusterButtonBack2
         Color.FromArgb(155, 183,
-            224), // ButtonClusterButtonBorder1                                                      
+            224), // ButtonClusterButtonBorder1
         Color.FromArgb(117, 150,
-            191), // ButtonClusterButtonBorder2                                                      
-        Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor                                                    
-        Color.FromArgb(230, 239, 249), // GridListNormal1                                                    
-        Color.FromArgb(209, 226, 244), // GridListNormal2                                                    
-        Color.FromArgb(209, 226, 244), // GridListPressed1                                                    
-        Color.FromArgb(252, 253, 255), // GridListPressed2                                                    
-        Color.FromArgb(168, 200, 234), // GridListSelected                                                    
-        Color.FromArgb(230, 239, 249), // GridSheetColNormal1                                                    
-        Color.FromArgb(209, 226, 244), // GridSheetColNormal2                                                    
-        Color.FromArgb(223, 226, 228), // GridSheetColPressed1                                                    
-        Color.FromArgb(188, 197, 210), // GridSheetColPressed2                                                    
+            191), // ButtonClusterButtonBorder2
+        Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor
+        Color.FromArgb(230, 239, 249), // GridListNormal1
+        Color.FromArgb(209, 226, 244), // GridListNormal2
+        Color.FromArgb(209, 226, 244), // GridListPressed1
+        Color.FromArgb(252, 253, 255), // GridListPressed2
+        Color.FromArgb(168, 200, 234), // GridListSelected
+        Color.FromArgb(230, 239, 249), // GridSheetColNormal1
+        Color.FromArgb(209, 226, 244), // GridSheetColNormal2
+        Color.FromArgb(223, 226, 228), // GridSheetColPressed1
+        Color.FromArgb(188, 197, 210), // GridSheetColPressed2
         Color.FromArgb(188, 213, 239), // GridSheetColSelected1
         Color.FromArgb(168, 200, 234), // GridSheetColSelected2
-        Color.FromArgb(228, 236, 247), // GridSheetRowNormal                                                   
+        Color.FromArgb(228, 236, 247), // GridSheetRowNormal
         Color.FromArgb(187, 196, 209), // GridSheetRowPressed
         Color.FromArgb(255, 213, 141), // GridSheetRowSelected
         Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -485,7 +485,7 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
     private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
     private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
     private static readonly Padding _contentPaddingCalendar = new Padding(2);
-    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
+    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);
     private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
     private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
     private static readonly Padding _contentPaddingButtonCalendar = new Padding(-1);
@@ -661,7 +661,7 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
     #region Instance Fields
     private KryptonColorTable2007BlueLightMode? _table;
     private readonly Color[] _ribbonColours;
-    private readonly Color[] _trackBarColours;
+    private readonly Color[] _trackBarColors;
     private readonly ImageList _checkBoxList;
     private readonly ImageList _galleryButtonList;
     private readonly Image?[] _radioButtonArray;
@@ -708,7 +708,7 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
         }
         if (trackBarColors != null)
         {
-            _trackBarColours = trackBarColors;
+            _trackBarColors = trackBarColors;
         }
 
         // Get the font settings from the system
@@ -5436,14 +5436,14 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[1];
+                return _trackBarColors[1];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
                     PaletteState.Disabled => GlobalStaticValues.EMPTY_COLOR,
-                    _ => _trackBarColours[4]
+                    _ => _trackBarColors[4]
                 };
             default:
                 // Should never happen!
@@ -5472,9 +5472,9 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[2];
+                return _trackBarColors[2];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -5512,9 +5512,9 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -5554,14 +5554,14 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {
@@ -5603,14 +5603,14 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverDarkMode.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
  *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *
  */
 #endregion
 
@@ -200,7 +200,7 @@ public class PaletteOffice2007SilverDarkMode : PaletteOffice2007SilverDarkModeBa
         Color.FromArgb(226, 229, 234), // RibbonGroupFrameInside2
         Color.FromArgb(220, 224, 231), // RibbonGroupFrameInside3
         Color.FromArgb(232, 234, 238), // RibbonGroupFrameInside4
-        Color.FromArgb(76, 83, 92), // RibbonGroupCollapsedText         
+        Color.FromArgb(76, 83, 92), // RibbonGroupCollapsedText
         Color.FromArgb(179, 185, 195), // AlternatePressedBack1
         Color.FromArgb(216, 224, 224), // AlternatePressedBack2
         Color.FromArgb(125, 125, 125), // AlternatePressedBorder1
@@ -214,38 +214,38 @@ public class PaletteOffice2007SilverDarkMode : PaletteOffice2007SilverDarkModeBa
         Color.FromArgb(210, 215, 221), // RibbonQATMini2
         Color.FromArgb(195, 200, 206), // RibbonQATMini3
         Color.FromArgb(10, Color.White), // RibbonQATMini4
-        Color.FromArgb(32, Color.White), // RibbonQATMini5                                                       
+        Color.FromArgb(32, Color.White), // RibbonQATMini5
         Color.FromArgb(200, 200, 200), // RibbonQATMini1I
         Color.FromArgb(233, 234, 238), // RibbonQATMini2I
         Color.FromArgb(223, 224, 228), // RibbonQATMini3I
         Color.FromArgb(10, Color.White), // RibbonQATMini4I
-        Color.FromArgb(32, Color.White), // RibbonQATMini5I                                                       
-        Color.FromArgb(217, 222, 230), // RibbonQATFullbar1                                                      
-        Color.FromArgb(214, 219, 227), // RibbonQATFullbar2                                                      
-        Color.FromArgb(194, 201, 212), // RibbonQATFullbar3                                                      
-        Color.FromArgb(103, 103, 103), // RibbonQATButtonDark                                                      
-        Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
-        Color.FromArgb(219, 218, 228), // RibbonQATOverflow1                                                      
-        Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-        Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark                                                      
-        Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight                                                      
-        Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1                                                      
-        Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2                                                      
-        Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1                                                      
-        Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2                                                      
-        Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor                                                    
-        Color.FromArgb(119, 132, 161), // GridListNormal1                                                    
-        Color.FromArgb(83, 99, 136), // GridListNormal2                                                    
-        Color.FromArgb(83, 99, 136), // GridListPressed1                                                    
-        Color.FromArgb(252, 253, 253), // GridListPressed2                                                    
-        Color.FromArgb(83, 99, 136), // GridListSelected                                                    
-        Color.FromArgb(119, 132, 161), // GridSheetColNormal1                                                    
-        Color.FromArgb(83, 99, 136), // GridSheetColNormal2                                                    
-        Color.FromArgb(208, 208, 208), // GridSheetColPressed1                                                    
-        Color.FromArgb(166, 166, 166), // GridSheetColPressed2                                                    
+        Color.FromArgb(32, Color.White), // RibbonQATMini5I
+        Color.FromArgb(217, 222, 230), // RibbonQATFullbar1
+        Color.FromArgb(214, 219, 227), // RibbonQATFullbar2
+        Color.FromArgb(194, 201, 212), // RibbonQATFullbar3
+        Color.FromArgb(103, 103, 103), // RibbonQATButtonDark
+        Color.FromArgb(225, 225, 225), // RibbonQATButtonLight
+        Color.FromArgb(219, 218, 228), // RibbonQATOverflow1
+        Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
+        Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark
+        Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight
+        Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1
+        Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2
+        Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1
+        Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2
+        Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor
+        Color.FromArgb(119, 132, 161), // GridListNormal1
+        Color.FromArgb(83, 99, 136), // GridListNormal2
+        Color.FromArgb(83, 99, 136), // GridListPressed1
+        Color.FromArgb(252, 253, 253), // GridListPressed2
+        Color.FromArgb(83, 99, 136), // GridListSelected
+        Color.FromArgb(119, 132, 161), // GridSheetColNormal1
+        Color.FromArgb(83, 99, 136), // GridSheetColNormal2
+        Color.FromArgb(208, 208, 208), // GridSheetColPressed1
+        Color.FromArgb(166, 166, 166), // GridSheetColPressed2
         Color.FromArgb(54, 64, 88), // GridSheetColSelected1
         Color.FromArgb(83, 99, 136), // GridSheetColSelected2
-        Color.FromArgb(231, 231, 231), // GridSheetRowNormal                                                   
+        Color.FromArgb(231, 231, 231), // GridSheetRowNormal
         Color.FromArgb(184, 191, 196), // GridSheetRowPressed
         Color.FromArgb(245, 199, 149), // GridSheetRowSelected
         Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -405,7 +405,7 @@ public class PaletteOffice2007SilverDarkMode : PaletteOffice2007SilverDarkModeBa
         },
         _ => base.GetButtonSpecImage(style, state)
     };
-    #endregion    
+    #endregion
 
     #region Tab Row Background
 
@@ -458,7 +458,7 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
     private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
     private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
     private static readonly Padding _contentPaddingCalendar = new Padding(2);
-    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
+    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);
     private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
     private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
     private static readonly Padding _contentPaddingButtonCalendar = new Padding(-1);
@@ -634,7 +634,7 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
     #region Instance Fields
     private KryptonColorTable2007SilverDarkMode? _table;
     private readonly Color[] _ribbonColours;
-    private readonly Color[] _trackBarColours;
+    private readonly Color[] _trackBarColors;
     private readonly ImageList _checkBoxList;
     private readonly ImageList _galleryButtonList;
     private readonly Image?[] _radioButtonArray;
@@ -681,7 +681,7 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
         }
         if (trackBarColors != null)
         {
-            _trackBarColours = trackBarColors;
+            _trackBarColors = trackBarColors;
         }
 
         // Get the font settings from the system
@@ -5396,14 +5396,14 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[1];
+                return _trackBarColors[1];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
                     PaletteState.Disabled => GlobalStaticValues.EMPTY_COLOR,
-                    _ => _trackBarColours[4]
+                    _ => _trackBarColors[4]
                 };
             default:
                 // Should never happen!
@@ -5432,9 +5432,9 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[2];
+                return _trackBarColors[2];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -5472,9 +5472,9 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -5514,14 +5514,14 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {
@@ -5563,14 +5563,14 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverLightMode.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
  *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *
  */
 #endregion
 
@@ -200,7 +200,7 @@ public class PaletteOffice2007SilverLightMode : PaletteOffice2007SilverLightMode
         Color.FromArgb(226, 229, 234), // RibbonGroupFrameInside2
         Color.FromArgb(220, 224, 231), // RibbonGroupFrameInside3
         Color.FromArgb(232, 234, 238), // RibbonGroupFrameInside4
-        Color.FromArgb(76, 83, 92), // RibbonGroupCollapsedText         
+        Color.FromArgb(76, 83, 92), // RibbonGroupCollapsedText
         Color.FromArgb(179, 185, 195), // AlternatePressedBack1
         Color.FromArgb(216, 224, 224), // AlternatePressedBack2
         Color.FromArgb(125, 125, 125), // AlternatePressedBorder1
@@ -214,38 +214,38 @@ public class PaletteOffice2007SilverLightMode : PaletteOffice2007SilverLightMode
         Color.FromArgb(210, 215, 221), // RibbonQATMini2
         Color.FromArgb(195, 200, 206), // RibbonQATMini3
         Color.FromArgb(10, Color.White), // RibbonQATMini4
-        Color.FromArgb(32, Color.White), // RibbonQATMini5                                                       
+        Color.FromArgb(32, Color.White), // RibbonQATMini5
         Color.FromArgb(200, 200, 200), // RibbonQATMini1I
         Color.FromArgb(233, 234, 238), // RibbonQATMini2I
         Color.FromArgb(223, 224, 228), // RibbonQATMini3I
         Color.FromArgb(10, Color.White), // RibbonQATMini4I
-        Color.FromArgb(32, Color.White), // RibbonQATMini5I                                                       
-        Color.FromArgb(217, 222, 230), // RibbonQATFullbar1                                                      
-        Color.FromArgb(214, 219, 227), // RibbonQATFullbar2                                                      
-        Color.FromArgb(194, 201, 212), // RibbonQATFullbar3                                                      
-        Color.FromArgb(103, 103, 103), // RibbonQATButtonDark                                                      
-        Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
-        Color.FromArgb(219, 218, 228), // RibbonQATOverflow1                                                      
-        Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-        Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark                                                      
-        Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight                                                      
-        Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1                                                      
-        Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2                                                      
-        Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1                                                      
-        Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2                                                      
-        Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor                                                    
-        Color.FromArgb(224, 225, 231), // GridListNormal1                                                    
-        Color.FromArgb(195, 198, 209), // GridListNormal2                                                    
-        Color.FromArgb(195, 198, 209), // GridListPressed1                                                    
-        Color.FromArgb(252, 253, 253), // GridListPressed2                                                    
-        Color.FromArgb(195, 198, 209), // GridListSelected                                                    
-        Color.FromArgb(224, 225, 231), // GridSheetColNormal1                                                    
-        Color.FromArgb(195, 198, 209), // GridSheetColNormal2                                                    
-        Color.FromArgb(208, 208, 208), // GridSheetColPressed1                                                    
-        Color.FromArgb(166, 166, 166), // GridSheetColPressed2                                                    
+        Color.FromArgb(32, Color.White), // RibbonQATMini5I
+        Color.FromArgb(217, 222, 230), // RibbonQATFullbar1
+        Color.FromArgb(214, 219, 227), // RibbonQATFullbar2
+        Color.FromArgb(194, 201, 212), // RibbonQATFullbar3
+        Color.FromArgb(103, 103, 103), // RibbonQATButtonDark
+        Color.FromArgb(225, 225, 225), // RibbonQATButtonLight
+        Color.FromArgb(219, 218, 228), // RibbonQATOverflow1
+        Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
+        Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark
+        Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight
+        Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1
+        Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2
+        Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1
+        Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2
+        Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor
+        Color.FromArgb(224, 225, 231), // GridListNormal1
+        Color.FromArgb(195, 198, 209), // GridListNormal2
+        Color.FromArgb(195, 198, 209), // GridListPressed1
+        Color.FromArgb(252, 253, 253), // GridListPressed2
+        Color.FromArgb(195, 198, 209), // GridListSelected
+        Color.FromArgb(224, 225, 231), // GridSheetColNormal1
+        Color.FromArgb(195, 198, 209), // GridSheetColNormal2
+        Color.FromArgb(208, 208, 208), // GridSheetColPressed1
+        Color.FromArgb(166, 166, 166), // GridSheetColPressed2
         Color.FromArgb(54, 64, 88), // GridSheetColSelected1
         Color.FromArgb(195, 198, 209), // GridSheetColSelected2
-        Color.FromArgb(231, 231, 231), // GridSheetRowNormal                                                   
+        Color.FromArgb(231, 231, 231), // GridSheetRowNormal
         Color.FromArgb(184, 191, 196), // GridSheetRowPressed
         Color.FromArgb(245, 199, 149), // GridSheetRowSelected
         Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -405,7 +405,7 @@ public class PaletteOffice2007SilverLightMode : PaletteOffice2007SilverLightMode
         },
         _ => base.GetButtonSpecImage(style, state)
     };
-    #endregion    
+    #endregion
 
     #region Tab Row Background
 
@@ -458,7 +458,7 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
     private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
     private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
     private static readonly Padding _contentPaddingCalendar = new Padding(2);
-    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
+    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);
     private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
     private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
     private static readonly Padding _contentPaddingButtonCalendar = new Padding(-1);
@@ -676,7 +676,7 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
     #region Instance Fields
     private KryptonColorTable2007SilverLightMode? _table;
     private readonly Color[] _ribbonColours;
-    private readonly Color[] _trackBarColours;
+    private readonly Color[] _trackBarColors;
     private readonly ImageList _checkBoxList;
     private readonly ImageList _galleryButtonList;
     private readonly Image?[] _radioButtonArray;
@@ -724,7 +724,7 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
         }
         if (trackBarColors != null)
         {
-            _trackBarColours = trackBarColors;
+            _trackBarColors = trackBarColors;
         }
 
         // Get the font settings from the system
@@ -5434,14 +5434,14 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[1];
+                return _trackBarColors[1];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
                     PaletteState.Disabled => GlobalStaticValues.EMPTY_COLOR,
-                    _ => _trackBarColours[4]
+                    _ => _trackBarColors[4]
                 };
             default:
                 // Should never happen!
@@ -5470,9 +5470,9 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[2];
+                return _trackBarColors[2];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -5510,9 +5510,9 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -5552,14 +5552,14 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {
@@ -5601,14 +5601,14 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Non Official Themes/PaletteOffice2007DarkGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Non Official Themes/PaletteOffice2007DarkGray.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
  *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *
  */
 #endregion
 
@@ -58,7 +58,7 @@ public class PaletteOffice2007DarkGray : PaletteOffice2007Base
 
     #region Colour Arrays
 
-    private static readonly Color[] _trackBarColours =
+    private static readonly Color[] _trackBarColors =
     [
         Color.FromArgb(130, 130, 130), // Tick marks
         Color.FromArgb(156, 160, 165), // Top track
@@ -196,7 +196,7 @@ public class PaletteOffice2007DarkGray : PaletteOffice2007Base
         Color.FromArgb(226, 229, 234), // RibbonGroupFrameInside2
         Color.FromArgb(220, 224, 231), // RibbonGroupFrameInside3
         Color.FromArgb(232, 234, 238), // RibbonGroupFrameInside4
-        Color.FromArgb(68, 68, 68), // RibbonGroupCollapsedText         
+        Color.FromArgb(68, 68, 68), // RibbonGroupCollapsedText
         Color.FromArgb(179, 185, 195), // AlternatePressedBack1
         Color.FromArgb(216, 224, 224), // AlternatePressedBack2
         Color.FromArgb(125, 125, 125), // AlternatePressedBorder1
@@ -210,38 +210,38 @@ public class PaletteOffice2007DarkGray : PaletteOffice2007Base
         Color.FromArgb(210, 215, 221), // RibbonQATMini2
         Color.FromArgb(195, 200, 206), // RibbonQATMini3
         Color.FromArgb(10, Color.White), // RibbonQATMini4
-        Color.FromArgb(32, Color.White), // RibbonQATMini5                                                       
+        Color.FromArgb(32, Color.White), // RibbonQATMini5
         Color.FromArgb(200, 200, 200), // RibbonQATMini1I
         Color.FromArgb(233, 234, 238), // RibbonQATMini2I
         Color.FromArgb(223, 224, 228), // RibbonQATMini3I
         Color.FromArgb(10, Color.White), // RibbonQATMini4I
-        Color.FromArgb(32, Color.White), // RibbonQATMini5I                                                       
-        Color.FromArgb(217, 222, 230), // RibbonQATFullbar1                                                      
-        Color.FromArgb(214, 219, 227), // RibbonQATFullbar2                                                      
-        Color.FromArgb(194, 201, 212), // RibbonQATFullbar3                                                      
-        Color.FromArgb(103, 103, 103), // RibbonQATButtonDark                                                      
-        Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
-        Color.FromArgb(219, 218, 228), // RibbonQATOverflow1                                                      
-        Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-        Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark                                                      
-        Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight                                                      
-        Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1                                                      
-        Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2                                                      
-        Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1                                                      
-        Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2                                                      
-        Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor                                                    
-        Color.White, // GridListNormal1                                                    
-        Color.FromArgb(212, 215, 219), // GridListNormal2                                                    
-        Color.FromArgb(210, 213, 218), // GridListPressed1                                                    
-        Color.FromArgb(252, 253, 253), // GridListPressed2                                                    
-        Color.FromArgb(186, 189, 194), // GridListSelected                                                    
-        Color.FromArgb(241, 243, 243), // GridSheetColNormal1                                                    
-        Color.FromArgb(200, 201, 202), // GridSheetColNormal2                                                    
-        Color.FromArgb(208, 208, 208), // GridSheetColPressed1                                                    
-        Color.FromArgb(166, 166, 166), // GridSheetColPressed2                                                    
+        Color.FromArgb(32, Color.White), // RibbonQATMini5I
+        Color.FromArgb(217, 222, 230), // RibbonQATFullbar1
+        Color.FromArgb(214, 219, 227), // RibbonQATFullbar2
+        Color.FromArgb(194, 201, 212), // RibbonQATFullbar3
+        Color.FromArgb(103, 103, 103), // RibbonQATButtonDark
+        Color.FromArgb(225, 225, 225), // RibbonQATButtonLight
+        Color.FromArgb(219, 218, 228), // RibbonQATOverflow1
+        Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
+        Color.FromArgb(173, 177, 181), // RibbonGroupSeparatorDark
+        Color.FromArgb(232, 235, 237), // RibbonGroupSeparatorLight
+        Color.FromArgb(231, 234, 238), // ButtonClusterButtonBack1
+        Color.FromArgb(241, 243, 243), // ButtonClusterButtonBack2
+        Color.FromArgb(197, 198, 199), // ButtonClusterButtonBorder1
+        Color.FromArgb(157, 158, 159), // ButtonClusterButtonBorder2
+        Color.FromArgb(238, 238, 244), // NavigatorMiniBackColor
+        Color.White, // GridListNormal1
+        Color.FromArgb(212, 215, 219), // GridListNormal2
+        Color.FromArgb(210, 213, 218), // GridListPressed1
+        Color.FromArgb(252, 253, 253), // GridListPressed2
+        Color.FromArgb(186, 189, 194), // GridListSelected
+        Color.FromArgb(241, 243, 243), // GridSheetColNormal1
+        Color.FromArgb(200, 201, 202), // GridSheetColNormal2
+        Color.FromArgb(208, 208, 208), // GridSheetColPressed1
+        Color.FromArgb(166, 166, 166), // GridSheetColPressed2
         Color.FromArgb(255, 204, 153), // GridSheetColSelected1
         Color.FromArgb(255, 155, 104), // GridSheetColSelected2
-        Color.FromArgb(231, 231, 231), // GridSheetRowNormal                                                   
+        Color.FromArgb(231, 231, 231), // GridSheetRowNormal
         Color.FromArgb(184, 191, 196), // GridSheetRowPressed
         Color.FromArgb(245, 199, 149), // GridSheetRowSelected
         Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -323,7 +323,7 @@ public class PaletteOffice2007DarkGray : PaletteOffice2007Base
     }
 
     /// <summary>Initializes a new instance of the <see cref="PaletteOffice2007DarkGray" /> class.</summary>
-    public PaletteOffice2007DarkGray() : base(_themeName, _schemeOfficeColours, _checkBoxList, _galleryButtonList, _radioButtonArray, _trackBarColours)
+    public PaletteOffice2007DarkGray() : base(_themeName, _schemeOfficeColours, _checkBoxList, _galleryButtonList, _radioButtonArray, _trackBarColors)
     {
 
     }
@@ -399,7 +399,7 @@ public class PaletteOffice2007DarkGray : PaletteOffice2007Base
         },
         _ => base.GetButtonSpecImage(style, state)
     };
-    #endregion    
+    #endregion
 
     #region Tab Row Background
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlackDarkMode.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
  *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *
  */
 #endregion
 
@@ -239,38 +239,38 @@ public class PaletteOffice2010BlackDarkMode : PaletteOffice2010BlackDarkModeBase
         Color.FromArgb(140, 140, 140), // RibbonQATMini3I
         Color.FromArgb(12, Color.White), // RibbonQATMini4I
         Color.FromArgb(14, Color.White), // RibbonQATMini5I
-        Color.FromArgb(141, 144, 147), // RibbonQATFullbar1                                                      
-        Color.FromArgb(133, 135, 137), // RibbonQATFullbar2                                                      
-        Color.FromArgb(93, 96, 100), // RibbonQATFullbar3                                                      
-        Color.FromArgb(103, 103, 103), // RibbonQATButtonDark                                                      
-        Color.FromArgb(225, 225, 225), // RibbonQATButtonLight                                                      
-        Color.FromArgb(118, 128, 142), // RibbonQATOverflow1                                                      
-        Color.FromArgb(55, 60, 67), // RibbonQATOverflow2                                                      
+        Color.FromArgb(141, 144, 147), // RibbonQATFullbar1
+        Color.FromArgb(133, 135, 137), // RibbonQATFullbar2
+        Color.FromArgb(93, 96, 100), // RibbonQATFullbar3
+        Color.FromArgb(103, 103, 103), // RibbonQATButtonDark
+        Color.FromArgb(225, 225, 225), // RibbonQATButtonLight
+        Color.FromArgb(118, 128, 142), // RibbonQATOverflow1
+        Color.FromArgb(55, 60, 67), // RibbonQATOverflow2
         Color.FromArgb(163, 168,
-            170), // RibbonGroupSeparatorDark                                                      
+            170), // RibbonGroupSeparatorDark
         Color.FromArgb(230, 233,
-            235), // RibbonGroupSeparatorLight                                                      
+            235), // RibbonGroupSeparatorLight
         Color.FromArgb(210, 217,
-            219), // ButtonClusterButtonBack1                                                      
+            219), // ButtonClusterButtonBack1
         Color.FromArgb(214, 222,
-            223), // ButtonClusterButtonBack2                                                      
+            223), // ButtonClusterButtonBack2
         Color.FromArgb(179, 188,
-            191), // ButtonClusterButtonBorder1                                                      
+            191), // ButtonClusterButtonBorder1
         Color.FromArgb(145, 156,
-            159), // ButtonClusterButtonBorder2                                                      
-        Color.FromArgb(235, 235, 235), // NavigatorMiniBackColor                                                    
-        Color.FromArgb(10, 10, 10), // GridListNormal1                                                    
-        Color.FromArgb(41, 41, 41), // GridListNormal2                                                    
-        Color.FromArgb(41, 41, 41), // GridListPressed1                                                    
-        Color.FromArgb(61, 61, 61), // GridListPressed2                                                    
-        Color.FromArgb(33, 33, 33), // GridListSelected                                                    
-        Color.FromArgb(10, 10, 10), // GridSheetColNormal1                                                    
-        Color.FromArgb(41, 41, 41), // GridSheetColNormal2                                                    
-        Color.FromArgb(224, 224, 224), // GridSheetColPressed1                                                    
-        Color.FromArgb(195, 195, 195), // GridSheetColPressed2                                                    
+            159), // ButtonClusterButtonBorder2
+        Color.FromArgb(235, 235, 235), // NavigatorMiniBackColor
+        Color.FromArgb(10, 10, 10), // GridListNormal1
+        Color.FromArgb(41, 41, 41), // GridListNormal2
+        Color.FromArgb(41, 41, 41), // GridListPressed1
+        Color.FromArgb(61, 61, 61), // GridListPressed2
+        Color.FromArgb(33, 33, 33), // GridListSelected
+        Color.FromArgb(10, 10, 10), // GridSheetColNormal1
+        Color.FromArgb(41, 41, 41), // GridSheetColNormal2
+        Color.FromArgb(224, 224, 224), // GridSheetColPressed1
+        Color.FromArgb(195, 195, 195), // GridSheetColPressed2
         Color.FromArgb(91, 91, 91), // GridSheetColSelected1
         Color.FromArgb(33, 33, 33), // GridSheetColSelected2
-        Color.FromArgb(237, 237, 237), // GridSheetRowNormal                                                   
+        Color.FromArgb(237, 237, 237), // GridSheetRowNormal
         Color.FromArgb(196, 196, 196), // GridSheetRowPressed
         Color.FromArgb(61, 61, 61), // GridSheetRowSelected
         Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -322,7 +322,7 @@ public class PaletteOffice2010BlackDarkMode : PaletteOffice2010BlackDarkModeBase
         Color.FromArgb(148, 148, 143), // ButtonNavigatorPressed2
         Color.FromArgb(91, 91, 91), // ButtonNavigatorChecked1
         Color.FromArgb(73, 73, 73), // ButtonNavigatorChecked2
-        Color.FromArgb(91, 91, 91) // ToolTipBottom                                                                      
+        Color.FromArgb(91, 91, 91) // ToolTipBottom
     ];
 
     #endregion
@@ -831,7 +831,7 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
     private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
     private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
     private static readonly Padding _contentPaddingCalendar = new Padding(2);
-    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
+    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);
     private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
     private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
     private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -1026,7 +1026,7 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
     #region Instance Fields
     private KryptonColorTable2010BlackDarkMode? _table;
     private readonly Color[] _ribbonColours;
-    private readonly Color[] _trackBarColours;
+    private readonly Color[] _trackBarColors;
     private readonly ImageList _checkBoxList;
     private readonly ImageList _galleryButtonList;
     private readonly Image?[] _radioButtonArray;
@@ -1074,7 +1074,7 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
         }
         if (trackBarColors != null)
         {
-            _trackBarColours = trackBarColors;
+            _trackBarColors = trackBarColors;
         }
 
         // Get the font settings from the system
@@ -5011,14 +5011,14 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[1];
+                return _trackBarColors[1];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
                     PaletteState.Disabled => GlobalStaticValues.EMPTY_COLOR,
-                    _ => _trackBarColours[4]
+                    _ => _trackBarColors[4]
                 };
             default:
                 // Should never happen!
@@ -5046,9 +5046,9 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[2];
+                return _trackBarColors[2];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -5084,9 +5084,9 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -5125,14 +5125,14 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {
@@ -5173,14 +5173,14 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueDarkMode.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
  *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *
  */
 #endregion
 
@@ -233,38 +233,38 @@ public class PaletteOffice2010BlueDarkMode : PaletteOffice2010BlueDarkModeBase
         Color.FromArgb(219, 231, 247), // RibbonQATMini2
         Color.FromArgb(195, 213, 236), // RibbonQATMini3
         Color.FromArgb(128, Color.White), // RibbonQATMini4
-        Color.FromArgb(72, Color.White), // RibbonQATMini5                                                       
+        Color.FromArgb(72, Color.White), // RibbonQATMini5
         Color.FromArgb(153, 176, 206), // RibbonQATMini1I
         Color.FromArgb(226, 233, 241), // RibbonQATMini2I
         Color.FromArgb(198, 210, 226), // RibbonQATMini3I
         Color.FromArgb(128, Color.White), // RibbonQATMini4I
-        Color.FromArgb(72, Color.White), // RibbonQATMini5I                                                      
-        Color.FromArgb(178, 205, 237), // RibbonQATFullbar1                                                      
-        Color.FromArgb(170, 197, 234), // RibbonQATFullbar2                                                      
-        Color.FromArgb(126, 161, 205), // RibbonQATFullbar3                                                      
-        Color.FromArgb(86, 125, 177), // RibbonQATButtonDark                                                      
-        Color.FromArgb(234, 242, 249), // RibbonQATButtonLight                                                      
-        Color.FromArgb(192, 220, 255), // RibbonQATOverflow1                                                      
-        Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
-        Color.FromArgb(140, 172, 211), // RibbonGroupSeparatorDark                                                      
-        Color.FromArgb(248, 250, 252), // RibbonGroupSeparatorLight                                                      
-        Color.FromArgb(192, 212, 241), // ButtonClusterButtonBack1                                                      
-        Color.FromArgb(200, 219, 238), // ButtonClusterButtonBack2                                                      
-        Color.FromArgb(155, 183, 224), // ButtonClusterButtonBorder1                                                      
-        Color.FromArgb(117, 150, 191), // ButtonClusterButtonBorder2                                                      
-        Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor                                                    
-        Color.FromArgb(134, 179, 236), // GridListNormal1                                                    
-        Color.FromArgb(63, 122, 197), // GridListNormal2                                                    
-        Color.FromArgb(63, 122, 197), // GridListPressed1                                                    
-        Color.FromArgb(252, 253, 255), // GridListPressed2                                                    
-        Color.FromArgb(170, 195, 240), // GridListSelected                                                    
-        Color.FromArgb(134, 179, 236), // GridSheetColNormal1                                                    
-        Color.FromArgb(63, 122, 197), // GridSheetColNormal2                                                    
-        Color.FromArgb(223, 226, 228), // GridSheetColPressed1                                                    
-        Color.FromArgb(188, 197, 210), // GridSheetColPressed2                                                    
+        Color.FromArgb(72, Color.White), // RibbonQATMini5I
+        Color.FromArgb(178, 205, 237), // RibbonQATFullbar1
+        Color.FromArgb(170, 197, 234), // RibbonQATFullbar2
+        Color.FromArgb(126, 161, 205), // RibbonQATFullbar3
+        Color.FromArgb(86, 125, 177), // RibbonQATButtonDark
+        Color.FromArgb(234, 242, 249), // RibbonQATButtonLight
+        Color.FromArgb(192, 220, 255), // RibbonQATOverflow1
+        Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
+        Color.FromArgb(140, 172, 211), // RibbonGroupSeparatorDark
+        Color.FromArgb(248, 250, 252), // RibbonGroupSeparatorLight
+        Color.FromArgb(192, 212, 241), // ButtonClusterButtonBack1
+        Color.FromArgb(200, 219, 238), // ButtonClusterButtonBack2
+        Color.FromArgb(155, 183, 224), // ButtonClusterButtonBorder1
+        Color.FromArgb(117, 150, 191), // ButtonClusterButtonBorder2
+        Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor
+        Color.FromArgb(134, 179, 236), // GridListNormal1
+        Color.FromArgb(63, 122, 197), // GridListNormal2
+        Color.FromArgb(63, 122, 197), // GridListPressed1
+        Color.FromArgb(252, 253, 255), // GridListPressed2
+        Color.FromArgb(170, 195, 240), // GridListSelected
+        Color.FromArgb(134, 179, 236), // GridSheetColNormal1
+        Color.FromArgb(63, 122, 197), // GridSheetColNormal2
+        Color.FromArgb(223, 226, 228), // GridSheetColPressed1
+        Color.FromArgb(188, 197, 210), // GridSheetColPressed2
         Color.FromArgb(249, 217, 159), // GridSheetColSelected1
         Color.FromArgb(241, 193, 95), // GridSheetColSelected2
-        Color.FromArgb(228, 236, 247), // GridSheetRowNormal                                                   
+        Color.FromArgb(228, 236, 247), // GridSheetRowNormal
         Color.FromArgb(187, 196, 209), // GridSheetRowPressed
         Color.FromArgb(255, 213, 141), // GridSheetRowSelected
         Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -318,7 +318,7 @@ public class PaletteOffice2010BlueDarkMode : PaletteOffice2010BlueDarkModeBase
         Color.FromArgb(198, 214, 231), // ButtonNavigatorPressed2
         Color.FromArgb(200, 219, 240), // ButtonNavigatorChecked1
         Color.FromArgb(177, 201, 228), // ButtonNavigatorChecked2
-        Color.FromArgb(201, 217, 239) // ToolTipBottom                                                                      
+        Color.FromArgb(201, 217, 239) // ToolTipBottom
     ];
 
     #endregion
@@ -477,7 +477,7 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
     private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
     private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
     private static readonly Padding _contentPaddingCalendar = new Padding(2);
-    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
+    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);
     private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
     private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
     private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -671,7 +671,7 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
     #region Instance Fields
     private KryptonColorTable2010BlueDarkMode? _table;
     private readonly Color[] _ribbonColours;
-    private readonly Color[] _trackBarColours;
+    private readonly Color[] _trackBarColors;
     private readonly ImageList _checkBoxList;
     private readonly ImageList _galleryButtonList;
     private readonly Image?[] _radioButtonArray;
@@ -718,7 +718,7 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
         }
         if (trackBarColors != null)
         {
-            _trackBarColours = trackBarColors;
+            _trackBarColors = trackBarColors;
         }
 
         // Get the font settings from the system
@@ -4633,14 +4633,14 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[1];
+                return _trackBarColors[1];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
                     PaletteState.Disabled => GlobalStaticValues.EMPTY_COLOR,
-                    _ => _trackBarColours[4]
+                    _ => _trackBarColors[4]
                 };
             default:
                 // Should never happen!
@@ -4668,9 +4668,9 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[2];
+                return _trackBarColors[2];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -4706,9 +4706,9 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -4747,14 +4747,14 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {
@@ -4795,14 +4795,14 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueLightMode.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
  *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *
  */
 #endregion
 
@@ -238,44 +238,44 @@ public class PaletteOffice2010BlueLightMode : PaletteOffice2010BlueLightModeBase
         Color.FromArgb(219, 231, 247), // RibbonQATMini2
         Color.FromArgb(195, 213, 236), // RibbonQATMini3
         Color.FromArgb(128, Color.White), // RibbonQATMini4
-        Color.FromArgb(72, Color.White), // RibbonQATMini5                                                       
+        Color.FromArgb(72, Color.White), // RibbonQATMini5
         Color.FromArgb(153, 176, 206), // RibbonQATMini1I
         Color.FromArgb(226, 233, 241), // RibbonQATMini2I
         Color.FromArgb(198, 210, 226), // RibbonQATMini3I
         Color.FromArgb(128, Color.White), // RibbonQATMini4I
-        Color.FromArgb(72, Color.White), // RibbonQATMini5I                                                      
-        Color.FromArgb(178, 205, 237), // RibbonQATFullbar1                                                      
-        Color.FromArgb(170, 197, 234), // RibbonQATFullbar2                                                      
-        Color.FromArgb(126, 161, 205), // RibbonQATFullbar3                                                      
-        Color.FromArgb(86, 125, 177), // RibbonQATButtonDark                                                      
-        Color.FromArgb(234, 242, 249), // RibbonQATButtonLight                                                      
-        Color.FromArgb(192, 220, 255), // RibbonQATOverflow1                                                      
-        Color.FromArgb(55, 100, 160), // RibbonQATOverflow2                                                      
+        Color.FromArgb(72, Color.White), // RibbonQATMini5I
+        Color.FromArgb(178, 205, 237), // RibbonQATFullbar1
+        Color.FromArgb(170, 197, 234), // RibbonQATFullbar2
+        Color.FromArgb(126, 161, 205), // RibbonQATFullbar3
+        Color.FromArgb(86, 125, 177), // RibbonQATButtonDark
+        Color.FromArgb(234, 242, 249), // RibbonQATButtonLight
+        Color.FromArgb(192, 220, 255), // RibbonQATOverflow1
+        Color.FromArgb(55, 100, 160), // RibbonQATOverflow2
         Color.FromArgb(140, 172,
-            211), // RibbonGroupSeparatorDark                                                      
+            211), // RibbonGroupSeparatorDark
         Color.FromArgb(248, 250,
-            252), // RibbonGroupSeparatorLight                                                      
+            252), // RibbonGroupSeparatorLight
         Color.FromArgb(192, 212,
-            241), // ButtonClusterButtonBack1                                                      
+            241), // ButtonClusterButtonBack1
         Color.FromArgb(200, 219,
-            238), // ButtonClusterButtonBack2                                                      
+            238), // ButtonClusterButtonBack2
         Color.FromArgb(155, 183,
-            224), // ButtonClusterButtonBorder1                                                      
+            224), // ButtonClusterButtonBorder1
         Color.FromArgb(117, 150,
-            191), // ButtonClusterButtonBorder2                                                      
-        Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor                                                    
-        Color.FromArgb(230, 239, 249), // GridListNormal1                                                    
-        Color.FromArgb(209, 226, 244), // GridListNormal2                                                    
-        Color.FromArgb(209, 226, 244), // GridListPressed1                                                    
-        Color.FromArgb(252, 253, 255), // GridListPressed2                                                    
-        Color.FromArgb(168, 200, 234), // GridListSelected                                                    
-        Color.FromArgb(230, 239, 249), // GridSheetColNormal1                                                    
-        Color.FromArgb(209, 226, 244), // GridSheetColNormal2                                                    
-        Color.FromArgb(223, 226, 228), // GridSheetColPressed1                                                    
-        Color.FromArgb(188, 197, 210), // GridSheetColPressed2                                                    
+            191), // ButtonClusterButtonBorder2
+        Color.FromArgb(213, 228, 242), // NavigatorMiniBackColor
+        Color.FromArgb(230, 239, 249), // GridListNormal1
+        Color.FromArgb(209, 226, 244), // GridListNormal2
+        Color.FromArgb(209, 226, 244), // GridListPressed1
+        Color.FromArgb(252, 253, 255), // GridListPressed2
+        Color.FromArgb(168, 200, 234), // GridListSelected
+        Color.FromArgb(230, 239, 249), // GridSheetColNormal1
+        Color.FromArgb(209, 226, 244), // GridSheetColNormal2
+        Color.FromArgb(223, 226, 228), // GridSheetColPressed1
+        Color.FromArgb(188, 197, 210), // GridSheetColPressed2
         Color.FromArgb(188, 213, 239), // GridSheetColSelected1
         Color.FromArgb(168, 200, 234), // GridSheetColSelected2
-        Color.FromArgb(228, 236, 247), // GridSheetRowNormal                                                   
+        Color.FromArgb(228, 236, 247), // GridSheetRowNormal
         Color.FromArgb(187, 196, 209), // GridSheetRowPressed
         Color.FromArgb(255, 213, 141), // GridSheetRowSelected
         Color.FromArgb(188, 195, 209), // GridDataCellBorder
@@ -330,7 +330,7 @@ public class PaletteOffice2010BlueLightMode : PaletteOffice2010BlueLightModeBase
         Color.FromArgb(200, 219, 240), // ButtonNavigatorChecked1
         Color.FromArgb(177, 201, 228), // ButtonNavigatorChecked2
         Color.FromArgb(201, 217,
-            239) // ToolTipBottom                                                                      
+            239) // ToolTipBottom
     ];
 
     #endregion
@@ -489,7 +489,7 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
     private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
     private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
     private static readonly Padding _contentPaddingCalendar = new Padding(2);
-    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
+    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);
     private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
     private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
     private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -661,7 +661,7 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
     #region Instance Fields
     private KryptonColorTable2010BlueLightMode? _table;
     private readonly Color[] _ribbonColours;
-    private readonly Color[] _trackBarColours;
+    private readonly Color[] _trackBarColors;
     private readonly ImageList _checkBoxList;
     private readonly ImageList _galleryButtonList;
     private readonly Image?[] _radioButtonArray;
@@ -708,7 +708,7 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
         }
         if (trackBarColors != null)
         {
-            _trackBarColours = trackBarColors;
+            _trackBarColors = trackBarColors;
         }
 
         // Get the font settings from the system
@@ -4623,14 +4623,14 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[1];
+                return _trackBarColors[1];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
                     PaletteState.Disabled => GlobalStaticValues.EMPTY_COLOR,
-                    _ => _trackBarColours[4]
+                    _ => _trackBarColors[4]
                 };
             default:
                 // Should never happen!
@@ -4658,9 +4658,9 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[2];
+                return _trackBarColors[2];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -4696,9 +4696,9 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -4737,14 +4737,14 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {
@@ -4785,14 +4785,14 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/PaletteVisualStudioBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/PaletteVisualStudioBase.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
  *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *
  */
 #endregion
 
@@ -25,7 +25,7 @@ public abstract class PaletteVisualStudioBase : PaletteBase
     private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
     private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
     private static readonly Padding _contentPaddingCalendar = new Padding(2);
-    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
+    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);
     private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
     private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
     private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -222,7 +222,7 @@ public abstract class PaletteVisualStudioBase : PaletteBase
 
     private readonly Color[] _ribbonColours;
 
-    private readonly Color[] _trackBarColours;
+    private readonly Color[] _trackBarColors;
     private readonly ImageList _checkBoxList;
     private readonly ImageList _galleryButtonList;
     private readonly Image?[] _radioButtonArray;
@@ -272,7 +272,7 @@ public abstract class PaletteVisualStudioBase : PaletteBase
 
         if (trackBarColours != null)
         {
-            _trackBarColours = trackBarColours;
+            _trackBarColors = trackBarColours;
         }
 
         DefineFonts();
@@ -280,7 +280,7 @@ public abstract class PaletteVisualStudioBase : PaletteBase
 
     #endregion
 
-    #region Renderer        
+    #region Renderer
     /// <summary>Gets the renderer to use for this palette.</summary>
     /// <returns> Renderer to use for drawing palette settings.</returns>
     public override IRenderer GetRenderer() => KryptonManager.RenderVisualStudio;
@@ -3264,14 +3264,14 @@ public abstract class PaletteVisualStudioBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[1];
+                return _trackBarColors[1];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
                     PaletteState.Disabled => GlobalStaticValues.EMPTY_COLOR,
-                    _ => _trackBarColours[4]
+                    _ => _trackBarColors[4]
                 };
             default:
                 // Should never happen!
@@ -3299,9 +3299,9 @@ public abstract class PaletteVisualStudioBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[2];
+                return _trackBarColors[2];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -3337,9 +3337,9 @@ public abstract class PaletteVisualStudioBase : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -3378,14 +3378,14 @@ public abstract class PaletteVisualStudioBase : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {
@@ -3426,14 +3426,14 @@ public abstract class PaletteVisualStudioBase : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2007/PaletteVisualStudio2010With2007Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2007/PaletteVisualStudio2010With2007Base.cs
@@ -1,9 +1,9 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -22,7 +22,7 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
     private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
     private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
     private static readonly Padding _contentPaddingCalendar = new Padding(2);
-    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
+    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);
     private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
     private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
     private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -220,7 +220,7 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
 
     private readonly Color[] _ribbonColours;
 
-    private readonly Color[] _trackBarColours;
+    private readonly Color[] _trackBarColors;
     private readonly ImageList _checkBoxList;
     private readonly ImageList _galleryButtonList;
     private readonly Image?[] _radioButtonArray;
@@ -269,7 +269,7 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
 
         if (trackBarColours != null)
         {
-            _trackBarColours = trackBarColours;
+            _trackBarColors = trackBarColours;
         }
 
         DefineFonts();
@@ -4055,14 +4055,14 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[1];
+                return _trackBarColors[1];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
                     PaletteState.Disabled => GlobalStaticValues.EMPTY_COLOR,
-                    _ => _trackBarColours[4]
+                    _ => _trackBarColors[4]
                 };
             default:
                 // Should never happen!
@@ -4090,9 +4090,9 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[2];
+                return _trackBarColors[2];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -4128,9 +4128,9 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -4169,14 +4169,14 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {
@@ -4217,14 +4217,14 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2010/PaletteVisualStudio2010With2010Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2010/PaletteVisualStudio2010With2010Base.cs
@@ -1,9 +1,9 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -22,7 +22,7 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
     private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
     private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
     private static readonly Padding _contentPaddingCalendar = new Padding(2);
-    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
+    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);
     private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
     private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
     private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -221,7 +221,7 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
 
     private readonly Color[] _ribbonColours;
 
-    private readonly Color[] _trackBarColours;
+    private readonly Color[] _trackBarColors;
     private readonly ImageList _checkBoxList;
     private readonly ImageList _galleryButtonList;
     private readonly Image?[] _radioButtonArray;
@@ -270,7 +270,7 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
 
         if (trackBarColours != null)
         {
-            _trackBarColours = trackBarColours;
+            _trackBarColors = trackBarColours;
         }
 
         DefineFonts();
@@ -4056,14 +4056,14 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[1];
+                return _trackBarColors[1];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
                     PaletteState.Disabled => GlobalStaticValues.EMPTY_COLOR,
-                    _ => _trackBarColours[4]
+                    _ => _trackBarColors[4]
                 };
             default:
                 // Should never happen!
@@ -4091,9 +4091,9 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[2];
+                return _trackBarColors[2];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -4129,9 +4129,9 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -4170,14 +4170,14 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {
@@ -4218,14 +4218,14 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2013/PaletteVisualStudio2010With2013Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2013/PaletteVisualStudio2010With2013Base.cs
@@ -1,9 +1,9 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -22,7 +22,7 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
     private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
     private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
     private static readonly Padding _contentPaddingCalendar = new Padding(2);
-    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
+    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);
     private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
     private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
     private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -219,7 +219,7 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
 
     private readonly Color[] _ribbonColours;
 
-    private readonly Color[] _trackBarColours;
+    private readonly Color[] _trackBarColors;
     private readonly ImageList _checkBoxList;
     private readonly ImageList _galleryButtonList;
     private readonly Image?[] _radioButtonArray;
@@ -268,7 +268,7 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
 
         if (trackBarColours != null)
         {
-            _trackBarColours = trackBarColours;
+            _trackBarColors = trackBarColours;
         }
 
         DefineFonts();
@@ -276,7 +276,7 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
 
     #endregion
 
-    #region Renderer        
+    #region Renderer
     /// <summary>Gets the renderer to use for this palette.</summary>
     /// <returns> Renderer to use for drawing palette settings.</returns>
     public override IRenderer GetRenderer() => KryptonManager.RenderVisualStudio2010With2013;
@@ -4053,14 +4053,14 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[1];
+                return _trackBarColors[1];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
                     PaletteState.Disabled => GlobalStaticValues.EMPTY_COLOR,
-                    _ => _trackBarColours[4]
+                    _ => _trackBarColors[4]
                 };
             default:
                 // Should never happen!
@@ -4088,9 +4088,9 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[2];
+                return _trackBarColors[2];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -4126,9 +4126,9 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -4167,14 +4167,14 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {
@@ -4215,14 +4215,14 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/365/PaletteVisualStudio2010With365Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/365/PaletteVisualStudio2010With365Base.cs
@@ -1,9 +1,9 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -22,7 +22,7 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
     private static readonly Padding _contentPaddingHeader2 = new Padding(2, 1, 2, 1);
     private static readonly Padding _contentPaddingDock = new Padding(2, 2, 2, 1);
     private static readonly Padding _contentPaddingCalendar = new Padding(2);
-    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);         
+    //private static readonly Padding _contentPaddingHeaderForm = new Padding(owningForm!.RealWindowBorders.Left, owningForm!.RealWindowBorders.Bottom / 2, 0, 0);
     private static readonly Padding _contentPaddingLabel = new Padding(3, 1, 3, 1);
     private static readonly Padding _contentPaddingLabel2 = new Padding(8, 2, 8, 2);
     private static readonly Padding _contentPaddingButtonInputControl = new Padding(0);
@@ -220,7 +220,7 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
 
     private readonly Color[] _ribbonColours;
 
-    private readonly Color[] _trackBarColours;
+    private readonly Color[] _trackBarColors;
     private readonly ImageList _checkBoxList;
     private readonly ImageList _galleryButtonList;
     private readonly Image?[] _radioButtonArray;
@@ -269,7 +269,7 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
 
         if (trackBarColours != null)
         {
-            _trackBarColours = trackBarColours;
+            _trackBarColors = trackBarColours;
         }
 
         DefineFonts();
@@ -4055,14 +4055,14 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[1];
+                return _trackBarColors[1];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
                     PaletteState.Disabled => GlobalStaticValues.EMPTY_COLOR,
-                    _ => _trackBarColours[4]
+                    _ => _trackBarColors[4]
                 };
             default:
                 // Should never happen!
@@ -4090,9 +4090,9 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[2];
+                return _trackBarColors[2];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -4128,9 +4128,9 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
         switch (element)
         {
             case PaletteElement.TrackBarTick:
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 return state switch
                 {
@@ -4169,14 +4169,14 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {
@@ -4217,14 +4217,14 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[0];
+                return _trackBarColors[0];
             case PaletteElement.TrackBarTrack:
                 if (CommonHelper.IsOverrideState(state))
                 {
                     return GlobalStaticValues.EMPTY_COLOR;
                 }
 
-                return _trackBarColours[3];
+                return _trackBarColors[3];
             case PaletteElement.TrackBarPosition:
                 if (CommonHelper.IsOverrideStateExclude(state, PaletteState.FocusOverride))
                 {


### PR DESCRIPTION
Refactor _trackBarColours to _trackBarColors for consistency across palette classes.

Fixes #2305 

Purely internal rename changes, no breaking code or public API.

No changelog entry needed.

<img width="1041" height="430" alt="{D96B2553-5204-48D9-9CE0-E84215B437CA}" src="https://github.com/user-attachments/assets/4fc17d24-3cf3-44bc-98ab-566a6a033b09" />
