### PR TITLE
(fix) 2348-V100-Replace raw memory-DC double-buffering with GDI+ bitmap buffering

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 ====
 
 ## 2025-11-xx - Build 2511 (V10 - alpha) - November 2025
+* Resolved [#2348](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2348), Replace raw memory-DC double-buffering with GDI+ bitmap buffering
 * Resolved [#2341](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2341), Fix exception in `RenderStandard.ContentFontForButtonForm` during teardown
 * Implemented [#2328](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2328), Set the baseline support to .NET Framework 4.7.2
 	- **Note:** This is a breaking change, as the minimum supported version of .NET Framework has been raised from 4.6.2 to 4.7.2.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckedListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckedListBox.cs
@@ -393,7 +393,6 @@ public class KryptonCheckedListBox : VisualControlBase,
         private object? _innerArray;
         private readonly ViewManager? _viewManager;
         private readonly KryptonCheckedListBox _kryptonCheckedListBox;
-        private readonly IntPtr _screenDC;
         private bool _mouseOver;
         private bool _killNextSelect;
         private int _lastSelected;
@@ -442,9 +441,6 @@ public class KryptonCheckedListBox : VisualControlBase,
             base.MultiColumn = false;
             base.DrawMode = DrawMode.OwnerDrawVariable;
             // ReSharper restore RedundantBaseQualifier
-
-            // We need to create and cache a device context compatible with the display
-            _screenDC = PI.CreateCompatibleDC(IntPtr.Zero);
         }
 
         /// <summary>
@@ -454,10 +450,6 @@ public class KryptonCheckedListBox : VisualControlBase,
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);
-            if (_screenDC != IntPtr.Zero)
-            {
-                PI.DeleteDC(_screenDC);
-            }
         }
         #endregion
 
@@ -836,70 +828,50 @@ public class KryptonCheckedListBox : VisualControlBase,
             // No point drawing when one of the dimensions is zero
             if (realRect is { Width: > 0, Height: > 0 })
             {
-                var hBitmap = PI.CreateCompatibleBitmap(hdc, realRect.Width, realRect.Height);
+                // Cache a copy of the message so the ref parameter is not captured inside the lambda
+                var messageCopy = m;
 
-                // If we managed to get a compatible bitmap
-                if (hBitmap != IntPtr.Zero)
+                RenderBufferedPaintHelper.PaintBuffered(hdc, realRect, g =>
                 {
-                    // Must use the screen device context for the bitmap when drawing into the
-                    // bitmap otherwise the Opacity and RightToLeftLayout will not work correctly.
-                    // Select the new bitmap into the screen DC
-                    IntPtr oldBitmap = PI.SelectObject(_screenDC, hBitmap);
+                    // Use local (0,0)-based bounds for layout/render
+                    var localBounds = new Rectangle(Point.Empty, realRect.Size);
 
+                    // Ask the view element to layout in given space, needs this before a render call
+                    using (var context = new ViewLayoutContext(this, _kryptonCheckedListBox.Renderer))
+                    {
+                        context.DisplayRectangle = localBounds;
+                        ViewDrawPanel.Layout(context);
+                    }
+
+                    using (var context = new RenderContext(this, _kryptonCheckedListBox, g,
+                               localBounds, _kryptonCheckedListBox.Renderer))
+                    {
+                        ViewDrawPanel.Render(context);
+                    }
+
+                    // Replace given DC with the buffered graphics DC for base window proc drawing
+                    var tempHdc = g.GetHdc();
                     try
                     {
-                        // Easier to draw using a graphics instance than a DC!
-                        using (Graphics g = Graphics.FromHdc(_screenDC))
-                        {
-                            // Ask the view element to layout in given space, needs this before a render call
-                            using (var context = new ViewLayoutContext(this, _kryptonCheckedListBox.Renderer))
-                            {
-                                context.DisplayRectangle = realRect;
-                                ViewDrawPanel.Layout(context);
-                            }
-
-                            using (var context = new RenderContext(this, _kryptonCheckedListBox, g,
-                                       realRect, _kryptonCheckedListBox.Renderer))
-                            {
-                                ViewDrawPanel.Render(context);
-                            }
-
-                            // Replace given DC with the screen DC for base window proc drawing
-                            var beforeDC = m.WParam;
-                            m.WParam = _screenDC;
-                            DefWndProc(ref m);
-                            m.WParam = beforeDC;
-
-                            if (Items.Count == 0)
-                            {
-                                using var context = new RenderContext(this, _kryptonCheckedListBox, g,
-                                    realRect, _kryptonCheckedListBox.Renderer);
-                                ViewDrawPanel.Render(context);
-                            }
-                        }
-
-                        // Now blit from the bitmap from the screen to the real dc
-                        PI.BitBlt(hdc, 0, 0, realRect.Width, realRect.Height, _screenDC, 0, 0, PI.SRCCOPY);
-
-                        // When disabled with no items the above code does not draw the background! Strange but true, and
-                        // so we need to draw the background instead directly, without using a bit blitting of bitmap
-                        if (Items.Count == 0)
-                        {
-                            using Graphics g = Graphics.FromHdc(hdc);
-                            using var context = new RenderContext(this, _kryptonCheckedListBox, g,
-                                realRect, _kryptonCheckedListBox.Renderer);
-                            ViewDrawPanel.Render(context);
-                        }
+                        // Create a local copy of the cached message with the new HDC
+                        var localMessage = messageCopy;
+                        localMessage.WParam = tempHdc;
+                        DefWndProc(ref localMessage);
                     }
                     finally
                     {
-                        // Restore the original bitmap
-                        PI.SelectObject(_screenDC, oldBitmap);
-
-                        // Delete the temporary bitmap
-                        PI.DeleteObject(hBitmap);
+                        g.ReleaseHdc(tempHdc);
                     }
-                }
+
+                    // When disabled with no items the above code does not draw the background! Strange but true,
+                    // so we need to draw the background instead directly
+                    if (Items.Count == 0)
+                    {
+                        using var context = new RenderContext(this, _kryptonCheckedListBox, g,
+                            localBounds, _kryptonCheckedListBox.Renderer);
+                        ViewDrawPanel.Render(context);
+                    }
+                });
             }
 
             // Do we need to match the original BeginPaint?
@@ -974,7 +946,6 @@ public class KryptonCheckedListBox : VisualControlBase,
     private readonly FixedContentValue? _contentValues;
     private bool? _fixedActive;
     private ButtonStyle _style;
-    private readonly IntPtr _screenDC;
     private int _lastSelectedIndex;
     private bool _mouseOver;
     private bool _alwaysActive;
@@ -1215,9 +1186,6 @@ public class KryptonCheckedListBox : VisualControlBase,
         // Create the view manager instance
         ViewManager = new ViewManager(this, _drawDockerOuter);
 
-        // We need to create and cache a device context compatible with the display
-        _screenDC = PI.CreateCompatibleDC(IntPtr.Zero);
-
         // Add text box to the controls collection
         ((KryptonReadOnlyControls)Controls).AddInternal(_listBox);
 
@@ -1236,10 +1204,6 @@ public class KryptonCheckedListBox : VisualControlBase,
     protected override void Dispose(bool disposing)
     {
         base.Dispose(disposing);
-        if (_screenDC != IntPtr.Zero)
-        {
-            PI.DeleteDC(_screenDC);
-        }
     }
     #endregion
 
@@ -2354,60 +2318,26 @@ public class KryptonCheckedListBox : VisualControlBase,
         // Update check box to show correct checked image
         _drawCheckBox.CheckState = GetItemCheckState(e.Index);
 
-        // Grab the raw device context for the graphics instance
-        var hdc = e.Graphics.GetHdc();
-
-        try
+        RenderBufferedPaintHelper.PaintBuffered(e.Graphics, e.Bounds, g =>
         {
-            // Create bitmap that all drawing occurs onto, then we can blit it later to remove flicker
-            var hBitmap = PI.CreateCompatibleBitmap(hdc, e.Bounds.Right, e.Bounds.Bottom);
+            // Use local (0,0)-based bounds for off-screen bitmap rendering
+            var localBounds = new Rectangle(Point.Empty, e.Bounds.Size);
 
-            // If we managed to get a compatible bitmap
-            if (hBitmap != IntPtr.Zero)
+            // Ask the view element to layout in given space, needs this before a render call
+            using (var context = new ViewLayoutContext(this, Renderer))
             {
-                // Must use the screen device context for the bitmap when drawing into the
-                // bitmap otherwise the Opacity and RightToLeftLayout will not work correctly.
-                IntPtr oldBitmap = PI.SelectObject(_screenDC, hBitmap);
-
-                try
-                {
-                    // Easier to draw using a graphics instance than a DC!
-                    using (Graphics g = Graphics.FromHdc(_screenDC))
-                    {
-                        // Ask the view element to layout in given space, needs this before a render call
-                        using (var context = new ViewLayoutContext(this, Renderer))
-                        {
-                            context.DisplayRectangle = e.Bounds;
-                            _listBox.ViewDrawPanel.Layout(context);
-                            _layoutDocker.Layout(context);
-                        }
-
-                        // Ask the view element to actually draw
-                        using (var context = new RenderContext(this, g, e.Bounds, Renderer))
-                        {
-                            _listBox.ViewDrawPanel.Render(context);
-                            _layoutDocker.Render(context);
-                        }
-
-                        // Now blit from the bitmap from the screen to the real dc
-                        PI.BitBlt(hdc, e.Bounds.X, e.Bounds.Y, e.Bounds.Width, e.Bounds.Height, _screenDC, e.Bounds.X, e.Bounds.Y, PI.SRCCOPY);
-                    }
-                }
-                finally
-                {
-                    // Restore the original bitmap
-                    PI.SelectObject(_screenDC, oldBitmap);
-
-                    // Delete the temporary bitmap
-                    PI.DeleteObject(hBitmap);
-                }
+                context.DisplayRectangle = localBounds;
+                _listBox.ViewDrawPanel.Layout(context);
+                _layoutDocker.Layout(context);
             }
-        }
-        finally
-        {
-            // Must reserve the GetHdc() call before
-            e.Graphics.ReleaseHdc();
-        }
+
+            // Ask the view element to actually draw
+            using (var context = new RenderContext(this, g, localBounds, Renderer))
+            {
+                _listBox.ViewDrawPanel.Render(context);
+                _layoutDocker.Render(context);
+            }
+        });
     }
 
     private void OnListBoxMeasureItem(object? sender, MeasureItemEventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckedListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckedListBox.cs
@@ -1187,6 +1187,7 @@ public class KryptonCheckedListBox : VisualControlBase,
         // ReSharper disable RedundantBaseQualifier
         base.OnClick(e);
     // ReSharper restore RedundantBaseQualifier
+
     #endregion
 
     #region Public

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckedListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonCheckedListBox.cs
@@ -442,15 +442,6 @@ public class KryptonCheckedListBox : VisualControlBase,
             base.DrawMode = DrawMode.OwnerDrawVariable;
             // ReSharper restore RedundantBaseQualifier
         }
-
-        /// <summary>
-        /// Releases all resources used by the Control.
-        /// </summary>
-        /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
-        protected override void Dispose(bool disposing)
-        {
-            base.Dispose(disposing);
-        }
         #endregion
 
         #region Public
@@ -1196,15 +1187,6 @@ public class KryptonCheckedListBox : VisualControlBase,
         // ReSharper disable RedundantBaseQualifier
         base.OnClick(e);
     // ReSharper restore RedundantBaseQualifier
-
-    /// <summary>
-    /// Releases all resources used by the Control.
-    /// </summary>
-    /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
-    protected override void Dispose(bool disposing)
-    {
-        base.Dispose(disposing);
-    }
     #endregion
 
     #region Public

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -1222,8 +1222,6 @@ public class KryptonComboBox : VisualControlBase,
         }
 
         base.Dispose(disposing);
-
-
     }
     #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -324,11 +324,15 @@ public class KryptonComboBox : VisualControlBase,
                     //}
                     //}
 
