### PR TITLE
2196-V95-KCommand-KContextMenuItem-enhancements

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2025-08-25 - Build 2508 (Patch 8) - August 2025
+* Resolved [#2319](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2319), Enhance KryptonContextMenuItem and KryptonCommand functionality
 * Resolved [#2178](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2178), Fix `KryptonPropertyGrid` enabling logic for `Reset` menu-item
 * Resolved [#2300](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2300), Fix memory leak in PaletteBase
 * Resolved [#2277](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2277), Added colors in the `Color[] _schemeOfficeColors`.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCommand.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCommand.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2024. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -77,7 +77,7 @@ namespace Krypton.Toolkit
             _assignedButtonSpec = null;
         }
 
-        /// <summary> 
+        /// <summary>
         /// Clean up any resources being used.
         /// </summary>
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
@@ -381,6 +381,10 @@ namespace Krypton.Toolkit
         /// Generates a Execute event for a button.
         /// </summary>
         public void PerformExecute() => OnExecute(EventArgs.Empty);
+
+        // Allow specifying the originating sender so shared commands can identify the source control
+        public void PerformExecute(object? sender)
+            => Execute?.Invoke(sender ?? this, EventArgs.Empty);
 
         #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuItem.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/View Draw/ViewDrawMenuItem.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2024. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -121,7 +121,7 @@ namespace Krypton.Toolkit
                 string shortcutString = KryptonContextMenuItem.ShortcutKeyDisplayString;
                 if (string.IsNullOrEmpty(shortcutString))
                 {
-                    shortcutString = (KryptonContextMenuItem.ShortcutKeys != Keys.None) 
+                    shortcutString = (KryptonContextMenuItem.ShortcutKeys != Keys.None)
                         ? new KeysConverter().ConvertToString(KryptonContextMenuItem.ShortcutKeys) ?? string.Empty
                         : string.Empty;
                 }
@@ -142,12 +142,12 @@ namespace Krypton.Toolkit
 
             // SubMenu Indicator
             HasSubMenu = KryptonContextMenuItem.Items.Count > 0;
-            _subMenuContent = new ViewDrawMenuItemContent(menuItemState.ItemImage.Content, new FixedContentValue(null, null, 
-                !HasSubMenu 
-                    ? _empty16x16 
-                    : provider.ProviderImages.GetContextMenuSubMenuImage(), 
-                KryptonContextMenuItem.Items.Count == 0 
-                    ? GlobalStaticValues.TRANSPARENCY_KEY_COLOR 
+            _subMenuContent = new ViewDrawMenuItemContent(menuItemState.ItemImage.Content, new FixedContentValue(null, null,
+                !HasSubMenu
+                    ? _empty16x16
+                    : provider.ProviderImages.GetContextMenuSubMenuImage(),
+                KryptonContextMenuItem.Items.Count == 0
+                    ? GlobalStaticValues.TRANSPARENCY_KEY_COLOR
                     : GlobalStaticValues.EMPTY_COLOR),
                 3);
             docker.Add(new ViewLayoutCenter(_subMenuContent), ViewDockStyle.Right);
@@ -284,7 +284,10 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Resolves the correct text string to use from the menu item.
         /// </summary>
-        public string ResolveText => _cachedCommand != null ? _cachedCommand.Text : KryptonContextMenuItem.Text;
+        public string ResolveText => _cachedCommand != null
+            && !string.IsNullOrEmpty(_cachedCommand.Text)
+                ? _cachedCommand.Text
+                : KryptonContextMenuItem.Text;
 
         #endregion
 
@@ -292,7 +295,10 @@ namespace Krypton.Toolkit
         /// <summary>
         /// Resolves the correct extra text string to use from the menu item.
         /// </summary>
-        public string ResolveExtraText => _cachedCommand != null ? _cachedCommand.ExtraText : KryptonContextMenuItem.ExtraText;
+        public string ResolveExtraText => _cachedCommand != null
+            && !string.IsNullOrEmpty(_cachedCommand.ExtraText)
+                ? _cachedCommand.ExtraText
+                : KryptonContextMenuItem.ExtraText;
 
         #endregion
 
@@ -326,7 +332,7 @@ namespace Krypton.Toolkit
                 // If menu item is split into regular button and sub menu areas
                 if (SplitSeparator.Draw)
                 {
-                    // If mouse is inside or to the right of the slip indicator, 
+                    // If mouse is inside or to the right of the slip indicator,
                     // then a sub menu is required when the button is used
                     return pt.X > SplitSeparator.ClientRectangle.X;
                 }


### PR DESCRIPTION
Enhance KryptonContextMenuItem and KryptonCommand functionality

- Added `CommandParameter` property to `KryptonContextMenuItem` for passing parameters to commands.
- Introduced a new `PerformExecute` method in `KryptonCommand` to allow sender specification.
- Updated `ButtonsTest` in `TestForm` app to demonstrate command execution with parameters.
- Added custom `ReferenceConverter` to fix `Property value is not valid` design time error when trying to change command assignments.

Fixes #2196 
---
This introduces several enhancements to command handling for `KryptonContextMenuItem`.

### 1. Command `Execute` Sender Identity

-   **Previously**: When multiple menu items shared the same `KryptonCommand`, the `Execute` event handler would always receive the command object itself as the `sender`. This made it impossible to determine which specific menu item was clicked without creating separate command instances or using individual `Click` events.
-   **Now**: The `KryptonContextMenuItem` instance that initiates the action is passed as the `sender` to the command's `Execute` event. This allows the event handler to cast the sender and identify the exact originator of the command.

    A single `KryptonCommand` can be assigned to multiple items, and the handler can differentiate them based on their properties (`Text`, `Tag`, etc.).

    ```csharp
    void Command_Execute(object sender, EventArgs e)
    {
        var item = (KryptonContextMenuItem)sender;   // <-- The exact originating item
        // ...
    }
    ```

### 2. Design-Time `CommandParameter`

A `CommandParameter` property has been added to `KryptonContextMenuItem`. This provides a formal mechanism for distinguishing items at design-time without needing to parse the `Text` property.

```csharp
void Command_Execute(object sender, EventArgs e)
{
    var param = ((KryptonContextMenuItem)sender).CommandParameter;
    switch (param)
    {
        case "OpenFile": /* ... */ break;
        case "SaveFile": /* ... */ break;
        case "CloseApp": /* ... */ break;
    }
}
```

### 3. Improved Designer Experience

A custom `ReferenceConverter` has been implemented for the `KryptonCommand` property on `KryptonContextMenuItem`. This resolves a design-time issue where a "Property value is not valid" error would occur if the referenced `KryptonCommand` was removed from the designer.

---

### Implementation Rationale

The separation of concerns between the command and the menu item is key to this design.

-   **`KryptonCommand`**: A shared object that can be attached to many UI elements. It exposes state common to all of them (e.g., `Enabled`, `Checked`, `Text`).
-   **`KryptonContextMenuItem`**: The actual control the user clicks. While multiple items can share a command, each must retain its own identity.

The `CommandParameter` parameter allows each to carry a unique value while sharing the command's logic and state.

```txt
+-------------   one object   -------------+
¦              KryptonCommand              ¦
¦   Execute event fires once per click     ¦
+-------------------------------------------+
       ?           ?              ?
       ¦ shared    ¦ shared       ¦ shared
+----------+   +--------+     +--------+
¦ Item A   ¦   ¦ Item B ¦     ¦ Item C ¦   <-- separate controls
¦ Param=1  ¦   ¦ Param=2¦     ¦ Param=3¦
+----------+   +--------+     +--------+
```

Inside a single `Execute` handler, the implementation could be as follows:

```csharp
void Command_Execute(object sender, EventArgs e)
{
    var item = (KryptonContextMenuItem)sender;
    var param = item.CommandParameter as string;
    switch (item.CommandParameter)
    {
        case "1": // ... action for Item A
            break;
        case "2": // ... action for Item B
            break;
        case "3": // ... action for Item C
            break;
    }
}
```

This architecture allows a single `KryptonCommand` to synchronize state across different controls (buttons, ribbon items, etc.) while providing a clear way to identify which specific menu item triggered the action.

---

This is a demo setup within the `ButtonsTest` form:

1st and 2nd context menu items share the same event handler, but have different text and `CommandParameter` (the command's `Text` property is left empty so the context menu items' `Text` is used):
<img width="1249" height="476" alt="image" src="https://github.com/user-attachments/assets/b75cda54-30ba-461d-9e0a-968d0e68c452" />
<img width="1250" height="476" alt="image" src="https://github.com/user-attachments/assets/4404c69d-3ba3-41c8-b47e-93f818baaa87" />

Clicks on the context menu items now allow to distinguish between the calling sender in the event handler (CommandParameter), so the same action may be used on several menu items:
<img width="745" height="338" alt="image" src="https://github.com/user-attachments/assets/34d2722f-5a1a-4091-8cd1-9e283ee33fac" />
<img width="818" height="379" alt="image" src="https://github.com/user-attachments/assets/7ce78f73-1cb7-4b74-ac50-bf93545bcf1a" />
<img width="817" height="378" alt="image" src="https://github.com/user-attachments/assets/8d40ff65-1144-4284-9b06-d13c05722917" />




