### PR TITLE
2196-V100-KCommand-KContextMenuItem-enhancements

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuItem.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuItem.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -24,6 +24,14 @@ namespace Krypton.Toolkit;
 [DefaultEvent(nameof(Click))]
 public class KryptonContextMenuItem : KryptonContextMenuItemBase
 {
+    #region Nested Classes
+    // Provides proper design-time reference conversion for the KryptonCommand property even when the item is not sited.
+    private sealed class KryptonCommandReferenceConverter : ReferenceConverter
+    {
+        public KryptonCommandReferenceConverter() : base(typeof(KryptonCommand)) { }
+    }
+    #endregion
+
     #region Instance Fields
     private bool _enabled;
     private bool _splitSubMenu;
@@ -40,6 +48,7 @@ public class KryptonContextMenuItem : KryptonContextMenuItemBase
     private Keys _shortcutKeys;
     private readonly PaletteContextMenuItemStateRedirect _stateRedirect;
     private KryptonCommand? _command;
+    private object? _commandParameter;
 
     #endregion
 
@@ -623,6 +632,7 @@ public class KryptonContextMenuItem : KryptonContextMenuItemBase
     [Category(@"Behavior")]
     [Description(@"Command associated with the menu item.")]
     [DefaultValue(null)]
+    [TypeConverter(typeof(KryptonCommandReferenceConverter))]
     public virtual KryptonCommand? KryptonCommand
     {
         get => _command;
@@ -636,6 +646,32 @@ public class KryptonContextMenuItem : KryptonContextMenuItemBase
             }
         }
     }
+
+    /// <summary>
+    /// Gets and sets an optional parameter value that can be used inside a shared KryptonCommand Execute handler.
+    /// </summary>
+    [KryptonPersist]
+    [Category(@"Behavior")]
+    [Description(@"Value passed to the KryptonCommand Execute handler to discriminate between menu items.")]
+    [DefaultValue(null)]
+    [Browsable(true)]
+    [TypeConverter(typeof(StringConverter))]
+    public object? CommandParameter
+    {
+        get => _commandParameter;
+
+        set
+        {
+            if (!Equals(_commandParameter, value))
+            {
+                _commandParameter = value;
+                OnPropertyChanged(new PropertyChangedEventArgs(nameof(CommandParameter)));
+            }
+        }
+    }
+
+    private bool ShouldSerializeCommandParameter() => CommandParameter != null;
+    private void ResetCommandParameter() => CommandParameter = null;
 
     /// <summary>
     /// Generates a Click event for the component.
@@ -673,8 +709,8 @@ public class KryptonContextMenuItem : KryptonContextMenuItemBase
 
         OnClick(EventArgs.Empty);
 
-        // If we have an attached command then execute it
-        KryptonCommand?.PerformExecute();
+        // If we have an attached command then execute it, indicating this item as the sender
+        KryptonCommand?.PerformExecute(this);
     }
     #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCommand.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -77,7 +77,7 @@ public class KryptonCommand : Component, IKryptonCommand, INotifyPropertyChanged
         _assignedButtonSpec = null;
     }
 
-    /// <summary> 
+    /// <summary>
     /// Clean up any resources being used.
     /// </summary>
     /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
@@ -381,6 +381,10 @@ public class KryptonCommand : Component, IKryptonCommand, INotifyPropertyChanged
     /// Generates a Execute event for a button.
     /// </summary>
     public void PerformExecute() => OnExecute(EventArgs.Empty);
+
+    // Allow specifying the originating sender so shared commands can identify the source control
+    public void PerformExecute(object? sender)
+        => Execute?.Invoke(sender ?? this, EventArgs.Empty);
 
     #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuItem.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuItem.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -121,7 +121,7 @@ internal class ViewDrawMenuItem : ViewDrawCanvas
             string shortcutString = KryptonContextMenuItem.ShortcutKeyDisplayString;
             if (string.IsNullOrEmpty(shortcutString))
             {
-                shortcutString = (KryptonContextMenuItem.ShortcutKeys != Keys.None) 
+                shortcutString = (KryptonContextMenuItem.ShortcutKeys != Keys.None)
                     ? new KeysConverter().ConvertToString(KryptonContextMenuItem.ShortcutKeys) ?? string.Empty
                     : string.Empty;
             }
@@ -142,12 +142,12 @@ internal class ViewDrawMenuItem : ViewDrawCanvas
 
         // SubMenu Indicator
         HasSubMenu = KryptonContextMenuItem.Items.Count > 0;
