### PR TITLE
2329-V95-AccurateText-StringFormatToFlags-handles-conversion-incorrect

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2025-08-25 - Build 2508 (Patch 8) - August 2025
+* Resolved [#2329](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2329), `AccurateText.StringFormatToFlags()` performs incorrect conversion to TextFormatFlags.
 * Resolved [#2319](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2319), Enhance KryptonContextMenuItem and KryptonCommand functionality
 * Resolved [#2178](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2178), Fix `KryptonPropertyGrid` enabling logic for `Reset` menu-item
 * Resolved [#2277](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2277), Added colors in the `Color[] _schemeOfficeColors`.

--- a/Source/Krypton Components/Krypton.Toolkit/AccurateText/AccurateText.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/AccurateText/AccurateText.cs
@@ -658,70 +658,71 @@ namespace Krypton.Toolkit
             return sf;
         }
 
-        private static TextFormatFlags StringFormatToFlags(StringFormat sf)
+        private static TextFormatFlags StringFormatToFlags2(StringFormat sf)
         {
             var flags = new TextFormatFlags();
 
+            // Link is dead
             // Translation table: http://msdn.microsoft.com/msdnmag/issues/06/03/TextRendering/default.aspx?fig=true#fig4
 
             flags = sf.Alignment switch
             {
                 // Horizontal Alignment
-                StringAlignment.Center => flags & TextFormatFlags.HorizontalCenter,
-                StringAlignment.Far => flags & TextFormatFlags.Right,
-                _ => flags & TextFormatFlags.Left
+                StringAlignment.Center => TextFormatFlags.HorizontalCenter,
+                StringAlignment.Far => TextFormatFlags.Right,
+                _ => TextFormatFlags.Left
             };
-            flags = sf.LineAlignment switch
+
+            flags |= sf.LineAlignment switch
             {
                 // Vertical Alignment
-                StringAlignment.Far => flags & TextFormatFlags.Bottom,
-                StringAlignment.Center => flags & TextFormatFlags.VerticalCenter,
-                _ => flags & TextFormatFlags.Top
+                StringAlignment.Far => TextFormatFlags.Bottom,
+                StringAlignment.Center => TextFormatFlags.VerticalCenter,
+                _ => TextFormatFlags.Top
             };
+
             switch (sf.Trimming)
             {
                 // Ellipsis
                 case StringTrimming.EllipsisCharacter:
-                    flags &= TextFormatFlags.EndEllipsis;
+                    flags |= TextFormatFlags.EndEllipsis;
                     break;
                 case StringTrimming.EllipsisPath:
-                    flags &= TextFormatFlags.PathEllipsis;
+                    flags |= TextFormatFlags.PathEllipsis;
                     break;
                 case StringTrimming.EllipsisWord:
-                    flags &= TextFormatFlags.WordEllipsis;
+                    flags |= TextFormatFlags.WordEllipsis;
                     break;
             }
 
-            switch (sf.HotkeyPrefix)
+            flags |= sf.HotkeyPrefix switch
             {
                 // Hotkey Prefix
-                case HotkeyPrefix.None:
-                    flags &= TextFormatFlags.NoPrefix;
-                    break;
-                case HotkeyPrefix.Hide:
-                    flags &= TextFormatFlags.HidePrefix;
-                    break;
-            }
+                HotkeyPrefix.None => TextFormatFlags.NoPrefix,
+                HotkeyPrefix.Hide => TextFormatFlags.HidePrefix,
+                // Underlines the hotkey character
+                _ => TextFormatFlags.PrefixOnly
+            };
 
             switch (sf.FormatFlags)
             {
                 // Text Padding
                 case StringFormatFlags.FitBlackBox:
-                    flags &= TextFormatFlags.NoPadding;
+                    flags |= TextFormatFlags.NoPadding;
                     break;
                 // Text Wrapping
                 case StringFormatFlags.NoWrap:
-                    flags &= TextFormatFlags.SingleLine;
+                    flags |= TextFormatFlags.SingleLine;
                     break;
                 case StringFormatFlags.LineLimit:
-                    flags &= TextFormatFlags.TextBoxControl;
+                    flags |= TextFormatFlags.TextBoxControl;
                     break;
                 // Other Flags
                 case StringFormatFlags.DirectionRightToLeft:
-                    flags &= TextFormatFlags.RightToLeft;
+                    flags |= TextFormatFlags.RightToLeft;
                     break;
                 case StringFormatFlags.NoClip:
-                    flags &= TextFormatFlags.NoClipping;
+                    flags |= TextFormatFlags.NoClipping;
                     break;
             }
 


### PR DESCRIPTION
[Issue 2329-AccurateText-StringFormatToFlags-handles-conversion-incorrect](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2329)
- Method updated
- And the changelog

<img width="225" height="138" alt="compile-results" src="https://github.com/user-attachments/assets/7a6bb2b4-4733-4450-9b82-e3df4211607a" />