-                    // Paint the entire area in the background color
-                    using (Graphics g = Graphics.FromHdc(hdc))
+                    // Grab the client area of the control
+                    PI.GetClientRect(Handle, out PI.RECT rect);
+                    var clientRectangle = new Rectangle(rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top);
+
+                    // Use buffered painting to avoid invalid parameter exceptions
+                    RenderBufferedPaintHelper.PaintBuffered(hdc, clientRectangle, g =>
                     {
-                        // Grab the client area of the control
-                        PI.GetClientRect(Handle, out PI.RECT rect);
+                        // Use local (0,0)-based bounds for painting
+                        var localBounds = new Rectangle(Point.Empty, clientRectangle.Size);
 
                         PaletteState state = _kryptonComboBox.Enabled
                             ? _kryptonComboBox.IsActive
@@ -339,15 +343,14 @@ public class KryptonComboBox : VisualControlBase,
 
                         // Drawn entire client area in the background color
                         using var backBrush = new SolidBrush(states.PaletteBack.GetBackColor1(state));
-                        g.FillRectangle(backBrush, new Rectangle(rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top));
+                        g.FillRectangle(backBrush, localBounds);
 
                         // Get the constant used to crack open the display
                         var dropDownWidth = SystemInformation.VerticalScrollBarWidth;
                         Size borderSize = SystemInformation.BorderSize;
 
                         // Create rect for the text area
-                        rect.top += borderSize.Height;
-                        rect.bottom -= borderSize.Height;
+                        var workingRect = new Rectangle(rect.left, rect.top + borderSize.Height, rect.right - rect.left, rect.bottom - rect.top - (borderSize.Height * 2));
 
                         // Create rectangle that represents the drop-down button
                         Rectangle dropRect;
@@ -355,26 +358,22 @@ public class KryptonComboBox : VisualControlBase,
                         // Update text and drop-down rects dependent on the right to left setting
                         if (_kryptonComboBox.RightToLeft == RightToLeft.Yes)
                         {
-                            dropRect = new Rectangle(rect.left + borderSize.Width + 1, rect.top + 1, dropDownWidth - 2, rect.bottom - rect.top - 2);
-                            rect.left += borderSize.Width + dropDownWidth;
-                            rect.right -= borderSize.Width;
+                            dropRect = new Rectangle(workingRect.Left + borderSize.Width + 1, workingRect.Top + 1, dropDownWidth - 2, workingRect.Height - 2);
+                            workingRect = new Rectangle(workingRect.Left + borderSize.Width + dropDownWidth, workingRect.Top, workingRect.Width - borderSize.Width - dropDownWidth, workingRect.Height);
                         }
                         else
                         {
-                            rect.left += borderSize.Width;
-                            rect.right -= borderSize.Width + dropDownWidth;
-                            dropRect = new Rectangle(rect.right + 1, rect.top + 1, dropDownWidth - 2, rect.bottom - rect.top - 2);
+                            workingRect = new Rectangle(workingRect.Left + borderSize.Width, workingRect.Top, workingRect.Width - borderSize.Width - dropDownWidth, workingRect.Height);
+                            dropRect = new Rectangle(workingRect.Right + 1, workingRect.Top + 1, dropDownWidth - 2, workingRect.Height - 2);
                         }
 
-                        // Exclude border from being drawn, we need to take off another 2 pixels from all edges
-                        PI.IntersectClipRect(hdc, rect.left + 2, rect.top, rect.right - 2, rect.bottom);
                         var displayText = _kryptonComboBox.Text;
                         if (!string.IsNullOrWhiteSpace(_kryptonComboBox.CueHint.CueHintText)
                             && string.IsNullOrEmpty(displayText)
                            )
                         {
                             // Go perform the drawing of the CueHint
-                            _kryptonComboBox.CueHint.PerformPaint(_kryptonComboBox, g, rect, backBrush);
+                            _kryptonComboBox.CueHint.PerformPaint(_kryptonComboBox, g, workingRect, backBrush);
                         }
                         else
                             ////////////////////////////////////////////////////////
@@ -386,7 +385,11 @@ public class KryptonComboBox : VisualControlBase,
                         {
                             using var graphicsHint = new GraphicsTextHint(g, CommonHelper.PaletteTextHintToRenderingHint(states.Content.GetContentShortTextHint(state)));
 
-                            TextFormatFlags flags = TextFormatFlags.TextBoxControl | TextFormatFlags.NoPadding | TextFormatFlags.VerticalCenter;
+                            // Configure text rendering hint to match palette
+                            g.TextRenderingHint = CommonHelper.PaletteTextHintToRenderingHint(states.Content.GetContentShortTextHint(state));
+
+                            // Configure text formatting flags
+                            TextFormatFlags flags = TextFormatFlags.TextBoxControl | TextFormatFlags.NoPadding | TextFormatFlags.EndEllipsis | TextFormatFlags.NoPrefix | TextFormatFlags.VerticalCenter;
 
                             // Use the correct prefix setting
                             flags |= TextFormatFlags.NoPrefix;
@@ -411,8 +414,7 @@ public class KryptonComboBox : VisualControlBase,
                             }
 
                             // Draw text using font defined by the control
-                            var rectangle = new Rectangle(rect.left, rect.top, rect.right - rect.left,
-                                rect.bottom - rect.top);
+                            var rectangle = new Rectangle(workingRect.Left + 2, workingRect.Top, workingRect.Width - 4, workingRect.Height);
                             rectangle = CommonHelper.ApplyPadding(VisualOrientation.Top, rectangle, states.Content.GetBorderContentPadding(null, state));
                             // Find correct text color
                             Color textColor = states.Content.GetContentShortTextColor1(state);
@@ -428,12 +430,9 @@ public class KryptonComboBox : VisualControlBase,
                                 flags);
                         }
 
-                        // Remove clipping settings
-                        PI.SelectClipRgn(hdc, IntPtr.Zero);
-
                         // Draw the drop-down button
                         DrawDropButton(g, dropRect);
-                    }
+                    });
 
                     // Do we need to match the original BeginPaint?
                     if (m.WParam == IntPtr.Zero)
@@ -842,7 +841,6 @@ public class KryptonComboBox : VisualControlBase,
     private readonly ViewDrawButton _drawButton;
     private readonly ViewDrawPanel _drawPanel;
     private Padding _layoutPadding;
-    private IntPtr _screenDC;
     private readonly ButtonSpecAny _toolTipSpec;
     private VisualPopupToolTip _toolTip;
     private bool _firstTimePaint;
@@ -1187,9 +1185,6 @@ public class KryptonComboBox : VisualControlBase,
         ToolTipManager.CancelToolTip += OnCancelToolTip;
         _buttonManager.ToolTipManager = ToolTipManager;
 
-        // We need to create and cache a device context compatible with the display
-        _screenDC = PI.CreateCompatibleDC(IntPtr.Zero);
-
         // Add combo box holder to the controls collection
         ((KryptonReadOnlyControls)Controls).AddInternal(_comboHolder);
 
@@ -1228,11 +1223,7 @@ public class KryptonComboBox : VisualControlBase,
 
         base.Dispose(disposing);
 
-        if (_screenDC != IntPtr.Zero)
-        {
-            PI.DeleteDC(_screenDC);
-            _screenDC = IntPtr.Zero;
-        }
+
     }
     #endregion
 
@@ -2883,58 +2874,19 @@ public class KryptonComboBox : VisualControlBase,
                 // Update the view with the calculated state
                 _drawButton.ElementState = buttonState;
 
-                // Grab the raw device context for the graphics instance
-                var hdc = e.Graphics.GetHdc();
-
-                try
+                // Ask the view element to layout in given space (ensures correct palette-rendered visuals)
+                using (var layoutContext = new ViewLayoutContext(this, Renderer))
                 {
-                    // Create bitmap that all drawing occurs onto, then we can blit it later to remove flicker
-                    var hBitmap = PI.CreateCompatibleBitmap(hdc, drawBounds.Right, drawBounds.Bottom);
-
-                    // If we managed to get a compatible bitmap
-                    if (hBitmap != IntPtr.Zero)
-                    {
-                        // Must use the screen device context for the bitmap when drawing into the
-                        // bitmap otherwise the Opacity and RightToLeftLayout will not work correctly.
-                        // Select the new bitmap into the screen DC
-                        var oldBitmap = PI.SelectObject(_screenDC, hBitmap);
-
-                        try
-                        {
-                            // Easier to draw using a graphics instance than a DC!
-                            using Graphics g = Graphics.FromHdc(_screenDC);
-                            // Ask the view element to layout in given space, needs this before a render call
-                            using (var context = new ViewLayoutContext(this, Renderer))
-                            {
-                                context.DisplayRectangle = drawBounds;
-                                _drawPanel.Layout(context);
-                                _drawButton.Layout(context);
-                            }
-
-                            // Ask the view element to actually draw
-                            using (var context = new RenderContext(this, g, drawBounds, Renderer))
-                            {
-                                _drawPanel.Render(context);
-                                _drawButton.Render(context);
-                            }
-
-                            // Now blit from the bitmap from the screen to the real dc
-                            PI.BitBlt(hdc, drawBounds.X, drawBounds.Y, drawBounds.Width, drawBounds.Height, _screenDC, drawBounds.X, drawBounds.Y, PI.SRCCOPY);
-                        }
-                        finally
-                        {
-                            // Restore the original bitmap
-                            PI.SelectObject(_screenDC, oldBitmap);
-
-                            // Delete the temporary bitmap
-                            PI.DeleteObject(hBitmap);
-                        }
-                    }
+                    layoutContext.DisplayRectangle = drawBounds;
+                    _drawPanel.Layout(layoutContext);
+                    _drawButton.Layout(layoutContext);
                 }
-                finally
+
+                // Render using the buffered Graphics so we match main control visuals, including images/fonts
+                using (var renderContext = new RenderContext(this, e.Graphics, drawBounds, Renderer))
                 {
-                    // Must reserve the GetHdc() call before
-                    e.Graphics.ReleaseHdc();
+                    _drawPanel.Render(renderContext);
+                    _drawButton.Render(renderContext);
                 }
             }
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDomainUpDown.cs
@@ -343,50 +343,48 @@ public class KryptonDomainUpDown : VisualControlBase,
                     // Do we need to BeginPaint or just take the given HDC?
                     var hdc = m.WParam == IntPtr.Zero ? PI.BeginPaint(Handle, ref ps) : m.WParam;
 
-                    // Paint the entire area in the background color
-                    using (Graphics g = Graphics.FromHdc(hdc))
+                    // Determine client rectangle
+                    PI.GetClientRect(Handle, out PI.RECT rect);
+                    Rectangle clientRect = new(rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top);
+
+                    // Copy message for safe modification inside lambda
+                    Message msgCopy = m;
+
+                    RenderBufferedPaintHelper.PaintBuffered(hdc, clientRect, g =>
                     {
-                        // Grab the client area of the control
-                        PI.GetClientRect(Handle, out PI.RECT rect);
+                        // Use local (0,0)-based bounds for painting
+                        var localBounds = new Rectangle(Point.Empty, clientRect.Size);
 
                         PaletteState state = DomainUpDown.Enabled
-                                ? (DomainUpDown.IsActive ? PaletteState.Tracking : PaletteState.Normal)
-                                : PaletteState.Disabled
-                            ;
+                            ? (DomainUpDown.IsActive ? PaletteState.Tracking : PaletteState.Normal)
+                            : PaletteState.Disabled;
+
                         PaletteInputControlTripleStates states = DomainUpDown.GetTripleState();
 
-                        // Drawn entire client area in the background color
-                        using (var backBrush = new SolidBrush(states.PaletteBack.GetBackColor1(state)))
-                        {
-                            g.FillRectangle(backBrush, new Rectangle(rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top));
-                        }
+                        // Fill background
+                        using var backBrush = new SolidBrush(states.PaletteBack.GetBackColor1(state));
+                        g.FillRectangle(backBrush, localBounds);
 
-                        // Create rect for the text area
-                        Size borderSize = SystemInformation.BorderSize;
-                        rect.left -= borderSize.Width + 1;
-
-                        //////////////////////////////////////////////////////
-                        // Following to allow the Draw to always happen, to allow centering etc
-                        _internalDomainUpDown.TextAlign =
-                            states.Content.GetContentShortTextH(state) switch
-                            {
-                                PaletteRelativeAlign.Center => HorizontalAlignment.Center,
-                                PaletteRelativeAlign.Far => HorizontalAlignment.Right,
-                                _ => HorizontalAlignment.Left
-                            };
-
-                        // Let base implementation draw the actual text area
-                        if (m.WParam == IntPtr.Zero)
+                        // Adjust text alignment based on palette
+                        _internalDomainUpDown.TextAlign = states.Content.GetContentShortTextH(state) switch
                         {
-                            m.WParam = hdc;
-                            DefWndProc(ref m);
-                            m.WParam = IntPtr.Zero;
-                        }
-                        else
+                            PaletteRelativeAlign.Center => HorizontalAlignment.Center,
+                            PaletteRelativeAlign.Far => HorizontalAlignment.Right,
+                            _ => HorizontalAlignment.Left
+                        };
+
+                        // Let base control draw its content into the buffered graphics
+                        IntPtr memHdc = g.GetHdc();
+                        try
                         {
-                            DefWndProc(ref m);
+                            msgCopy.WParam = memHdc;
+                            DefWndProc(ref msgCopy);
                         }
-                    }
+                        finally
+                        {
+                            g.ReleaseHdc(memHdc);
+                        }
+                    });
 
                     // Do we need to match the original BeginPaint?
                     if (m.WParam == IntPtr.Zero)
@@ -444,7 +442,6 @@ public class KryptonDomainUpDown : VisualControlBase,
         #region Instance Fields
         private PaletteTripleToPalette _palette;
         private ViewDrawButton _viewButton;
-        private IntPtr _screenDC;
         private Point _mousePressed;
         #endregion
 
@@ -462,9 +459,6 @@ public class KryptonDomainUpDown : VisualControlBase,
         {
             _mousePressed = new Point(-int.MaxValue, -int.MaxValue);
 
-            // We need to create and cache a device context compatible with the display
-            _screenDC = PI.CreateCompatibleDC(IntPtr.Zero);
-
         }
         #endregion
 
@@ -474,11 +468,6 @@ public class KryptonDomainUpDown : VisualControlBase,
         /// </summary>
         public void Dispose()
         {
-            if (_screenDC != IntPtr.Zero)
-            {
-                PI.DeleteDC(_screenDC);
-                _screenDC = IntPtr.Zero;
-            }
         }
 
         /// <summary>
