### PR TITLE
2178-V95-Fix-KryptonPropertyGrid-Reset-menu-item

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2025-08-25 - Build 2508 (Patch 8) - August 2025
+* Resolved [#2178](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2178), Fix `KryptonPropertyGrid` enabling logic for `Reset` menu-item
 * Resolved [#2300](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2300), Fix memory leak in PaletteBase
 * Resolved [#2235](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2235), `OSUtilities` Adds OsVersionInfo to the properties.
 * Resolved [#2264](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2264), Implementation of style: `PaletteBackStyle.Control`, `PaletteContentStyle.LabelAlternateControl` and `PaletteContentStyle.LabelAlternatePanel` in all themes.


### PR DESCRIPTION
### Problem  
In `KryptonPropertyGrid` the “Reset” item in the custom context-menu was:  
1. Always shown as enabled because the enable logic relied only on the presence of a `DefaultValueAttribute`.  
2. Updated inside a `PropertyGrid_MouseDown` handler that never fires when the user right-clicks a property row (the underlying `PropertyGrid` sends `WM_CONTEXTMENU` directly).  
As a result the item was never greyed out for properties already at their default value, and any code inside `PropertyGrid_MouseDown` was effectively dead.

### Fix  
1. **Reliable trigger:**  
   • Moved the enable/disable logic to the `WM_CONTEXTMENU` branch of `WndProc`, which **always executes** for right-clicks on property rows.  
2. **Accurate enable check:**  
   • New helper `CanResetCurrentProperty()`  
     – Iterates through all selected objects.  
     – Uses `PropertyDescriptor.CanResetValue(obj)`; if that fails, falls back to comparing the current value with `DefaultValueAttribute`.  
3. **Dead code removal:**  
   • `PropertyGrid_MouseDown` is now deleted along with its subscription.

### Outcome  
“Reset” is only enabled when the selected property differs from its default.  
No unnecessary event handler remains.

Fixes #2178 

<img width="885" height="363" alt="{F392BFAD-6401-4553-A261-99757BF8583A}" src="https://github.com/user-attachments/assets/8dec472e-70a7-4889-aaa8-f5fac054db66" />
