### PR TITLE
2341-V100-fix-prevent-exception-in-ContentFontForButtonForm

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 ====
 
 ## 2025-11-xx - Build 2511 (V10 - alpha) - November 2025
+* Resolved [#2341](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2341), Fix exception in `RenderStandard.ContentFontForButtonForm` during teardown
 * Implemented [#2328](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2328), Set the baseline support to .NET Framework 4.7.2
 	- **Note:** This is a breaking change, as the minimum supported version of .NET Framework has been raised from 4.6.2 to 4.7.2.
 * Resolved [#2329](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2329), `AccurateText.StringFormatToFlags()` performs incorrect conversion to TextFormatFlags.

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderStandard.cs
@@ -2,9 +2,9 @@
 /*
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
  */
 #endregion
 
@@ -496,7 +496,7 @@ public class RenderStandard : RenderBase
         {
             var borderWidth = palette.GetBorderWidth(state);
 
-            // Divide the rounding effect by PI to get the actual pixel distance needed 
+            // Divide the rounding effect by PI to get the actual pixel distance needed
             // for offsetting. But add 2, so it starts indenting on a rounding of just 1.
             int roundPadding = Convert.ToInt16((palette.GetBorderRounding(state) + borderWidth + 2) / Math.PI);
 
@@ -510,7 +510,7 @@ public class RenderStandard : RenderBase
                 roundPadding += halfExtra;
             }
 
-            // Enforce the width of the border as the minimum to ensure 
+            // Enforce the width of the border as the minimum to ensure
             // it still works as expected for small values of rounding
             if (roundPadding < borderWidth)
             {
@@ -1060,7 +1060,7 @@ public class RenderStandard : RenderBase
         Debug.Assert(context.Control != null);
         Debug.Assert(!context.Control!.IsDisposed);
 
-        // Provide a maximum sized rectangle for placing content into, in 
+        // Provide a maximum sized rectangle for placing content into, in
         // order to work out how much of the space is actually allocated
         var displayRect = new Rectangle(Point.Empty, new Size(int.MaxValue, int.MaxValue));
 
@@ -1252,7 +1252,7 @@ public class RenderStandard : RenderBase
         var col1 = col0 + colWidths[0];
 
         // Do we need to add a spacing gap after the first column?
-        if (((colWidths[0] > 0) && (colWidths[1] > 0)) 
+        if (((colWidths[0] > 0) && (colWidths[1] > 0))
             || ((colWidths[0] > 0) && (colWidths[1] == 0) && (colWidths[2] > 0))
            )
         {
@@ -2565,7 +2565,7 @@ public class RenderStandard : RenderBase
         switch (orientation)
         {
             case VisualOrientation.Bottom:
-                // Translate to opposite side of origin, so the rotate can 
+                // Translate to opposite side of origin, so the rotate can
                 // then bring it back to original position but mirror image
                 translateX = (displayRect.X * 2) + displayRect.Width;
                 translateY = (displayRect.Y * 2) + displayRect.Height;
@@ -2575,7 +2575,7 @@ public class RenderStandard : RenderBase
             case VisualOrientation.Left:
                 // Invert the dimensions of the rectangle for drawing upwards
                 displayRect = displayRect with { Width = displayRect.Height, Height = displayRect.Width };
-                // Translate back from a quarter left turn to the original place 
+                // Translate back from a quarter left turn to the original place
                 translateX = displayRect.X - displayRect.Y;
                 translateY = displayRect.X + displayRect.Y + displayRect.Width;
                 rotation = -90f;
@@ -2584,7 +2584,7 @@ public class RenderStandard : RenderBase
             case VisualOrientation.Right:
                 // Invert the dimensions of the rectangle for drawing upwards
                 displayRect = displayRect with { Width = displayRect.Height, Height = displayRect.Width };
-                // Translate back from a quarter right turn to the original place 
+                // Translate back from a quarter right turn to the original place
                 translateX = displayRect.X + displayRect.Y + displayRect.Height;
                 translateY = -(displayRect.X - displayRect.Y);
                 rotation = 90f;
@@ -3901,7 +3901,7 @@ public class RenderStandard : RenderBase
         {   // Deal with issues arrising within https://github.com/Krypton-Suite/Standard-Toolkit/issues/1871
             borderRounding = 0.1f;
         }
-            
+
         if (rect is { Width: > 0, Height: > 0 })
         {
             // Only use a rounding that will fit inside the rect
@@ -3910,7 +3910,7 @@ public class RenderStandard : RenderBase
 
             if (middle)
             {
-                // Shrink the rect by half the width of the pen, because the pen will 
+                // Shrink the rect by half the width of the pen, because the pen will
                 // draw half the distance overlapping each side of the centre anyway.
                 // Unless not drawing into the middle in which case give the outside.
                 int halfBorderWidthTL = (int)((borderWidth + .5f) / 2f);
@@ -4440,7 +4440,7 @@ public class RenderStandard : RenderBase
         // A zero size rectangle cannot be drawn, so return a null path
         if (rect is { Width: > 0, Height: > 0 })
         {
-            // Shrink the rect by half the width of the pen, because the pen will 
+            // Shrink the rect by half the width of the pen, because the pen will
             // draw half the distance overlapping each side of the centre anyway.
             var halfBorderWidth = borderWidth / 2;
 
@@ -5720,7 +5720,8 @@ public class RenderStandard : RenderBase
             if ((font!.Height > fontSpace) && (fontSpace > 5))
             {
                 // Find the point size from the pixel height required
-                var point = 72 / context.Graphics.DpiY * (fontSpace / 1.333f);
+                var dpiY = Math.Max(context.Graphics.DpiY, 1f);
+                var point = 72 / dpiY * (fontSpace / 1.333f);
 
                 // No point having a font smaller than 3 points
                 if (point > 3)
@@ -6127,7 +6128,7 @@ public class RenderStandard : RenderBase
             // Should we try and trim the text into the space?
             if (trim != PaletteTextTrim.Hide)
             {
-                // If there is some room available after taking 
+                // If there is some room available after taking
                 // into account the need for a spacing gap
                 if ((allocateWidth == requiredSize.Width) ||
                     ((allocateWidth > requiredSize.Width) && applyGap))
@@ -11166,7 +11167,7 @@ public class RenderStandard : RenderBase
     {
         if (rect is { Width: > 0, Height: > 0 })
         {
-            // Grab the colors needed for drawing                
+            // Grab the colors needed for drawing
             Color c1 = palette.GetRibbonBackColor1(state);
             Color c2 = palette.GetRibbonBackColor2(state);
             Color c3 = palette.GetRibbonBackColor3(state);


### PR DESCRIPTION
`RenderStandard` class, exception in method `ContentFontForButtonForm`.
Not easily reproducable, could be timing issue during a form close.

Actual fix is in lines 5723-5724

Is this worthwhile applying?

Fixes https://github.com/Krypton-Suite/Standard-Toolkit/issues/2341

---

<img width="2204" height="1175" alt="image" src="https://github.com/user-attachments/assets/0c6efa51-ef87-4e33-b71c-88977fe1f360" />

---

* A.I. explanation

What happens:

1. You are in `Krypton.Toolkit.Rendering.RenderStandard.ContentFontForButtonForm(...)`.
2. The method decides the normal header font is too tall for the caption bar and wants to create a smaller one:  

   ```c#
   var point = 72 / context.Graphics.DpiY * (fontSpace / 1.333f);
   font = new Font(font.FontFamily, point, font.Style);  // ← throws
   ```
3. `new Font(…)` throws `System.ArgumentException ("Ungültiger Parameter.")`.  
   GDI+ raises that exception when the requested `emSize` is invalid:
   • ≤ 0,  
   • `NaN` / `Infinity`,  
   • or larger than the GDI+ limit (≈ 2048 pt).

Why it fails here:

`point` is computed with a division by `context.Graphics.DpiY`.  
If `DpiY` is 0 (or extremely small) the result becomes `Infinity` (or > 2048) and the
constructor fails.  
`DpiY == 0` can occur when the `Graphics` object you get from
`ViewLayoutContext.Graphics` has already been disposed or was never initialised
properly.

How to confirm:

• While stopped in the debugger, add a watch on  
  `context.Graphics.DpiY` and on the calculated `point`.  
  You will see it is 0 → `Infinity` (or some enormous value).

Suggested fix:

Defensively clamp the value before creating the font:

```c#
float dpiY = context.Graphics.DpiY;
if (dpiY <= 0f) dpiY = 96f;                     // fallback to a sane default
float point = 72f / dpiY * (fontSpace / 1.333f);

if (!float.IsNaN(point) &&
    !float.IsInfinity(point) &&
    point > 3f && point <= 2048f)
{
    font = new Font(font.FontFamily, point, font.Style);
}
```

(or simply short-circuit when `dpiY <= 0`).

That prevents the invalid‐parameter condition while still shrinking the font when feasible.
