### PR TITLE
2354-V95-KryptonDataGridView-add-property-for-DoubleBuffering

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2025-08-25 - Build 2508 (Patch 8) - August 2025
+* Implemented [#2354](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2354), `KryptonDataGridView.DoubleBuffered` property added.
 * Implemented [#2220](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2220), Enables limited support on multiple Krypton Controls for unicode surrogates.
 * Implemented [#2338](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2338), Update specific pre-processor directives
 * Resolved [#2341](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2341), Fix exception in `RenderStandard.ContentFontForButtonForm` during teardown

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -225,6 +225,16 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Public New
+        /// <inheritdoc/>
+        [Category(@"Behavior")]
+        [DefaultValue(true)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public new bool DoubleBuffered 
+        {
+            get => base.DoubleBuffered;
+            set => base.DoubleBuffered = value;
+        }
+
         /// <summary>
         /// Gets or sets the number of columns displayed in the KryptonDataGridView.
         /// </summary>


### PR DESCRIPTION
[Issue 2354-KryptonDataGridView-add-property-for-DoubleBuffering](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2354)
- Adds DoubleBuffering functionality
- And the changelog

<img width="312" height="153" alt="compile-results" src="https://github.com/user-attachments/assets/eb6cfaca-b9ac-42af-9837-f95e4a33ef44" />
