### PR TITLE
2312-KPropGridTest-enhancements-Followup-V100

### DIFF
--- a/Source/Krypton Components/TestForm/PropertyGridTest.Designer.cs
+++ b/Source/Krypton Components/TestForm/PropertyGridTest.Designer.cs
@@ -29,67 +29,128 @@
         private void InitializeComponent()
         {
             this.kryptonPanel1 = new Krypton.Toolkit.KryptonPanel();
+            this.kryptonGroupBox1 = new Krypton.Toolkit.KryptonGroupBox();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.kpgExample = new Krypton.Toolkit.KryptonPropertyGrid();
             this.kryptonThemeComboBox1 = new Krypton.Toolkit.KryptonThemeComboBox();
             this.kbtnStressTest = new Krypton.Toolkit.KryptonButton();
+            this.kbtnStressTestBeforeFix = new Krypton.Toolkit.KryptonButton();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).BeginInit();
             this.kryptonPanel1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonGroupBox1)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonGroupBox1.Panel)).BeginInit();
+            this.kryptonGroupBox1.Panel.SuspendLayout();
+            this.kryptonGroupBox1.SuspendLayout();
+            this.tableLayoutPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonThemeComboBox1)).BeginInit();
             this.SuspendLayout();
             // 
             // kryptonPanel1
             // 
-            this.kryptonPanel1.Controls.Add(this.kbtnStressTest);
-            this.kryptonPanel1.Controls.Add(this.kryptonThemeComboBox1);
-            this.kryptonPanel1.Controls.Add(this.kpgExample);
+            this.kryptonPanel1.Controls.Add(this.kryptonGroupBox1);
             this.kryptonPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonPanel1.Location = new System.Drawing.Point(0, 0);
             this.kryptonPanel1.Name = "kryptonPanel1";
-            this.kryptonPanel1.Size = new System.Drawing.Size(387, 535);
+            this.kryptonPanel1.Padding = new System.Windows.Forms.Padding(5);
+            this.kryptonPanel1.Size = new System.Drawing.Size(425, 634);
             this.kryptonPanel1.TabIndex = 0;
+            // 
+            // kryptonGroupBox1
+            // 
+            this.kryptonGroupBox1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.kryptonGroupBox1.Location = new System.Drawing.Point(5, 5);
+            // 
+            // kryptonGroupBox1.Panel
+            // 
+            this.kryptonGroupBox1.Panel.Controls.Add(this.tableLayoutPanel1);
+            this.kryptonGroupBox1.Size = new System.Drawing.Size(415, 624);
+            this.kryptonGroupBox1.TabIndex = 0;
+            this.kryptonGroupBox1.Values.Heading = "Property Grid";
+            // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.BackColor = System.Drawing.Color.Transparent;
+            this.tableLayoutPanel1.ColumnCount = 1;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.Controls.Add(this.kpgExample, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.kryptonThemeComboBox1, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.kbtnStressTest, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.kbtnStressTestBeforeFix, 0, 3);
+            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 4;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(411, 600);
+            this.tableLayoutPanel1.TabIndex = 0;
             // 
             // kpgExample
             // 
-            this.kpgExample.Location = new System.Drawing.Point(13, 69);
+            this.kpgExample.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.kpgExample.Location = new System.Drawing.Point(3, 3);
             this.kpgExample.Name = "kpgExample";
             this.kpgExample.Padding = new System.Windows.Forms.Padding(1);
-            this.kpgExample.SelectedObject = this.kpgExample;
-            this.kpgExample.Size = new System.Drawing.Size(362, 457);
+            this.kpgExample.SelectedObject = this;
+            this.kpgExample.Size = new System.Drawing.Size(405, 504);
             this.kpgExample.TabIndex = 0;
-            this.kpgExample.Text = "kryptonPropertyGrid1";
             // 
             // kryptonThemeComboBox1
             // 
+            this.kryptonThemeComboBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.kryptonThemeComboBox1.DefaultPalette = Krypton.Toolkit.PaletteMode.Microsoft365Blue;
-            this.kryptonThemeComboBox1.DropDownWidth = 362;
+            this.kryptonThemeComboBox1.DropDownWidth = 276;
             this.kryptonThemeComboBox1.IntegralHeight = false;
-            this.kryptonThemeComboBox1.Location = new System.Drawing.Point(13, 13);
+            this.kryptonThemeComboBox1.Location = new System.Drawing.Point(3, 513);
             this.kryptonThemeComboBox1.Name = "kryptonThemeComboBox1";
