### PR TITLE
2220-V100-KryptonLabel-does-not-support-surrogates

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 ====
 
 ## 2025-11-xx - Build 2511 (V10 - alpha) - November 2025
+* Implemented [#2220](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2220), `KryptonLabel` enables limited support for unicode surrogates.
 * Resolved [#2324](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2324), Update PlatformInvoke.cs imports (see #2316)
 * Resolved [#2318](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2318), `KryptonForm` does not handle the `ControlRemoved` and `ControlAdded` event correctly.
 * Resolved [#2319](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2319), Enhance KryptonContextMenuItem and KryptonCommand functionality

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLabel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonLabel.cs
@@ -92,6 +92,37 @@ public class KryptonLabel : VisualSimpleBase, IContentValues
 
     #region Public
     /// <summary>
+    /// Enables the display of Unicode Surrogates, but only when the Orientation is set to Top.
+    /// </summary>
+    [Browsable(true)]
+    [EditorBrowsable(EditorBrowsableState.Always)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+    [RefreshProperties(RefreshProperties.All)]
+    [DefaultValue(false)]
+    [Description("Enables the display of Unicode Surrogates, but only when the Orientation is set to Top.")]
+    public virtual bool EnableUnicodeSurrogates 
+    {
+        get;
+        set
+        {
+            if (field != value)
+            {
+                // store the new setting
+                field = value;
+
+                // When enabled Orientation must be Top
+                if (value)
+                {
+                    Orientation = VisualOrientation.Top;
+                }
+
+                // refresh
+                Invalidate();
+            }
+        }
+    }
+
+    /// <summary>
     /// Gets and sets the automatic resize of the control to fit contents.
     /// </summary>
     [Browsable(true)]
@@ -493,6 +524,39 @@ public class KryptonLabel : VisualSimpleBase, IContentValues
         // Always need to draw the background because always transparent
         true;
 
+    /// <inheritdoc/>
+    protected override void OnPaint(PaintEventArgs? e)
+    {
+        // Base first then it's out turn
+        base.OnPaint(e);
+
+        if (EnableUnicodeSurrogates && Orientation == VisualOrientation.Top)
+        {
+            PaletteContent state;
+            PaletteState paletteState;
+
+            if (Enabled)
+            {
+                state = StateNormal;
+                paletteState = PaletteState.Normal;
+            }
+            else
+            {
+                state = StateDisabled;
+                paletteState = PaletteState.Disabled;
+            }
+
+            Font font = state.GetContentShortTextFont(paletteState) ?? KryptonManager.CurrentGlobalPalette.BaseFont;
+            Color foreColor = state.GetContentShortTextColor1(paletteState);
+            Color backColor = KryptonManager.CurrentGlobalPalette.GetBackColor1(PaletteBackStyle.PanelClient, paletteState);
+
+            TextFormatFlags textFormatFlags = RightToLeft == RightToLeft.No
+                ? TextFormatFlags.Left | TextFormatFlags.VerticalCenter
+                : TextFormatFlags.Right | TextFormatFlags.VerticalCenter;
+
+            TextRenderer.DrawText(e!.Graphics, Text, font, e.ClipRectangle, foreColor, backColor, textFormatFlags);
+        }
+    }
     #endregion
 
     #region Implementation


### PR DESCRIPTION
[Issue 2220-KryptonLabel-does-not-support-surrogates](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2220)
- Enables unicode surrogates in horizontal mode
- And the changelog

<img width="261" height="177" alt="compile-results" src="https://github.com/user-attachments/assets/1f4c27a6-26cc-4a6b-a165-40b81d7212c4" />
