### PR TITLE
2354-V100-KryptonDataGridView-add-property-for-DoubleBuffering

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 ====
 
 ## 2025-11-xx - Build 2511 (V10 - alpha) - November 2025
+* Implemented [#2354](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2354), `KryptonDataGridView.DoubleBuffered` property added.
 * Implemented [#2220](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2220), Enables limited support on multiple Krypton Controls for unicode surrogates.
 * Implemented [#2339](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2339), Add a emoji parser for future features
 * Implemented [#2338](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2338), Update specific pre-processor directives

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -225,6 +225,23 @@ public class KryptonDataGridView : DataGridView
     #endregion
 
     #region Public New
+    /// <inheritdoc/>
+    [Category(@"Behavior")]
+    [DefaultValue(true)]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+    public new bool DoubleBuffered 
+    {
+        get => base.DoubleBuffered;
+        set
+        {
+            if (base.DoubleBuffered != value)
+            {
+                base.DoubleBuffered = value;
+                Invalidate();
+            }
+        }
+    }
+
     /// <summary>
     /// Gets or sets the number of columns displayed in the KryptonDataGridView.
     /// </summary>


### PR DESCRIPTION
[Issue 2354-KryptonDataGridView-add-property-for-DoubleBuffering](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2354)
- Adds DoubleBuffering functionality
- And the changelog

<img width="243" height="124" alt="compile-results" src="https://github.com/user-attachments/assets/c688f847-01a3-48fd-bbea-da8dcd8d5629" />