-        _subMenuContent = new ViewDrawMenuItemContent(menuItemState.ItemImage.Content, new FixedContentValue(null, null, 
-                !HasSubMenu 
-                    ? _empty16x16 
-                    : provider.ProviderImages.GetContextMenuSubMenuImage(), 
-                KryptonContextMenuItem.Items.Count == 0 
-                    ? GlobalStaticValues.TRANSPARENCY_KEY_COLOR 
+        _subMenuContent = new ViewDrawMenuItemContent(menuItemState.ItemImage.Content, new FixedContentValue(null, null,
+                !HasSubMenu
+                    ? _empty16x16
+                    : provider.ProviderImages.GetContextMenuSubMenuImage(),
+                KryptonContextMenuItem.Items.Count == 0
+                    ? GlobalStaticValues.TRANSPARENCY_KEY_COLOR
                     : GlobalStaticValues.EMPTY_COLOR),
             3);
         docker.Add(new ViewLayoutCenter(_subMenuContent), ViewDockStyle.Right);
@@ -284,7 +284,10 @@ internal class ViewDrawMenuItem : ViewDrawCanvas
     /// <summary>
     /// Resolves the correct text string to use from the menu item.
     /// </summary>
-    public string ResolveText => _cachedCommand != null ? _cachedCommand.Text : KryptonContextMenuItem.Text;
+    public string ResolveText => _cachedCommand != null
+        && !string.IsNullOrEmpty(_cachedCommand.Text)
+            ? _cachedCommand.Text
+            : KryptonContextMenuItem.Text;
 
     #endregion
 
@@ -292,7 +295,10 @@ internal class ViewDrawMenuItem : ViewDrawCanvas
     /// <summary>
     /// Resolves the correct extra text string to use from the menu item.
     /// </summary>
-    public string ResolveExtraText => _cachedCommand != null ? _cachedCommand.ExtraText : KryptonContextMenuItem.ExtraText;
+    public string ResolveExtraText => _cachedCommand != null
+        && !string.IsNullOrEmpty(_cachedCommand.ExtraText)
+            ? _cachedCommand.ExtraText
+            : KryptonContextMenuItem.ExtraText;
 
     #endregion
 
@@ -326,7 +332,7 @@ internal class ViewDrawMenuItem : ViewDrawCanvas
             // If menu item is split into regular button and sub menu areas
             if (SplitSeparator.Draw)
             {
-                // If mouse is inside or to the right of the slip indicator, 
+                // If mouse is inside or to the right of the slip indicator,
                 // then a sub menu is required when the button is used
                 return pt.X > SplitSeparator.ClientRectangle.X;
             }

--- a/Source/Krypton Components/TestForm/ButtonsTest.Designer.cs
+++ b/Source/Krypton Components/TestForm/ButtonsTest.Designer.cs
@@ -47,7 +47,9 @@ namespace TestForm
             this.kryptonContextMenu1 = new Krypton.Toolkit.KryptonContextMenu();
             this.kryptonContextMenuItems1 = new Krypton.Toolkit.KryptonContextMenuItems();
             this.kryptonContextMenuItem1 = new Krypton.Toolkit.KryptonContextMenuItem();
+            this.kryptonCommand1 = new Krypton.Toolkit.KryptonCommand();
             this.kryptonContextMenuItem2 = new Krypton.Toolkit.KryptonContextMenuItem();
+            this.kryptonCommand2 = new Krypton.Toolkit.KryptonCommand();
             this.kryptonContextMenuItem3 = new Krypton.Toolkit.KryptonContextMenuItem();
             this.kryptonButton6 = new Krypton.Toolkit.KryptonButton();
             this.kryptonButton7 = new Krypton.Toolkit.KryptonButton();
@@ -79,7 +81,7 @@ namespace TestForm
             this.kryptonPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonPanel1.Location = new System.Drawing.Point(0, 0);
             this.kryptonPanel1.Name = "kryptonPanel1";
-            this.kryptonPanel1.Size = new System.Drawing.Size(543, 220);
+            this.kryptonPanel1.Size = new System.Drawing.Size(542, 233);
             this.kryptonPanel1.TabIndex = 0;
             // 
             // kbtnButtonStyles
@@ -94,12 +96,14 @@ namespace TestForm
             // 
             // kryptonThemeComboBox1
             // 
+            this.kryptonThemeComboBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.kryptonThemeComboBox1.DefaultPalette = Krypton.Toolkit.PaletteMode.Microsoft365Blue;
             this.kryptonThemeComboBox1.DropDownWidth = 492;
             this.kryptonThemeComboBox1.IntegralHeight = false;
             this.kryptonThemeComboBox1.Location = new System.Drawing.Point(18, 13);
             this.kryptonThemeComboBox1.Name = "kryptonThemeComboBox1";
-            this.kryptonThemeComboBox1.Size = new System.Drawing.Size(492, 22);
+            this.kryptonThemeComboBox1.Size = new System.Drawing.Size(504, 22);
             this.kryptonThemeComboBox1.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
             this.kryptonThemeComboBox1.TabIndex = 9;
             // 
@@ -133,6 +137,7 @@ namespace TestForm
             this.kryptonButton5.KryptonContextMenu = this.kryptonContextMenu1;
             this.kryptonButton5.Location = new System.Drawing.Point(267, 134);
             this.kryptonButton5.Name = "kryptonButton5";
+            this.kryptonButton5.ShowSplitOption = true;
             this.kryptonButton5.Size = new System.Drawing.Size(243, 25);
             this.kryptonButton5.TabIndex = 6;
             this.kryptonButton5.Values.DropDownArrowColor = System.Drawing.Color.Empty;
@@ -144,26 +149,40 @@ namespace TestForm
             // kryptonContextMenu1
             // 
             this.kryptonContextMenu1.Items.AddRange(new Krypton.Toolkit.KryptonContextMenuItemBase[] {
-            this.kryptonContextMenuItems1});
+            ((Krypton.Toolkit.KryptonContextMenuItemBase)(this.kryptonContextMenuItems1))});
             // 
             // kryptonContextMenuItems1
             // 
             this.kryptonContextMenuItems1.Items.AddRange(new Krypton.Toolkit.KryptonContextMenuItemBase[] {
-            this.kryptonContextMenuItem1,
-            this.kryptonContextMenuItem2,
-            this.kryptonContextMenuItem3});
+            ((Krypton.Toolkit.KryptonContextMenuItemBase)(this.kryptonContextMenuItem1)),
+            ((Krypton.Toolkit.KryptonContextMenuItemBase)(this.kryptonContextMenuItem2)),
+            ((Krypton.Toolkit.KryptonContextMenuItemBase)(this.kryptonContextMenuItem3))});
             // 
             // kryptonContextMenuItem1
             // 
