### PR TITLE
2318-V100-KryptonForm-does-not-handle-the-ControlRemoved-event-correctly

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 ====
 
 ## 2025-11-xx - Build 2511 (V10 - alpha) - November 2025
+* Resolved [#2318](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2318), `KryptonForm` does not handle the `ControlRemoved` and `ControlAdded` event correctly.
 * Resolved [#2178](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2178), Fix `KryptonPropertyGrid` enabling logic for `Reset` menu-item
 * Resolved [#2312](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2312), (fix) correct GDI resource handling of components' WmPaint
 * Resolved [#2309](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2309), `KryptonDataGridViewImageColumn` causes lagging in grid refresh when a new row is auto added.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -176,8 +176,11 @@ public class KryptonForm : VisualForm,
             Margin = new Padding(0),
             Name = "InternalKryptonPanel",
             Size = new Size(100, 100),
-            TabStop = false
+            TabStop = false,
         };
+        // B2318 - Since the introduction of the InternalPanel override for OnControlRemoved and OnControlAdded don't fire correctly.
+        _internalKryptonPanel.ControlRemoved += (s, e) => OnControlRemoved(e);
+        _internalKryptonPanel.ControlAdded += (s, e) => OnControlAdded(e);
 
         // Create the root element that contains the title bar and null filler
         _drawDocker = new ViewDrawForm(StateActive.Back, StateActive.Border)
@@ -1052,6 +1055,7 @@ public class KryptonForm : VisualForm,
     /// Raises the ControlRemoved event.
     /// </summary>
     /// <param name="e">An EventArgs containing event data.</param>
+    //protected override void OnControlRemoved(ControlEventArgs e)
     protected override void OnControlRemoved(ControlEventArgs e)
     {
         // Is the cached reference being removed?
@@ -1063,6 +1067,8 @@ public class KryptonForm : VisualForm,
             // Recalc to test if status strip should be unintegrated
             RecalcNonClient();
         }
+
+        base.OnControlRemoved(e);
     }
 
     /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -178,7 +178,7 @@ public class KryptonForm : VisualForm,
             Size = new Size(100, 100),
             TabStop = false,
         };
-        // B2318 - Since the introduction of the InternalPanel override for OnControlRemoved and OnControlAdded don't fire correctly.
+        // B2318 - Since the introduction of the InternalPanel overrides for OnControlRemoved and OnControlAdded don't fire correctly.
         _internalKryptonPanel.ControlRemoved += (s, e) => OnControlRemoved(e);
         _internalKryptonPanel.ControlAdded += (s, e) => OnControlAdded(e);
 


### PR DESCRIPTION
[Issue 2318-KryptonForm-does-not-handle-the-ControlRemoved-event-correctly](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2318)
- Events restored
- And the changelog

<img width="256" height="181" alt="compile-results" src="https://github.com/user-attachments/assets/e4320abe-d846-42e5-8795-31e91b22186b" />
