### PR TITLE
2178-V85-LTS-Fix-KryptonPropertyGrid-Reset-menu-item

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2025-08-25 - Build 2508 (Patch 8) - August 2025
+* Resolved [#2178](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2178), Fix `KryptonPropertyGrid` enabling logic for `Reset` menu-item
 * Resolved [#2277](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2277), Added colors in the `Color[] _schemeOfficeColors`.
 * Resolved [#2301](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2301), Fix memory leak in PaletteBase
 * Resolved [#2235](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2235), `OSUtilities` Adds OsVersionInfo to the properties.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPropertyGrid.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPropertyGrid.cs
@@ -1,7 +1,7 @@
 ﻿#region BSD License
 /*
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2021 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege, et al. 2021 - 2025. All rights reserved.
  */
 #endregion
 
@@ -56,7 +56,7 @@ namespace Krypton.Toolkit
             }
 
             /// <summary>
-            /// Releases all resources used by the Control. 
+            /// Releases all resources used by the Control.
             /// </summary>
             /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
             protected override void Dispose(bool disposing)
@@ -119,7 +119,7 @@ namespace Krypton.Toolkit
                 switch (m.Msg)
                 {
                     case PI.WM_.ERASEBKGND:
-                        // Do not draw the background here, always do it in the paint 
+                        // Do not draw the background here, always do it in the paint
                         // instead to prevent flicker because of a two stage drawing process
                         break;
 
@@ -165,7 +165,7 @@ namespace Krypton.Toolkit
                     {
                         try
                         {
-                            // Must use the screen device context for the bitmap when drawing into the 
+                            // Must use the screen device context for the bitmap when drawing into the
                             // bitmap otherwise the Opacity and RightToLeftLayout will not work correctly.
                             PI.SelectObject(_screenDC, hBitmap);
 
@@ -262,7 +262,7 @@ namespace Krypton.Toolkit
         {
             // Contains another control and needs marking as such for validation to work
             SetStyle(ControlStyles.ContainerControl, true);
-            // Cannot select this control, only the child tree view and does not generate a 
+            // Cannot select this control, only the child tree view and does not generate a
             SetStyle(ControlStyles.Selectable | ControlStyles.StandardClick, false);
 
             // Default fields
@@ -321,8 +321,6 @@ namespace Krypton.Toolkit
             menuItems.Items.Add(_resetMenuItem);
 
             KryptonContextMenu.Items.Add(menuItems);
-
-            _propertyGrid.MouseDown += PropertyGrid_MouseDown;
         }
 
         /// <summary>
@@ -724,7 +722,7 @@ namespace Krypton.Toolkit
             switch (m.Msg)
             {
                 case PI.WM_.ERASEBKGND:
-                    // Do not draw the background here, always do it in the paint 
+                    // Do not draw the background here, always do it in the paint
                     // instead to prevent flicker because of a two stage drawing process
                     break;
                 case PI.WM_.VSCROLL:
@@ -759,6 +757,10 @@ namespace Krypton.Toolkit
                         // If the mouse position is within our client area
                         if (ClientRectangle.Contains(mousePt))
                         {
+                            // Update reset menu item enabled/text state just before showing menu
+                            bool canReset = CanResetCurrentProperty();
+                            _resetMenuItem.Enabled = canReset;
+
                             // Show the context menu
                             KryptonContextMenu.Show(this, PointToScreen(mousePt));
                         }
@@ -922,32 +924,6 @@ namespace Krypton.Toolkit
         [EditorBrowsable(EditorBrowsableState.Advanced)]
         protected override ControlCollection CreateControlsInstance() => new KryptonReadOnlyControls(this);
 
-        private void PropertyGrid_MouseDown(object? sender, MouseEventArgs e)
-        {
-            if (e.Button == MouseButtons.Right && _propertyGrid.SelectedGridItem != null)
-            {
-                // Check if the selected property can be reset
-                if (_propertyGrid.SelectedGridItem is GridItem selectedGridItem &&
-                    selectedGridItem.PropertyDescriptor != null)
-                {
-                    PropertyDescriptor prop = selectedGridItem.PropertyDescriptor;
-
-                    // Ensure _propertyGrid.SelectedObject is not null before calling CanResetValue
-                    bool canReset = (prop.Attributes[typeof(DefaultValueAttribute)] != null ||
-                                     (_propertyGrid.SelectedObject != null && prop.CanResetValue(_propertyGrid.SelectedObject)));
-
-                    _resetMenuItem.Enabled = canReset; // Disable if it cannot be reset
-                }
-                else
-                {
-                    _resetMenuItem.Enabled = false; // Disable if no valid property is selected
-                }
-
-                // Show the KryptonContextMenu
-                KryptonContextMenu?.Show(this, PointToScreen(e.Location));
-            }
-        }
-
         private void OnPropertyGridClick(object? sender, EventArgs e) => OnClick(e);
 
         private void OnResetClick(object? sender, EventArgs e)
@@ -971,6 +947,52 @@ namespace Krypton.Toolkit
             }
         }
 
+        /// <summary>
+        /// Determine if currently selected property can be reset.
+        /// </summary>
+        /// <returns>True when reset is possible.</returns>
+        private bool CanResetCurrentProperty()
+        {
+            if (_propertyGrid.SelectedGridItem is not GridItem selectedGridItem || selectedGridItem.PropertyDescriptor is null)
+            {
+                return false;
+            }
+
+            PropertyDescriptor prop = selectedGridItem.PropertyDescriptor;
+
+            object[]? targets = _propertyGrid.SelectedObjects?.Length > 0
+                ? _propertyGrid.SelectedObjects
+                : _propertyGrid.SelectedObject is not null
+                    ? new[] { _propertyGrid.SelectedObject }
+                    : null;
+
+            if (targets == null)
+            {
+                return false;
+            }
+
+            foreach (object target in targets)
+            {
+                if (prop.CanResetValue(target))
+                {
+                    return true;
+                }
+            }
+
+            if (prop.Attributes[typeof(DefaultValueAttribute)] is DefaultValueAttribute dva)
+            {
+                foreach (object target in targets)
+                {
+                    object? current = prop.GetValue(target);
+                    if (!Equals(current, dva.Value))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
 
         #endregion
     }


### PR DESCRIPTION
### Problem  
In `KryptonPropertyGrid` the “Reset” item in the custom context-menu was:  
1. Always shown as enabled because the enable logic relied only on the presence of a `DefaultValueAttribute`.  
2. Updated inside a `PropertyGrid_MouseDown` handler that never fires when the user right-clicks a property row (the underlying `PropertyGrid` sends `WM_CONTEXTMENU` directly).  
As a result the item was never greyed out for properties already at their default value, and any code inside `PropertyGrid_MouseDown` was effectively dead.

### Fix  
1. **Reliable trigger:**  
   • Moved the enable/disable logic to the `WM_CONTEXTMENU` branch of `WndProc`, which **always executes** for right-clicks on property rows.  
2. **Accurate enable check:**  
   • New helper `CanResetCurrentProperty()`  
     – Iterates through all selected objects.  
     – Uses `PropertyDescriptor.CanResetValue(obj)`; if that fails, falls back to comparing the current value with `DefaultValueAttribute`.  
3. **Dead code removal:**  
   • `PropertyGrid_MouseDown` is now deleted along with its subscription.

### Outcome  
“Reset” is only enabled when the selected property differs from its default.  
No unnecessary event handler remains.

Fixes #2178 