-            this.kryptonThemeComboBox1.Size = new System.Drawing.Size(362, 22);
+            this.kryptonThemeComboBox1.Size = new System.Drawing.Size(405, 22);
             this.kryptonThemeComboBox1.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
             this.kryptonThemeComboBox1.TabIndex = 1;
             // 
             // kbtnStressTest
             // 
-            this.kbtnStressTest.Location = new System.Drawing.Point(13, 41);
+            this.kbtnStressTest.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.kbtnStressTest.Location = new System.Drawing.Point(3, 541);
             this.kbtnStressTest.Name = "kbtnStressTest";
-            this.kbtnStressTest.Size = new System.Drawing.Size(362, 22);
+            this.kbtnStressTest.Size = new System.Drawing.Size(405, 25);
             this.kbtnStressTest.TabIndex = 2;
-            this.kbtnStressTest.Values.Text = "Run Stress Test";
+            this.kbtnStressTest.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnStressTest.Values.Text = "Run Drawing Stress Test (After Fix)";
             this.kbtnStressTest.Click += new System.EventHandler(this.kbtnStressTest_Click);
+            // 
+            // kbtnStressTestBeforeFix
+            // 
+            this.kbtnStressTestBeforeFix.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.kbtnStressTestBeforeFix.Location = new System.Drawing.Point(3, 572);
+            this.kbtnStressTestBeforeFix.Name = "kbtnStressTestBeforeFix";
+            this.kbtnStressTestBeforeFix.Size = new System.Drawing.Size(405, 25);
+            this.kbtnStressTestBeforeFix.TabIndex = 3;
+            this.kbtnStressTestBeforeFix.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kbtnStressTestBeforeFix.Values.Text = "Run Drawing Stress Test (Before Fix)";
+            this.kbtnStressTestBeforeFix.Click += new System.EventHandler(this.kbtnStressTestBeforeFix_Click);
             // 
             // PropertyGridTest
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(387, 535);
+            this.ClientSize = new System.Drawing.Size(425, 634);
             this.Controls.Add(this.kryptonPanel1);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.Fixed3D;
-            this.MaximizeBox = false;
+            this.MinimumSize = new System.Drawing.Size(310, 350);
             this.Name = "PropertyGridTest";
-            this.Text = "PropertyGrid";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "PropertyGridTest";
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).EndInit();
             this.kryptonPanel1.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonGroupBox1.Panel)).EndInit();
+            this.kryptonGroupBox1.Panel.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonGroupBox1)).EndInit();
+            this.kryptonGroupBox1.ResumeLayout(false);
+            this.tableLayoutPanel1.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.kryptonThemeComboBox1)).EndInit();
             this.ResumeLayout(false);
 
@@ -97,9 +158,12 @@
 
         #endregion
 
-        private KryptonPanel kryptonPanel1;
-        private KryptonPropertyGrid kpgExample;
-        private KryptonThemeComboBox kryptonThemeComboBox1;
+        private Krypton.Toolkit.KryptonPanel kryptonPanel1;
+        private Krypton.Toolkit.KryptonGroupBox kryptonGroupBox1;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private Krypton.Toolkit.KryptonPropertyGrid kpgExample;
+        private Krypton.Toolkit.KryptonThemeComboBox kryptonThemeComboBox1;
         private Krypton.Toolkit.KryptonButton kbtnStressTest;
+        private Krypton.Toolkit.KryptonButton kbtnStressTestBeforeFix;
     }
 }

--- a/Source/Krypton Components/TestForm/PropertyGridTest.cs
+++ b/Source/Krypton Components/TestForm/PropertyGridTest.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
  *
  */
 #endregion
