### PR TITLE
66-V100-Fix-KryptonRibbonGroupContainerCollectionEditor-for.NET5-7

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 ====
 
 ## 2025-11-xx - Build 2511 (V10 - alpha) - November 2025
+* Implemented [#66](https://github.com/Krypton-Suite/Standard-Toolkit/issues/66), Fix `KryptonRibbonGroupContainerCollectionEditor` for .NET 5-7.
 * Implemented [#2354](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2354), `KryptonDataGridView.DoubleBuffered` property added.
 * Implemented [#2220](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2220), Enables limited support on multiple Krypton Controls for unicode surrogates.
 * Implemented [#2339](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2339), Add a emoji parser for future features

--- a/Source/Krypton Components/Krypton.Ribbon/Designers/Collection Editors/KryptonRibbonGroupContainerCollectionEditor.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Designers/Collection Editors/KryptonRibbonGroupContainerCollectionEditor.cs
@@ -1,12 +1,12 @@
-﻿#region BSD License
+#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -14,24 +14,33 @@ namespace Krypton.Ribbon;
 
 internal class KryptonRibbonGroupContainerCollectionEditor : CollectionEditor
 {
+    #region Static Fields
+    private static readonly Type[] _supportedTypes =
+    [
+        typeof(KryptonRibbonGroupLines),
+        typeof(KryptonRibbonGroupTriple),
+        typeof(KryptonRibbonGroupSeparator)
+    ];
+    #endregion
+
     /// <summary>
     /// Initialize a new instance of the KryptonRibbonGroupTopCollectionEditor class.
     /// </summary>
     public KryptonRibbonGroupContainerCollectionEditor()
         : base(typeof(KryptonRibbonGroupContainerCollection))
     {
+#if NET5_0_OR_GREATER && !NET8_0_OR_GREATER
+        // .NET 5–7 designer relies on NewItemTypes; property has a setter in those versions.
+        NewItemTypes = _supportedTypes;
+#else
+        // .NET Framework and .NET 8+ fall back to CreateNewItemTypes().
+#endif
     }
 
     /// <summary>
-    /// Gets the data types that this collection editor can contain. 
+    /// Gets the data types that this collection editor can contain.
     /// </summary>
     /// <returns>An array of data types that this collection can contain.</returns>
-    protected override Type[] CreateNewItemTypes() =>
-        // Bug https://github.com/Krypton-Suite/Standard-Toolkit/issues/66
-        // For some reason in .Net5 onwards, the following function is not called
-        [
-            typeof(KryptonRibbonGroupLines),
-            typeof(KryptonRibbonGroupTriple),
-            typeof(KryptonRibbonGroupSeparator)
-        ];
+    // Older designers still invoke this method; simply return the shared list.
+    protected override Type[] CreateNewItemTypes() => _supportedTypes;
 }


### PR DESCRIPTION
.NET 5 to 7 intermittently used `NewItemTypes` in the CollectionEditor instead of `CreateNewItemTypes`,
which caused it at design time to reach down to the abstract class.

Needs closer testing!