### PR TITLE
Fix exceptions in KryptonTextBox and KryptonMaskedTextBox when disabl…

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 ====
 
 ## 2025-11-xx - Build 2511 (V10 - alpha) - November 2025
+* Implemented [#2384](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2384), Fix exceptions in `KryptonTextBox`, `KryptonMaskedTextBox` when disabled
 * Implemented [#2368](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2368), Fix exception in `PaletteRedirectGrids.GetInheritBack` due to missing `BoldedOverride`.
 * Implemented [#2365](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2365), Fix exception in `KryptonCustomPaletteBase.GetPaletteBackGridHeaderColumn` for `BoldedOverride` state.
 * Implemented [#2349](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2349), Fix `KryptonListBox` shifting on visible item selection.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonMaskedTextBox.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -222,20 +222,19 @@ public class KryptonMaskedTextBox : VisualControlBase,
 
                             // Draw using a solid brush
                             var drawText = MaskedTextProvider?.ToDisplayString() ?? Text;
-                            try
-                            {
-                                using var foreBrush = new SolidBrush(ForeColor);
-                                g.DrawString(drawText, Font, foreBrush,
-                                    new RectangleF(rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top),
-                                    stringFormat);
-                            }
-                            catch (ArgumentException)
-                            {
-                                using var foreBrush = new SolidBrush(ForeColor);
-                                g.DrawString(drawText, _kryptonMaskedTextBox.GetTripleState().PaletteContent?.GetContentShortTextFont(PaletteState.Disabled)!, foreBrush,
-                                    new RectangleF(rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top),
-                                    stringFormat);
-                            }
+
+                            // Define the font to use for disabled painting – always query the palette first.
+                            // Avoids exception - magnitudes faster than another repaint AND try/catch.
+                            var disabledFont = _kryptonMaskedTextBox
+                                                   .GetTripleState()
+                                                   .PaletteContent?
+                                                   .GetContentShortTextFont(PaletteState.Disabled)
+                                               ?? Font; // Fallback: current Font if palette returns null
+
+                            using var foreBrush = new SolidBrush(ForeColor);
+                            g.DrawString(drawText, disabledFont, foreBrush,
+                                new RectangleF(rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top),
+                                stringFormat);
                         }
 
                         // Remove clipping settings
@@ -962,7 +961,7 @@ public class KryptonMaskedTextBox : VisualControlBase,
     }
 
     /// <summary>
-    /// Gets or sets the input mask to use at run time. 
+    /// Gets or sets the input mask to use at run time.
     /// </summary>
     [Category(@"Behavior")]
     [Description(@"Sets the string governing the input allowed for the control.")]

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTextBox.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -226,23 +226,17 @@ public class KryptonTextBox : VisualControlBase,
                                 drawString = new string(PasswordChar, Text.Length);
                             }
 
-                            // Draw using a solid brush
-                            try
-                            {
-                                using var foreBrush = new SolidBrush(ForeColor);
-                                g.DrawString(drawString, Font, foreBrush,
-                                    textRectangle,
-                                    stringFormat);
-                            }
-                            catch (ArgumentException)
-                            {
-                                using var foreBrush = new SolidBrush(ForeColor);
-                                g.DrawString(drawString,
-                                    _kryptonTextBox.GetTripleState().PaletteContent?
-                                        .GetContentShortTextFont(PaletteState.Disabled)!, foreBrush,
-                                    textRectangle,
-                                    stringFormat);
-                            }
+                            // Define the font to use for disabled painting – always query the palette first.
+                            // Avoids exception - magnitudes faster than another repaint AND try/catch.
+                            var disabledFont = _kryptonTextBox
+                                                   .GetTripleState()
+                                                   .PaletteContent?
+                                                   .GetContentShortTextFont(PaletteState.Disabled)
+                                               ?? Font; // Fallback: current Font if palette returns null
+                            using var foreBrush = new SolidBrush(ForeColor);
+                            g.DrawString(drawString, disabledFont, foreBrush,
+                                textRectangle,
+                                stringFormat);
                         }
 
                         // Remove clipping settings
@@ -1171,7 +1165,7 @@ public class KryptonTextBox : VisualControlBase,
     public void Clear() => _textBox.Clear();
 
     /// <summary>
-    /// Clears information about the most recent operation from the undo buffer of the rich text box. 
+    /// Clears information about the most recent operation from the undo buffer of the rich text box.
     /// </summary>
     public void ClearUndo() => _textBox.ClearUndo();
 


### PR DESCRIPTION
Fixes #2386 

We **can** eliminate the first-chance exception completely with a small, targeted change.

Why the exception happens  
• Immediately after a theme swap, the internal `Font` still points to the *old* palette font object, which has just been disposed.  
• The first call to `Graphics.DrawString` therefore throws.  
• A single `OnNeedPaint` later the control updates its `Font` to the fresh palette font, so everything continues to work – but the debugger has already stopped on that first-chance exception.

A surgical fix  
Instead of asking the component for its `Font` during the disabled-paint path, ask the **palette** directly; it will hand back the new font object even during the transition frame.

```csharp
// Define the font to use for disabled painting – always query the palette first.
var disabledFont = _kryptonMaskedTextBox
    .GetTripleState()
    .PaletteContent?
    .GetContentShortTextFont(PaletteState.Disabled)
    ?? Font;  // Fallback: current Font if palette returns null

// Draw using a solid brush
using var foreBrush = new SolidBrush(ForeColor);
g.DrawString(drawText, disabledFont,
             new RectangleF(rect.left, rect.top,
                            rect.right - rect.left, rect.bottom - rect.top),
             stringFormat);
```

What changes:

1. We **remove the try/catch** block altogether – nothing throws because `disabledFont`
   is always a valid, live object.
2. No performance hit: calling the palette getter is fast (it just returns a cached `Font`).
3. No more debugger noise when switching Microsoft 365 themes – or any future palette
   that swaps fonts at runtime.


Example exception (if stop on error for that type is enabled):
<img width="1066" height="238" alt="{13B9543D-2AFC-49C9-B2E2-22B7F4742772}" src="https://github.com/user-attachments/assets/974770d2-ea66-4155-b08a-1027c6b50598" />
