### PR TITLE
2178-V100-Fix-KryptonPropertyGrid-Reset-menu-item

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 ====
 
 ## 2025-11-xx - Build 2511 (V10 - alpha) - November 2025
+* Resolved [#2178](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2178), Fix `KryptonPropertyGrid` enabling logic for `Reset` menu-item
 * Resolved [#2309](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2309), `KryptonDataGridViewImageColumn` causes lagging in grid refresh when a new row is auto added.
 * Resolved [#2296](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2296), Fix `Visual Controls' components from showing blank content.
 * Resolved [#2299](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2299), Fix memory leak in PaletteBase

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPropertyGrid.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPropertyGrid.cs
@@ -53,7 +53,7 @@ public class KryptonPropertyGrid : VisualControlBase,
         }
 
         /// <summary>
-        /// Releases all resources used by the Control. 
+        /// Releases all resources used by the Control.
         /// </summary>
         /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
         protected override void Dispose(bool disposing)
@@ -116,7 +116,7 @@ public class KryptonPropertyGrid : VisualControlBase,
             switch (m.Msg)
             {
                 case PI.WM_.ERASEBKGND:
-                    // Do not draw the background here, always do it in the paint 
+                    // Do not draw the background here, always do it in the paint
                     // instead to prevent flicker because of a two stage drawing process
                     break;
 
@@ -162,7 +162,7 @@ public class KryptonPropertyGrid : VisualControlBase,
                 {
                     try
                     {
-                        // Must use the screen device context for the bitmap when drawing into the 
+                        // Must use the screen device context for the bitmap when drawing into the
                         // bitmap otherwise the Opacity and RightToLeftLayout will not work correctly.
                         PI.SelectObject(_screenDC, hBitmap);
 
@@ -256,7 +256,7 @@ public class KryptonPropertyGrid : VisualControlBase,
     {
         // Contains another control and needs marking as such for validation to work
         SetStyle(ControlStyles.ContainerControl, true);
-        // Cannot select this control, only the child tree view and does not generate a 
+        // Cannot select this control, only the child tree view and does not generate a
         SetStyle(ControlStyles.Selectable | ControlStyles.StandardClick, false);
 
         // Default fields
@@ -315,8 +315,6 @@ public class KryptonPropertyGrid : VisualControlBase,
         menuItems.Items.Add(_resetMenuItem);
 
         KryptonContextMenu.Items.Add(menuItems);
-
-        _propertyGrid.MouseDown += PropertyGrid_MouseDown;
     }
 
     /// <summary>
@@ -705,7 +703,7 @@ public class KryptonPropertyGrid : VisualControlBase,
         switch (m.Msg)
         {
             case PI.WM_.ERASEBKGND:
-                // Do not draw the background here, always do it in the paint 
+                // Do not draw the background here, always do it in the paint
                 // instead to prevent flicker because of a two stage drawing process
                 break;
 
@@ -742,6 +740,10 @@ public class KryptonPropertyGrid : VisualControlBase,
                     // If the mouse position is within our client area
                     if (ClientRectangle.Contains(mousePt))
                     {
+                        // Update reset menu item enabled/text state just before showing menu
+                        bool canReset = CanResetCurrentProperty();
+                        _resetMenuItem.Enabled = canReset;
+
                         // Show the context menu
                         KryptonContextMenu.Show(this, PointToScreen(mousePt));
                     }
@@ -905,32 +907,53 @@ public class KryptonPropertyGrid : VisualControlBase,
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     protected override ControlCollection CreateControlsInstance() => new KryptonReadOnlyControls(this);
 
-    private void PropertyGrid_MouseDown(object? sender, MouseEventArgs e)
+    /// <summary>
+    /// Determine if currently selected property can be reset.
+    /// </summary>
+    /// <returns>True when reset is possible.</returns>
+    private bool CanResetCurrentProperty()
     {
-        if (e.Button == MouseButtons.Right && _propertyGrid.SelectedGridItem != null)
+        if (_propertyGrid.SelectedGridItem is not GridItem selectedGridItem || selectedGridItem.PropertyDescriptor is null)
         {
-            // Check if the selected property can be reset
-            if (_propertyGrid.SelectedGridItem is GridItem selectedGridItem &&
-                selectedGridItem.PropertyDescriptor != null)
-            {
-                PropertyDescriptor prop = selectedGridItem.PropertyDescriptor;
-
-                // Ensure _propertyGrid.SelectedObject is not null before calling CanResetValue
-                bool canReset = (prop.Attributes[typeof(DefaultValueAttribute)] != null ||
-                                 (_propertyGrid.SelectedObject != null && prop.CanResetValue(_propertyGrid.SelectedObject)));
-
-                _resetMenuItem.Enabled = canReset; // Disable if it cannot be reset
-            }
-            else
-            {
-                _resetMenuItem.Enabled = false; // Disable if no valid property is selected
-            }
-
-            // Show the KryptonContextMenu
-            KryptonContextMenu?.Show(this, PointToScreen(e.Location));
+            return false;
         }
+
+        PropertyDescriptor prop = selectedGridItem.PropertyDescriptor;
+
+        object[]? targets = _propertyGrid.SelectedObjects?.Length > 0
+            ? _propertyGrid.SelectedObjects
+            : _propertyGrid.SelectedObject is not null
+                ? new[] { _propertyGrid.SelectedObject }
+                : null;
+
+        if (targets == null)
+        {
+            return false;
+        }
+
+        foreach (object target in targets)
+        {
+            if (prop.CanResetValue(target))
+            {
+                return true;
+            }
+        }
+
+        if (prop.Attributes[typeof(DefaultValueAttribute)] is DefaultValueAttribute dva)
+        {
+            foreach (object target in targets)
+            {
+                object? current = prop.GetValue(target);
+                if (!Equals(current, dva.Value))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
-        
+
     private void OnPropertyGridClick(object? sender, EventArgs e) => OnClick(e);
 
     private void OnResetClick(object? sender, EventArgs e)


### PR DESCRIPTION
### Problem  
In `KryptonPropertyGrid` the “Reset” item in the custom context-menu was:  
1. Always shown as enabled because the enable logic relied only on the presence of a `DefaultValueAttribute`.  
2. Updated inside a `PropertyGrid_MouseDown` handler that never fires when the user right-clicks a property row (the underlying `PropertyGrid` sends `WM_CONTEXTMENU` directly).  
As a result the item was never greyed out for properties already at their default value, and any code inside `PropertyGrid_MouseDown` was effectively dead.

### Fix  
1. **Reliable trigger:**  
   • Moved the enable/disable logic to the `WM_CONTEXTMENU` branch of `WndProc`, which **always executes** for right-clicks on property rows.  
2. **Accurate enable check:**  
   • New helper `CanResetCurrentProperty()`  
     – Iterates through all selected objects.  
     – Uses `PropertyDescriptor.CanResetValue(obj)`; if that fails, falls back to comparing the current value with `DefaultValueAttribute`.  
3. **Dead code removal:**  
   • `PropertyGrid_MouseDown` is now deleted along with its subscription.

### Outcome  
“Reset” is only enabled when the selected property differs from its default.  
No unnecessary event handler remains.

Fixes #2178 