-            this.kryptonContextMenuItem1.Text = "Choice 1";
+            this.kryptonContextMenuItem1.CommandParameter = "DoThing1";
+            this.kryptonContextMenuItem1.KryptonCommand = this.kryptonCommand1;
+            this.kryptonContextMenuItem1.Text = "Choice 1 (Command 1)";
+            // 
+            // kryptonCommand1
+            // 
+            this.kryptonCommand1.Execute += new System.EventHandler(this.kryptonCommand1_Execute);
             // 
             // kryptonContextMenuItem2
             // 
-            this.kryptonContextMenuItem2.Text = "Choice 2";
+            this.kryptonContextMenuItem2.CommandParameter = "DoThing2";
+            this.kryptonContextMenuItem2.KryptonCommand = this.kryptonCommand1;
+            this.kryptonContextMenuItem2.Text = "Choice 2 (Command 1)";
+            // 
+            // kryptonCommand2
+            // 
+            this.kryptonCommand2.Execute += new System.EventHandler(this.kryptonCommand1_Execute);
             // 
             // kryptonContextMenuItem3
             // 
-            this.kryptonContextMenuItem3.Text = "Choice 3";
+            this.kryptonContextMenuItem3.CommandParameter = "ThisIsCmd2";
+            this.kryptonContextMenuItem3.KryptonCommand = this.kryptonCommand2;
+            this.kryptonContextMenuItem3.Text = "Choice 3 (Command 2)";
             // 
             // kryptonButton6
             // 
@@ -182,6 +201,7 @@ namespace TestForm
             this.kryptonButton7.KryptonContextMenu = this.kryptonContextMenu1;
             this.kryptonButton7.Location = new System.Drawing.Point(18, 134);
             this.kryptonButton7.Name = "kryptonButton7";
+            this.kryptonButton7.ShowSplitOption = true;
             this.kryptonButton7.Size = new System.Drawing.Size(243, 25);
             this.kryptonButton7.TabIndex = 5;
             this.kryptonButton7.Values.DropDownArrowColor = System.Drawing.Color.Empty;
@@ -253,12 +273,13 @@ namespace TestForm
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ButtonSpecs.Add(this.buttonSpecAny1);
-            this.ClientSize = new System.Drawing.Size(543, 220);
+            this.ClientSize = new System.Drawing.Size(542, 233);
             this.Controls.Add(this.kryptonPanel1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.Fixed3D;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MaximizeBox = false;
             this.MinimizeBox = false;
+            this.MinimumSize = new System.Drawing.Size(544, 280);
             this.Name = "ButtonsTest";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
@@ -292,5 +313,7 @@ namespace TestForm
         private ButtonSpecAny buttonSpecAny1;
         private KryptonThemeComboBox kryptonThemeComboBox1;
         private KryptonButton kbtnButtonStyles;
+        private KryptonCommand kryptonCommand1;
+        private KryptonCommand kryptonCommand2;
     }
 }

--- a/Source/Krypton Components/TestForm/ButtonsTest.cs
+++ b/Source/Krypton Components/TestForm/ButtonsTest.cs
@@ -1,11 +1,13 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
+ *
  */
 #endregion
+
+using Krypton.Toolkit;
 
 namespace TestForm;
 
@@ -30,5 +32,14 @@ public partial class ButtonsTest : KryptonForm
     private void kbtnButtonStyles_Click(object sender, EventArgs e)
     {
         new ButtonStyleExamples().Show();
+    }
+
+    private void kryptonCommand1_Execute(object sender, EventArgs e)
+    {
+        var typeName = sender.GetType().FullName;
+        var item = sender as KryptonContextMenuItem;
+        var paramText = item?.CommandParameter is string s ? s : "<no param>";
+
+        KryptonMessageBox.Show($"Command executed by:\nType: {typeName}\nParam: {paramText}", "Context Item Called");
     }
 }

--- a/Source/Krypton Components/TestForm/ButtonsTest.resx
+++ b/Source/Krypton Components/TestForm/ButtonsTest.resx
@@ -121,90 +121,96 @@
   <data name="kryptonColorButton1.Values.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
