### PR TITLE
2368-V100-Fix-Exception-PaletteRedirectGrids.GetInheritBack

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 ====
 
 ## 2025-11-xx - Build 2511 (V10 - alpha) - November 2025
+* Implemented [#2368](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2368), Fix exception in `PaletteRedirectGrids.GetInheritBack` due to missing `BoldedOverride`.
 * Implemented [#2354](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2354), `KryptonDataGridView.DoubleBuffered` property added.
 * Implemented [#2220](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2220), Enables limited support on multiple Krypton Controls for unicode surrogates.
 * Implemented [#2339](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2339), Add a emoji parser for future features

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectGrids.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectGrids.cs
@@ -1012,6 +1012,7 @@ public class PaletteRedirectGrids : PaletteRedirect
                 }
                 break;
 
+            case PaletteState.BoldedOverride:
             case PaletteState.Normal:
                 switch (style)
                 {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectGrids.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectGrids.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
  *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *
  */
 #endregion
 
@@ -833,7 +833,7 @@ public class PaletteRedirectGrids : PaletteRedirect
     {
         IPaletteContent inherit = GetInheritContent(style, state);
 
-        return inherit?.GetBorderContentPadding(owningForm, state) 
+        return inherit?.GetBorderContentPadding(owningForm, state)
                ?? Target!.GetBorderContentPadding(owningForm, style, state);
     }
 
@@ -847,7 +847,7 @@ public class PaletteRedirectGrids : PaletteRedirect
     {
         IPaletteContent inherit = GetInheritContent(style, state);
 
-        return inherit?.GetContentAdjacentGap(state) 
+        return inherit?.GetContentAdjacentGap(state)
                ?? Target!.GetContentAdjacentGap(style, state);
     }
     #endregion
@@ -887,6 +887,7 @@ public class PaletteRedirectGrids : PaletteRedirect
                 }
                 break;
 
+            case PaletteState.BoldedOverride:
             case PaletteState.Normal:
                 switch (style)
                 {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectGrids.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Base/PaletteRedirect/PaletteRedirectGrids.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
  *
  */
 #endregion


### PR DESCRIPTION
Fixes #2368 

Added `case PaletteState.BoldedOverride:` to map to `case PaletteState.Normal:` in `PaletteRedirectGrids.GetInheritBack` until there's a better solution or more specific `state` handling.