### PR TITLE
2354-V85-KryptonDataGridView-add-property-for-DoubleBuffering

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2025-08-25 - Build 2508 (Patch 8) - August 2025
+* Implemented [#2354](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2354), `KryptonDataGridView.DoubleBuffered` property added.
 * Implemented [#2338](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2338), Update specific pre-processor directives
 * Resolved [#2341](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2341), Fix exception in `RenderStandard.ContentFontForButtonForm` during teardown
 * Resolved [#2329](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2329), `AccurateText.StringFormatToFlags()` performs incorrect conversion to TextFormatFlags.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -232,7 +232,14 @@ namespace Krypton.Toolkit
         public new bool DoubleBuffered 
         {
             get => base.DoubleBuffered;
-            set => base.DoubleBuffered = value;
+            set
+            {
+                if (base.DoubleBuffered != value)
+                {
+                    base.DoubleBuffered = value;
+                    Invalidate();
+                }
+            }
         }
 
         /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -225,6 +225,16 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Public New
+        /// <inheritdoc/>
+        [Category(@"Behavior")]
+        [DefaultValue(true)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public new bool DoubleBuffered 
+        {
+            get => base.DoubleBuffered;
+            set => base.DoubleBuffered = value;
+        }
+
         /// <summary>
         /// Gets or sets the number of columns displayed in the KryptonDataGridView.
         /// </summary>


### PR DESCRIPTION
[Issue 2354-KryptonDataGridView-add-property-for-DoubleBuffering](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2354)
- Adds DoubleBuffering functionality
- And the changelog

<img width="261" height="121" alt="compile-results" src="https://github.com/user-attachments/assets/cb9b90c1-b47b-49e8-83af-5ebfb151ccb8" />