-        DAAACwwBP0AiyAAAAAd0SU1FB9gBEgI0L+a2mIYAAAASSURBVDhPY2AYBaNgFIwCCAAABBAAAUy7RlUA
-        AAAASUVORK5CYII=
+        DAAACwwBP0AiyAAAAAd0SU1FB9gBEgI0L+a2mIYAAAATSURBVDhPYxgFo2AUjAIwYGAAAAQQAAGnRHxj
+        AAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="kcbtnDropDown.Values.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
-        DAAACwwBP0AiyAAAAAd0SU1FB9gBEgI0L+a2mIYAAAASSURBVDhPY2AYBaNgFIwCCAAABBAAAUy7RlUA
-        AAAASUVORK5CYII=
+        DAAACwwBP0AiyAAAAAd0SU1FB9gBEgI0L+a2mIYAAAATSURBVDhPYxgFo2AUjAIwYGAAAAQQAAGnRHxj
+        AAAAAElFTkSuQmCC
 </value>
   </data>
   <metadata name="kryptonContextMenu1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="kryptonCommand1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>245, 17</value>
+  </metadata>
+  <metadata name="kryptonCommand2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>449, 17</value>
+  </metadata>
   <data name="kryptonButton5.Values.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAK+SURBVDhPrZJbSJNhGMefbxusudxm4VJTZ07TLEwTupDA
