### PR TITLE
2309-V100-KryptonDataGridViewImageColumn-causes-lagging-in-grid-refresh

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 ==== 
 
 ## 2025-11-xx - Build 2511 (V10 - alpha) - November 2025
+* Resolved [#2309](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2309), `KryptonDataGridViewImageColumn` causes lagging in grid refresh when a new row is auto added.
 * Resolved [#2235](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2235), `OSUtilities` Adds OsVersionInfo to the properties.
 * Resolved [#2264](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2264), Implementation of style: `PaletteBackStyle.Control`, `PaletteContentStyle.LabelAlternateControl` and `PaletteContentStyle.LabelAlternatePanel` in all themes
 * Resolved [#2200](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2200), `KryptonAutoHiddenSlidePanel.PreFilterMessage` will now use the ActiveFormTracker.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewImageColumn.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridViewImageColumn.cs
@@ -39,16 +39,16 @@ public class KryptonDataGridViewImageColumn : DataGridViewImageColumn, IIconCell
     #region IIconCell implementation
     protected override void OnDataGridViewChanged()
     {
-        IconSpecs.CollectionChanged -= OnIconSpecsCollectionChanged;
-
         // KDGV needs a column refresh only
         if (DataGridView is KryptonDataGridView dataGridView)
         {
             _dataGridView = dataGridView;
             IconSpecs.CollectionChanged += OnIconSpecsCollectionChanged;
         }
-        else
+        else if (_dataGridView is not null)
         {
+            // only unhook on KDGV type
+            IconSpecs.CollectionChanged -= OnIconSpecsCollectionChanged;
             _dataGridView = null;
         }
 
@@ -68,7 +68,7 @@ public class KryptonDataGridViewImageColumn : DataGridViewImageColumn, IIconCell
     /// <summary>
     /// Create a cloned copy of the column.
     /// </summary>
-    /// <returns></returns>
+    /// <returns>The cloned object.</returns>
     public override object Clone()
     {
         var cloned = base.Clone() as KryptonDataGridViewImageColumn ?? throw new NullReferenceException(GlobalStaticValues.VariableCannotBeNull("cloned"));


### PR DESCRIPTION
[Issue 2309-KryptonDataGridViewImageColumn-causes-lagging-in-grid-refresh](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2309)
- Grid refresh restored
- And the change log

<img width="247" height="158" alt="compile-results" src="https://github.com/user-attachments/assets/f5789acf-e947-4423-9f13-d1e4859e7637" />