@@ -548,44 +537,18 @@ public class KryptonDomainUpDown : VisualControlBase,
 
                     try
                     {
-                        // Create bitmap that all drawing occurs onto, then we can blit it later to remove flicker
-                        var hBitmap = PI.CreateCompatibleBitmap(hdc, clientRect.Right, clientRect.Bottom);
-
-                        // If we managed to get a compatible bitmap
-                        if (hBitmap != IntPtr.Zero)
+                        RenderBufferedPaintHelper.PaintBuffered(hdc, clientRect, g =>
                         {
-                            // Must use the screen device context for the bitmap when drawing into the
-                            // bitmap otherwise the Opacity and RightToLeftLayout will not work correctly.
-                            IntPtr oldBitmap = PI.SelectObject(_screenDC, hBitmap);
-                            try
-                            {
-                                // Easier to draw using a graphics instance than a DC!
-                                using Graphics g = Graphics.FromHdc(_screenDC);
-                                // Drawn entire client area in the background color
-                                using (var backBrush = new SolidBrush(DomainUpDown.DomainUpDown.BackColor))
-                                {
-                                    g.FillRectangle(backBrush, clientRect);
-                                }
+                            // Use local (0,0)-based bounds for painting
+                            var localBounds = new Rectangle(Point.Empty, clientRect.Size);
 
-                                // Draw the actual up and down buttons split inside the client rectangle
-                                DrawUpDownButtons(g,
-                                    clientRect with { Height = clientRect.Height - 1 });
-
-                                // Now blit from the bitmap from the screen to the real dc
-                                PI.BitBlt(hdc, clientRect.X, clientRect.Y, clientRect.Width, clientRect.Height,
-                                    _screenDC, clientRect.X, clientRect.Y, PI.SRCCOPY);
-                            }
-                            finally
-                            {
-                                PI.SelectObject(_screenDC, oldBitmap);
-                                // Delete the temporary bitmap
-                                PI.DeleteObject(hBitmap);
-                            }
-                        }
+                            using (var backBrush = new SolidBrush(DomainUpDown.DomainUpDown.BackColor))
+                                g.FillRectangle(backBrush, localBounds);
+                            DrawUpDownButtons(g, localBounds with { Height = localBounds.Height - 1 });
+                        });
                     }
                     finally
                     {
-                        // Do we need to match the original BeginPaint?
                         if (m.WParam == IntPtr.Zero)
                         {
                             PI.EndPaint(Handle, ref ps);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListBox.cs
@@ -595,14 +595,6 @@ public class KryptonListBox : VisualControlBase,
         base.OnClick(e);
     // ReSharper restore RedundantBaseQualifier
 
-    /// <summary>
-    /// Releases all resources used by the Control.
-    /// </summary>
-    /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
-    protected override void Dispose(bool disposing)
-    {
-        base.Dispose(disposing);
-    }
     #endregion
 
     #region Public

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListBox.cs
@@ -1,4 +1,4 @@
-﻿#region BSD License
+#region BSD License
 /*
  *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -33,8 +33,9 @@ public class KryptonListBox : VisualControlBase,
         #region Instance Fields
         private readonly ViewManager? _viewManager;
         private readonly KryptonListBox _kryptonListBox;
-        private readonly IntPtr _screenDC;
         private bool _mouseOver;
+        // Capture scroll position before user click
+        private int _preClickTopIndex;
 
         #endregion
 
@@ -76,20 +77,8 @@ public class KryptonListBox : VisualControlBase,
             // ReSharper restore RedundantBaseQualifier
 
             // We need to create and cache a device context compatible with the display
-            _screenDC = PI.CreateCompatibleDC(IntPtr.Zero);
-        }
-
-        /// <summary>
-        /// Releases all resources used by the Control.
-        /// </summary>
-        /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
-        protected override void Dispose(bool disposing)
-        {
-            base.Dispose(disposing);
-            if (_screenDC != IntPtr.Zero)
-            {
-                PI.DeleteDC(_screenDC);
-            }
+            // Track pre-click scroll
+            MouseDown += OnInternalListBoxMouseDown;
         }
         #endregion
 
@@ -260,88 +249,84 @@ public class KryptonListBox : VisualControlBase,
         {
             var ps = new PI.PAINTSTRUCT();
 
-            // Do we need to BeginPaint or just take the given HDC?
-            var hdc = m.WParam == IntPtr.Zero ? PI.BeginPaint(Handle, ref ps) : m.WParam;
+            // Acquire the DC to paint into (BeginPaint if not provided)
+            IntPtr hdc = m.WParam == IntPtr.Zero ? PI.BeginPaint(Handle, ref ps) : m.WParam;
 
-            // Create bitmap that all drawing occurs onto, then we can blit it later to remove flicker
             Rectangle realRect = CommonHelper.RealClientRectangle(Handle);
 
-            // No point drawing when one of the dimensions is zero
             if (realRect is { Width: > 0, Height: > 0 })
             {
-                var hBitmap = PI.CreateCompatibleBitmap(hdc, realRect.Width, realRect.Height);
+                // Copy incoming message so we can safely modify WParam inside the lambda (avoids CS1628)
+                Message msgCopy = m;
 
-                // If we managed to get a compatible bitmap
-                if (hBitmap != IntPtr.Zero)
+                RenderBufferedPaintHelper.PaintBuffered(hdc, realRect, g =>
                 {
-                    // Must use the screen device context for the bitmap when drawing into the
-                    // bitmap otherwise the Opacity and RightToLeftLayout will not work correctly.
-                    // Select the new bitmap into the screen DC
-                    var oldBitmap = PI.SelectObject(_screenDC, hBitmap);
+                    var localBounds = new Rectangle(Point.Empty, realRect.Size);
 
-                    try
+                    // Layout the view elements
+                    using (var layoutContext = new ViewLayoutContext(this, _kryptonListBox.Renderer))
                     {
+                        layoutContext.DisplayRectangle = localBounds;
+                        ViewDrawPanel.Layout(layoutContext);
+                    }
 
-                        // Easier to draw using a graphics instance than a DC!
-                        using (Graphics g = Graphics.FromHdc(_screenDC))
-                        {
-                            // Ask the view element to layout in given space, needs this before a render call
-                            using (var context = new ViewLayoutContext(this, _kryptonListBox.Renderer))
-                            {
-                                context.DisplayRectangle = realRect;
-                                ViewDrawPanel.Layout(context);
-                            }
+                    // Render background / borders
+                    using (var renderContext = new RenderContext(this, _kryptonListBox, g, localBounds, _kryptonListBox.Renderer))
+                    {
+                        ViewDrawPanel.Render(renderContext);
 
-                            using (var context = new RenderContext(this, _kryptonListBox, g, realRect,
-                                       _kryptonListBox.Renderer))
-                            {
-                                ViewDrawPanel.Render(context);
-                            }
-
-                            // Replace given DC with the screen DC for base window proc drawing
-                            var beforeDC = m.WParam;
-                            m.WParam = _screenDC;
-                            DefWndProc(ref m);
-                            m.WParam = beforeDC;
-
-                            if (Items.Count == 0)
-                            {
-                                using var context = new RenderContext(this, _kryptonListBox, g, realRect,
-                                    _kryptonListBox.Renderer);
-                                ViewDrawPanel.Render(context);
-                            }
-                        }
-
-                        // Now blit from the bitmap from the screen to the real dc
-                        PI.BitBlt(hdc, 0, 0, realRect.Width, realRect.Height, _screenDC, 0, 0, PI.SRCCOPY);
-
-                        // When disabled with no items the above code does not draw the background!
+                        // If empty, render the empty state visuals again
                         if (Items.Count == 0)
                         {
-                            using Graphics g = Graphics.FromHdc(hdc);
-                            using var context = new RenderContext(this, _kryptonListBox, g, realRect,
-                                _kryptonListBox.Renderer);
-                            ViewDrawPanel.Render(context);
+                            ViewDrawPanel.Render(renderContext);
                         }
+                    }
+
+                    // Let base ListBox paint its standard content into the buffered Graphics
+                    IntPtr memHdc = g.GetHdc();
+                    try
+                    {
+                        msgCopy.WParam = memHdc;
+                        DefWndProc(ref msgCopy);
                     }
                     finally
                     {
-                        // Restore the original bitmap
-                        PI.SelectObject(_screenDC, oldBitmap);
-
-                        // Delete the temporary bitmap
-                        PI.DeleteObject(hBitmap);
+                        g.ReleaseHdc(memHdc);
                     }
-                }
+                });
             }
 
-            // Do we need to match the original BeginPaint?
+            // Complete BeginPaint if we started one
             if (m.WParam == IntPtr.Zero)
             {
                 PI.EndPaint(Handle, ref ps);
             }
         }
         #endregion
+
+        protected override void OnSelectedIndexChanged(EventArgs e)
+        {
+            // Prevent scrollbar flicker by disabling redraw
+            PI.SendMessage(Handle, PI.SETREDRAW, (IntPtr)0, IntPtr.Zero);
+            BeginUpdate();
+            try
+            {
+                // Let base update selection and possibly auto-scroll
+                base.OnSelectedIndexChanged(e);
+                // Then restore scroll to previous position
+                TopIndex = Math.Min(_preClickTopIndex, Items.Count - 1);
+            }
+            finally
+            {
+                EndUpdate();
+                // Re-enable redraw and repaint
+                PI.SendMessage(Handle, PI.SETREDRAW, (IntPtr)1, IntPtr.Zero);
+                Invalidate();
+            }
+        }
+
+        // Store the TopIndex before a click drives selection
+        private void OnInternalListBoxMouseDown(object? sender, MouseEventArgs e) => _preClickTopIndex = TopIndex;
     }
     #endregion
 
@@ -361,7 +346,6 @@ public class KryptonListBox : VisualControlBase,
     private readonly FixedContentValue? _contentValues;
     private bool? _fixedActive;
     private ButtonStyle _style;
-    private readonly IntPtr _screenDC;
     private int[] _lastSelectedColl;
     private int _lastSelectedIndex;
     private bool _mouseOver;
@@ -602,9 +586,6 @@ public class KryptonListBox : VisualControlBase,
         // Create the view manager instance
         ViewManager = new ViewManager(this, _drawDockerOuter);
 
-        // We need to create and cache a device context compatible with the display
-        _screenDC = PI.CreateCompatibleDC(IntPtr.Zero);
-
         // Add list box to the controls collection
         ((KryptonReadOnlyControls)Controls).AddInternal(_listBox);
     }
@@ -621,10 +602,6 @@ public class KryptonListBox : VisualControlBase,
     protected override void Dispose(bool disposing)
     {
         base.Dispose(disposing);
-        if (_screenDC != IntPtr.Zero)
-        {
-            PI.DeleteDC(_screenDC);
-        }
     }
     #endregion
 
@@ -1320,9 +1297,25 @@ public class KryptonListBox : VisualControlBase,
     /// <param name="e">An EventArgs that contains the event data.</param>
     protected override void OnPaletteChanged(EventArgs e)
     {
-        _listBox.Recreate();
-        _listBox.RefreshItemSizes();
-        _listBox.Invalidate();
+        _listBox.BeginUpdate();
+        try
+        {
+            // Preserve scroll and selected index to avoid shifting when theme changes
+            int oldTopIndex = _listBox.TopIndex;
+            int oldSelectedIndex = _listBox.SelectedIndex;
+            _listBox.Recreate();
+            // Restore scroll position and selection
+            _listBox.TopIndex = Math.Min(oldTopIndex, _listBox.Items.Count - 1);
+            if (oldSelectedIndex >= 0 && oldSelectedIndex < _listBox.Items.Count)
+                _listBox.SelectedIndex = oldSelectedIndex;
+            _listBox.RefreshItemSizes();
+            _listBox.Invalidate();
+        }
+        finally
+        {
+            _listBox.EndUpdate();
+        }
+
         base.OnPaletteChanged(e);
     }
 
@@ -1591,55 +1584,26 @@ public class KryptonListBox : VisualControlBase,
         // Update the view with the calculated state
         _drawButton.ElementState = buttonState;
 
-        // Grab the raw device context for the graphics instance
-        var hdc = e.Graphics.GetHdc();
-
-        try
+        // Perform buffered painting to avoid GDI+ invalid parameter issues
+        RenderBufferedPaintHelper.PaintBuffered(e.Graphics, e.Bounds, g =>
         {
-            // Create bitmap that all drawing occurs onto, then we can blit it later to remove flicker
-            var hBitmap = PI.CreateCompatibleBitmap(hdc, e.Bounds.Right, e.Bounds.Bottom);
+            var localBounds = new Rectangle(Point.Empty, e.Bounds.Size);
 
-            // If we managed to get a compatible bitmap
-            if (hBitmap != IntPtr.Zero)
+            // Layout view elements for this item
+            using (var layoutContext = new ViewLayoutContext(this, Renderer))
             {
-                try
-                {
-                    // Must use the screen device context for the bitmap when drawing into the
-                    // bitmap otherwise the Opacity and RightToLeftLayout will not work correctly.
-                    PI.SelectObject(_screenDC, hBitmap);
-
-                    // Easier to draw using a graphics instance than a DC!
-                    using Graphics g = Graphics.FromHdc(_screenDC);
-                    // Ask the view element to layout in given space, needs this before a render call
-                    using (var context = new ViewLayoutContext(this, Renderer))
-                    {
-                        context.DisplayRectangle = e.Bounds;
-                        _listBox.ViewDrawPanel.Layout(context);
-                        _drawButton.Layout(context);
-                    }
-
-                    // Ask the view element to actually draw
-                    using (var context = new RenderContext(this, g, e.Bounds, Renderer))
-                    {
-                        _listBox.ViewDrawPanel.Render(context);
-                        _drawButton.Render(context);
-                    }
-
-                    // Now blit from the bitmap from the screen to the real dc
-                    PI.BitBlt(hdc, e.Bounds.X, e.Bounds.Y, e.Bounds.Width, e.Bounds.Height, _screenDC, e.Bounds.X, e.Bounds.Y, PI.SRCCOPY);
-                }
-                finally
-                {
-                    // Delete the temporary bitmap
-                    PI.DeleteObject(hBitmap);
-                }
+                layoutContext.DisplayRectangle = localBounds;
+                _listBox.ViewDrawPanel.Layout(layoutContext);
+                _drawButton.Layout(layoutContext);
             }
-        }
-        finally
-        {
-            // Must reserve the GetHdc() call before
-            e.Graphics.ReleaseHdc();
-        }
+
+            // Render the item visuals
+            using (var renderContext = new RenderContext(this, g, localBounds, Renderer))
+            {
+                _listBox.ViewDrawPanel.Render(renderContext);
+                _drawButton.Render(renderContext);
+            }
+        });
     }
 
     private void OnListBoxMeasureItem(object? sender, MeasureItemEventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListView.cs
@@ -72,16 +72,6 @@ public class KryptonListView : VisualControlBase,
             base.BorderStyle = BorderStyle.None;
             // ReSharper restore RedundantBaseQualifier
         }
-
-        /// <summary>
-        /// Releases all resources used by the Control.
-        /// </summary>
-        /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
-        protected override void Dispose(bool disposing)
-        {
-            base.Dispose(disposing);
-        }
-
         #endregion
 
         #region Public
@@ -467,15 +457,6 @@ public class KryptonListView : VisualControlBase,
         => VirtualItemsSelectionRangeChanged?.Invoke(this, e);
 
     private void OnListViewClick(object? sender, EventArgs e) => OnClick(e);
-
-    /// <summary>
-    /// Clean up any resources being used.
-    /// </summary>
-    /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-    protected override void Dispose(bool disposing)
-    {
-        base.Dispose(disposing);
-    }
 
     #region Public
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonListView.cs
@@ -30,7 +30,6 @@ public class KryptonListView : VisualControlBase,
 
         private readonly ViewManager? _viewManager;
         private readonly KryptonListView _kryptonListView;
-        private readonly IntPtr _screenDC;
         private bool _mouseOver;
 
         #endregion
@@ -72,9 +71,6 @@ public class KryptonListView : VisualControlBase,
             base.Size = Size.Empty;
             base.BorderStyle = BorderStyle.None;
             // ReSharper restore RedundantBaseQualifier
-
-            // We need to create and cache a device context compatible with the display
-            _screenDC = PI.CreateCompatibleDC(IntPtr.Zero);
         }
 
         /// <summary>
@@ -84,10 +80,6 @@ public class KryptonListView : VisualControlBase,
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);
-            if (_screenDC != IntPtr.Zero)
-            {
-                PI.DeleteDC(_screenDC);
-            }
         }
 
         #endregion
@@ -224,73 +216,56 @@ public class KryptonListView : VisualControlBase,
         {
             var ps = new PI.PAINTSTRUCT();
 
-            // Do we need to BeginPaint or just take the given HDC?
+            // Acquire the DC that we should ultimately paint to
             IntPtr hdc = m.WParam == IntPtr.Zero ? PI.BeginPaint(Handle, ref ps) : m.WParam;
 
-            // Create bitmap that all drawing occurs onto, then we can blit it later to remove flicker
             Rectangle realRect = CommonHelper.RealClientRectangle(Handle);
-
-            // No point drawing when one of the dimensions is zero
             if (realRect is { Width: > 0, Height: > 0 })
             {
-                IntPtr hBitmap = PI.CreateCompatibleBitmap(hdc, realRect.Width, realRect.Height);
+                // Copy of the incoming message so we can safely modify WParam inside the lambda
+                Message msgCopy = m;
 
-                // If we managed to get a compatible bitmap
-                if (hBitmap != IntPtr.Zero)
+                RenderBufferedPaintHelper.PaintBuffered(hdc, realRect, g =>
                 {
-                    // Must use the screen device context for the bitmap when drawing into the
-                    // bitmap otherwise the Opacity and RightToLeftLayout will not work correctly.
-                    // Select the new bitmap into the screen DC
-                    var oldBitmap = PI.SelectObject(_screenDC, hBitmap);
+                    // Use local (0,0)-based bounds for layout/render
+                    var localBounds = new Rectangle(Point.Empty, realRect.Size);
 
+                    // Perform layout using the provided Graphics
+                    using (var layoutContext = new ViewLayoutContext(this, _kryptonListView.Renderer))
+                    {
+                        layoutContext.DisplayRectangle = localBounds;
+                        ViewDrawPanel.Layout(layoutContext);
+                    }
+
+                    // Render the panel background/border/etc.
+                    using (var renderContext = new RenderContext(this, _kryptonListView, g,
+                        localBounds, _kryptonListView.Renderer))
+                    {
+                        ViewDrawPanel.Render(renderContext);
+                    }
+
+                    // Ensure the ListView background colour stays in sync with the palette
+                    Color newBackColor = ViewDrawPanel.GetPalette().GetBackColor1(ViewDrawPanel.State);
+                    if (newBackColor != BackColor)
+                    {
+                        BackColor = newBackColor;
+                    }
+
+                    // Let the base ListView paint its usual contents into the buffered Graphics
+                    IntPtr memHdc = g.GetHdc();
                     try
                     {
-                        // Easier to draw using a graphics instance than a DC!
-                        using (Graphics g = Graphics.FromHdc(_screenDC))
-                        {
-                            // Ask the view element to layout in given space, needs this before a render call
-                            using (var context = new ViewLayoutContext(this, _kryptonListView.Renderer))
-                            {
-                                context.DisplayRectangle = realRect;
-                                ViewDrawPanel.Layout(context);
-                            }
-
-                            using (var context = new RenderContext(this, _kryptonListView, g, realRect,
-                                       _kryptonListView.Renderer))
-                            {
-                                ViewDrawPanel.Render(context);
-                            }
-
-                            // We can only control the background color by using the built in property and not
-                            // by overriding the drawing directly, therefore we can only provide a single color.
-                            Color color1 = ViewDrawPanel.GetPalette().GetBackColor1(ViewDrawPanel.State);
-                            if (color1 != BackColor)
-                            {
-                                BackColor = color1;
-                            }
-
-                            // Replace given DC with the screen DC for base window proc drawing
-                            IntPtr beforeDC = m.WParam;
-                            m.WParam = _screenDC;
-                            DefWndProc(ref m);
-                            m.WParam = beforeDC;
-                        }
-
-                        // Now blit from the bitmap from the screen to the real dc
-                        PI.BitBlt(hdc, 0, 0, realRect.Width, realRect.Height, _screenDC, 0, 0, PI.SRCCOPY);
+                        msgCopy.WParam = memHdc;
+                        DefWndProc(ref msgCopy);
                     }
                     finally
                     {
-                        // Restore the original bitmap
-                        PI.SelectObject(_screenDC, oldBitmap);
-
-                        // Delete the temporary bitmap
-                        PI.DeleteObject(hBitmap);
+                        g.ReleaseHdc(memHdc);
                     }
-                }
+                });
             }
 
-            // Do we need to match the original BeginPaint?
+            // Complete the original BeginPaint call if we made one
             if (m.WParam == IntPtr.Zero)
             {
                 PI.EndPaint(Handle, ref ps);
@@ -313,7 +288,6 @@ public class KryptonListView : VisualControlBase,
     private readonly ViewLayoutFill _layoutFill;
     private readonly InternalListView _listView;
     private bool? _fixedActive;
-    private readonly IntPtr _screenDC;
     private bool _mouseOver;
     private bool _alwaysActive;
     private bool _forcedLayout;
@@ -458,9 +432,6 @@ public class KryptonListView : VisualControlBase,
         // Create the view manager instance
         ViewManager = new ViewManager(this, _drawDockerOuter);
 
-        // We need to create and cache a device context compatible with the display
-        _screenDC = PI.CreateCompatibleDC(IntPtr.Zero);
-
         // Add tree view to the controls collection
         ((KryptonReadOnlyControls)Controls).AddInternal(_listView);
     }
@@ -504,10 +475,6 @@ public class KryptonListView : VisualControlBase,
     protected override void Dispose(bool disposing)
     {
         base.Dispose(disposing);
-        if (_screenDC != IntPtr.Zero)
-        {
-            PI.DeleteDC(_screenDC);
-        }
     }
 
     #region Public
@@ -999,47 +966,6 @@ public class KryptonListView : VisualControlBase,
         get => _listView.View;
         set => _listView.View = value;
     }
-
-    /* TODO: Need to wire up the virtual events as well
-    /// <summary>Gets or sets the number of <see cref="T:System.Windows.Forms.ListViewItem" /> objects contained in the list when in virtual mode.</summary>
-    /// <returns>The number of <see cref="T:System.Windows.Forms.ListViewItem" /> objects contained in the <see cref="T:System.Windows.Forms.ListView" /> when in virtual mode.</returns>
-    /// <exception cref="T:System.ArgumentException">
-    /// <see cref="P:System.Windows.Forms.ListView.VirtualListSize" /> is set to a value less than 0.</exception>
-    /// <exception cref="T:System.InvalidOperationException">
-    /// <see cref="P:System.Windows.Forms.ListView.VirtualMode" /> is set to <see langword="true" />, <see cref="P:System.Windows.Forms.ListView.VirtualListSize" /> is greater than 0, and <see cref="E:System.Windows.Forms.ListView.RetrieveVirtualItem" /> is not handled.</exception>
-    [Category("Behavior")]
-    [DefaultValue(0)]
-    [RefreshProperties(RefreshProperties.Repaint)]
-    [Description("ListViewVirtualListSizeDescr")]
-    public int VirtualListSize
-    {
-        get => _listView.VirtualListSize;
-        set => _listView.VirtualListSize = value;
-    }
-
-    /// <summary>Gets or sets a value indicating whether you have provided your own data-management operations for the <see cref="T:System.Windows.Forms.ListView" /> control.</summary>
-    /// <returns>
-    /// <see langword="true" /> if <see cref="T:System.Windows.Forms.ListView" /> uses data-management operations that you provide; otherwise, <see langword="false" />. The default is <see langword="false" />.</returns>
-    /// <exception cref="T:System.InvalidOperationException">
-    ///         <see cref="P:System.Windows.Forms.ListView.VirtualMode" /> is set to <see langword="true" /> and one of the following conditions exist:
-    ///
-    /// <see cref="P:System.Windows.Forms.ListView.VirtualListSize" /> is greater than 0 and <see cref="E:System.Windows.Forms.ListView.RetrieveVirtualItem" /> is not handled.
-    ///  -or-
-    ///
-    /// <see cref="P:System.Windows.Forms.ListView.Items" />, <see cref="P:System.Windows.Forms.ListView.CheckedItems" />, or <see cref="P:System.Windows.Forms.ListView.SelectedItems" /> contains items.
-    ///  -or-
-    ///
-    /// Edits are made to <see cref="P:System.Windows.Forms.ListView.Items" />.</exception>
-    [Category("Behavior")]
-    [DefaultValue(false)]
-    [RefreshProperties(RefreshProperties.Repaint)]
-    [Description("ListViewVirtualModeDescr")]
-    public bool VirtualMode
-    {
-        get => _listView.VirtualMode;
-        set => _listView.VirtualMode = value;
-    }
-    */
 
     /// <summary>Arranges items in the control when they are displayed as icons with a specified alignment setting.</summary>
     /// <param name="value">One of the <see cref="T:System.Windows.Forms.ListViewAlignment" /> values.</param>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPropertyGrid.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPropertyGrid.cs
@@ -49,16 +49,6 @@ public class KryptonPropertyGrid : VisualControlBase,
             ToolStripRenderer = ToolStripManager.Renderer;
             UseCompatibleTextRendering = false;
         }
-
-        /// <summary>
-        /// Releases all resources used by the Control.
-        /// </summary>
-        /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
-        protected override void Dispose(bool disposing)
-        {
-            base.Dispose(disposing);
-        }
-
         #endregion
 
         #region Public
@@ -290,15 +280,6 @@ public class KryptonPropertyGrid : VisualControlBase,
         menuItems.Items.Add(_resetMenuItem);
 
         KryptonContextMenu.Items.Add(menuItems);
-    }
-
-    /// <summary>
-    /// Clean up any resources being used.
-    /// </summary>
-    /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-    protected override void Dispose(bool disposing)
-    {
-        base.Dispose(disposing);
     }
     #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPropertyGrid.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonPropertyGrid.cs