-        iyi8sIsor7wXojuNuhzdjDxmoYE1nacWM1JSswTL8rQ5T2ubcy41N9xwit+XR0j0+8cWCA6qm37w8D68
-        7/N7eE9Ef+F2VZVkQK86Fj7/T7Ib7TfSDIHuXOPUms96YmV/lnrXB4X54XWH5OqGI7NrJ1WZ9ZO3Mpvd
-        hox2P9Q9B8jpXsKuJwpYI+w7GWyYmPaVfuHNQIdYbW4lWUjO0+iPXWhyOTOMvs10ox9pXTtQv15DvGEd
-        We2zYJ1RgJuABQKWGRw4BPhpY7bZLwIXgscrKK6PONs0v63u2kGycRVJL/1IavMjrmUNmQYnOIcCcBF4
-        ZzCYUA4vYXtUsDOgiT4eapCqm1tXGdehavXxiS3LSGxehlIfwPnWGbBWBTBD4O3E83YGvI2AOcLWoIDr
-        KyUpFRRrIhKfubmYtg0oGwK8UhdAtG4FsnoW6kYXtqalgIOCIg8rAV8JmCXsDhDbV3pKSoWFhcLsuiHX
-        OcM80vUOpDfakdZgQ/ILF3L0I/CaEsBNyMFZ5ODGgiHDD6scnl7FnCaPRKGL/P7uZNOmKwrsuAKsRcGz
-        Y6ERntF4XHo+iMQ6B9R100iuncKZ2imk6tzIetjZdviMW2/oGsYIsBH4CeIxQeAnid8xSRD/1A5RRQCS
-        Si8kFV6Iq1eg0LoRfefj9cMGQVY7RM2wCwALA5gYwEzghmRQ1UxCXOZBZNk3SCsWoXjsQ3zJh5YjcpBp
-        jVzBdgqHYQvKDDBC4D7LkVA5DpF2CZJHC4is9iPmXv/I5SLN708UjrVCqgwYRT0wB3dC4D7JEFtmAWn9
-        kGkXEVvS9z6jsDwm3DvCk/wUsV8v1O52097ekBxxlXZI7k/vn777tjw/JUUcXv9HfDV0xdEYa774wDio
-        LHp1NXz9v/EL/YSqQjqcEQUAAAAASUVORK5CYII=
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAK/SURBVDhPrZJbSNNRHMfPLrDmcpuFS21u5jTNwjShBwl8
+        iMKHeojyyfcgetOox9HLSKdmoYE1N28tZqSUZgmW5W3et7Y551Jzw43N4X95hUT/387mIKioHvrAl3P7
+        fb/8zuGQP3GtulrYb1AeiC3/nXy9/XKWMdhVaJoO+ayHAruzpGd1gFccO/6VQt1QfH7dlDK3YepqbrPb
+        mNPuh6p7DwVdS9j2JAAhgl0nB2tmTnugj3cl2CFQjbYScdRcpDYcONXkcuaYfOvZJj+yXm1B9TwEuXEV
+        ee2zYJw0wE2ABaplDvYcXHyzcTaZj1wXIte7dL0h7njT/KaKGtNNK0h76kdamx8pLSHkGp0IO6SAi4B1
+        RsSJzuEl2BzhbvWrEw9GAzJ1c6tK0yqUrT5W0bIMRfMyZIYgTrbOgLHSgBlqthOWtXPA2mjAHMHGADfc
+        W05ENEAdp3jkDie1rUHWGGRluiASdQGIGxio9C5sWESAgwbYCAsrNX+imiXY7idMb/kRESkpKeHl1w+6
+        ThjnkW1wIFtvR1ajDelPXCgwDMNrTkV4UoLwONVYRGJ8tUrg6ZHOqYsIP/qQX14fblp3JYCZkIIZl7LM
+        WHSEZ0SOM48HoKh3QFVvQXrdNI5RZercyLvb2RY1R9h4QS5gjLZG78dO0lYn6ThF2C2zEPKHdvC1QQir
+        vBBqvRDUBCDVuJF4493FmH2flQ5+M+xcYJy+tJlqlCA8KIaydgqCCg/iKz5DpF2E9L4P8rK3LTHbDyxq
+        iZTp5A3BFjFTDdOADxKkVk2Ar1mC8N4C4mv8SLrVN3y2VL3/iX7GqhXJgiZ+N0YjndCA92IkV4yDaPwQ
+        axaRXNb7JqekMilW/nseFGcI/AaeZruL7OwMSpBSZYfwtmX36M2XlcUZGYJY2d/x1ZJzDn3y6Ok7pgFZ
+        6bPzse3/DSHfAf2EqkKNe37BAAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="kryptonButton6.Values.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAK+SURBVDhPrZJbSJNhGMefbxusudxm4VJTZ07TLEwTupDA
-        iyi8sIsor7wXojuNuhzdjDxmoYE1nacWM1JSswTL8rQ5T2ubcy41N9xwit+XR0j0+8cWCA6qm37w8D68
-        7/N7eE9Ef+F2VZVkQK86Fj7/T7Ib7TfSDIHuXOPUms96YmV/lnrXB4X54XWH5OqGI7NrJ1WZ9ZO3Mpvd
-        hox2P9Q9B8jpXsKuJwpYI+w7GWyYmPaVfuHNQIdYbW4lWUjO0+iPXWhyOTOMvs10ox9pXTtQv15DvGEd
-        We2zYJ1RgJuABQKWGRw4BPhpY7bZLwIXgscrKK6PONs0v63u2kGycRVJL/1IavMjrmUNmQYnOIcCcBF4
-        ZzCYUA4vYXtUsDOgiT4eapCqm1tXGdehavXxiS3LSGxehlIfwPnWGbBWBTBD4O3E83YGvI2AOcLWoIDr
-        KyUpFRRrIhKfubmYtg0oGwK8UhdAtG4FsnoW6kYXtqalgIOCIg8rAV8JmCXsDhDbV3pKSoWFhcLsuiHX
-        OcM80vUOpDfakdZgQ/ILF3L0I/CaEsBNyMFZ5ODGgiHDD6scnl7FnCaPRKGL/P7uZNOmKwrsuAKsRcGz
-        Y6ERntF4XHo+iMQ6B9R100iuncKZ2imk6tzIetjZdviMW2/oGsYIsBH4CeIxQeAnid8xSRD/1A5RRQCS
-        Si8kFV6Iq1eg0LoRfefj9cMGQVY7RM2wCwALA5gYwEzghmRQ1UxCXOZBZNk3SCsWoXjsQ3zJh5YjcpBp
-        jVzBdgqHYQvKDDBC4D7LkVA5DpF2CZJHC4is9iPmXv/I5SLN708UjrVCqgwYRT0wB3dC4D7JEFtmAWn9
-        kGkXEVvS9z6jsDwm3DvCk/wUsV8v1O52097ekBxxlXZI7k/vn777tjw/JUUcXv9HfDV0xdEYa774wDio
-        LHp1NXz9v/EL/YSqQjqcEQUAAAAASUVORK5CYII=
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAK/SURBVDhPrZJbSNNRHMfPLrDmcpuFS21u5jTNwjShBwl8
+        iMKHeojyyfcgetOox9HLSKdmoYE1N28tZqSUZgmW5W3et7Y551Jzw43N4X95hUT/387mIKioHvrAl3P7
+        fb/8zuGQP3GtulrYb1AeiC3/nXy9/XKWMdhVaJoO+ayHAruzpGd1gFccO/6VQt1QfH7dlDK3YepqbrPb
+        mNPuh6p7DwVdS9j2JAAhgl0nB2tmTnugj3cl2CFQjbYScdRcpDYcONXkcuaYfOvZJj+yXm1B9TwEuXEV
+        ee2zYJw0wE2ABaplDvYcXHyzcTaZj1wXIte7dL0h7njT/KaKGtNNK0h76kdamx8pLSHkGp0IO6SAi4B1
+        RsSJzuEl2BzhbvWrEw9GAzJ1c6tK0yqUrT5W0bIMRfMyZIYgTrbOgLHSgBlqthOWtXPA2mjAHMHGADfc
+        W05ENEAdp3jkDie1rUHWGGRluiASdQGIGxio9C5sWESAgwbYCAsrNX+imiXY7idMb/kRESkpKeHl1w+6
+        ThjnkW1wIFtvR1ajDelPXCgwDMNrTkV4UoLwONVYRGJ8tUrg6ZHOqYsIP/qQX14fblp3JYCZkIIZl7LM
+        WHSEZ0SOM48HoKh3QFVvQXrdNI5RZercyLvb2RY1R9h4QS5gjLZG78dO0lYn6ThF2C2zEPKHdvC1QQir
+        vBBqvRDUBCDVuJF4493FmH2flQ5+M+xcYJy+tJlqlCA8KIaydgqCCg/iKz5DpF2E9L4P8rK3LTHbDyxq
+        iZTp5A3BFjFTDdOADxKkVk2Ar1mC8N4C4mv8SLrVN3y2VL3/iX7GqhXJgiZ+N0YjndCA92IkV4yDaPwQ
+        axaRXNb7JqekMilW/nseFGcI/AaeZruL7OwMSpBSZYfwtmX36M2XlcUZGYJY2d/x1ZJzDn3y6Ok7pgFZ
+        6bPzse3/DSHfAf2EqkKNe37BAAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="kryptonButton7.Values.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAK+SURBVDhPrZJbSJNhGMefbxusudxm4VJTZ07TLEwTupDA
-        iyi8sIsor7wXojuNuhzdjDxmoYE1nacWM1JSswTL8rQ5T2ubcy41N9xwit+XR0j0+8cWCA6qm37w8D68
-        7/N7eE9Ef+F2VZVkQK86Fj7/T7Ib7TfSDIHuXOPUms96YmV/lnrXB4X54XWH5OqGI7NrJ1WZ9ZO3Mpvd
-        hox2P9Q9B8jpXsKuJwpYI+w7GWyYmPaVfuHNQIdYbW4lWUjO0+iPXWhyOTOMvs10ox9pXTtQv15DvGEd
-        We2zYJ1RgJuABQKWGRw4BPhpY7bZLwIXgscrKK6PONs0v63u2kGycRVJL/1IavMjrmUNmQYnOIcCcBF4
-        ZzCYUA4vYXtUsDOgiT4eapCqm1tXGdehavXxiS3LSGxehlIfwPnWGbBWBTBD4O3E83YGvI2AOcLWoIDr
-        KyUpFRRrIhKfubmYtg0oGwK8UhdAtG4FsnoW6kYXtqalgIOCIg8rAV8JmCXsDhDbV3pKSoWFhcLsuiHX
-        OcM80vUOpDfakdZgQ/ILF3L0I/CaEsBNyMFZ5ODGgiHDD6scnl7FnCaPRKGL/P7uZNOmKwrsuAKsRcGz
-        Y6ERntF4XHo+iMQ6B9R100iuncKZ2imk6tzIetjZdviMW2/oGsYIsBH4CeIxQeAnid8xSRD/1A5RRQCS
-        Si8kFV6Iq1eg0LoRfefj9cMGQVY7RM2wCwALA5gYwEzghmRQ1UxCXOZBZNk3SCsWoXjsQ3zJh5YjcpBp
-        jVzBdgqHYQvKDDBC4D7LkVA5DpF2CZJHC4is9iPmXv/I5SLN708UjrVCqgwYRT0wB3dC4D7JEFtmAWn9
-        kGkXEVvS9z6jsDwm3DvCk/wUsV8v1O52097ekBxxlXZI7k/vn777tjw/JUUcXv9HfDV0xdEYa774wDio
-        LHp1NXz9v/EL/YSqQjqcEQUAAAAASUVORK5CYII=
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAK/SURBVDhPrZJbSNNRHMfPLrDmcpuFS21u5jTNwjShBwl8
+        iMKHeojyyfcgetOox9HLSKdmoYE1N28tZqSUZgmW5W3et7Y551Jzw43N4X95hUT/387mIKioHvrAl3P7
+        fb/8zuGQP3GtulrYb1AeiC3/nXy9/XKWMdhVaJoO+ayHAruzpGd1gFccO/6VQt1QfH7dlDK3YepqbrPb
+        mNPuh6p7DwVdS9j2JAAhgl0nB2tmTnugj3cl2CFQjbYScdRcpDYcONXkcuaYfOvZJj+yXm1B9TwEuXEV
+        ee2zYJw0wE2ABaplDvYcXHyzcTaZj1wXIte7dL0h7njT/KaKGtNNK0h76kdamx8pLSHkGp0IO6SAi4B1
+        RsSJzuEl2BzhbvWrEw9GAzJ1c6tK0yqUrT5W0bIMRfMyZIYgTrbOgLHSgBlqthOWtXPA2mjAHMHGADfc
+        W05ENEAdp3jkDie1rUHWGGRluiASdQGIGxio9C5sWESAgwbYCAsrNX+imiXY7idMb/kRESkpKeHl1w+6
+        ThjnkW1wIFtvR1ajDelPXCgwDMNrTkV4UoLwONVYRGJ8tUrg6ZHOqYsIP/qQX14fblp3JYCZkIIZl7LM
+        WHSEZ0SOM48HoKh3QFVvQXrdNI5RZercyLvb2RY1R9h4QS5gjLZG78dO0lYn6ThF2C2zEPKHdvC1QQir
+        vBBqvRDUBCDVuJF4493FmH2flQ5+M+xcYJy+tJlqlCA8KIaydgqCCg/iKz5DpF2E9L4P8rK3LTHbDyxq
+        iZTp5A3BFjFTDdOADxKkVk2Ar1mC8N4C4mv8SLrVN3y2VL3/iX7GqhXJgiZ+N0YjndCA92IkV4yDaPwQ
+        axaRXNb7JqekMilW/nseFGcI/AaeZruL7OwMSpBSZYfwtmX36M2XlcUZGYJY2d/x1ZJzDn3y6Ok7pgFZ
+        6bPzse3/DSHfAf2EqkKNe37BAAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="kryptonButton8.Values.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAK+SURBVDhPrZJbSJNhGMefbxusudxm4VJTZ07TLEwTupDA
-        iyi8sIsor7wXojuNuhzdjDxmoYE1nacWM1JSswTL8rQ5T2ubcy41N9xwit+XR0j0+8cWCA6qm37w8D68
-        7/N7eE9Ef+F2VZVkQK86Fj7/T7Ib7TfSDIHuXOPUms96YmV/lnrXB4X54XWH5OqGI7NrJ1WZ9ZO3Mpvd
-        hox2P9Q9B8jpXsKuJwpYI+w7GWyYmPaVfuHNQIdYbW4lWUjO0+iPXWhyOTOMvs10ox9pXTtQv15DvGEd
-        We2zYJ1RgJuABQKWGRw4BPhpY7bZLwIXgscrKK6PONs0v63u2kGycRVJL/1IavMjrmUNmQYnOIcCcBF4
-        ZzCYUA4vYXtUsDOgiT4eapCqm1tXGdehavXxiS3LSGxehlIfwPnWGbBWBTBD4O3E83YGvI2AOcLWoIDr
-        KyUpFRRrIhKfubmYtg0oGwK8UhdAtG4FsnoW6kYXtqalgIOCIg8rAV8JmCXsDhDbV3pKSoWFhcLsuiHX
-        OcM80vUOpDfakdZgQ/ILF3L0I/CaEsBNyMFZ5ODGgiHDD6scnl7FnCaPRKGL/P7uZNOmKwrsuAKsRcGz
-        Y6ERntF4XHo+iMQ6B9R100iuncKZ2imk6tzIetjZdviMW2/oGsYIsBH4CeIxQeAnid8xSRD/1A5RRQCS
-        Si8kFV6Iq1eg0LoRfefj9cMGQVY7RM2wCwALA5gYwEzghmRQ1UxCXOZBZNk3SCsWoXjsQ3zJh5YjcpBp
-        jVzBdgqHYQvKDDBC4D7LkVA5DpF2CZJHC4is9iPmXv/I5SLN708UjrVCqgwYRT0wB3dC4D7JEFtmAWn9
-        kGkXEVvS9z6jsDwm3DvCk/wUsV8v1O52097ekBxxlXZI7k/vn777tjw/JUUcXv9HfDV0xdEYa774wDio
-        LHp1NXz9v/EL/YSqQjqcEQUAAAAASUVORK5CYII=
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAK/SURBVDhPrZJbSNNRHMfPLrDmcpuFS21u5jTNwjShBwl8
+        iMKHeojyyfcgetOox9HLSKdmoYE1N28tZqSUZgmW5W3et7Y551Jzw43N4X95hUT/387mIKioHvrAl3P7
+        fb/8zuGQP3GtulrYb1AeiC3/nXy9/XKWMdhVaJoO+ayHAruzpGd1gFccO/6VQt1QfH7dlDK3YepqbrPb
+        mNPuh6p7DwVdS9j2JAAhgl0nB2tmTnugj3cl2CFQjbYScdRcpDYcONXkcuaYfOvZJj+yXm1B9TwEuXEV
+        ee2zYJw0wE2ABaplDvYcXHyzcTaZj1wXIte7dL0h7njT/KaKGtNNK0h76kdamx8pLSHkGp0IO6SAi4B1
+        RsSJzuEl2BzhbvWrEw9GAzJ1c6tK0yqUrT5W0bIMRfMyZIYgTrbOgLHSgBlqthOWtXPA2mjAHMHGADfc
+        W05ENEAdp3jkDie1rUHWGGRluiASdQGIGxio9C5sWESAgwbYCAsrNX+imiXY7idMb/kRESkpKeHl1w+6
+        ThjnkW1wIFtvR1ajDelPXCgwDMNrTkV4UoLwONVYRGJ8tUrg6ZHOqYsIP/qQX14fblp3JYCZkIIZl7LM
+        WHSEZ0SOM48HoKh3QFVvQXrdNI5RZercyLvb2RY1R9h4QS5gjLZG78dO0lYn6ThF2C2zEPKHdvC1QQir
+        vBBqvRDUBCDVuJF4493FmH2flQ5+M+xcYJy+tJlqlCA8KIaydgqCCg/iKz5DpF2E9L4P8rK3LTHbDyxq
+        iZTp5A3BFjFTDdOADxKkVk2Ar1mC8N4C4mv8SLrVN3y2VL3/iX7GqhXJgiZ+N0YjndCA92IkV4yDaPwQ
+        axaRXNb7JqekMilW/nseFGcI/AaeZruL7OwMSpBSZYfwtmX36M2XlcUZGYJY2d/x1ZJzDn3y6Ok7pgFZ
+        6bPzse3/DSHfAf2EqkKNe37BAAAAAElFTkSuQmCC
 </value>
   </data>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">