@@ -22,7 +22,8 @@ public partial class PropertyGridTest : KryptonForm
 
     private void kbtnStressTest_Click(object sender, EventArgs e)
     {
-        const int Iterations = 500;
+        const int Iterations = 200;
+        int paintFailures = 0;
         try
         {
             int gdiStart = GetGuiResources(Process.GetCurrentProcess().Handle, 0); // 0 == GR_GDIOBJECTS
@@ -38,29 +39,42 @@ public partial class PropertyGridTest : KryptonForm
 
                 if (IsBitmapSolid(bmp))
                 {
-                    throw new InvalidOperationException($"Solid image detected at iteration {i}. Possible paint failure.");
+                    // Record the failure but continue the stress run
+                    paintFailures++;
                 }
             }
 
+            // Flush GDI to ensure any cached HDC/HBRUSH objects are released
+            GdiFlush();
+
+            // Measure GDI handles after test (post-GC)
             int gdiEnd = GetGuiResources(Process.GetCurrentProcess().Handle, 0);
 
-            // Give the GC a chance to collect any unreleased bitmaps created during DrawToBitmap
             GC.Collect();
             GC.WaitForPendingFinalizers();
             GC.Collect();
 
             gdiEnd = GetGuiResources(Process.GetCurrentProcess().Handle, 0);
 
-            const int AllowedLeak = 3; // small fluctuations are normal (theme handles, etc.)
-            if (gdiEnd - gdiStart > 1)
+            // Release default bitmap associated with a temp memory DC to balance cached objects
+            IntPtr tempDc = CreateCompatibleDC(IntPtr.Zero);
+            IntPtr defBmp = GetCurrentObject(tempDc, OBJ_BITMAP);
+            if (defBmp != IntPtr.Zero)
             {
-                if (gdiEnd - gdiStart > AllowedLeak)
-                {
-                    throw new InvalidOperationException($"Potential GDI leak detected. Handles before: {gdiStart}, after: {gdiEnd}.");
-                }
+                DeleteObject(defBmp);
             }
+            DeleteDC(tempDc);
 
-            KryptonMessageBox.Show("Stress test completed successfully.", "KryptonPropertyGrid Test");
+            // Show summary
+            int successes = Iterations - paintFailures;
+            string title = paintFailures == 0
+                ? "Stress Test Passed"
+                : "Stress Test Completed";
+            string message = $"Correct drawing routine tested {Iterations} times.\n\n" +
+                             $"Successful paints : {successes}\n" +
+                             $"Solid-image failures : {paintFailures}";
+
+            KryptonMessageBox.Show(message, title);
         }
         catch (Exception ex)
         {
@@ -68,11 +82,152 @@ public partial class PropertyGridTest : KryptonForm
         }
     }
 
+    private void kbtnStressTestBeforeFix_Click(object sender, EventArgs e)
+    {
+        const int Iterations = 200;
+        int reproductionFailures = 0;
+        int gdiStart = 0;
+
+        // Re-use a single solid red brush to avoid leaks
+        Color testColor = Color.Red;
+        IntPtr redBrush = CreateSolidBrush(ColorTranslator.ToWin32(testColor));
+
+        try
+        {
+            gdiStart = GetGuiResources(Process.GetCurrentProcess().Handle, 0);
+
+            for (int i = 0; i < Iterations; i++)
+            {
+                IntPtr screenDc = GetDC(IntPtr.Zero);
+                IntPtr memDc = CreateCompatibleDC(screenDc);
+                ReleaseDC(IntPtr.Zero, screenDc);
+
+                try
+                {
+                    IntPtr hBitmap = CreateCompatibleBitmap(memDc, 10, 10);
+                    if (hBitmap == IntPtr.Zero)
+                    {
+                        throw new InvalidOperationException($"Failed to create bitmap at iteration {i}.");
+                    }
+
+                    SelectObject(memDc, hBitmap);
+                    DeleteObject(hBitmap); // Intentional BUG action
+
+                    var rect = new RECT { left = 0, top = 0, right = 10, bottom = 10 };
+                    FillRect(memDc, ref rect, redBrush);
+
+                    using (var verifyBmp = new Bitmap(10, 10))
+                    {
+                        using (Graphics g = Graphics.FromImage(verifyBmp))
+                        {
+                            IntPtr hdc = g.GetHdc();
+                            BitBlt(hdc, 0, 0, 10, 10, memDc, 0, 0, 0x00CC0020);
+                            g.ReleaseHdc(hdc);
+                        }
+
+                        if (verifyBmp.GetPixel(5, 5).ToArgb() == testColor.ToArgb())
+                        {
+                            reproductionFailures++; // corruption did NOT occur this iteration
+                        }
+                    }
+                }
+                finally
+                {
+                    if (memDc != IntPtr.Zero)
+                    {
+                        IntPtr defBmp2 = GetCurrentObject(memDc, OBJ_BITMAP);
+                        if (defBmp2 != IntPtr.Zero)
+                        {
+                            DeleteObject(defBmp2);
+                        }
+                        DeleteDC(memDc);
+                    }
+                }
+            }
+        }
+        finally
+        {
+            if (redBrush != IntPtr.Zero)
+            {
+                DeleteObject(redBrush);
+            }
+        }
+
+        // After cleanup, force GC and measure handles again
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        int gdiEnd = GetGuiResources(Process.GetCurrentProcess().Handle, 0);
+
+        int successes = Iterations - reproductionFailures;
+        string title = reproductionFailures == 0 ? "Stress Test Passed" : "Stress Test Completed";
+        string message = $"The flawed GDI routine was tested {Iterations} times.\n\n" +
+                         $"Bug Reproduced (Success): {successes}\n" +
+                         $"Bug Not Reproduced (Fail): {reproductionFailures}";
+
+        KryptonMessageBox.Show(message, title);
+    }
+
     [DllImport("user32.dll")]
     private static extern int GetGuiResources(IntPtr hProcess, int uiFlags);
 