@@ -22,7 +22,6 @@ public class KryptonPropertyGrid : VisualControlBase,
         #region Instance Fields
         private readonly ViewManager? _viewManager;
         private readonly KryptonPropertyGrid _kryptonPropertyGrid;
-        private readonly IntPtr _screenDC;
         #endregion
 
         #region Identity
@@ -47,7 +46,6 @@ public class KryptonPropertyGrid : VisualControlBase,
             // ReSharper restore RedundantBaseQualifier
 
             // We need to create and cache a device context compatible with the display
-            _screenDC = PI.CreateCompatibleDC(IntPtr.Zero);
             ToolStripRenderer = ToolStripManager.Renderer;
             UseCompatibleTextRendering = false;
         }
@@ -59,10 +57,6 @@ public class KryptonPropertyGrid : VisualControlBase,
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);
-            if (_screenDC != IntPtr.Zero)
-            {
-                PI.DeleteDC(_screenDC);
-            }
         }
 
         #endregion
@@ -146,74 +140,54 @@ public class KryptonPropertyGrid : VisualControlBase,
         {
             var ps = new PI.PAINTSTRUCT();
 
-            // Do we need to BeginPaint or just take the given HDC?
+            // Acquire the DC to paint into (BeginPaint if not provided)
             IntPtr hdc = m.WParam == IntPtr.Zero ? PI.BeginPaint(Handle, ref ps) : m.WParam;
 
-            // Create bitmap that all drawing occurs onto, then we can blit it later to remove flicker
-            Rectangle realRect = CommonHelper.RealClientRectangle(Handle);
-
-            // No point drawing when one of the dimensions is zero
-            if (realRect is { Width: > 0, Height: > 0 })
+            Rectangle clientRect = CommonHelper.RealClientRectangle(Handle);
+            if (clientRect is { Width: > 0, Height: > 0 })
             {
-                IntPtr hBitmap = PI.CreateCompatibleBitmap(hdc, realRect.Width, realRect.Height);
+                // Copy incoming message to allow safe modification inside the lambda (avoids CS1628)
+                Message msgCopy = m;
 
-                // If we managed to get a compatible bitmap
-                if (hBitmap != IntPtr.Zero)
+                RenderBufferedPaintHelper.PaintBuffered(hdc, clientRect, g =>
                 {
-                    // Must use the screen device context for the bitmap when drawing into the
-                    // bitmap otherwise the Opacity and RightToLeftLayout will not work correctly.
-                    // Select the new bitmap into the screen DC
-                    IntPtr oldBitmap = PI.SelectObject(_screenDC, hBitmap);
+                    var localBounds = new Rectangle(Point.Empty, clientRect.Size);
 
+                    // Layout using provided buffered Graphics
+                    using (var layoutContext = new ViewLayoutContext(this, _kryptonPropertyGrid.Renderer))
+                    {
+                        layoutContext.DisplayRectangle = localBounds;
+                        ViewDrawPanel.Layout(layoutContext);
+                    }
+
+                    // Render panel background/borders etc.
+                    using (var renderContext = new RenderContext(this, _kryptonPropertyGrid, g, localBounds, _kryptonPropertyGrid.Renderer))
+                    {
+                        ViewDrawPanel.Render(renderContext);
+                    }
+
+                    // Keep ListView background colour in sync with palette
+                    Color newBackColor = ViewDrawPanel.GetPalette().GetBackColor1(ViewDrawPanel.State);
+                    if (newBackColor != BackColor)
+                    {
+                        BackColor = newBackColor;
+                    }
+
+                    // Let base PropertyGrid paint its standard content
+                    IntPtr memHdc = g.GetHdc();
                     try
                     {
-
-                        // Easier to draw using a graphics instance than a DC!
-                        using (Graphics g = Graphics.FromHdc(_screenDC))
-                        {
-                            // Ask the view element to layout in given space, needs this before a render call
-                            using (var context = new ViewLayoutContext(this, _kryptonPropertyGrid.Renderer))
-                            {
-                                context.DisplayRectangle = realRect;
-                                ViewDrawPanel.Layout(context);
-                            }
-
-                            using (var context = new RenderContext(this, _kryptonPropertyGrid, g, realRect,
-                                       _kryptonPropertyGrid.Renderer))
-                            {
-                                ViewDrawPanel.Render(context);
-                            }
-
-                            // We can only control the background color by using the built in property and not
-                            // by overriding the drawing directly, therefore we can only provide a single color.
-                            Color color1 = ViewDrawPanel.GetPalette().GetBackColor1(ViewDrawPanel.State);
-                            if (color1 != BackColor)
-                            {
-                                BackColor = color1;
-                            }
-
-                            // Replace given DC with the screen DC for base window proc drawing
-                            IntPtr beforeDC = m.WParam;
-                            m.WParam = _screenDC;
-                            DefWndProc(ref m);
-                            m.WParam = beforeDC;
-                        }
-
-                        // Now blit from the bitmap from the screen to the real dc
-                        PI.BitBlt(hdc, 0, 0, realRect.Width, realRect.Height, _screenDC, 0, 0, PI.SRCCOPY);
+                        msgCopy.WParam = memHdc;
+                        DefWndProc(ref msgCopy);
                     }
                     finally
                     {
-                        // Restore the original bitmap
-                        PI.SelectObject(_screenDC, oldBitmap);
-
-                        // Delete the temporary bitmap
-                        PI.DeleteObject(hBitmap);
+                        g.ReleaseHdc(memHdc);
                     }
-                }
+                });
             }
 
