### PR TITLE
2220-V85-KryptonLabel-does-not-support-surrogates

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2025-08-25 - Build 2508 (Patch 8) - August 2025
+* Implemented [#2220](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2220), Enables limited support on multiple Krypton Controls for unicode surrogates.
 * Implemented [#2338](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2338), Update specific pre-processor directives
 * Resolved [#2341](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2341), Fix exception in `RenderStandard.ContentFontForButtonForm` during teardown
 * Resolved [#2329](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2329), `AccurateText.StringFormatToFlags()` performs incorrect conversion to TextFormatFlags.

--- a/Source/Krypton Components/Krypton.Toolkit/AccurateText/AccurateText.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/AccurateText/AccurateText.cs
@@ -290,8 +290,7 @@ namespace Krypton.Toolkit
                         switch (Application.RenderWithVisualStyles)
                         {
                             case true when composition && glowing:
-                                DrawCompositionGlowingText(g, memento.Text, memento.Font, rect, state,
-                                    SystemColors.ActiveCaptionText, true);
+                                DrawCompositionGlowingText(g, memento.Text, memento.Font, rect, state, SystemColors.ActiveCaptionText, true);
                                 break;
                             case true when composition:
                             {
@@ -299,12 +298,37 @@ namespace Krypton.Toolkit
                                 var tmpBrush = brush as SolidBrush;
                                 Color tmpColor = tmpBrush?.Color ?? SystemColors.ActiveCaptionText;
 
-                                DrawCompositionText(g, memento.Text, memento.Font, rect, state,
-                                    tmpColor, true, memento.Format);
+                                DrawCompositionText(g, memento.Text, memento.Font, rect, state, tmpColor, true, memento.Format);
                                 break;
                             }
                             default:
-                                g.DrawString(memento.Text, memento.Font, brush, rect, memento.Format);
+                                // Support for unicode surrogates is only available when drawing horizontally.
+                                if (orientation == VisualOrientation.Top)
+                                {
+                                    // Only a brush is provided, so we have to get the color from it since
+                                    // DrawText only works with solid colors.
+                                    Color color = brush is SolidBrush b
+                                        ? b.Color
+                                        : brush is LinearGradientBrush l
+                                            ? l.LinearColors[0]
+                                            : KryptonManager.CurrentGlobalPalette.GetContentShortTextColor1(PaletteContentStyle.LabelNormalControl, PaletteState.Normal);
+
+                                    // Convert from StringFormat to TextFormatFlags
+                                    var tff = StringFormatToFlags(memento.Format);
+
+                                    // End line ellipsis don't work well with DrawText and tend to cut off words when not needed
+                                    // DrawString seems to do this better
+                                    tff &= ~(TextFormatFlags.EndEllipsis | TextFormatFlags.WordEllipsis | TextFormatFlags.PathEllipsis);
+
+                                    // Whatever happens, NoClipping is on
+                                    tff |= TextFormatFlags.NoClipping;
+
+                                    TextRenderer.DrawText(g, memento.Text, memento.Font!, rect, color, tff);
+                                }
+                                else
+                                {
+                                    g.DrawString(memento.Text, memento.Font!, brush, rect, memento.Format);
+                                }
                                 break;
                         }
                     }
@@ -658,7 +682,7 @@ namespace Krypton.Toolkit
             return sf;
         }
 
-        private static TextFormatFlags StringFormatToFlags2(StringFormat sf)
+        private static TextFormatFlags StringFormatToFlags(StringFormat sf)
         {
             var flags = new TextFormatFlags();
 


### PR DESCRIPTION
[Issue 2220-KryptonLabel-does-not-support-surrogates](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2220)
- Enables unicode surrogates in horizontal mode
- And the changelog

<img width="233" height="126" alt="compile-results" src="https://github.com/user-attachments/assets/8f5ab341-d617-4ecd-825f-c3c56c2af304" />