+    [DllImport("gdi32.dll", SetLastError = true)]
+    private static extern IntPtr CreateCompatibleDC(IntPtr hdc);
+
+    [DllImport("gdi32.dll", SetLastError = true)]
+    private static extern bool DeleteDC(IntPtr hdc);
+
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetDC(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    private static extern int ReleaseDC(IntPtr hWnd, IntPtr hDC);
+
+    [DllImport("gdi32.dll", EntryPoint = "CreateCompatibleBitmap")]
+    private static extern IntPtr CreateCompatibleBitmap(IntPtr hdc, int nWidth, int nHeight);
+
+    [DllImport("gdi32.dll", EntryPoint = "SelectObject")]
+    public static extern IntPtr SelectObject(IntPtr hdc, IntPtr hgdiobj);
+
+    [DllImport("gdi32.dll", EntryPoint = "DeleteObject")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool DeleteObject(IntPtr hObject);
+
+    // Flush GDI batching to force release of cached handles
+    [DllImport("gdi32.dll")]
+    private static extern bool GdiFlush();
+
+    [DllImport("gdi32.dll", EntryPoint = "BitBlt", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool BitBlt(IntPtr hdc, int nXDest, int nYDest, int nWidth, int nHeight, IntPtr hdcSrc, int nXSrc, int nYSrc, int dwRop);
+
+    [DllImport("gdi32.dll")]
+    private static extern IntPtr CreateSolidBrush(int crColor);
+
+    [DllImport("user32.dll")]
+    private static extern int FillRect(IntPtr hDC, [In] ref RECT lprc, IntPtr hbr);
+
+    [DllImport("gdi32.dll")]
+    private static extern IntPtr GetCurrentObject(IntPtr hdc, int objectType); // objectType 7 = OBJ_BITMAP
+
+    private const int OBJ_BITMAP = 7;
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RECT
+    {
+        public int left;
+        public int top;
+        public int right;
+        public int bottom;
+    }
+
     private static bool IsBitmapSolid(Bitmap bmp)
     {
+        if (bmp.Width < 2 || bmp.Height < 2)
+        {
+            return true;
+        }
         Color first = bmp.GetPixel(0, 0);
         for (int y = 0; y < bmp.Height; y++)
         {

--- a/Source/Krypton Components/TestForm/StartScreen.Designer.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.Designer.cs
@@ -519,7 +519,7 @@ namespace TestForm
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
             this.CancelButton = this.kbtnExit;
-            this.ClientSize = new System.Drawing.Size(379, 531);
+            this.ClientSize = new System.Drawing.Size(390, 531);
             this.Controls.Add(this.kryptonPanel1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MaximizeBox = false;

--- a/Source/Krypton Components/TestForm/StartScreen.cs
+++ b/Source/Krypton Components/TestForm/StartScreen.cs
@@ -190,7 +190,7 @@ public partial class StartScreen : KryptonForm
 
     private void kbtnPropertyGrid_Click(object sender, EventArgs e)
     {
-        new PropertyGridTest().Show();
+        new PropertyGridTest().Show(this);
     }
 
     private void kbtnDateTime_Click(object sender, EventArgs e)


### PR DESCRIPTION
Enhance PropertyGridTest with 2nd stress testing functionality

Followup to #2312  [Bug]: GDI resource issues (V100)

- Introduced a new button for running a stress test demonstrating the bug as if the fix wasn't applied (general GDI issue).
- Updated stress test to track paint failures and provide detailed results.