-            // Do we need to match the original BeginPaint?
+            // Complete BeginPaint if we started one
             if (m.WParam == IntPtr.Zero)
             {
                 PI.EndPaint(Handle, ref ps);
@@ -230,7 +204,6 @@ public class KryptonPropertyGrid : VisualControlBase,
     private readonly ViewLayoutFill _layoutFill;
     private readonly InternalPropertyGrid _propertyGrid;
     private bool? _fixedActive;
-    private readonly IntPtr _screenDC;
     private bool _alwaysActive;
     private bool _forcedLayout;
     private readonly KryptonContextMenuItem _resetMenuItem;
@@ -304,9 +277,6 @@ public class KryptonPropertyGrid : VisualControlBase,
         // Create the view manager instance
         ViewManager = new ViewManager(this, _drawDockerOuter);
 
-        // We need to create and cache a device context compatible with the display
-        _screenDC = PI.CreateCompatibleDC(IntPtr.Zero);
-
         // Add tree view to the controls collection
         ((KryptonReadOnlyControls)Controls).AddInternal(_propertyGrid);
 
@@ -329,10 +299,6 @@ public class KryptonPropertyGrid : VisualControlBase,
     protected override void Dispose(bool disposing)
     {
         base.Dispose(disposing);
-        if (_screenDC != IntPtr.Zero)
-        {
-            PI.DeleteDC(_screenDC);
-        }
     }
     #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonRichTextBox.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -138,7 +138,7 @@ public class KryptonRichTextBox : VisualControlBase,
             var lParam = Marshal.AllocCoTaskMem(Marshal.SizeOf(fmtRange));
             Marshal.StructureToPtr(fmtRange, lParam, false);
 
-            //Send the rendered data for printing 
+            //Send the rendered data for printing
             var res = (IntPtr)PI.SendMessage(Handle, PI.EM_FORMATRANGE, wParam, lParam);
 
             //Free the block of memory allocated
@@ -224,11 +224,15 @@ public class KryptonRichTextBox : VisualControlBase,
                         var ps = new PI.PAINTSTRUCT();
                         // Do we need to BeginPaint or just take the given HDC?
                         IntPtr hdc = m.WParam == IntPtr.Zero ? PI.BeginPaint(Handle, ref ps) : m.WParam;
-                        using (Graphics g = Graphics.FromHdc(hdc))
-                        {
-                            // Grab the client area of the control
-                            PI.GetClientRect(Handle, out PI.RECT rect);
 
+                        // Obtain client rectangle bounds
+                        PI.GetClientRect(Handle, out PI.RECT rect);
+                        Rectangle clientRect = new Rectangle(0, 0, rect.right - rect.left, rect.bottom - rect.top);
+
+                        var localBounds = new Rectangle(Point.Empty, clientRect.Size);
+
+                        RenderBufferedPaintHelper.PaintBuffered(hdc, clientRect, g =>
+                        {
                             PaletteState state = _kryptonRichTextBox.Enabled
                                 ? _kryptonRichTextBox.IsActive
                                     ? PaletteState.Tracking
@@ -236,13 +240,15 @@ public class KryptonRichTextBox : VisualControlBase,
                                 : PaletteState.Disabled;
                             IPaletteTriple states = _kryptonRichTextBox.GetTripleState();
 
-                            // Drawn entire client area in the background color
+                            // Fill background
                             using var backBrush = new SolidBrush(states.PaletteBack.GetBackColor1(state));
-                            // Go perform the drawing of the CueHint
-                            _kryptonRichTextBox.CueHint.PerformPaint(_kryptonRichTextBox, g, rect, backBrush);
-                        }
+                            g.FillRectangle(backBrush, localBounds);
 
-                        // Do we need to match the original BeginPaint?
+                            // Draw CueHint text
+                            _kryptonRichTextBox.CueHint.PerformPaint(_kryptonRichTextBox, g, localBounds, backBrush);
+                        });
+
+                        // Complete BeginPaint if we started it
                         if (m.WParam == IntPtr.Zero)
                         {
                             PI.EndPaint(Handle, ref ps);
@@ -520,7 +526,7 @@ public class KryptonRichTextBox : VisualControlBase,
 
     #region Public
     /// <summary>
-    /// 
+    ///
     /// </summary>
     [Category(@"Visuals")]
     [Description(@"Set a watermark/prompt message for the user.")]
@@ -1309,7 +1315,7 @@ public class KryptonRichTextBox : VisualControlBase,
     public void Clear() => _richTextBox.Clear();
 
     /// <summary>
-    /// Clears information about the most recent operation from the undo buffer of the rich text box. 
+    /// Clears information about the most recent operation from the undo buffer of the rich text box.
     /// </summary>
     public void ClearUndo() => _richTextBox.ClearUndo();
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -139,53 +139,58 @@ public class KryptonTextBox : VisualControlBase,
 
                     // Do we need to BeginPaint or just take the given HDC?
                     var hdc = m.WParam == IntPtr.Zero ? PI.BeginPaint(Handle, ref ps) : m.WParam;
+                    var originalWParam = m.WParam;
 
-                    // Paint the entire area in the background color
-                    using Graphics g = Graphics.FromHdc(hdc);
                     // Grab the client area of the control
                     PI.GetClientRect(Handle, out PI.RECT rect);
+                    var textRectangle = new Rectangle(rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top);
 
-                    var textRectangle = new Rectangle(rect.left, rect.top, rect.right - rect.left,
-                        rect.bottom - rect.top);
-
-                    // Create rect for the text area
-                    Size borderSize = SystemInformation.BorderSize;
-                    rect.left -= borderSize.Width + 1;
-
-                    if (!string.IsNullOrWhiteSpace(_kryptonTextBox.CueHint.CueHintText)
-                        && string.IsNullOrEmpty(_kryptonTextBox.Text)
-                       )
+                    // If enabled then use buffered painting, otherwise handle normally to avoid DefWndProc issues
+                    if (_kryptonTextBox.Enabled)
                     {
-                        // Go perform the drawing of the CueHint
-                        using var backBrush = new SolidBrush(BackColor);
-                        _kryptonTextBox.CueHint.PerformPaint(_kryptonTextBox, g, textRectangle, backBrush);
-                    }
-                    else
-                    {
-                        using (var backBrush = new SolidBrush(BackColor))
-                        {
-                            // Draw entire client area in the background color
-                            g.FillRectangle(backBrush,
-                                textRectangle);
-                        }
+                        // Copy message for safe modification inside lambda
+                        Message msgCopy = m;
 
-                        // If enabled then let the combo draw the text area
-                        if (_kryptonTextBox.Enabled)
+                        // Use buffered painting to avoid invalid parameter exceptions
+                        RenderBufferedPaintHelper.PaintBuffered(hdc, textRectangle, g =>
                         {
-                            // Let base implementation draw the actual text area
-                            if (m.WParam == IntPtr.Zero)
+                            var localBounds = new Rectangle(Point.Empty, textRectangle.Size);
+
+                            if (!string.IsNullOrWhiteSpace(_kryptonTextBox.CueHint.CueHintText)
+                                && string.IsNullOrEmpty(_kryptonTextBox.Text))
                             {
-                                m.WParam = hdc;
-                                DefWndProc(ref m);
-                                m.WParam = IntPtr.Zero;
+                                // Go perform the drawing of the CueHint
+                                using var backBrush = new SolidBrush(BackColor);
+                                _kryptonTextBox.CueHint.PerformPaint(_kryptonTextBox, g, localBounds, backBrush);
                             }
                             else
                             {
-                                DefWndProc(ref m);
+                                using var backBrush = new SolidBrush(BackColor);
+                                g.FillRectangle(backBrush, localBounds);
                             }
-                        }
-                        else
+
+                            // Let base implementation draw the actual text area into the buffered graphics
+                            IntPtr memHdc = g.GetHdc();
+                            try
+                            {
+                                msgCopy.WParam = memHdc;
+                                DefWndProc(ref msgCopy);
+                            }
+                            finally
+                            {
+                                g.ReleaseHdc(memHdc);
+                            }
+                        });
+                    }
+                    else
+                    {
+                        // Use buffered painting for disabled state
+                        RenderBufferedPaintHelper.PaintBuffered(hdc, textRectangle, g =>
                         {
+                            var localBounds = new Rectangle(Point.Empty, textRectangle.Size);
+                            using var backBrush = new SolidBrush(BackColor);
+                            g.FillRectangle(backBrush, localBounds);
+
                             // Set the correct text rendering hint for the text drawing. We only draw if the edit text is disabled so we
                             // just always grab the disable state value. Without this line the wrong hint can occur because it inherits
                             // it from the device context. Resulting in blurred text.
@@ -230,9 +235,7 @@ public class KryptonTextBox : VisualControlBase,
                             try
                             {
                                 using var foreBrush = new SolidBrush(ForeColor);
-                                g.DrawString(drawString, Font, foreBrush,
-                                    textRectangle,
-                                    stringFormat);
+                                g.DrawString(drawString, Font, foreBrush, localBounds, stringFormat);
                             }
                             catch (ArgumentException)
                             {
@@ -240,17 +243,13 @@ public class KryptonTextBox : VisualControlBase,
                                 g.DrawString(drawString,
                                     _kryptonTextBox.GetTripleState().PaletteContent?
                                         .GetContentShortTextFont(PaletteState.Disabled)!, foreBrush,
-                                    textRectangle,
-                                    stringFormat);
+                                    localBounds, stringFormat);
                             }
-                        }
-
-                        // Remove clipping settings
-                        PI.SelectClipRgn(hdc, IntPtr.Zero);
+                        });
                     }
 
                     // Do we need to match the original BeginPaint?
-                    if (m.WParam == IntPtr.Zero)
+                    if (originalWParam == IntPtr.Zero)
                     {
                         PI.EndPaint(Handle, ref ps);
                     }
