### PR TITLE
2220-V95-KryptonLabel-does-not-support-surrogates

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2025-08-25 - Build 2508 (Patch 8) - August 2025
+* Implemented [#2220](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2220), Enables limited support on multiple Krypton Controls for unicode surrogates.
 * Implemented [#2338](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2338), Update specific pre-processor directives
 * Resolved [#2341](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2341), Fix exception in `RenderStandard.ContentFontForButtonForm` during teardown
 * Resolved [#2329](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2329), `AccurateText.StringFormatToFlags()` performs incorrect conversion to TextFormatFlags.


### PR DESCRIPTION
[Issue 2220-KryptonLabel-does-not-support-surrogates](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2220)
- Enables unicode surrogates in horizontal mode
- And the changelog

<img width="243" height="149" alt="compile-results" src="https://github.com/user-attachments/assets/92af7594-023c-47b6-a6a2-5031fb0dc075" />
