### PR TITLE
2329-V95-AccurateText-StringFormatToFlags-handles-conversion-incorrect

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/AccurateText/AccurateText.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/AccurateText/AccurateText.cs
@@ -426,7 +426,7 @@ public class AccurateText : GlobalId
         return sf;
     }
 
-    private static TextFormatFlags StringFormatToFlags2(StringFormat sf)
+    private static TextFormatFlags StringFormatToFlags(StringFormat sf)
     {
         var flags = new TextFormatFlags();
 


### PR DESCRIPTION
[Issue 2329-AccurateText-StringFormatToFlags-handles-conversion-incorrect](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2329)
- Updates previous PR #2330