@@ -1171,7 +1170,7 @@ public class KryptonTextBox : VisualControlBase,
     public void Clear() => _textBox.Clear();
 
     /// <summary>
-    /// Clears information about the most recent operation from the undo buffer of the rich text box. 
+    /// Clears information about the most recent operation from the undo buffer of the rich text box.
     /// </summary>
     public void ClearUndo() => _textBox.ClearUndo();
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeListBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonThemeListBox.cs
@@ -1,9 +1,9 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2023 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -54,7 +54,7 @@ public class KryptonThemeListBox : KryptonListBox, IKryptonThemeSelectorBase
     [DefaultValue(null)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
     [Obsolete("Deprecated and will be removed in V110. Set a global custom palette through 'ThemeManager.ApplyTheme(...)'.")]
-    public KryptonCustomPaletteBase? KryptonCustomPalette 
+    public KryptonCustomPaletteBase? KryptonCustomPalette
     {
         get => _kryptonCustomPalette;
         set => _kryptonCustomPalette = value;
@@ -68,7 +68,7 @@ public class KryptonThemeListBox : KryptonListBox, IKryptonThemeSelectorBase
     [Description(@"The default palette mode.")]
     [DefaultValue(PaletteMode.Global)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
-    public PaletteMode DefaultPalette 
+    public PaletteMode DefaultPalette
     {
         get => _defaultPalette;
         set => SelectedIndex = CommonHelperThemeSelectors.DefaultPaletteSetter(ref _defaultPalette, value, Items, SelectedIndex);
@@ -100,7 +100,9 @@ public class KryptonThemeListBox : KryptonListBox, IKryptonThemeSelectorBase
     /// <param name="e">Eventargs object data (not used).</param>
     private void KryptonManagerGlobalPaletteChanged(object? sender, EventArgs e)
     {
-        SelectedIndex = CommonHelperThemeSelectors.KryptonManagerGlobalPaletteChanged(_isLocalUpdate, ref _isExternalUpdate, SelectedIndex, Items);
+        int newIndex = CommonHelperThemeSelectors.KryptonManagerGlobalPaletteChanged(_isLocalUpdate, ref _isExternalUpdate, SelectedIndex, Items);
+        if (newIndex >= 0 && newIndex != SelectedIndex)
+            SelectedIndex = newIndex;
     }
 
     #endregion
@@ -117,8 +119,9 @@ public class KryptonThemeListBox : KryptonListBox, IKryptonThemeSelectorBase
 
         if (!CommonHelperThemeSelectors.OnSelectedIndexChanged(ref _isLocalUpdate, _isExternalUpdate, ref _defaultPalette, themeName, _manager, _kryptonCustomPalette))
         {
-            //theme change went wrong, make the active theme the selected theme in the list.
-            SelectedIndex = CommonHelperThemeSelectors.GetPaletteIndex(Items, _manager.GlobalPaletteMode);
+            int fallbackIndex = CommonHelperThemeSelectors.GetPaletteIndex(Items, _manager.GlobalPaletteMode);
+            if (fallbackIndex >= 0 && fallbackIndex != SelectedIndex)
+                SelectedIndex = fallbackIndex;
         }
 
         base.OnSelectedIndexChanged(e);
@@ -141,7 +144,7 @@ public class KryptonThemeListBox : KryptonListBox, IKryptonThemeSelectorBase
     /// <summary>Gets or sets the format specifier characters that indicate how a value is to be Displayed.</summary>
     [Browsable(false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public new string FormatString 
+    public new string FormatString
     {
         get => base.FormatString;
         set => base.FormatString = value;
@@ -155,7 +158,7 @@ public class KryptonThemeListBox : KryptonListBox, IKryptonThemeSelectorBase
     /// <summary>Gets and sets the selected index.</summary>
     [Browsable(false)]
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
-    public new int SelectedIndex 
+    public new int SelectedIndex
     {
         get => base.SelectedIndex;
         set => base.SelectedIndex = value;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
@@ -72,15 +72,6 @@ public class KryptonTreeView : VisualControlBase,
             base.BorderStyle = BorderStyle.None;
             // ReSharper restore RedundantBaseQualifier
         }
-
-        /// <summary>
-        /// Releases all resources used by the Control.
-        /// </summary>
-        /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
-        protected override void Dispose(bool disposing)
-        {
-            base.Dispose(disposing);
-        }
         #endregion
 
         #region Public
@@ -649,14 +640,6 @@ public class KryptonTreeView : VisualControlBase,
 
     private void OnTreeClick(object? sender, EventArgs e) => OnClick(e);
 
-    /// <summary>
-    /// Releases all resources used by the Control.
-    /// </summary>
-    /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
-    protected override void Dispose(bool disposing)
-    {
-        base.Dispose(disposing);
-    }
     #endregion
 
     #region Public

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTreeView.cs
@@ -36,7 +36,6 @@ public class KryptonTreeView : VisualControlBase,
         #region Instance Fields
         private readonly ViewManager? _viewManager;
         private readonly KryptonTreeView _kryptonTreeView;
-        private readonly IntPtr _screenDC;
         private bool _mouseOver;
         #endregion
 
@@ -72,9 +71,6 @@ public class KryptonTreeView : VisualControlBase,
             base.Size = Size.Empty;
             base.BorderStyle = BorderStyle.None;
             // ReSharper restore RedundantBaseQualifier
-
-            // We need to create and cache a device context compatible with the display
-            _screenDC = PI.CreateCompatibleDC(IntPtr.Zero);
         }
 
         /// <summary>
@@ -84,10 +80,6 @@ public class KryptonTreeView : VisualControlBase,
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);
-            if (_screenDC != IntPtr.Zero)
-            {
-                PI.DeleteDC(_screenDC);
-            }
         }
         #endregion
 
@@ -238,61 +230,50 @@ public class KryptonTreeView : VisualControlBase,
             // No point drawing when one of the dimensions is zero
             if (realRect is { Width: > 0, Height: > 0 })
             {
-                IntPtr hBitmap = PI.CreateCompatibleBitmap(hdc, realRect.Width, realRect.Height);
+                // Cache a copy of the message to safely use inside the lambda below
+                var messageCopy = m;
 
-                // If we managed to get a compatible bitmap
-                if (hBitmap != IntPtr.Zero)
+                // Use buffered painting to avoid invalid parameter exceptions
+                RenderBufferedPaintHelper.PaintBuffered(hdc, realRect, g =>
                 {
-                    // Must use the screen device context for the bitmap when drawing into the
-                    // bitmap otherwise the Opacity and RightToLeftLayout will not work correctly.
-                    // Select the new bitmap into the screen DC
-                    var oldBitmap = PI.SelectObject(_screenDC, hBitmap);
+                    var localBounds = new Rectangle(Point.Empty, realRect.Size);
 
+                    // Ask the view element to layout in given space, needs this before a render call
+                    using (var context = new ViewLayoutContext(this, _kryptonTreeView.Renderer))
+                    {
+                        context.DisplayRectangle = localBounds;
+                        ViewDrawPanel.Layout(context);
+                    }
+
+                    using (var context = new RenderContext(this, _kryptonTreeView,
+                           g, localBounds, _kryptonTreeView.Renderer))
+                    {
+                        ViewDrawPanel.Render(context);
+                    }
+
+                    // We can only control the background color by using the built in property and not
+                    // by overriding the drawing directly, therefore we can only provide a single color.
+                    Color color1 = ViewDrawPanel.GetPalette().GetBackColor1(ViewDrawPanel.State);
+                    if (color1 != BackColor)
+                    {
+                        BackColor = color1;
+                    }
+
+                    // Since we're using buffered painting, we need to handle DefWndProc differently
+                    // The original DC operations are handled by the buffer helper
+                    var tempHdc = g.GetHdc();
                     try
                     {
-                        // Easier to draw using a graphics instance than a DC!
-                        using (Graphics g = Graphics.FromHdc(_screenDC))
-                        {
-                            // Ask the view element to layout in given space, needs this before a render call
-                            using (var context = new ViewLayoutContext(this, _kryptonTreeView.Renderer))
-                            {
-                                context.DisplayRectangle = realRect;
-                                ViewDrawPanel.Layout(context);
-                            }
-
-                            using (var context = new RenderContext(this, _kryptonTreeView, g, realRect,
-                                       _kryptonTreeView.Renderer))
-                            {
-                                ViewDrawPanel.Render(context);
-                            }
-
-                            // We can only control the background color by using the built in property and not
-                            // by overriding the drawing directly, therefore we can only provide a single color.
-                            Color color1 = ViewDrawPanel.GetPalette().GetBackColor1(ViewDrawPanel.State);
-                            if (color1 != BackColor)
-                            {
-                                BackColor = color1;
-                            }
-
-                            // Replace given DC with the screen DC for base window proc drawing
-                            IntPtr beforeDC = m.WParam;
-                            m.WParam = _screenDC;
-                            DefWndProc(ref m);
-                            m.WParam = beforeDC;
-                        }
-
-                        // Now blit from the bitmap from the screen to the real dc
-                        PI.BitBlt(hdc, 0, 0, realRect.Width, realRect.Height, _screenDC, 0, 0, PI.SRCCOPY);
+                        // Create a local copy of the cached message with the new HDC
+                        var localMessage = messageCopy;
+                        localMessage.WParam = tempHdc;
+                        DefWndProc(ref localMessage);
                     }
                     finally
                     {
-                        // Restore the original bitmap
-                        PI.SelectObject(_screenDC, oldBitmap);
-
-                        // Delete the temporary bitmap
-                        PI.DeleteObject(hBitmap);
+                        g.ReleaseHdc(tempHdc);
                     }
-                }
+                });
             }
 
             // Do we need to match the original BeginPaint?
@@ -329,7 +310,6 @@ public class KryptonTreeView : VisualControlBase,
     private readonly FixedContentValue? _contentValues;
     private bool? _fixedActive;
     private ButtonStyle _style;
-    private readonly IntPtr _screenDC;
     private bool _itemHeightDefault;
     private bool _mouseOver;
     private bool _alwaysActive;
@@ -663,9 +643,6 @@ public class KryptonTreeView : VisualControlBase,
         // Create the view manager instance
         ViewManager = new ViewManager(this, _drawDockerOuter);
 
-        // We need to create and cache a device context compatible with the display
-        _screenDC = PI.CreateCompatibleDC(IntPtr.Zero);
-
         // Add tree view to the controls collection
         ((KryptonReadOnlyControls)Controls).AddInternal(_treeView);
     }
@@ -679,10 +656,6 @@ public class KryptonTreeView : VisualControlBase,
     protected override void Dispose(bool disposing)
     {
         base.Dispose(disposing);
-        if (_screenDC != IntPtr.Zero)
-        {
-            PI.DeleteDC(_screenDC);
-        }
     }
     #endregion
 
@@ -2162,228 +2135,201 @@ public class KryptonTreeView : VisualControlBase,
         // Update the view with the calculated state
         _drawButton.ElementState = buttonState;
 
-        // Grab the raw device context for the graphics instance
-        var hdc = e.Graphics.GetHdc();
+        Rectangle bounds = e.Bounds;
+        var indent = _treeView.Indent;
 
-        try
+        // Create indent rectangle and adjust bounds for remainder
+        var nodeIndent = NodeIndent(e.Node) + 2;
+        var indentBounds = bounds with { X = bounds.X + nodeIndent - indent, Width = indent };
+        bounds.X += nodeIndent;
+        bounds.Width -= nodeIndent;
+
+        // Use buffered painting to avoid invalid parameter exceptions
+        RenderBufferedPaintHelper.PaintBuffered(e.Graphics, e.Bounds, g =>
         {
-            Rectangle bounds = e.Bounds;
-            var indent = _treeView.Indent;
+            var localBounds = new Rectangle(Point.Empty, e.Bounds.Size);
+            var localNodeBounds = new Rectangle(bounds.X - e.Bounds.X, bounds.Y - e.Bounds.Y, bounds.Width, bounds.Height);
+            var localIndentBounds = new Rectangle(indentBounds.X - e.Bounds.X, indentBounds.Y - e.Bounds.Y, indentBounds.Width, indentBounds.Height);
 
-            // Create indent rectangle and adjust bounds for remainder
-            var nodeIndent = NodeIndent(e.Node) + 2;
-            var indentBounds = bounds with { X = bounds.X + nodeIndent - indent, Width = indent };
-            bounds.X += nodeIndent;
-            bounds.Width -= nodeIndent;
-
-            // Create bitmap that all drawing occurs onto, then we can blit it later to remove flicker
-            var hBitmap = PI.CreateCompatibleBitmap(hdc, bounds.Right, bounds.Bottom);
-
-            // If we managed to get a compatible bitmap
-            if (hBitmap != IntPtr.Zero)
+            using (var context = new ViewLayoutContext(this, Renderer))
             {
-                try
+                context.DisplayRectangle = localBounds;
+                _treeView.ViewDrawPanel.Layout(context);
+                context.DisplayRectangle = localNodeBounds;
+
+                // If no using full row selection, then layout using only required width
+                Size prefSize = _layoutDocker.GetPreferredSize(context);
+                if (!FullRowSelect)
                 {
-                    // Must use the screen device context for the bitmap when drawing into the
-                    // bitmap otherwise the Opacity and RightToLeftLayout will not work correctly.
-                    PI.SelectObject(_screenDC, hBitmap);
-
-                    // Easier to draw using a graphics instance than a DC!
-                    using Graphics g = Graphics.FromHdc(_screenDC);
-                    using (var context = new ViewLayoutContext(this, Renderer))
+                    if (prefSize.Width < localNodeBounds.Width)
                     {
-                        context.DisplayRectangle = e.Bounds;
-                        _treeView.ViewDrawPanel.Layout(context);
-                        context.DisplayRectangle = bounds;
-
-                        // If no using full row selection, then layout using only required width
-                        Size prefSize = _layoutDocker.GetPreferredSize(context);
-                        if (!FullRowSelect)
-                        {
-                            if (prefSize.Width < bounds.Width)
-                            {
-                                bounds.Width = prefSize.Width;
-                            }
-                        }
-
-                        // Always ensure we have enough space for drawing all the elements
-                        if (bounds.Width < prefSize.Width)
-                        {
-                            bounds.Width = prefSize.Width;
-                        }
-
-                        context.DisplayRectangle = bounds;
-
-                        _layoutDocker.Layout(context);
+                        localNodeBounds.Width = prefSize.Width;
                     }
-
-                    using (var context = new RenderContext(this, g, e.Bounds, Renderer))
-                    {
-                        _treeView.ViewDrawPanel.Render(context);
-                    }
-
-                    // Do we have an indent area for drawing plus/minus/lines?
-                    if (indentBounds.X >= 0)
-                    {
-                        // Do we draw lines between nodes?
-                        if (ShowLines
-                            && (Redirector.GetMetricBool(PaletteState.Normal, PaletteMetricBool.TreeViewLines) != InheritBool.False))
-                        {
-                            // Find center points
-                            var hCenter = indentBounds.X + (indentBounds.Width / 2) - 1;
-                            var vCenter = indentBounds.Y + (indentBounds.Height / 2);
-                            vCenter -= (vCenter + 1) % 2;
-
-                            // Default to showing full line height
-                            var top = indentBounds.Y;
-                            top -= (top + 1) % 2;
-                            var bottom = indentBounds.Bottom;
-
-                            // If the first root node then do not show top half of line
-                            if ((e.Node.Parent == null) && (e.Node.PrevNode == null))
-                            {
-                                top = vCenter;
-                            }
-
-                            // If the last node in collection then do not show bottom half of line
-                            if (e.Node.NextNode == null)
-                            {
-                                bottom = vCenter;
-                            }
-
-                            // Draw the horizontal and vertical lines
-                            Color lineColor = Redirector.GetContentShortTextColor1(PaletteContentStyle.InputControlStandalone, PaletteState.Normal);
-                            using var linePen = new Pen(lineColor);
-                            linePen.DashStyle = DashStyle.Dot;
-                            linePen.DashOffset = indent % 2;
-                            g.DrawLine(linePen, hCenter, top, hCenter, bottom);
-                            g.DrawLine(linePen, hCenter - 1, vCenter - 1, indentBounds.Right, vCenter - 1);
-                            hCenter -= indent;
-
-                            // Draw the vertical lines for previous node levels
-                            while (hCenter >= 0)
-                            {
-                                var begin = indentBounds.Y;
-                                begin -= (begin + 1) % 2;
-                                g.DrawLine(linePen, hCenter, begin, hCenter, indentBounds.Bottom);
-                                hCenter -= indent;
-                            }
-                        }
-
-                        // Do we draw any plus/minus images in indent bounds?
-                        if (ShowPlusMinus && (e.Node.Nodes.Count > 0))
-                        {
-                            Image? drawImage = _redirectImages!.GetTreeViewImage(e.Node.IsExpanded);
-                            if (drawImage != null)
-                            {
-                                float dpiFactor = g.DpiX / 96F;
-                                drawImage = CommonHelper.ScaleImageForSizedDisplay(drawImage,
-                                    drawImage.Width * dpiFactor,
-                                    drawImage.Height * dpiFactor, false)!;
-                                g.DrawImage(drawImage, new Rectangle(indentBounds.X + ((indentBounds.Width - drawImage.Width) / 2) - 1,
-                                    indentBounds.Y + ((indentBounds.Height - drawImage.Height) / 2),
-                                    drawImage.Width, drawImage.Height));
-                            }
-                        }
-                    }
-
-                    using (var context = new RenderContext(this, g, bounds, Renderer))
-                    {
-                        _layoutDocker.Render(context);
-                    }
-
-                    // Do we draw an image for the node?
-                    if (ImageList != null)
-                    {
-                        Image? drawImage = null;
-                        var imageCount = ImageList.Images.Count;
-
-                        try
-                        {
-                            if (e.Node.IsSelected)
-                            {
-                                // Check node values before tree level values
-                                if (!string.IsNullOrEmpty(e.Node.SelectedImageKey))
-                                {
-                                    drawImage = ImageList.Images[e.Node.SelectedImageKey];
-                                }
-                                else if ((e.Node.SelectedImageIndex >= 0) && (e.Node.SelectedImageIndex < imageCount))
-                                {
-                                    drawImage = ImageList.Images[e.Node.SelectedImageIndex];
-                                }
-                                else if (!string.IsNullOrEmpty(SelectedImageKey))
-                                {
-                                    drawImage = ImageList.Images[SelectedImageKey];
-                                }
-                                else if ((SelectedImageIndex >= 0) && (SelectedImageIndex < imageCount))
-                                {
-                                    drawImage = ImageList.Images[SelectedImageIndex];
-                                }
-                            }
-                            else
-                            {
-                                // Check node values before tree level values
-                                if (!string.IsNullOrEmpty(e.Node.ImageKey))
-                                {
-                                    drawImage = ImageList.Images[e.Node.ImageKey];
-                                }
-                                else if ((e.Node.ImageIndex >= 0) && (e.Node.ImageIndex < imageCount))
-                                {
-                                    drawImage = ImageList.Images[e.Node.ImageIndex];
-                                }
-                                else if (!string.IsNullOrEmpty(ImageKey))
-                                {
-                                    drawImage = ImageList.Images[ImageKey];
-                                }
-                                else if ((ImageIndex >= 0) && (ImageIndex < imageCount))
-                                {
-                                    drawImage = ImageList.Images[ImageIndex];
-                                }
-                            }
-
-                            if (drawImage != null)
-                            {
-                                float dpiFactor = g.DpiX / 96F;
-                                drawImage = CommonHelper.ScaleImageForSizedDisplay(drawImage,
-                                    drawImage.Width * dpiFactor,
-                                    drawImage.Height * dpiFactor, false)!;
-                                g.DrawImage(drawImage, _layoutImage.ClientRectangle);
-                            }
-                        }
-                        catch
-                        {
-                            // ignored
-                        }
-                    }
-
-                    // Draw a node state image?
-                    if (_layoutImageCenterState.Visible)
-                    {
-                        if (drawStateImage != null)
-                        {
-                            float dpiFactor = g.DpiX / 96F;
-                            drawStateImage = CommonHelper.ScaleImageForSizedDisplay(drawStateImage,
-                                drawStateImage.Width * dpiFactor,
-                                drawStateImage.Height * dpiFactor, false)!;
-                            g.DrawImage(drawStateImage, _layoutImageState.ClientRectangle);
-                        }
-                    }
-
-                    // Now blit from the bitmap from the screen to the real dc
-                    PI.BitBlt(hdc, e.Bounds.X, e.Bounds.Y, e.Bounds.Width, e.Bounds.Height, _screenDC, e.Bounds.X, e.Bounds.Y, PI.SRCCOPY);
                 }
-                finally
+
+                // Always ensure we have enough space for drawing all the elements
+                if (localNodeBounds.Width < prefSize.Width)
                 {
-                    // Delete the temporary bitmap
-                    PI.DeleteObject(hBitmap);
+                    localNodeBounds.Width = prefSize.Width;
+                }
+
+                context.DisplayRectangle = localNodeBounds;
+
+                _layoutDocker.Layout(context);
+            }
+
+            using (var context = new RenderContext(this, g, localBounds, Renderer))
+            {
+                _treeView.ViewDrawPanel.Render(context);
+            }
+
+            // Do we have an indent area for drawing plus/minus/lines?
+            if (localIndentBounds.X >= 0)
+            {
+                // Do we draw lines between nodes?
+                if (ShowLines
+                    && (Redirector.GetMetricBool(PaletteState.Normal, PaletteMetricBool.TreeViewLines) != InheritBool.False))
+                {
+                    // Find center points
+                    var hCenter = localIndentBounds.X + (localIndentBounds.Width / 2) - 1;
+                    var vCenter = localIndentBounds.Y + (localIndentBounds.Height / 2);
+                    vCenter -= (vCenter + 1) % 2;
+
+                    // Default to showing full line height
+                    var top = localIndentBounds.Y;
+                    top -= (top + 1) % 2;
+                    var bottom = localIndentBounds.Bottom;
+
+                    // If the first root node then do not show top half of line
+                    if ((e.Node.Parent == null) && (e.Node.PrevNode == null))
+                    {
+                        top = vCenter;
+                    }
+
+                    // If the last node in collection then do not show bottom half of line
+                    if (e.Node.NextNode == null)
+                    {
+                        bottom = vCenter;
+                    }
+
+                    // Draw the horizontal and vertical lines
+                    Color lineColor = Redirector.GetContentShortTextColor1(PaletteContentStyle.InputControlStandalone, PaletteState.Normal);
+                    using var linePen = new Pen(lineColor);
+                    linePen.DashStyle = DashStyle.Dot;
+                    linePen.DashOffset = indent % 2;
+                    g.DrawLine(linePen, hCenter, top, hCenter, bottom);
+                    g.DrawLine(linePen, hCenter - 1, vCenter - 1, localIndentBounds.Right, vCenter - 1);
+                    hCenter -= indent;
+
+                    // Draw the vertical lines for previous node levels
+                    while (hCenter >= 0)
+                    {
+                        var begin = localIndentBounds.Y;
+                        begin -= (begin + 1) % 2;
+                        g.DrawLine(linePen, hCenter, begin, hCenter, localIndentBounds.Bottom);
+                        hCenter -= indent;
+                    }
+                }
+
+                // Do we draw any plus/minus images in indent bounds?
+                if (ShowPlusMinus && (e.Node.Nodes.Count > 0))
+                {
+                    Image? drawImage = _redirectImages!.GetTreeViewImage(e.Node.IsExpanded);
+                    if (drawImage != null)
+                    {
+                        float dpiFactor = g.DpiX / 96F;
+                        drawImage = CommonHelper.ScaleImageForSizedDisplay(drawImage,
+                            drawImage.Width * dpiFactor,
+                            drawImage.Height * dpiFactor, false)!;
+                        g.DrawImage(drawImage, new Rectangle(localIndentBounds.X + ((localIndentBounds.Width - drawImage.Width) / 2) - 1,
+                            localIndentBounds.Y + ((localIndentBounds.Height - drawImage.Height) / 2),
+                            drawImage.Width, drawImage.Height));
+                    }
                 }
             }
-        }
-        finally
-        {
-            // Must reserve the GetHdc() call before
-            e.Graphics.ReleaseHdc();
-        }
+
+            using (var context = new RenderContext(this, g, localNodeBounds, Renderer))
+            {
+                _layoutDocker.Render(context);
+            }
+
+            // Do we draw an image for the node?
+            if (ImageList != null)
+            {
+                Image? drawImage = null;
+                var imageCount = ImageList.Images.Count;
+
+                try
+                {
+                    if (e.Node.IsSelected)
+                    {
+                        // Check node values before tree level values
+                        if (!string.IsNullOrEmpty(e.Node.SelectedImageKey))
+                        {
+                            drawImage = ImageList.Images[e.Node.SelectedImageKey];
+                        }
+                        else if ((e.Node.SelectedImageIndex >= 0) && (e.Node.SelectedImageIndex < imageCount))
+                        {
+                            drawImage = ImageList.Images[e.Node.SelectedImageIndex];
+                        }
+                        else if (!string.IsNullOrEmpty(SelectedImageKey))
+                        {
+                            drawImage = ImageList.Images[SelectedImageKey];
+                        }
+                        else if ((SelectedImageIndex >= 0) && (SelectedImageIndex < imageCount))
+                        {
+                            drawImage = ImageList.Images[SelectedImageIndex];
+                        }
+                    }
+                    else
+                    {
+                        // Check node values before tree level values
+                        if (!string.IsNullOrEmpty(e.Node.ImageKey))
+                        {
+                            drawImage = ImageList.Images[e.Node.ImageKey];
+                        }
+                        else if ((e.Node.ImageIndex >= 0) && (e.Node.ImageIndex < imageCount))
+                        {
+                            drawImage = ImageList.Images[e.Node.ImageIndex];
+                        }
+                        else if (!string.IsNullOrEmpty(ImageKey))
+                        {
+                            drawImage = ImageList.Images[ImageKey];
+                        }
+                        else if ((ImageIndex >= 0) && (ImageIndex < imageCount))
+                        {
+                            drawImage = ImageList.Images[ImageIndex];
+                        }
+                    }
+
+                    if (drawImage != null)
+                    {
+                        float dpiFactor = g.DpiX / 96F;
+                        drawImage = CommonHelper.ScaleImageForSizedDisplay(drawImage,
+                            drawImage.Width * dpiFactor,
+                            drawImage.Height * dpiFactor, false)!;
+                        g.DrawImage(drawImage, _layoutImage.ClientRectangle);
+                    }
+                }
+                catch
+                {
+                    // ignored
+                }
+            }
+
+            // Draw a node state image?
+            if (_layoutImageCenterState.Visible)
+            {
+                if (drawStateImage != null)
+                {
+                    float dpiFactor = g.DpiX / 96F;
+                    drawStateImage = CommonHelper.ScaleImageForSizedDisplay(drawStateImage,
+                        drawStateImage.Width * dpiFactor,
+                        drawStateImage.Height * dpiFactor, false)!;
+                    g.DrawImage(drawStateImage, _layoutImageState.ClientRectangle);
+                }
+            }
+        });
     }
 
     private void OnTreeViewGotFocus(object? sender, EventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/CommonDialogHandler.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/CommonDialogHandler.cs
@@ -1,15 +1,15 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2021 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2021 - 2025. All rights reserved.
+ *
  */
 #endregion
 
 #if NET8_0_OR_GREATER
 using MethodInvoker = System.Windows.Forms.MethodInvoker;
-#endif 
+#endif
 
 // ReSharper disable InconsistentNaming
 
@@ -308,24 +308,33 @@ internal class CommonDialogHandler
                     {
                         var ps = new PI.PAINTSTRUCT();
 
-                        // Do we need to BeginPaint or just take the given HDC?
+                        // Acquire device context for the child control
                         var hdc = PI.BeginPaint(control.hWnd, ref ps);
                         if (hdc == IntPtr.Zero)
                         {
                             break;
                         }
 
-                        using (Graphics g = Graphics.FromHdc(hdc))
+                        // Determine the bounds of the child window (always start at 0,0 inside its own DC)
+                        var bounds = new Rectangle(Point.Empty, control.Size);
+
+                        // Avoid CS1628 by copying message data if needed later (none here, but keep pattern consistent)
+                        RenderBufferedPaintHelper.PaintBuffered(hdc, bounds, g =>
                         {
+                            // Use local (0,0)-based bounds for off-screen bitmap rendering
+                            var localBounds = new Rectangle(Point.Empty, bounds.Size);
+
                             using var gh = new GraphicsHint(g, PaletteGraphicsHint.AntiAlias);
                             var lineColor = KryptonManager.CurrentGlobalPalette.GetBorderColor1(PaletteBorderStyle.ControlGroupBox, PaletteState.Normal);
-                            DrawRoundedRectangle(g, new Pen(lineColor), new Point(0, 10),
-                                control.Size - new Size(1, 11), 5);
+                            DrawRoundedRectangle(g,
+                                new Pen(lineColor),
+                                new Point(0, 10),
+                                localBounds.Size - new Size(1, 11), 5);
                             var font = KryptonManager.CurrentGlobalPalette.GetContentShortTextFont(PaletteContentStyle.LabelNormalPanel, PaletteState.Normal);
                             TextRenderer.DrawText(g, control.Text, font, new Point(4, 0), _defaultFontColour,
                                 _backColour,
                                 TextFormatFlags.HidePrefix | TextFormatFlags.NoClipping);
-                        }
+                        });
 
                         PI.EndPaint(control.hWnd, ref ps);
                         PI.ReleaseDC(control.hWnd, hdc);
@@ -470,7 +479,7 @@ internal class CommonDialogHandler
                 AutoReset = false,
                 Enabled = true
             };