### PR DESCRIPTION
Enhance KryptonContextMenuItem and KryptonCommand functionality

- Added `CommandParameter` property to `KryptonContextMenuItem` for passing parameters to commands.
- Introduced a new `PerformExecute` method in `KryptonCommand` to allow sender specification.
- Updated `ButtonsTest` in `TestForm` app to demonstrate command execution with parameters.
- Added custom `ReferenceConverter` to fix `Property value is not valid` design time error when trying to change command assignments.

Fixes #2196 
---
This introduces several enhancements to command handling for `KryptonContextMenuItem`.

### 1. Command `Execute` Sender Identity

-   **Previously**: When multiple menu items shared the same `KryptonCommand`, the `Execute` event handler would always receive the command object itself as the `sender`. This made it impossible to determine which specific menu item was clicked without creating separate command instances or using individual `Click` events.
-   **Now**: The `KryptonContextMenuItem` instance that initiates the action is passed as the `sender` to the command's `Execute` event. This allows the event handler to cast the sender and identify the exact originator of the command.

    A single `KryptonCommand` can be assigned to multiple items, and the handler can differentiate them based on their properties (`Text`, `Tag`, etc.).

    ```csharp
    void Command_Execute(object sender, EventArgs e)
    {
        var item = (KryptonContextMenuItem)sender;   // <-- The exact originating item
        // ...
    }
    ```