-            // Hook up the Elapsed event for the timer. 
+            // Hook up the Elapsed event for the timer.
             _resizeTimer.Elapsed += OnResizeTimedEvent;
         }
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderBufferedPaintHelper.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderBufferedPaintHelper.cs
@@ -7,6 +7,9 @@
 
 namespace Krypton.Toolkit;
 
+/// <summary>
+/// Helper class for performing buffered painting operations.
+/// </summary>
 public static class RenderBufferedPaintHelper
 {
     /// <summary>
@@ -17,18 +20,14 @@ public static class RenderBufferedPaintHelper
     /// <param name="paintAction">Delegate that does the actual drawing into the provided Graphics.</param>
     public static void PaintBuffered(Graphics targetGraphics, Rectangle targetRectangle, Action<Graphics> paintAction)
     {
-        if (targetRectangle.Width <= 0 || targetRectangle.Height <= 0)
+        if ((targetRectangle.Width <= 0) || (targetRectangle.Height <= 0))
             return;
 
-        using (var bitmap = new Bitmap(targetRectangle.Width, targetRectangle.Height))
-        {
-            using (var gMem = Graphics.FromImage(bitmap))
-            {
-                paintAction(gMem);
-            }
+        using var bitmap = new Bitmap(targetRectangle.Width, targetRectangle.Height);
+        using var gMem = Graphics.FromImage(bitmap);
 
-            targetGraphics.DrawImageUnscaled(bitmap, targetRectangle.Location);
-        }
+        paintAction(gMem);
+        targetGraphics.DrawImageUnscaled(bitmap, targetRectangle.Location);
     }
 
     /// <summary>
@@ -39,9 +38,7 @@ public static class RenderBufferedPaintHelper
     /// <param name="paintAction">Delegate that does the actual drawing into the provided Graphics.</param>
     public static void PaintBuffered(IntPtr hdc, Rectangle targetRectangle, Action<Graphics> paintAction)
     {
-        using (var g = Graphics.FromHdc(hdc))
-        {
-            PaintBuffered(g, targetRectangle, paintAction);
-        }
+        using var g = Graphics.FromHdc(hdc);
+        PaintBuffered(g, targetRectangle, paintAction);
     }
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderBufferedPaintHelper.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderBufferedPaintHelper.cs
@@ -20,8 +20,10 @@ public static class RenderBufferedPaintHelper
     /// <param name="paintAction">Delegate that does the actual drawing into the provided Graphics.</param>
     public static void PaintBuffered(Graphics targetGraphics, Rectangle targetRectangle, Action<Graphics> paintAction)
     {
-        if ((targetRectangle.Width <= 0) || (targetRectangle.Height <= 0))
+        if (targetRectangle.Width <= 0 || targetRectangle.Height <= 0)
+        {
             return;
+        }
 
         using var bitmap = new Bitmap(targetRectangle.Width, targetRectangle.Height);
         using var gMem = Graphics.FromImage(bitmap);

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderBufferedPaintHelper.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/RenderBufferedPaintHelper.cs
@@ -1,0 +1,47 @@
+#region BSD License
+/*
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2025 - 2025. All rights reserved.
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+public static class RenderBufferedPaintHelper
+{
+    /// <summary>
+    /// Performs buffered painting by rendering into a GDI+ bitmap and then drawing it to the target graphics.
+    /// </summary>
+    /// <param name="targetGraphics">Graphics of the target surface (e.g. from HDC or PaintEvent).</param>
+    /// <param name="targetRectangle">Bounds to render into.</param>
+    /// <param name="paintAction">Delegate that does the actual drawing into the provided Graphics.</param>
+    public static void PaintBuffered(Graphics targetGraphics, Rectangle targetRectangle, Action<Graphics> paintAction)
+    {
+        if (targetRectangle.Width <= 0 || targetRectangle.Height <= 0)
+            return;
+
+        using (var bitmap = new Bitmap(targetRectangle.Width, targetRectangle.Height))
+        {
+            using (var gMem = Graphics.FromImage(bitmap))
+            {
+                paintAction(gMem);
+            }
+
+            targetGraphics.DrawImageUnscaled(bitmap, targetRectangle.Location);
+        }
+    }
+
+    /// <summary>
+    /// Performs buffered painting when only an HDC is available.
+    /// </summary>
+    /// <param name="hdc">Handle to device context.</param>
+    /// <param name="targetRectangle">Bounds to render into.</param>
+    /// <param name="paintAction">Delegate that does the actual drawing into the provided Graphics.</param>
+    public static void PaintBuffered(IntPtr hdc, Rectangle targetRectangle, Action<Graphics> paintAction)
+    {
+        using (var g = Graphics.FromHdc(hdc))
+        {
+            PaintBuffered(g, targetRectangle, paintAction);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2348 to update several components to use GDI+
Also fixes #2349 so that listbox doesn't shift display after selecting a different item.

## RenderBufferedPaintHelper Refactoring – Detailed Walk-through

This guide explains the buffered-painting fix and also highlights some C#-specific pitfalls.

---

### 1. The Original Manual GDI+ Pattern

Before refactoring, painting looked roughly like this in each `WmPaint` / `On…Paint` handler:

```csharp
// 1. Obtain HDC
var ps = new PI.PAINTSTRUCT();
IntPtr hdc = (m.WParam == IntPtr.Zero)
    ? PI.BeginPaint(Handle, ref ps)
    : m.WParam;

// 2. Create a memory DC + compatible bitmap
IntPtr memDc   = PI.CreateCompatibleDC(hdc);
IntPtr hBitmap = PI.CreateCompatibleBitmap(hdc, bounds.Width, bounds.Height);
IntPtr oldBmp  = PI.SelectObject(memDc, hBitmap);

try
{
    // 3. Wrap mem-DC in GDI+
    using (Graphics gMem = Graphics.FromHdc(memDc))
    {
        // • Layout view elements
        // • Render visuals into gMem
    }

    // 4. Blit back to screen DC
    PI.BitBlt(
        hdc,
        bounds.X, bounds.Y,
        bounds.Width, bounds.Height,
        memDc,
        bounds.X, bounds.Y,
        PI.SRCCOPY);
}
finally
{
    // 5. Clean up
    PI.SelectObject(memDc, oldBmp);
    PI.DeleteObject(hBitmap);
    PI.DeleteDC(memDc);
    if (m.WParam == IntPtr.Zero)
        PI.EndPaint(Handle, ref ps);
}
```

#### Cons
- Repetitive boilerplate in every control.
- Flicker if mis-ordered.
- **“Invalid parameter”** exceptions when rendering fonts via `Graphics.FromHdc`.
- High risk of resource leaks if any step throws.

---

### 2. Centralized Helper

We replace all of the above with a single call:

```csharp
RenderBufferedPaintHelper.PaintBuffered(hdc, bounds, g =>
{
    // 1. Layout your view elements
    using (var layout = new ViewLayoutContext(this, Renderer))
    {
        layout.DisplayRectangle = localBounds;
        panel.Layout(layout);
        button.Layout(layout);
    }

    // 2. Render into off-screen Graphics
    using (var render = new RenderContext(this, g, localBounds, Renderer))
    {
        panel.Render(render);
        button.Render(render);
    }

    // 3. (Optional) Forward default painting via HDC
    IntPtr memHdc = g.GetHdc();
    try
    {
        msgCopy.WParam = memHdc;
        DefWndProc(ref msgCopy);
    }
    finally
    {
        g.ReleaseHdc(memHdc);
    }
});
```

The helper does:
1. Create a `Bitmap(width, height)`.
2. Wrap it in `Graphics.FromImage(...)`.
3. Invoke your lambda (`paintAction`) on that `Graphics`.
4. Blit the bitmap into the target `Graphics`/HDC.

---

### 3. Step-by-Step Integration

1. **Cache incoming `Message`**  
   ```csharp
   // Avoid CS1628 when calling DefWndProc(ref …) inside lambda
   Message msgCopy = m;
   ```
2. **Call helper**  
   ```csharp
   RenderBufferedPaintHelper.PaintBuffered(hdc, bounds, g => { … });
   ```
3. **Inside lambda**  
   - Use **local** coordinates:
     ```csharp
     var localBounds = new Rectangle(Point.Empty, bounds.Size);
     layout.DisplayRectangle = localBounds;
     ```
   - Do _not_ refer to the absolute `bounds` in layout/render calls.
4. **No manual DC/bitmap/BitBlt plumbing** - the helper handles it.

---

### 4. C# Lambda & Closure Pitfalls

1. **Ref-capture of `Message m` → CS1628**  
   - **Error**:  
     ```
     Cannot use ref or out parameter 'm' inside an anonymous method, lambda expression, or query expression
     ```
   - **Why**: You cannot capture a `ref struct` or a parameter passed by reference into a lambda.
   - **Solution**: Copy to a local `Message msgCopy = m;` _before_ the lambda, then call `DefWndProc(ref msgCopy);`.

2. **Loop-variable closure**  
   - If you’re applying buffered paint inside a loop, e.g.:  
     ```csharp
     foreach (var item in items)
     {
         RenderBufferedPaintHelper.PaintBuffered(… g => {
             Render(item); // WRONG: all lambdas capture the same 'item'
         });
     }
     ```
   - **Solution**: Introduce a local copy in each iteration:  
     ```csharp
     foreach (var item in items)
     {
         var itemCopy = item;
         RenderBufferedPaintHelper.PaintBuffered(… g => {
             Render(itemCopy);
         });
     }
     ```

3. **Graphics.GetHdc() / ReleaseHdc()**  
   - Always wrap `GetHdc()` in a `try/finally` so `ReleaseHdc()` is _guaranteed_:  
     ```csharp
     IntPtr memHdc = g.GetHdc();
     try { … } 
     finally { g.ReleaseHdc(memHdc); }
     ```

4. **Coordinate Mismatch**  
   - The helper’s off-screen `Bitmap` is sized `(width, height)`.  
   - **Don’t** call `Layout` with the original `(X,Y)` offset―you must use `(0,0)`→`Size` inside the bitmap.  
   - Otherwise, items whose `Y > 0` will draw outside the small bitmap and vanish.

5. **Disposal & Exception Safety**  
   - Use `using` for all `Graphics`, `Bitmap`, and `RenderContext`/`ViewLayoutContext`.  
   - The helper itself wraps `Bitmap` in a `using`, but your own `Graphics`/`Hdc` calls still need proper `try/finally`.

---

### 5. Summary

- **Replace** manual memory-DC + bitmap + BitBlt sequences with `RenderBufferedPaintHelper.PaintBuffered(...)`.
- **Always** cache `Message` or loop variables to local copies to avoid C# lambda capture errors.
- **Use** local `(0,0)`–based rectangles inside the lambda.
- **Wrap** every `GetHdc()` in `try/finally` for safety.
- This pattern eliminates flicker, fixes “invalid parameter” font exceptions, and drastically reduces boilerplate.