### 2. Design-Time `CommandParameter`

A `CommandParameter` property has been added to `KryptonContextMenuItem`. This provides a formal mechanism for distinguishing items at design-time without needing to parse the `Text` property.

```csharp
void Command_Execute(object sender, EventArgs e)
{
    var param = ((KryptonContextMenuItem)sender).CommandParameter;
    switch (param)
    {
        case "OpenFile": /* ... */ break;
        case "SaveFile": /* ... */ break;
        case "CloseApp": /* ... */ break;
    }
}
```

### 3. Improved Designer Experience

A custom `ReferenceConverter` has been implemented for the `KryptonCommand` property on `KryptonContextMenuItem`. This resolves a design-time issue where a "Property value is not valid" error would occur if the referenced `KryptonCommand` was removed from the designer.

---

### Implementation Rationale

The separation of concerns between the command and the menu item is key to this design.

-   **`KryptonCommand`**: A shared object that can be attached to many UI elements. It exposes state common to all of them (e.g., `Enabled`, `Checked`, `Text`).
-   **`KryptonContextMenuItem`**: The actual control the user clicks. While multiple items can share a command, each must retain its own identity.

The `CommandParameter` parameter allows each to carry a unique value while sharing the command's logic and state.

```txt
+-------------   one object   -------------+
¦              KryptonCommand              ¦
¦   Execute event fires once per click     ¦
+-------------------------------------------+
       ?           ?              ?
       ¦ shared    ¦ shared       ¦ shared
+----------+   +--------+     +--------+
¦ Item A   ¦   ¦ Item B ¦     ¦ Item C ¦   <-- separate controls
¦ Param=1  ¦   ¦ Param=2¦     ¦ Param=3¦
+----------+   +--------+     +--------+
```

Inside a single `Execute` handler, the implementation could be as follows:

```csharp
void Command_Execute(object sender, EventArgs e)
{
    var item = (KryptonContextMenuItem)sender;
    var param = item.CommandParameter as string;
    switch (item.CommandParameter)
    {
        case "1": // ... action for Item A
            break;
        case "2": // ... action for Item B
            break;
        case "3": // ... action for Item C
            break;
    }
}
```

This architecture allows a single `KryptonCommand` to synchronize state across different controls (buttons, ribbon items, etc.) while providing a clear way to identify which specific menu item triggered the action.

---

This is a demo setup within the `ButtonsTest` form:

1st and 2nd context menu items share the same event handler, but have different text and `CommandParameter` (the command's `Text` property is left empty so the context menu items' `Text` is used):
<img width="1249" height="476" alt="image" src="https://github.com/user-attachments/assets/b75cda54-30ba-461d-9e0a-968d0e68c452" />
<img width="1250" height="476" alt="image" src="https://github.com/user-attachments/assets/4404c69d-3ba3-41c8-b47e-93f818baaa87" />

Clicks on the context menu items now allow to distinguish between the calling sender in the event handler (CommandParameter), so the same action may be used on several menu items:
<img width="745" height="338" alt="image" src="https://github.com/user-attachments/assets/34d2722f-5a1a-4091-8cd1-9e283ee33fac" />
<img width="818" height="379" alt="image" src="https://github.com/user-attachments/assets/7ce78f73-1cb7-4b74-ac50-bf93545bcf1a" />
<img width="817" height="378" alt="image" src="https://github.com/user-attachments/assets/8d40ff65-1144-4284-9b06-d13c05722917" />




