### PR TITLE
2389-v100-theme-arrays-transformation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -333,7 +333,3 @@ Source/Krypton Components/Temp.txt
 Source/Krypton Components/Krypton.Ribbon/Temp.txt
 
 .cursor/
-
-# Interim tools - devs only
-kptheme/
-Krypton.ThemeGen/

--- a/Documents/2021-palette-unification.md
+++ b/Documents/2021-palette-unification.md
@@ -16,28 +16,26 @@
     * `ButtonBorderColors`, `ButtonBackColors`
     * `RibbonGroupCollapsedBackContext`, `RibbonGroupCollapsedBackContextTracking`
     * `RibbonGroupCollapsedBorderContext`, `RibbonGroupCollapsedBorderContextTracking`
-    * These correspond to private static arrays (listed below) and must be folded into the scheme as named properties:
-      _appButtonNormal  
-      _appButtonPressed  
-      _appButtonTrack  
-      _arrowBorderColors  
-      _buttonBackColors  
-      _buttonBorderColors  
+    * These correspond to slot families registered via `RegisterColor<TEnum>` (publicly mutable at runtime; see the static constructor in `PaletteMicrosoft365Base.cs`) and must be folded into the scheme as named properties:
+      AppButtonNormalColor (5)  
+      AppButtonTrackColor (5)  
+      AppButtonPressedColor (5)  
+      ButtonBackColor (10)  
+      ButtonBorderColor (7)
+
+    * Additionally, fold remaining legacy arrays used by other themes/renderers into the scheme as named properties (to be removed during clean‑up):
+      _ribbonColors  
       _colorsB  
       _colorsG  
       _colorsS  
-      _ribbonColors  
       _ribbonGroupCollapsedBackContext  
       _ribbonGroupCollapsedBackContextTracking  
       _ribbonGroupCollapsedBorderContext  
       _ribbonGroupCollapsedBorderContextTracking  
-      _schemeBaseColors  
-      _schemeOfficeColours  
-      _schemeVisualStudioColors  
       _sparkleColors  
       _trackBarColors  
-      _trackBarColours  
-      _trackColors
+      _trackColors  
+      _arrowBorderColors
 * Use auto-properties - no arrays, no enums, no “slot” indices.
 
 ```csharp

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 ====
 
 ## 2025-11-xx - Build 2511 (V10 - alpha) - November 2025
+* Implemented [#2389](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2389), Transform private color arrays in base palettes.
 * Implemented [#2386](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2386), Fix exceptions in `KryptonTextBox`, `KryptonMaskedTextBox` when disabled
 * Implemented [#2384](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2384), Fix TrackBar colors usage in palettes.
 * Implemented [#2368](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2368), Fix exception in `PaletteRedirectGrids.GetInheritBack` due to missing `BoldedOverride`.

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Base/PaletteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Base/PaletteBase.cs
@@ -2112,6 +2112,36 @@ public abstract class PaletteBase : Component
 
     #region Palette Helpers
 
+    // GLOBAL lookup table that holds every colour previously kept in the old static Color[] arrays
+    // Key = (enum type that defines the slot, zero-based index)
+    private static readonly Dictionary<(Type Enum, int Index), Color> _colorLut = new Dictionary<(Type Enum, int Index), Color>();
+
+    /// <summary>
+    /// Called once from a family base static constructor to seed default colours for a particular enum slot.
+    /// </summary>
+    protected static void RegisterColor<TEnum>(TEnum slot, Color value) where TEnum : struct, Enum
+    {
+        _colorLut[(typeof(TEnum), Convert.ToInt32(slot))] = value;
+    }
+
+    /// <summary>
+    /// Retrieves a colour previously registered for <typeparamref name="TEnum"/>.
+    /// </summary>
+    public Color GetArrayColor<TEnum>(TEnum slot) where TEnum : struct, Enum
+    {
+        return _colorLut[(typeof(TEnum), Convert.ToInt32(slot))];
+    }
+
+    /// <summary>
+    /// Replaces a registered colour at run-time and triggers a repaint.
+    /// </summary>
+    public void SetArrayColor<TEnum>(TEnum slot, Color newColor) where TEnum : struct, Enum
+    {
+        _colorLut[(typeof(TEnum), Convert.ToInt32(slot))] = newColor;
+        // Inform listeners that colours have changed so UI repaints.
+        OnPalettePaint(this, new PaletteLayoutEventArgs(true, true));
+    }
+
     private readonly object _colorLock = new();
 
     /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Enumerations/PaletteEnumerations.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Enumerations/PaletteEnumerations.cs
@@ -1000,3 +1000,145 @@ public enum SchemeTrackingColors
 }
 
 #endregion
+
+#region Enumeration: AppButtonNormalColor
+
+/// <summary>Slot enum for AppButtonNormal array indexes.</summary>
+public enum AppButtonNormalColor
+{
+    Color1 = 0,
+    Color2 = 1,
+    Color3 = 2,
+    Color4 = 3,
+    Color5 = 4
+}
+
+#endregion
+
+#region Enumeration: AppButtonPressedColor
+
+/// <summary>Slot enum for AppButtonPressed array indexes.</summary>
+public enum AppButtonPressedColor
+{
+    Color1 = 0,
+    Color2 = 1,
+    Color3 = 2,
+    Color4 = 3,
+    Color5 = 4
+}
+
+#endregion
+
+#region Enumeration: AppButtonTrackColor
+
+/// <summary>Slot enum for AppButtonTrack array indexes.</summary>
+public enum AppButtonTrackColor
+{
+    Color1 = 0,
+    Color2 = 1,
+    Color3 = 2,
+    Color4 = 3,
+    Color5 = 4
+}
+
+#endregion
+
+#region Enumeration: ArrowBorderColor
+
+/// <summary>Slot enum for ArrowBorderColors array indexes.</summary>
+public enum ArrowBorderColor
+{
+    Color1 = 0,
+    Color2 = 1,
+    Color3 = 2,
+    Color4 = 3
+}
+
+#endregion
+
+#region Enumeration: ButtonBackColor
+
+/// <summary>Slot enum for ButtonBackColors array indexes.</summary>
+public enum ButtonBackColor
+{
+    Color1 = 0,
+    Color2 = 1,
+    Color3 = 2,
+    Color4 = 3,
+    Color5 = 4,
+    Color6 = 5,
+    Color7 = 6,
+    Color8 = 7,
+    Color9 = 8,
+    Color10 = 9
+}
+
+#endregion
+
+#region Enumeration: ButtonBorderColor
+
+/// <summary>Slot enum for ButtonBorderColors array indexes.</summary>
+public enum ButtonBorderColor
+{
+    Color1 = 0,
+    Color2 = 1,
+    Color3 = 2,
+    Color4 = 3,
+    Color5 = 4,
+    Color6 = 5,
+    Color7 = 6
+}
+
+#endregion
+
+#region Enumeration: RibbonGroupCollapsedBack
+
+/// <summary>Slot enum for RibbonGroupCollapsedBackContext array indexes.</summary>
+public enum RibbonGroupCollapsedBack
+{
+    Color1 = 0,
+    Color2 = 1,
+    Color3 = 2,
+    Color4 = 3
+}
+
+#endregion
+
+#region Enumeration: RibbonGroupCollapsedBackT
+
+/// <summary>Slot enum for RibbonGroupCollapsedBackContextTracking array indexes.</summary>
+public enum RibbonGroupCollapsedBackT
+{
+    Color1 = 0,
+    Color2 = 1,
+    Color3 = 2,
+    Color4 = 3
+}
+
+#endregion
+
+#region Enumeration: RibbonGroupCollapsedBorder
+
+/// <summary>Slot enum for RibbonGroupCollapsedBorderContext array indexes.</summary>
+public enum RibbonGroupCollapsedBorder
+{
+    Color1 = 0,
+    Color2 = 1,
+    Color3 = 2,
+    Color4 = 3
+}
+
+#endregion
+
+#region Enumeration: RibbonGroupCollapsedBorderT
+
+/// <summary>Slot enum for RibbonGroupCollapsedBorderContextTracking array indexes.</summary>
+public enum RibbonGroupCollapsedBorderT
+{
+    Color1 = 0,
+    Color2 = 1,
+    Color3 = 2,
+    Color4 = 3
+}
+
+#endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Bases/PaletteMicrosoft365Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Bases/PaletteMicrosoft365Base.cs
@@ -19,6 +19,45 @@ namespace Krypton.Toolkit;
 public abstract class PaletteMicrosoft365Base : PaletteBase
 {
     #region Static Fields
+    static PaletteMicrosoft365Base()
+    {
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color4, Color.FromArgb(254, 254, 255));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color5, Color.FromArgb(206, 213, 225));
+
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color1, Color.FromArgb(235, 227, 196));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color2, Color.FromArgb(228, 198, 149));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color3, Color.FromArgb(166, 97, 7));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color4, Color.FromArgb(242, 155, 57));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color5, Color.FromArgb(236, 136, 9));
+
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color1, Color.FromArgb(255, 251, 230));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color2, Color.FromArgb(248, 230, 143));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color3, Color.FromArgb(238, 213, 126));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color4, Color.FromArgb(254, 247, 129));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color5, Color.FromArgb(240, 201, 41));
+
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(250, 250, 250));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(250, 250, 250));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(248, 225, 135));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color4, Color.FromArgb(251, 248, 224));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color5, Color.FromArgb(255, 228, 138));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color6, Color.FromArgb(194, 118, 43));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color7, Color.FromArgb(255, 216, 108));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color8, Color.FromArgb(255, 244, 128));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color9, Color.FromArgb(255, 225, 104));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color10, Color.FromArgb(255, 249, 196));
+
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color1, Color.FromArgb(180, 180, 180));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color2, Color.FromArgb(237, 201, 88));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color3, Color.FromArgb(243, 213, 73));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color4, Color.FromArgb(194, 118, 43));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color5, Color.FromArgb(194, 158, 71));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color6, Color.FromArgb(194, 138, 48));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color7, Color.FromArgb(194, 164, 77));
+    }
 
     #region Padding
 
@@ -162,58 +201,6 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
     #endregion
 
     #region Color Arrays
-
-    private static readonly Color[] _appButtonNormal =
-    [
-        Color.FromArgb(243, 245, 248),
-        Color.FromArgb(214, 220, 231),
-        Color.FromArgb(188, 198, 211),
-        Color.FromArgb(254, 254, 255),
-        Color.FromArgb(206, 213, 225)
-    ];
-
-    private static readonly Color[] _appButtonTrack =
-    [
-        Color.FromArgb(255, 251, 230),
-        Color.FromArgb(248, 230, 143),
-        Color.FromArgb(238, 213, 126),
-        Color.FromArgb(254, 247, 129),
-        Color.FromArgb(240, 201, 41)
-    ];
-
-    private static readonly Color[] _appButtonPressed =
-    [
-        Color.FromArgb(235, 227, 196),
-        Color.FromArgb(228, 198, 149),
-        Color.FromArgb(166, 97, 7),
-        Color.FromArgb(242, 155, 57),
-        Color.FromArgb(236, 136, 9)
-    ];
-
-    private static readonly Color[] _buttonBorderColors =
-    [
-        Color.FromArgb(180, 180, 180), // Button, Disabled, Border
-        Color.FromArgb(237, 201, 88), // Button, Tracking, Border 1
-        Color.FromArgb(243, 213, 73), // Button, Tracking, Border 2
-        Color.FromArgb(194, 118, 43), // Button, Pressed, Border 1
-        Color.FromArgb(194, 158, 71), // Button, Pressed, Border 2
-        Color.FromArgb(194, 138, 48), // Button, Checked, Border 1
-        Color.FromArgb(194, 164, 77) // Button, Checked, Border 2
-    ];
-
-    private static readonly Color[] _buttonBackColors =
-    [
-        Color.FromArgb(250, 250, 250), // Button, Disabled, Back 1
-        Color.FromArgb(250, 250, 250), // Button, Disabled, Back 2
-        Color.FromArgb(248, 225, 135), // Button, Tracking, Back 1
-        Color.FromArgb(251, 248, 224), // Button, Tracking, Back 2
-        Color.FromArgb(255, 228, 138), // Button, Pressed, Back 1
-        Color.FromArgb(194, 118, 43), // Button, Pressed, Back 2
-        Color.FromArgb(255, 216, 108), // Button, Checked, Back 1
-        Color.FromArgb(255, 244, 128), // Button, Checked, Back 2
-        Color.FromArgb(255, 225, 104), // Button, Checked Tracking, Back 1
-        Color.FromArgb(255, 249, 196) // Button, Checked Tracking, Back 2
-    ];
 
     #endregion Color Arrays
 
@@ -427,7 +414,7 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
                 return state == PaletteState.CheckedNormal ? _ribbonColors[(int)SchemeBaseColors.GridDataCellSelected] : SystemColors.Window;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[6] : SystemColors.Window;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7) : SystemColors.Window;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -451,7 +438,7 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
                             case PaletteBackStyle.TabLowProfile:
                                 return GlobalStaticValues.EMPTY_COLOR;
                             case PaletteBackStyle.TabHighProfile:
-                                return state == PaletteState.Tracking ? _buttonBackColors[2] : _buttonBackColors[4];
+                                return state == PaletteState.Tracking ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3) : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5);
                             default:
                                 return SystemColors.Window;
                         }
@@ -463,11 +450,11 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
                         {
                             if (state == PaletteState.CheckedNormal)
                             {
-                                return _buttonBackColors[6];
+                                return GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
                             }
                             else
                             {
-                                return state == PaletteState.CheckedPressed ? _buttonBackColors[4] : _buttonBackColors[8];
+                                return state == PaletteState.CheckedPressed ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5) : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9);
                             }
                         }
                         else
@@ -506,7 +493,7 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeBaseColors.HeaderDockInactiveBack1];
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[6];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeBaseColors.HeaderSecondaryBack1];
@@ -577,7 +564,7 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[2],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -630,12 +617,12 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
                     PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack1],
                     PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
                         ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]
-                        : _buttonBackColors[6],
-                    PaletteState.Tracking => _buttonBackColors[2],
-                    PaletteState.Pressed or PaletteState.Checked or PaletteState.CheckedPressed => _buttonBackColors[4],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed or PaletteState.Checked or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
                         ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]
-                        : _buttonBackColors[8],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -643,7 +630,7 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorTrack1],
                     PaletteState.Pressed => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorPressed1],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorChecked1],
@@ -708,7 +695,7 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
                 return state == PaletteState.CheckedNormal ? _ribbonColors[(int)SchemeBaseColors.GridDataCellSelected] : SystemColors.Window;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[7] : SystemColors.Window;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8) : SystemColors.Window;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -730,7 +717,7 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.HeaderDockInactiveBack1],
-                    PaletteState.Tracking or PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => SystemColors.Window,
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
@@ -739,7 +726,7 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeBaseColors.HeaderDockInactiveBack1],
-                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.HeaderForm:
@@ -762,7 +749,7 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeBaseColors.HeaderDockInactiveBack2];
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[7];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeBaseColors.HeaderSecondaryBack2];
@@ -833,7 +820,7 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[3],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -881,19 +868,19 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
             case PaletteBackStyle.ContextMenuItemHighlight:
                 return state switch
                 {
-                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack1] : _buttonBackColors[1],
+                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack1] : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack2],
                     PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
                         ? GlobalStaticValues.EMPTY_COLOR
                         : _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack2],
                     PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
                         ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack2]
-                        : _buttonBackColors[7],
-                    PaletteState.Tracking => _buttonBackColors[3],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
                         ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]
-                        : _buttonBackColors[9],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color10),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -901,7 +888,7 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorTrack2],
                     PaletteState.Pressed => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorPressed2],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorChecked2],
@@ -1208,7 +1195,7 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeBaseColors.ControlBorder],
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1216,7 +1203,7 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
@@ -1229,8 +1216,8 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1266,23 +1253,23 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
             {
                 PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
                     ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack2]
-                    : _buttonBorderColors[0],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
                 PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
                     ? GlobalStaticValues.EMPTY_COLOR
                     : _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBorder],
-                PaletteState.CheckedNormal => _buttonBorderColors[5],
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
-                PaletteState.CheckedTracking => _buttonBorderColors[3],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color6),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1290,10 +1277,10 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1],
                 PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack1],
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorBorder],
@@ -1336,7 +1323,7 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeBaseColors.ControlBorder],
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1344,7 +1331,7 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
@@ -1357,8 +1344,8 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1394,21 +1381,21 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
             {
                 PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
                     ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack2]
-                    : _buttonBorderColors[0],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
                 PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBorder],
-                PaletteState.CheckedNormal => _buttonBorderColors[6],
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
-                PaletteState.CheckedTracking => _buttonBorderColors[4],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1416,10 +1403,10 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1],
                 PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack1],
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorBorder],
@@ -3731,11 +3718,11 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[0];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color1);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[0];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color1);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[0];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3846,11 +3833,11 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[1];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color2);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[1];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color2);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[1];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3935,11 +3922,11 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[2];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color3);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[2];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color3);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[2];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color3);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4017,11 +4004,11 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[3];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color4);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[3];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color4);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[3];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color4);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4099,11 +4086,11 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[4];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color5);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[4];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color5);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[4];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color5);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4259,8 +4246,8 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.Light(_ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder]),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBorderColors[1],
-                    PaletteState.Pressed => _buttonBorderColors[3],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                    PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4299,8 +4286,8 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
                         _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
                     PaletteState.Normal => ControlPaint.Light(
                         _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
-                    PaletteState.Tracking => ControlPaint.Light(_buttonBackColors[2]),
-                    PaletteState.Pressed => ControlPaint.Light(_buttonBackColors[4]),
+                    PaletteState.Tracking => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)),
+                    PaletteState.Pressed => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5)),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
 
@@ -4348,8 +4335,8 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(_ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1],
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[2],
-                    PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4396,8 +4383,8 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(_ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack2],
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[3],
-                    PaletteState.Pressed => _buttonBackColors[5],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Bases/PaletteMicrosoft365Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Bases/PaletteMicrosoft365Base.cs
@@ -19,8 +19,18 @@ namespace Krypton.Toolkit;
 public abstract class PaletteMicrosoft365Base : PaletteBase
 {
     #region Static Fields
+
+    // registration guard so default colours are initialised lazily only once
+    private static bool _defaultsRegistered;
+
     static PaletteMicrosoft365Base()
     {
+        if (_defaultsRegistered)
+        {
+            return;
+        }
+        _defaultsRegistered = true;
+
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
@@ -236,12 +246,33 @@ public abstract class PaletteMicrosoft365Base : PaletteBase
         [DisallowNull] ImageList checkBoxList,
         [DisallowNull] ImageList galleryButtonList,
         [DisallowNull] Image?[]  radioButtonArray)
-        : this(scheme.ToArray(),
-               checkBoxList,
-               galleryButtonList,
-               radioButtonArray,
-               scheme.ToTrackBarArray())
     {
+        Debug.Assert(scheme != null);
+        Debug.Assert(checkBoxList != null);
+        Debug.Assert(galleryButtonList != null);
+        Debug.Assert(radioButtonArray != null);
+
+        if (scheme != null)
+        {
+            _ribbonColors = scheme.ToArray();
+        }
+
+        if (checkBoxList != null)
+        {
+            _checkBoxList = checkBoxList;
+        }
+
+        if (galleryButtonList != null)
+        {
+            _galleryButtonList = galleryButtonList;
+        }
+
+        if (radioButtonArray != null)
+        {
+            _radioButtonArray = radioButtonArray;
+        }
+
+        DefineFonts();
         BaseColors = scheme;
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365BlackDarkModeAlternateBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365BlackDarkModeAlternateBase.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
  *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege, et al. 2024 - 2025. All rights reserved.
@@ -15,6 +15,45 @@ namespace Krypton.Toolkit;
 public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBase
 {
     #region Static Fields
+    static PaletteMicrosoft365BlackDarkModeAlternateBase()
+    {
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color4, Color.FromArgb(254, 254, 255));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color5, Color.FromArgb(206, 213, 225));
+
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color1, Color.FromArgb(235, 227, 196));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color2, Color.FromArgb(185, 185, 185));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color3, Color.FromArgb(35, 35, 35));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color4, Color.FromArgb(50, 50, 50));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color5, Color.FromArgb(100, 100, 100));
+
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color1, Color.FromArgb(255, 251, 230));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color2, Color.FromArgb(178, 178, 178));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color3, Color.FromArgb(176, 176, 176));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color4, Color.FromArgb(179, 179, 179));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color5, Color.FromArgb(160, 160, 160));
+
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(250, 250, 250));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(250, 250, 250));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(91, 91, 91));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color4, Color.FromArgb(129, 129, 129));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color5, Color.FromArgb(121, 121, 121));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color6, Color.FromArgb(91, 91, 91));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color7, Color.FromArgb(91, 91, 91));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color8, Color.FromArgb(88, 88, 88));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color9, Color.FromArgb(15, 15, 15));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color10, Color.FromArgb(70, 70, 70));
+
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color1, Color.FromArgb(180, 180, 180));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color2, Color.FromArgb(187, 186, 186));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color3, Color.FromArgb(139, 139, 139));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color4, Color.FromArgb(30, 30, 30));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color5, Color.FromArgb(4, 3, 3));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color6, Color.FromArgb(30, 30, 30));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color7, Color.FromArgb(4, 3, 3));
+    }
 
     #region Padding
 
@@ -159,58 +198,6 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
     #endregion
 
     #region Colour Arrays
-
-    private static readonly Color[] _appButtonNormal =
-    [
-        Color.FromArgb(243, 245, 248),
-        Color.FromArgb(214, 220, 231),
-        Color.FromArgb(188, 198, 211),
-        Color.FromArgb(254, 254, 255),
-        Color.FromArgb(206, 213, 225)
-    ];
-
-    private static readonly Color[] _appButtonTrack =
-    [
-        Color.FromArgb(255, 251, 230),
-        Color.FromArgb(178, 178, 178),
-        Color.FromArgb(176, 176, 176),
-        Color.FromArgb(179, 179, 179),
-        Color.FromArgb(160, 160, 160)
-    ];
-
-    private static readonly Color[] _appButtonPressed =
-    [
-        Color.FromArgb(235, 227, 196),
-        Color.FromArgb(185, 185, 185),
-        Color.FromArgb(35, 35, 35),
-        Color.FromArgb(50, 50, 50),
-        Color.FromArgb(100, 100, 100)
-    ];
-
-    private static readonly Color[] _buttonBorderColors =
-    [
-        Color.FromArgb(180, 180, 180), // Button, Disabled, Border
-        Color.FromArgb(187, 186, 186), // Button, Tracking, Border 1
-        Color.FromArgb(139, 139, 139), // Button, Tracking, Border 2
-        Color.FromArgb(30, 30, 30), // Button, Pressed, Border 1
-        Color.FromArgb(4, 3, 3), // Button, Pressed, Border 2
-        Color.FromArgb(30, 30, 30), // Button, Checked, Border 1
-        Color.FromArgb(4, 3, 3) // Button, Checked, Border 2
-    ];
-
-    private static readonly Color[] _buttonBackColors =
-    [
-        Color.FromArgb(250, 250, 250), // Button, Disabled, Back 1
-        Color.FromArgb(250, 250, 250), // Button, Disabled, Back 2
-        Color.FromArgb(91, 91, 91), // Button, Tracking, Back 1
-        Color.FromArgb(129, 129, 129), // Button, Tracking, Back 2
-        Color.FromArgb(121, 121, 121), // Button, Pressed, Back 1
-        Color.FromArgb(91, 91, 91), // Button, Pressed, Back 2
-        Color.FromArgb(91, 91, 91), // Button, Checked, Back 1
-        Color.FromArgb(88, 88, 88), // Button, Checked, Back 2
-        Color.FromArgb(15, 15, 15), // Button, Checked Tracking, Back 1
-        Color.FromArgb(70, 70, 70) // Button, Checked Tracking, Back 2
-    ];
 
     #endregion
 
@@ -401,7 +388,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
                 return state == PaletteState.CheckedNormal ? BaseColors.GridDataCellSelected : BaseColors.PanelAlternative;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[6] : BaseColors.PanelAlternative;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7) : BaseColors.PanelAlternative;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -425,7 +412,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
                             case PaletteBackStyle.TabLowProfile:
                                 return GlobalStaticValues.EMPTY_COLOR;
                             case PaletteBackStyle.TabHighProfile:
-                                return state == PaletteState.Tracking ? _buttonBackColors[2] : _buttonBackColors[4];
+                                return state == PaletteState.Tracking ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3) : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5);
                             default:
                                 return SystemColors.Window;
                         }
@@ -437,11 +424,11 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
                         {
                             if (state == PaletteState.CheckedNormal)
                             {
-                                return _buttonBackColors[6];
+                                return GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
                             }
                             else
                             {
-                                return state == PaletteState.CheckedPressed ? _buttonBackColors[4] : _buttonBackColors[8];
+                                return state == PaletteState.CheckedPressed ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5) : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9);
                             }
                         }
                         else
@@ -480,7 +467,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors.HeaderDockInactiveBack1;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[6];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors.HeaderSecondaryBack1;
@@ -587,7 +574,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[2],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -640,12 +627,12 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
                     PaletteState.NormalDefaultOverride => BaseColors.ButtonNormalDefaultBack1,
                     PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
                         ? BaseColors.ButtonNormalBack1
-                        : _buttonBackColors[6],
-                    PaletteState.Tracking => _buttonBackColors[2],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
                         ? BaseColors.ButtonNormalBack1
-                        : _buttonBackColors[8],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -653,7 +640,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => BaseColors.ButtonNavigatorTrack1,
                     PaletteState.Pressed => BaseColors.ButtonNavigatorPressed1,
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => BaseColors.ButtonNavigatorChecked1,
@@ -718,7 +705,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
                 return state == PaletteState.CheckedNormal ? BaseColors.GridDataCellSelected : SystemColors.Window;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[7] : SystemColors.Window;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8) : SystemColors.Window;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -740,7 +727,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal => BaseColors.HeaderDockInactiveBack1,
-                    PaletteState.Tracking or PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => SystemColors.Window,
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
@@ -749,7 +736,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal or PaletteState.CheckedNormal => BaseColors.HeaderDockInactiveBack1,
-                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.HeaderForm:
@@ -772,7 +759,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors.HeaderDockInactiveBack2;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[7];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors.HeaderSecondaryBack2;
@@ -879,7 +866,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[3],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -927,19 +914,19 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
             case PaletteBackStyle.ContextMenuItemHighlight:
                 return state switch
                 {
-                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? BaseColors.RibbonGalleryBack1 : _buttonBackColors[1],
+                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? BaseColors.RibbonGalleryBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Normal => BaseColors.ButtonNormalBack2,
                     PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
                         ? GlobalStaticValues.EMPTY_COLOR
                         : BaseColors.ButtonNormalDefaultBack2,
                     PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
                         ? BaseColors.ButtonNormalBack2
-                        : _buttonBackColors[7],
-                    PaletteState.Tracking => _buttonBackColors[3],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
                         ? BaseColors.ButtonNormalBack1
-                        : _buttonBackColors[9],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color10),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -947,7 +934,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => BaseColors.ButtonNavigatorTrack2,
                     PaletteState.Pressed => BaseColors.ButtonNavigatorPressed2,
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => BaseColors.ButtonNavigatorChecked2,
@@ -1280,7 +1267,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1288,7 +1275,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
@@ -1301,8 +1288,8 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1338,23 +1325,23 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
             {
                 PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
                     ? BaseColors.RibbonGalleryBack2
-                    : _buttonBorderColors[0],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => BaseColors.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
                     ? GlobalStaticValues.EMPTY_COLOR
                     : BaseColors.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[5],
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
-                PaletteState.CheckedTracking => _buttonBorderColors[3],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color6),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => BaseColors.ButtonNormalBorder,
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1362,10 +1349,10 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => BaseColors.ButtonNavigatorBorder,
@@ -1408,7 +1395,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1416,7 +1403,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
@@ -1429,8 +1416,8 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1466,21 +1453,21 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
             {
                 PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
                     ? BaseColors.RibbonGalleryBack2
-                    : _buttonBorderColors[0],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => BaseColors.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => BaseColors.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[6],
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
-                PaletteState.CheckedTracking => _buttonBorderColors[4],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => BaseColors.ButtonNormalBorder,
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1488,10 +1475,10 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => BaseColors.ButtonNavigatorBorder,
@@ -3685,11 +3672,11 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[0];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color1);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[0];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color1);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[0];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3800,11 +3787,11 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[1];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color2);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[1];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color2);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[1];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3889,11 +3876,11 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[2];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color3);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[2];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color3);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[2];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color3);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3971,11 +3958,11 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[3];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color4);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[3];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color4);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[3];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color4);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4053,11 +4040,11 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[4];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color5);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[4];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color5);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[4];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color5);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4211,8 +4198,8 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
                 {
                     PaletteState.Disabled => ControlPaint.Light(BaseColors.ButtonNormalBorder),
                     PaletteState.Normal => BaseColors.ButtonNormalBorder,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBorderColors[1],
-                    PaletteState.Pressed => _buttonBorderColors[3],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                    PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4251,8 +4238,8 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
                         BaseColors.ButtonNormalBack1),
                     PaletteState.Normal => ControlPaint.Light(
                         BaseColors.ButtonNormalBack1),
-                    PaletteState.Tracking => ControlPaint.Light(_buttonBackColors[2]),
-                    PaletteState.Pressed => ControlPaint.Light(_buttonBackColors[4]),
+                    PaletteState.Tracking => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)),
+                    PaletteState.Pressed => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5)),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
 
@@ -4299,8 +4286,8 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors.ButtonNormalBack1,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[2],
-                    PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
 
@@ -4348,8 +4335,8 @@ public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBas
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors.ButtonNormalBack2,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[3],
-                    PaletteState.Pressed => _buttonBackColors[5],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365BlackDarkModeAlternateBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365BlackDarkModeAlternateBase.cs
@@ -15,8 +15,18 @@ namespace Krypton.Toolkit;
 public abstract class PaletteMicrosoft365BlackDarkModeAlternateBase : PaletteBase
 {
     #region Static Fields
+
+    // registration guard so default colours are initialised lazily only once
+    private static bool _defaultsRegistered;
+
     static PaletteMicrosoft365BlackDarkModeAlternateBase()
     {
+        if (_defaultsRegistered)
+        {
+            return;
+        }
+        _defaultsRegistered = true;
+
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365BlackDarkModeBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365BlackDarkModeBase.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -19,6 +19,45 @@ namespace Krypton.Toolkit;
 public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
 {
     #region Static Fields
+    static PaletteMicrosoft365BlackDarkModeBase()
+    {
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color4, Color.FromArgb(254, 254, 255));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color5, Color.FromArgb(206, 213, 225));
+
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color1, Color.FromArgb(235, 227, 196));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color2, Color.FromArgb(185, 185, 185));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color3, Color.FromArgb(35, 35, 35));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color4, Color.FromArgb(50, 50, 50));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color5, Color.FromArgb(100, 100, 100));
+
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color1, Color.FromArgb(255, 251, 230));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color2, Color.FromArgb(178, 178, 178));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color3, Color.FromArgb(176, 176, 176));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color4, Color.FromArgb(179, 179, 179));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color5, Color.FromArgb(160, 160, 160));
+
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(250, 250, 250));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(250, 250, 250));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(91, 91, 91));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color4, Color.FromArgb(129, 129, 129));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color5, Color.FromArgb(121, 121, 121));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color6, Color.FromArgb(91, 91, 91));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color7, Color.FromArgb(91, 91, 91));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color8, Color.FromArgb(88, 88, 88));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color9, Color.FromArgb(41, 41, 41));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color10, Color.FromArgb(70, 70, 70));
+
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color1, Color.FromArgb(180, 180, 180));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color2, Color.FromArgb(187, 186, 186));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color3, Color.FromArgb(139, 139, 139));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color4, Color.FromArgb(30, 30, 30));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color5, Color.FromArgb(4, 3, 3));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color6, Color.FromArgb(30, 30, 30));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color7, Color.FromArgb(4, 3, 3));
+    }
 
     #region Padding
 
@@ -161,58 +200,6 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
     private static readonly Color _formCloseCheckedTracking2 = Color.FromArgb(255, 132, 130);
 
     #endregion
-
-    private static readonly Color[] _appButtonNormal =
-    [
-        Color.FromArgb(243, 245, 248),
-        Color.FromArgb(214, 220, 231),
-        Color.FromArgb(188, 198, 211),
-        Color.FromArgb(254, 254, 255),
-        Color.FromArgb(206, 213, 225)
-    ];
-
-    private static readonly Color[] _appButtonTrack =
-    [
-        Color.FromArgb(255, 251, 230),
-        Color.FromArgb(178, 178, 178),
-        Color.FromArgb(176, 176, 176),
-        Color.FromArgb(179, 179, 179),
-        Color.FromArgb(160, 160, 160)
-    ];
-
-    private static readonly Color[] _appButtonPressed =
-    [
-        Color.FromArgb(235, 227, 196),
-        Color.FromArgb(185, 185, 185),
-        Color.FromArgb(35, 35, 35),
-        Color.FromArgb(50, 50, 50),
-        Color.FromArgb(100, 100, 100)
-    ];
-
-    private static readonly Color[] _buttonBorderColors =
-    [
-        Color.FromArgb(180, 180, 180), // Button, Disabled, Border
-        Color.FromArgb(187, 186, 186), // Button, Tracking, Border 1
-        Color.FromArgb(139, 139, 139), // Button, Tracking, Border 2
-        Color.FromArgb(30, 30, 30), // Button, Pressed, Border 1
-        Color.FromArgb(4, 3, 3), // Button, Pressed, Border 2
-        Color.FromArgb(30, 30, 30), // Button, Checked, Border 1
-        Color.FromArgb(4, 3, 3) // Button, Checked, Border 2
-    ];
-
-    private static readonly Color[] _buttonBackColors =
-    [
-        Color.FromArgb(250, 250, 250), // Button, Disabled, Back 1
-        Color.FromArgb(250, 250, 250), // Button, Disabled, Back 2
-        Color.FromArgb(91, 91, 91), // Button, Tracking, Back 1
-        Color.FromArgb(129, 129, 129), // Button, Tracking, Back 2
-        Color.FromArgb(121, 121, 121), // Button, Pressed, Back 1
-        Color.FromArgb(91, 91, 91), // Button, Pressed, Back 2
-        Color.FromArgb(91, 91, 91), // Button, Checked, Back 1
-        Color.FromArgb(88, 88, 88), // Button, Checked, Back 2
-        Color.FromArgb(41, 41, 41), // Button, Checked Tracking, Back 1
-        Color.FromArgb(70, 70, 70) // Button, Checked Tracking, Back 2
-    ];
 
     #endregion
 
@@ -404,7 +391,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
                 return state == PaletteState.CheckedNormal ? BaseColors.GridDataCellSelected : BaseColors.PanelAlternative;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[6] : BaseColors.PanelAlternative;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7) : BaseColors.PanelAlternative;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -428,7 +415,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
                             case PaletteBackStyle.TabLowProfile:
                                 return GlobalStaticValues.EMPTY_COLOR;
                             case PaletteBackStyle.TabHighProfile:
-                                return state == PaletteState.Tracking ? _buttonBackColors[2] : _buttonBackColors[4];
+                                return state == PaletteState.Tracking ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3) : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5);
                             default:
                                 return SystemColors.Window;
                         }
@@ -440,11 +427,11 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
                         {
                             if (state == PaletteState.CheckedNormal)
                             {
-                                return _buttonBackColors[6];
+                                return GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
                             }
                             else
                             {
-                                return state == PaletteState.CheckedPressed ? _buttonBackColors[4] : _buttonBackColors[8];
+                                return state == PaletteState.CheckedPressed ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5) : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9);
                             }
                         }
                         else
@@ -483,7 +470,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors.HeaderDockInactiveBack1;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[6];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors.HeaderSecondaryBack1;
@@ -590,7 +577,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[2],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -643,12 +630,12 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
                     PaletteState.NormalDefaultOverride => BaseColors.ButtonNormalDefaultBack1,
                     PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
                         ? BaseColors.ButtonNormalBack1
-                        : _buttonBackColors[6],
-                    PaletteState.Tracking => _buttonBackColors[2],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
                         ? BaseColors.ButtonNormalBack1
-                        : _buttonBackColors[8],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -656,7 +643,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => BaseColors.ButtonNavigatorTrack1,
                     PaletteState.Pressed => BaseColors.ButtonNavigatorPressed1,
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => BaseColors.ButtonNavigatorChecked1,
@@ -721,7 +708,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
                 return state == PaletteState.CheckedNormal ? BaseColors.GridDataCellSelected : SystemColors.Window;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[7] : SystemColors.Window;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8) : SystemColors.Window;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -743,7 +730,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal => BaseColors.HeaderDockInactiveBack1,
-                    PaletteState.Tracking or PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => SystemColors.Window,
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
@@ -752,7 +739,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal or PaletteState.CheckedNormal => BaseColors.HeaderDockInactiveBack1,
-                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.HeaderForm:
@@ -775,7 +762,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors.HeaderDockInactiveBack2;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[7];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors.HeaderSecondaryBack2;
@@ -882,7 +869,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[3],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -930,19 +917,19 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemHighlight:
                 return state switch
                 {
-                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? BaseColors.RibbonGalleryBack1 : _buttonBackColors[1],
+                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? BaseColors.RibbonGalleryBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Normal => BaseColors.ButtonNormalBack2,
                     PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
                         ? GlobalStaticValues.EMPTY_COLOR
                         : BaseColors.ButtonNormalDefaultBack2,
                     PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
                         ? BaseColors.ButtonNormalBack2
-                        : _buttonBackColors[7],
-                    PaletteState.Tracking => _buttonBackColors[3],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
                         ? BaseColors.ButtonNormalBack1
-                        : _buttonBackColors[9],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color10),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -950,7 +937,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => BaseColors.ButtonNavigatorTrack2,
                     PaletteState.Pressed => BaseColors.ButtonNavigatorPressed2,
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => BaseColors.ButtonNavigatorChecked2,
@@ -1304,7 +1291,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1312,7 +1299,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
@@ -1325,8 +1312,8 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1362,7 +1349,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
                     ? BaseColors.RibbonGalleryBack2
-                    : _buttonBorderColors[0],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => BaseColors.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile
                     or PaletteBorderStyle.ButtonBreadCrumb
@@ -1372,19 +1359,19 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
                     or PaletteBorderStyle.ContextMenuItemHighlight
                     ? GlobalStaticValues.EMPTY_COLOR
                     : BaseColors.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[5],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color6),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 PaletteState.Pressed
-                    or PaletteState.CheckedPressed => _buttonBorderColors[3],
-                PaletteState.CheckedTracking => _buttonBorderColors[3],
+                    or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => BaseColors.ButtonNormalBorder,
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1392,10 +1379,10 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => BaseColors.ButtonNavigatorBorder,
@@ -1442,7 +1429,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1450,7 +1437,7 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
@@ -1463,8 +1450,8 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1500,22 +1487,22 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
                     ? BaseColors.RibbonGalleryBack2
-                    : _buttonBorderColors[0],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => BaseColors.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => BaseColors.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[6],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.Pressed
-                    or PaletteState.CheckedPressed => _buttonBorderColors[4],
-                PaletteState.CheckedTracking => _buttonBorderColors[4],
+                    or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => BaseColors.ButtonNormalBorder,
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1523,10 +1510,10 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => BaseColors.ButtonNavigatorBorder,
@@ -3756,11 +3743,11 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[0];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color1);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[0];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color1);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[0];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3871,11 +3858,11 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[1];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color2);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[1];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color2);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[1];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3960,11 +3947,11 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[2];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color3);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[2];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color3);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[2];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color3);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4042,11 +4029,11 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[3];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color4);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[3];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color4);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[3];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color4);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4124,11 +4111,11 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[4];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color5);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[4];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color5);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[4];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color5);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4284,8 +4271,8 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.Light(BaseColors.ButtonNormalBorder),
                     PaletteState.Normal => BaseColors.ButtonNormalBorder,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBorderColors[1],
-                    PaletteState.Pressed => _buttonBorderColors[3],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                    PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4324,8 +4311,8 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
                         BaseColors.ButtonNormalBack1),
                     PaletteState.Normal => ControlPaint.Light(
                         BaseColors.ButtonNormalBack1),
-                    PaletteState.Tracking => ControlPaint.Light(_buttonBackColors[2]),
-                    PaletteState.Pressed => ControlPaint.Light(_buttonBackColors[4]),
+                    PaletteState.Tracking => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)),
+                    PaletteState.Pressed => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5)),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
 
@@ -4372,8 +4359,8 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors.ButtonNormalBack1,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[2],
-                    PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
 
@@ -4421,8 +4408,8 @@ public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors.ButtonNormalBack2,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[3],
-                    PaletteState.Pressed => _buttonBackColors[5],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365BlackDarkModeBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365BlackDarkModeBase.cs
@@ -19,8 +19,18 @@ namespace Krypton.Toolkit;
 public abstract class PaletteMicrosoft365BlackDarkModeBase : PaletteBase
 {
     #region Static Fields
+
+    // registration guard so default colours are initialised lazily only once
+    private static bool _defaultsRegistered;
+
     static PaletteMicrosoft365BlackDarkModeBase()
     {
+        if (_defaultsRegistered)
+        {
+            return;
+        }
+        _defaultsRegistered = true;
+
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365BlueDarkModeBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365BlueDarkModeBase.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -20,6 +20,45 @@ namespace Krypton.Toolkit;
 public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
 {
     #region Static Fields
+    static PaletteMicrosoft365BlueDarkModeBase()
+    {
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color4, Color.FromArgb(254, 254, 255));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color5, Color.FromArgb(206, 213, 225));
+
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color1, Color.FromArgb(185, 215, 250));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color2, Color.FromArgb(190, 220, 245));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color3, Color.FromArgb(98, 155, 230));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color4, Color.FromArgb(110, 160, 225));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color5, Color.FromArgb(120, 175, 240));
+
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color1, Color.FromArgb(255, 251, 230));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color2, Color.FromArgb(180, 210, 255));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color3, Color.FromArgb(96, 147, 235));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color4, Color.FromArgb(110, 150, 240));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color5, Color.FromArgb(115, 155, 245));
+
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(221, 221, 221));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(236, 236, 236));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(167, 199, 241));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color4, Color.FromArgb(115, 150, 196));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color5, Color.FromArgb(96, 150, 220));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color6, Color.FromArgb(179, 209, 247));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color7, Color.FromArgb(32, 98, 183));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color8, Color.FromArgb(141, 180, 230));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color9, Color.FromArgb(63, 122, 197));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color10, Color.FromArgb(96, 147, 213));
+
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color1, Color.FromArgb(212, 212, 212));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color2, Color.FromArgb(179, 209, 255));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color3, Color.FromArgb(179, 209, 249));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color4, Color.FromArgb(96, 147, 230));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color5, Color.FromArgb(32, 98, 200));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color6, Color.FromArgb(96, 147, 235));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color7, Color.FromArgb(63, 122, 220));
+    }
 
     #region Padding
 
@@ -162,58 +201,6 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
     #endregion Colours
 
     #region Colour Arrays
-
-    private static readonly Color[] _appButtonNormal =
-    [
-        Color.FromArgb(243, 245, 248),
-        Color.FromArgb(214, 220, 231),
-        Color.FromArgb(188, 198, 211),
-        Color.FromArgb(254, 254, 255),
-        Color.FromArgb(206, 213, 225)
-    ];
-
-    private static readonly Color[] _appButtonTrack =
-    [
-        Color.FromArgb(255, 251, 230),
-        Color.FromArgb(180, 210, 255),
-        Color.FromArgb(96, 147, 235),
-        Color.FromArgb(110, 150, 240),
-        Color.FromArgb(115, 155, 245)
-    ];
-
-    private static readonly Color[] _appButtonPressed =
-    [
-        Color.FromArgb(185, 215, 250),
-        Color.FromArgb(190, 220, 245),
-        Color.FromArgb(98, 155, 230),
-        Color.FromArgb(110, 160, 225),
-        Color.FromArgb(120, 175, 240)
-    ];
-
-    private static readonly Color[] _buttonBorderColors =
-    [
-        Color.FromArgb(212, 212, 212), // Button, Disabled, Border
-        Color.FromArgb(179, 209, 255), // Button, Tracking, Border 1
-        Color.FromArgb(179, 209, 249), // Button, Tracking, Border 2
-        Color.FromArgb(96, 147, 230), // Button, Pressed, Border 1
-        Color.FromArgb(32, 98, 200), // Button, Pressed, Border 2
-        Color.FromArgb(96, 147, 235), // Button, Checked, Border 1
-        Color.FromArgb(63, 122, 220)  // Button, Checked, Border 2
-    ];
-
-    private static readonly Color[] _buttonBackColors =
-    [
-        Color.FromArgb(221, 221, 221), // Button, Disabled, Back 1
-        Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
-        Color.FromArgb(167, 199, 241), // Button, Tracking, Back 1
-        Color.FromArgb(115, 150, 196), // Button, Tracking, Back 2
-        Color.FromArgb(96, 150, 220), // Button, Pressed, Back 1
-        Color.FromArgb(179, 209, 247), // Button, Pressed, Back 2
-        Color.FromArgb(32, 98, 183), // Button, Checked, Back 1
-        Color.FromArgb(141, 180, 230), // Button, Checked, Back 2
-        Color.FromArgb(63, 122, 197), // Button, Checked Tracking, Back 1
-        Color.FromArgb(96, 147, 213)  // Button, Checked Tracking, Back 2
-    ];
 
     #endregion Colour Arrays
 
@@ -407,7 +394,7 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
                 return state == PaletteState.CheckedNormal ? BaseColors!.GridDataCellSelected : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[6] : BaseColors!.PanelAlternative;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7) : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -431,7 +418,7 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
                             case PaletteBackStyle.TabLowProfile:
                                 return GlobalStaticValues.EMPTY_COLOR;
                             case PaletteBackStyle.TabHighProfile:
-                                return state == PaletteState.Tracking ? _buttonBackColors[2] : _buttonBackColors[4];
+                                return state == PaletteState.Tracking ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3) : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5);
                             default:
                                 return SystemColors.Window;
                         }
@@ -443,11 +430,11 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
                         {
                             if (state == PaletteState.CheckedNormal)
                             {
-                                return _buttonBackColors[6];
+                                return GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
                             }
                             else
                             {
-                                return state == PaletteState.CheckedPressed ? _buttonBackColors[4] : _buttonBackColors[8];
+                                return state == PaletteState.CheckedPressed ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5) : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9);
                             }
                         }
                         else
@@ -488,7 +475,7 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderDockInactiveBack1;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[6];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderSecondaryBack1;
@@ -573,7 +560,7 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[2],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -626,12 +613,12 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
                     PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
                     PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
                         ? BaseColors!.ButtonNormalBack1
-                        : _buttonBackColors[6],
-                    PaletteState.Tracking => _buttonBackColors[2],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
                         ? BaseColors!.ButtonNormalBack1
-                        : _buttonBackColors[8],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -639,7 +626,7 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => BaseColors!.ButtonNavigatorTrack1,
                     PaletteState.Pressed => BaseColors!.ButtonNavigatorPressed1,
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => BaseColors!.ButtonNavigatorChecked1,
@@ -705,7 +692,7 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
                 return state == PaletteState.CheckedNormal ? BaseColors!.GridDataCellSelected : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[7] : BaseColors!.PanelAlternative;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8) : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -727,7 +714,7 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal => BaseColors!.HeaderDockInactiveBack1,
-                    PaletteState.Tracking or PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => SystemColors.Window,
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
@@ -736,7 +723,7 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.HeaderDockInactiveBack1,
-                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.HeaderForm:
@@ -759,7 +746,7 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderDockInactiveBack2;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[7];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderSecondaryBack2;
@@ -843,7 +830,7 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[3],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -891,19 +878,19 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemHighlight:
                 return state switch
                 {
-                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack1 : _buttonBackColors[1],
+                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack2,
                     PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
                         ? GlobalStaticValues.EMPTY_COLOR
                         : BaseColors!.ButtonNormalDefaultBack2,
                     PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
                         ? BaseColors!.ButtonNormalBack2
-                        : _buttonBackColors[7],
-                    PaletteState.Tracking => _buttonBackColors[3],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
                         ? BaseColors!.ButtonNormalBack1
-                        : _buttonBackColors[9],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color10),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
 
@@ -912,7 +899,7 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => BaseColors!.ButtonNavigatorTrack2,
                     PaletteState.Pressed => BaseColors!.ButtonNavigatorPressed2,
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => BaseColors!.ButtonNavigatorChecked2,
@@ -1246,7 +1233,7 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors!.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1254,7 +1241,7 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
@@ -1267,8 +1254,8 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1304,23 +1291,23 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
                     ? BaseColors!.RibbonGalleryBack2
-                    : _buttonBorderColors[0],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
                     ? GlobalStaticValues.EMPTY_COLOR
                     : BaseColors!.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[5],
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
-                PaletteState.CheckedTracking => _buttonBorderColors[3],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color6),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1328,10 +1315,10 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors!.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => BaseColors!.ButtonNavigatorBorder,
@@ -1375,7 +1362,7 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors!.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1383,7 +1370,7 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
@@ -1396,8 +1383,8 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1433,21 +1420,21 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
                     ? BaseColors!.RibbonGalleryBack2
-                    : _buttonBorderColors[0],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[6],
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
-                PaletteState.CheckedTracking => _buttonBorderColors[4],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1455,10 +1442,10 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors!.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => BaseColors!.ButtonNavigatorBorder,
@@ -3630,11 +3617,11 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[0];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color1);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[0];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color1);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[0];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3745,11 +3732,11 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[1];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color2);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[1];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color2);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[1];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3834,11 +3821,11 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[2];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color3);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[2];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color3);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[2];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color3);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3916,11 +3903,11 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[3];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color4);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[3];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color4);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[3];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color4);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3998,11 +3985,11 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[4];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color5);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[4];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color5);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[4];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color5);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4158,8 +4145,8 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.Light(BaseColors!.ButtonNormalBorder),
                     PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBorderColors[1],
-                    PaletteState.Pressed => _buttonBorderColors[3],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                    PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4198,8 +4185,8 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
                         BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => ControlPaint.Light(
                         BaseColors!.ButtonNormalBack1),
-                    PaletteState.Tracking => ControlPaint.Light(_buttonBackColors[2]),
-                    PaletteState.Pressed => ControlPaint.Light(_buttonBackColors[4]),
+                    PaletteState.Tracking => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)),
+                    PaletteState.Pressed => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5)),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
 
@@ -4247,8 +4234,8 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack1,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[2],
-                    PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4295,8 +4282,8 @@ public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack2,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[3],
-                    PaletteState.Pressed => _buttonBackColors[5],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365BlueDarkModeBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365BlueDarkModeBase.cs
@@ -20,8 +20,18 @@ namespace Krypton.Toolkit;
 public abstract class PaletteMicrosoft365BlueDarkModeBase : PaletteBase
 {
     #region Static Fields
+
+    // registration guard so default colours are initialised lazily only once
+    private static bool _defaultsRegistered;
+
     static PaletteMicrosoft365BlueDarkModeBase()
     {
+        if (_defaultsRegistered)
+        {
+            return;
+        }
+        _defaultsRegistered = true;
+
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365BlueLightModeBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365BlueLightModeBase.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -20,6 +20,45 @@ namespace Krypton.Toolkit;
 public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
 {
     #region Static Fields
+    static PaletteMicrosoft365BlueLightModeBase()
+    {
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color4, Color.FromArgb(254, 254, 255));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color5, Color.FromArgb(206, 213, 225));
+
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color1, Color.FromArgb(235, 227, 196));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color2, Color.FromArgb(228, 198, 149));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color3, Color.FromArgb(166, 97, 7));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color4, Color.FromArgb(242, 155, 57));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color5, Color.FromArgb(236, 136, 9));
+
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color1, Color.FromArgb(255, 251, 230));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color2, Color.FromArgb(248, 230, 143));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color3, Color.FromArgb(238, 213, 126));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color4, Color.FromArgb(254, 247, 129));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color5, Color.FromArgb(240, 201, 41));
+
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(221, 221, 221));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(236, 236, 236));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(188, 213, 239));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color4, Color.FromArgb(168, 200, 234));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color5, Color.FromArgb(209, 226, 244));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color6, Color.FromArgb(188, 213, 239));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color7, Color.FromArgb(189, 213, 233));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color8, Color.FromArgb(188, 213, 239));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color9, Color.FromArgb(209, 226, 244));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color10, Color.FromArgb(210, 226, 244));
+
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color1, Color.FromArgb(212, 212, 212));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color2, Color.FromArgb(168, 200, 234));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color3, Color.FromArgb(170, 210, 245));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color4, Color.FromArgb(155, 205, 230));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color5, Color.FromArgb(150, 200, 225));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color6, Color.FromArgb(148, 197, 220));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color7, Color.FromArgb(160, 205, 240));
+    }
 
     #region Padding
 
@@ -162,58 +201,6 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
     #endregion
 
     #region Colour Arrays
-
-    private static readonly Color[] _appButtonNormal =
-    [
-        Color.FromArgb(243, 245, 248),
-        Color.FromArgb(214, 220, 231),
-        Color.FromArgb(188, 198, 211),
-        Color.FromArgb(254, 254, 255),
-        Color.FromArgb(206, 213, 225)
-    ];
-
-    private static readonly Color[] _appButtonTrack =
-    [
-        Color.FromArgb(255, 251, 230),
-        Color.FromArgb(248, 230, 143),
-        Color.FromArgb(238, 213, 126),
-        Color.FromArgb(254, 247, 129),
-        Color.FromArgb(240, 201, 41)
-    ];
-
-    private static readonly Color[] _appButtonPressed =
-    [
-        Color.FromArgb(235, 227, 196),
-        Color.FromArgb(228, 198, 149),
-        Color.FromArgb(166, 97, 7),
-        Color.FromArgb(242, 155, 57),
-        Color.FromArgb(236, 136, 9)
-    ];
-
-    private static readonly Color[] _buttonBorderColors =
-    [
-        Color.FromArgb(212, 212, 212), // Button, Disabled, Border
-        Color.FromArgb(168, 200, 234), // Button, Tracking, Border 1
-        Color.FromArgb(170, 210, 245), // Button, Tracking, Border 2
-        Color.FromArgb(155, 205, 230), // Button, Pressed, Border 1
-        Color.FromArgb(150, 200, 225), // Button, Pressed, Border 2
-        Color.FromArgb(148, 197, 220), // Button, Checked, Border 1
-        Color.FromArgb(160, 205, 240) // Button, Checked, Border 2
-    ];
-
-    private static readonly Color[] _buttonBackColors =
-    [
-        Color.FromArgb(221, 221, 221), // Button, Disabled, Back 1
-        Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
-        Color.FromArgb(188, 213, 239), // Button, Tracking, Back 1
-        Color.FromArgb(168, 200, 234), // Button, Tracking, Back 2
-        Color.FromArgb(209, 226, 244), // Button, Pressed, Back 1
-        Color.FromArgb(188, 213, 239), // Button, Pressed, Back 2
-        Color.FromArgb(189, 213, 233), // Button, Checked, Back 1
-        Color.FromArgb(188, 213, 239), // Button, Checked, Back 2
-        Color.FromArgb(209, 226, 244), // Button, Checked Tracking, Back 1
-        Color.FromArgb(210, 226, 244) // Button, Checked Tracking, Back 2
-    ];
 
     #endregion
 
@@ -404,7 +391,7 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
                 return state == PaletteState.CheckedNormal ? BaseColors.GridDataCellSelected : BaseColors.PanelAlternative;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[6] : BaseColors.PanelAlternative;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7) : BaseColors.PanelAlternative;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -428,7 +415,7 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
                             case PaletteBackStyle.TabLowProfile:
                                 return GlobalStaticValues.EMPTY_COLOR;
                             case PaletteBackStyle.TabHighProfile:
-                                return state == PaletteState.Tracking ? _buttonBackColors[2] : _buttonBackColors[4];
+                                return state == PaletteState.Tracking ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3) : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5);
                             default:
                                 return SystemColors.Window;
                         }
@@ -440,11 +427,11 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
                         {
                             if (state == PaletteState.CheckedNormal)
                             {
-                                return _buttonBackColors[6];
+                                return GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
                             }
                             else
                             {
-                                return state == PaletteState.CheckedPressed ? _buttonBackColors[4] : _buttonBackColors[8];
+                                return state == PaletteState.CheckedPressed ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5) : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9);
                             }
                         }
                         else
@@ -483,7 +470,7 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors.HeaderDockInactiveBack1;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[6];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors.HeaderSecondaryBack1;
@@ -590,7 +577,7 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[2],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -643,12 +630,12 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
                     PaletteState.NormalDefaultOverride => BaseColors.ButtonNormalDefaultBack1,
                     PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
                         ? BaseColors.ButtonNormalBack1
-                        : _buttonBackColors[6],
-                    PaletteState.Tracking => _buttonBackColors[2],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
                         ? BaseColors.ButtonNormalBack1
-                        : _buttonBackColors[8],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -656,7 +643,7 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => BaseColors.ButtonNavigatorTrack1,
                     PaletteState.Pressed => BaseColors.ButtonNavigatorPressed1,
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => BaseColors.ButtonNavigatorChecked1,
@@ -721,7 +708,7 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
                 return state == PaletteState.CheckedNormal ? BaseColors.GridDataCellSelected : BaseColors.PanelAlternative;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[7] : BaseColors.PanelAlternative;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8) : BaseColors.PanelAlternative;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -743,7 +730,7 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal => BaseColors.HeaderDockInactiveBack1,
-                    PaletteState.Tracking or PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => SystemColors.Window,
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
@@ -752,7 +739,7 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal or PaletteState.CheckedNormal => BaseColors.HeaderDockInactiveBack1,
-                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.HeaderForm:
@@ -775,7 +762,7 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors.HeaderDockInactiveBack2;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[7];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors.HeaderSecondaryBack2;
@@ -882,7 +869,7 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[3],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -930,19 +917,19 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemHighlight:
                 return state switch
                 {
-                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? BaseColors.RibbonGalleryBack1 : _buttonBackColors[1],
+                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? BaseColors.RibbonGalleryBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Normal => BaseColors.ButtonNormalBack2,
                     PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
                         ? GlobalStaticValues.EMPTY_COLOR
                         : BaseColors.ButtonNormalDefaultBack2,
                     PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
                         ? BaseColors.ButtonNormalBack2
-                        : _buttonBackColors[7],
-                    PaletteState.Tracking => _buttonBackColors[3],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
                         ? BaseColors.ButtonNormalBack1
-                        : _buttonBackColors[9],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color10),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -950,7 +937,7 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => BaseColors.ButtonNavigatorTrack2,
                     PaletteState.Pressed => BaseColors.ButtonNavigatorPressed2,
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => BaseColors.ButtonNavigatorChecked2,
@@ -1282,7 +1269,7 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1290,7 +1277,7 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
@@ -1303,8 +1290,8 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1340,23 +1327,23 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
             {
                 PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
                     ? BaseColors.RibbonGalleryBack2
-                    : _buttonBorderColors[0],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => BaseColors.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
                     ? GlobalStaticValues.EMPTY_COLOR
                     : BaseColors.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[5],
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
-                PaletteState.CheckedTracking => _buttonBorderColors[3],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color6),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => BaseColors.ButtonNormalBorder,
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1364,10 +1351,10 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => BaseColors.ButtonNavigatorBorder,
@@ -1410,7 +1397,7 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1418,7 +1405,7 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
@@ -1431,8 +1418,8 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1468,21 +1455,21 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
             {
                 PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
                     ? BaseColors.RibbonGalleryBack2
-                    : _buttonBorderColors[0],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => BaseColors.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => BaseColors.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[6],
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
-                PaletteState.CheckedTracking => _buttonBorderColors[4],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => BaseColors.ButtonNormalBorder,
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1490,10 +1477,10 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => BaseColors.ButtonNavigatorBorder,
@@ -3667,11 +3654,11 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[0];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color1);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[0];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color1);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[0];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3785,11 +3772,11 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[1];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color2);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[1];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color2);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[1];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3874,11 +3861,11 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[2];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color3);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[2];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color3);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[2];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color3);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3960,11 +3947,11 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[3];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color4);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[3];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color4);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[3];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color4);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4045,11 +4032,11 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[4];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color5);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[4];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color5);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[4];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color5);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4204,8 +4191,8 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.Light(BaseColors.ButtonNormalBorder),
                     PaletteState.Normal => BaseColors.ButtonNormalBorder,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBorderColors[1],
-                    PaletteState.Pressed => _buttonBorderColors[3],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                    PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4244,8 +4231,8 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
                         BaseColors.ButtonNormalBack1),
                     PaletteState.Normal => ControlPaint.Light(
                         BaseColors.ButtonNormalBack1),
-                    PaletteState.Tracking => ControlPaint.Light(_buttonBackColors[2]),
-                    PaletteState.Pressed => ControlPaint.Light(_buttonBackColors[4]),
+                    PaletteState.Tracking => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)),
+                    PaletteState.Pressed => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5)),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
 
@@ -4293,8 +4280,8 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors.ButtonNormalBack1,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[2],
-                    PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4341,8 +4328,8 @@ public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors.ButtonNormalBack2,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[3],
-                    PaletteState.Pressed => _buttonBackColors[5],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365BlueLightModeBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365BlueLightModeBase.cs
@@ -20,8 +20,18 @@ namespace Krypton.Toolkit;
 public abstract class PaletteMicrosoft365BlueLightModeBase : PaletteBase
 {
     #region Static Fields
+
+    // registration guard so default colours are initialised lazily only once
+    private static bool _defaultsRegistered;
+
     static PaletteMicrosoft365BlueLightModeBase()
     {
+        if (_defaultsRegistered)
+        {
+            return;
+        }
+        _defaultsRegistered = true;
+
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365SilverDarkModeBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365SilverDarkModeBase.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -19,6 +19,45 @@ namespace Krypton.Toolkit;
 public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
 {
     #region Static Fields
+    static PaletteMicrosoft365SilverDarkModeBase()
+    {
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color4, Color.FromArgb(254, 254, 255));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color5, Color.FromArgb(206, 213, 225));
+
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color1, Color.FromArgb(235, 227, 196));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color2, Color.FromArgb(228, 198, 149));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color3, Color.FromArgb(166, 97, 7));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color4, Color.FromArgb(242, 155, 57));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color5, Color.FromArgb(236, 136, 9));
+
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color1, Color.FromArgb(255, 251, 230));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color2, Color.FromArgb(248, 230, 143));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color3, Color.FromArgb(238, 213, 126));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color4, Color.FromArgb(254, 247, 129));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color5, Color.FromArgb(240, 201, 41));
+
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(221, 221, 221));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(236, 236, 236));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(102, 117, 161));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color4, Color.FromArgb(106, 123, 164));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color5, Color.FromArgb(73, 84, 113));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color6, Color.FromArgb(102, 117, 161));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color7, Color.FromArgb(102, 117, 161));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color8, Color.FromArgb(122, 137, 174));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color9, Color.FromArgb(119, 134, 172));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color10, Color.FromArgb(135, 148, 182));
+
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color1, Color.FromArgb(212, 212, 212));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color2, Color.FromArgb(163, 179, 220));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color3, Color.FromArgb(128, 141, 173));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color4, Color.FromArgb(90, 99, 122));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color5, Color.FromArgb(118, 130, 160));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color6, Color.FromArgb(136, 150, 185));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color7, Color.FromArgb(174, 192, 236));
+    }
 
     #region Padding
 
@@ -162,58 +201,6 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
     #endregion
 
     #region Colour Arrays
-
-    private static readonly Color[] _appButtonNormal =
-    [
-        Color.FromArgb(243, 245, 248),
-        Color.FromArgb(214, 220, 231),
-        Color.FromArgb(188, 198, 211),
-        Color.FromArgb(254, 254, 255),
-        Color.FromArgb(206, 213, 225)
-    ];
-
-    private static readonly Color[] _appButtonTrack =
-    [
-        Color.FromArgb(255, 251, 230),
-        Color.FromArgb(248, 230, 143),
-        Color.FromArgb(238, 213, 126),
-        Color.FromArgb(254, 247, 129),
-        Color.FromArgb(240, 201, 41)
-    ];
-
-    private static readonly Color[] _appButtonPressed =
-    [
-        Color.FromArgb(235, 227, 196),
-        Color.FromArgb(228, 198, 149),
-        Color.FromArgb(166, 97, 7),
-        Color.FromArgb(242, 155, 57),
-        Color.FromArgb(236, 136, 9)
-    ];
-
-    private static readonly Color[] _buttonBorderColors =
-    [
-        Color.FromArgb(212, 212, 212), // Button, Disabled, Border
-        Color.FromArgb(163, 179, 220), // Button, Tracking, Border 1
-        Color.FromArgb(128, 141, 173), // Button, Tracking, Border 2
-        Color.FromArgb(90, 99, 122), // Button, Pressed, Border 1
-        Color.FromArgb(118, 130, 160), // Button, Pressed, Border 2
-        Color.FromArgb(136, 150, 185), // Button, Checked, Border 1
-        Color.FromArgb(174, 192, 236) // Button, Checked, Border 2
-    ];
-
-    private static readonly Color[] _buttonBackColors =
-    [
-        Color.FromArgb(221, 221, 221), // Button, Disabled, Back 1
-        Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
-        Color.FromArgb(102, 117, 161), // Button, Tracking, Back 1
-        Color.FromArgb(106, 123, 164), // Button, Tracking, Back 2
-        Color.FromArgb(73, 84, 113), // Button, Pressed, Back 1
-        Color.FromArgb(102, 117, 161), // Button, Pressed, Back 2
-        Color.FromArgb(102, 117, 161), // Button, Checked, Back 1
-        Color.FromArgb(122, 137, 174), // Button, Checked, Back 2
-        Color.FromArgb(119, 134, 172), // Button, Checked Tracking, Back 1
-        Color.FromArgb(135, 148, 182) // Button, Checked Tracking, Back 2
-    ];
 
     #endregion
 
@@ -447,7 +434,7 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
                     ? BaseColors.GridDataCellSelected : BaseColors.PanelAlternative;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[6] : BaseColors.PanelAlternative;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7) : BaseColors.PanelAlternative;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -471,7 +458,7 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
                             case PaletteBackStyle.TabLowProfile:
                                 return GlobalStaticValues.EMPTY_COLOR;
                             case PaletteBackStyle.TabHighProfile:
-                                return state == PaletteState.Tracking ? _buttonBackColors[2] : _buttonBackColors[4];
+                                return state == PaletteState.Tracking ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3) : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5);
                             default:
                                 return SystemColors.Window;
                         }
@@ -480,8 +467,8 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
                     case PaletteState.CheckedPressed:
                     case PaletteState.CheckedTracking:
                         return style == PaletteBackStyle.TabHighProfile
-                            ? state == PaletteState.CheckedNormal ? _buttonBackColors[6] :
-                            state == PaletteState.CheckedPressed ? _buttonBackColors[4] : _buttonBackColors[8]
+                            ? state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7) :
+                            state == PaletteState.CheckedPressed ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5) : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9)
                             : SystemColors.Window;
 
                     default:
@@ -515,7 +502,7 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors.HeaderDockInactiveBack1;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[6];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors.HeaderSecondaryBack1;
@@ -597,7 +584,7 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[2],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -652,12 +639,12 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
                     PaletteState.NormalDefaultOverride => BaseColors.ButtonNormalDefaultBack1,
                     PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
                         ? BaseColors.ButtonNormalBack1
-                        : _buttonBackColors[6],
-                    PaletteState.Tracking => _buttonBackColors[2],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
                         ? BaseColors.ButtonNormalBack1
-                        : _buttonBackColors[8],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -665,7 +652,7 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => BaseColors.ButtonNavigatorTrack1,
                     PaletteState.Pressed => BaseColors.ButtonNavigatorPressed1,
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => BaseColors.ButtonNavigatorChecked1,
@@ -730,7 +717,7 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
                 return state == PaletteState.CheckedNormal ? BaseColors.GridDataCellSelected : BaseColors.PanelAlternative;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[7] : BaseColors.PanelAlternative;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8) : BaseColors.PanelAlternative;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -752,7 +739,7 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal => BaseColors.HeaderDockInactiveBack1,
-                    PaletteState.Tracking or PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => SystemColors.Window,
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
@@ -761,7 +748,7 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal or PaletteState.CheckedNormal => BaseColors.HeaderDockInactiveBack1,
-                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.HeaderForm:
@@ -784,7 +771,7 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors.HeaderDockInactiveBack2;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[7];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors.HeaderSecondaryBack2;
@@ -866,7 +853,7 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[3],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -914,19 +901,19 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemHighlight:
                 return state switch
                 {
-                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? BaseColors.RibbonGalleryBack1 : _buttonBackColors[1],
+                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? BaseColors.RibbonGalleryBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Normal => BaseColors.ButtonNormalBack2,
                     PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
                         ? GlobalStaticValues.EMPTY_COLOR
                         : BaseColors.ButtonNormalDefaultBack2,
                     PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
                         ? BaseColors.ButtonNormalBack2
-                        : _buttonBackColors[7],
-                    PaletteState.Tracking => _buttonBackColors[3],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
                         ? BaseColors.ButtonNormalBack1
-                        : _buttonBackColors[9],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color10),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -934,7 +921,7 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => BaseColors.ButtonNavigatorTrack2,
                     PaletteState.Pressed => BaseColors.ButtonNavigatorPressed2,
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => BaseColors.ButtonNavigatorChecked2,
@@ -1267,7 +1254,7 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1275,7 +1262,7 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
@@ -1288,8 +1275,8 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1325,23 +1312,23 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
                     ? BaseColors.RibbonGalleryBack2
-                    : _buttonBorderColors[0],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => BaseColors.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
                     ? GlobalStaticValues.EMPTY_COLOR
                     : BaseColors.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[5],
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
-                PaletteState.CheckedTracking => _buttonBorderColors[3],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color6),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => BaseColors.ButtonNormalBorder,
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1349,10 +1336,10 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => BaseColors.ButtonNavigatorBorder,
@@ -1395,7 +1382,7 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1403,7 +1390,7 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
@@ -1416,8 +1403,8 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1453,21 +1440,21 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
                     ? BaseColors.RibbonGalleryBack2
-                    : _buttonBorderColors[0],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => BaseColors.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => BaseColors.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[6],
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
-                PaletteState.CheckedTracking => _buttonBorderColors[4],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => BaseColors.ButtonNormalBorder,
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1475,10 +1462,10 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => BaseColors.ButtonNavigatorBorder,
@@ -3650,11 +3637,11 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[0];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color1);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[0];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color1);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[0];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3769,11 +3756,11 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[1];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color2);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[1];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color2);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[1];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3860,11 +3847,11 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[2];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color3);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[2];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color3);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[2];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color3);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3944,11 +3931,11 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[3];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color4);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[3];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color4);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[3];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color4);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4028,11 +4015,11 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[4];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color5);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[4];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color5);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[4];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color5);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4188,8 +4175,8 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.Light(BaseColors.ButtonNormalBorder),
                     PaletteState.Normal => BaseColors.ButtonNormalBorder,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBorderColors[1],
-                    PaletteState.Pressed => _buttonBorderColors[3],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                    PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4228,8 +4215,8 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
                         BaseColors.ButtonNormalBack1),
                     PaletteState.Normal => ControlPaint.Light(
                         BaseColors.ButtonNormalBack1),
-                    PaletteState.Tracking => ControlPaint.Light(_buttonBackColors[2]),
-                    PaletteState.Pressed => ControlPaint.Light(_buttonBackColors[4]),
+                    PaletteState.Tracking => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)),
+                    PaletteState.Pressed => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5)),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
 
@@ -4277,8 +4264,8 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors.ButtonNormalBack1,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[2],
-                    PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4325,8 +4312,8 @@ public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors.ButtonNormalBack2,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[3],
-                    PaletteState.Pressed => _buttonBackColors[5],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365SilverDarkModeBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365SilverDarkModeBase.cs
@@ -19,8 +19,18 @@ namespace Krypton.Toolkit;
 public abstract class PaletteMicrosoft365SilverDarkModeBase : PaletteBase
 {
     #region Static Fields
+
+    // registration guard so default colours are initialised lazily only once
+    private static bool _defaultsRegistered;
+
     static PaletteMicrosoft365SilverDarkModeBase()
     {
+        if (_defaultsRegistered)
+        {
+            return;
+        }
+        _defaultsRegistered = true;
+
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365SilverLightModeBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365SilverLightModeBase.cs
@@ -19,8 +19,18 @@ namespace Krypton.Toolkit;
 public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
 {
     #region Static Fields
+
+    // registration guard so default colours are initialised lazily only once
+    private static bool _defaultsRegistered;
+
     static PaletteMicrosoft365SilverLightModeBase()
     {
+        if (_defaultsRegistered)
+        {
+            return;
+        }
+        _defaultsRegistered = true;
+
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365SilverLightModeBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Microsoft 365/Extra Themes/Bases/PaletteMicrosoft365SilverLightModeBase.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -19,6 +19,45 @@ namespace Krypton.Toolkit;
 public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
 {
     #region Static Fields
+    static PaletteMicrosoft365SilverLightModeBase()
+    {
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color4, Color.FromArgb(254, 254, 255));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color5, Color.FromArgb(206, 213, 225));
+
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color1, Color.FromArgb(235, 227, 196));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color2, Color.FromArgb(228, 198, 149));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color3, Color.FromArgb(166, 97, 7));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color4, Color.FromArgb(242, 155, 57));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color5, Color.FromArgb(236, 136, 9));
+
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color1, Color.FromArgb(255, 251, 230));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color2, Color.FromArgb(248, 230, 143));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color3, Color.FromArgb(238, 213, 126));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color4, Color.FromArgb(254, 247, 129));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color5, Color.FromArgb(240, 201, 41));
+
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(221, 221, 221));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(236, 236, 236));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(214, 216, 221));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color4, Color.FromArgb(194, 197, 204));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color5, Color.FromArgb(196, 198, 206));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color6, Color.FromArgb(214, 216, 221));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color7, Color.FromArgb(214, 216, 221));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color8, Color.FromArgb(216, 220, 222));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color9, Color.FromArgb(219, 224, 222));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color10, Color.FromArgb(225, 228, 224));
+
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color1, Color.FromArgb(212, 212, 212));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color2, Color.FromArgb(232, 234, 244));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color3, Color.FromArgb(183, 185, 193));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color4, Color.FromArgb(134, 136, 142));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color5, Color.FromArgb(146, 148, 155));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color6, Color.FromArgb(121, 123, 129));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color7, Color.FromArgb(170, 172, 181));
+    }
 
     #region Padding
 
@@ -162,58 +201,6 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
     #endregion
 
     #region Colour Arrays
-
-    private static readonly Color[] _appButtonNormal =
-    [
-        Color.FromArgb(243, 245, 248),
-        Color.FromArgb(214, 220, 231),
-        Color.FromArgb(188, 198, 211),
-        Color.FromArgb(254, 254, 255),
-        Color.FromArgb(206, 213, 225)
-    ];
-
-    private static readonly Color[] _appButtonTrack =
-    [
-        Color.FromArgb(255, 251, 230),
-        Color.FromArgb(248, 230, 143),
-        Color.FromArgb(238, 213, 126),
-        Color.FromArgb(254, 247, 129),
-        Color.FromArgb(240, 201, 41)
-    ];
-
-    private static readonly Color[] _appButtonPressed =
-    [
-        Color.FromArgb(235, 227, 196),
-        Color.FromArgb(228, 198, 149),
-        Color.FromArgb(166, 97, 7),
-        Color.FromArgb(242, 155, 57),
-        Color.FromArgb(236, 136, 9)
-    ];
-
-    private static readonly Color[] _buttonBorderColors =
-    [
-        Color.FromArgb(212, 212, 212), // Button, Disabled, Border
-        Color.FromArgb(232, 234, 244), // Button, Tracking, Border 1
-        Color.FromArgb(183, 185, 193), // Button, Tracking, Border 2
-        Color.FromArgb(134, 136, 142), // Button, Pressed, Border 1
-        Color.FromArgb(146, 148, 155), // Button, Pressed, Border 2
-        Color.FromArgb(121, 123, 129), // Button, Checked, Border 1
-        Color.FromArgb(170, 172, 181) // Button, Checked, Border 2
-    ];
-
-    private static readonly Color[] _buttonBackColors =
-    [
-        Color.FromArgb(221, 221, 221), // Button, Disabled, Back 1
-        Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
-        Color.FromArgb(214, 216, 221), // Button, Tracking, Back 1
-        Color.FromArgb(194, 197, 204), // Button, Tracking, Back 2
-        Color.FromArgb(196, 198, 206), // Button, Pressed, Back 1
-        Color.FromArgb(214, 216, 221), // Button, Pressed, Back 2
-        Color.FromArgb(214, 216, 221), // Button, Checked, Back 1
-        Color.FromArgb(216, 220, 222), // Button, Checked, Back 2
-        Color.FromArgb(219, 224, 222), // Button, Checked Tracking, Back 1
-        Color.FromArgb(225, 228, 224) // Button, Checked Tracking, Back 2
-    ];
 
     #endregion
 
@@ -404,7 +391,7 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
                     ? BaseColors.GridDataCellSelected : BaseColors.PanelAlternative;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[6] : BaseColors.PanelAlternative;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7) : BaseColors.PanelAlternative;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -428,7 +415,7 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
                             case PaletteBackStyle.TabLowProfile:
                                 return GlobalStaticValues.EMPTY_COLOR;
                             case PaletteBackStyle.TabHighProfile:
-                                return state == PaletteState.Tracking ? _buttonBackColors[2] : _buttonBackColors[4];
+                                return state == PaletteState.Tracking ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3) : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5);
                             default:
                                 return SystemColors.Window;
                         }
@@ -440,11 +427,11 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
                         {
                             if (state == PaletteState.CheckedNormal)
                             {
-                                return _buttonBackColors[6];
+                                return GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
                             }
                             else
                             {
-                                return state == PaletteState.CheckedPressed ? _buttonBackColors[4] : _buttonBackColors[8];
+                                return state == PaletteState.CheckedPressed ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5) : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9);
                             }
                         }
                         else
@@ -483,7 +470,7 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors.HeaderDockInactiveBack1;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[6];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors.HeaderSecondaryBack1;
@@ -590,7 +577,7 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[2],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -643,12 +630,12 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
                     PaletteState.NormalDefaultOverride => BaseColors.ButtonNormalDefaultBack1,
                     PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
                         ? BaseColors.ButtonNormalBack1
-                        : _buttonBackColors[6],
-                    PaletteState.Tracking => _buttonBackColors[2],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
                         ? BaseColors.ButtonNormalBack1
-                        : _buttonBackColors[8],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -656,7 +643,7 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => BaseColors.ButtonNavigatorTrack1,
                     PaletteState.Pressed => BaseColors.ButtonNavigatorPressed1,
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => BaseColors.ButtonNavigatorChecked1,
@@ -721,7 +708,7 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
                 return state == PaletteState.CheckedNormal ? BaseColors.GridDataCellSelected : BaseColors.PanelAlternative;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[7] : BaseColors.PanelAlternative;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8) : BaseColors.PanelAlternative;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -743,7 +730,7 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal => BaseColors.HeaderDockInactiveBack1,
-                    PaletteState.Tracking or PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => SystemColors.Window,
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
@@ -752,7 +739,7 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal or PaletteState.CheckedNormal => BaseColors.HeaderDockInactiveBack1,
-                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.HeaderForm:
@@ -775,7 +762,7 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors.HeaderDockInactiveBack2;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[7];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors.HeaderSecondaryBack2;
@@ -882,7 +869,7 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[3],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -930,19 +917,19 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemHighlight:
                 return state switch
                 {
-                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? BaseColors.RibbonGalleryBack1 : _buttonBackColors[1],
+                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? BaseColors.RibbonGalleryBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Normal => BaseColors.ButtonNormalBack2,
                     PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
                         ? GlobalStaticValues.EMPTY_COLOR
                         : BaseColors.ButtonNormalDefaultBack2,
                     PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
                         ? BaseColors.ButtonNormalBack2
-                        : _buttonBackColors[7],
-                    PaletteState.Tracking => _buttonBackColors[3],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
                         ? BaseColors.ButtonNormalBack1
-                        : _buttonBackColors[9],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color10),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -950,7 +937,7 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => BaseColors.ButtonNavigatorTrack2,
                     PaletteState.Pressed => BaseColors.ButtonNavigatorPressed2,
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => BaseColors.ButtonNavigatorChecked2,
@@ -1283,7 +1270,7 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1291,7 +1278,7 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
@@ -1304,8 +1291,8 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1341,23 +1328,23 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
             {
                 PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
                     ? BaseColors.RibbonGalleryBack2
-                    : _buttonBorderColors[0],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => BaseColors.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
                     ? GlobalStaticValues.EMPTY_COLOR
                     : BaseColors.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[5],
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
-                PaletteState.CheckedTracking => _buttonBorderColors[3],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color6),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => BaseColors.ButtonNormalBorder,
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1365,10 +1352,10 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => BaseColors.ButtonNavigatorBorder,
@@ -1411,7 +1398,7 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1419,7 +1406,7 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
@@ -1432,8 +1419,8 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1469,21 +1456,21 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
             {
                 PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
                     ? BaseColors.RibbonGalleryBack2
-                    : _buttonBorderColors[0],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => BaseColors.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => BaseColors.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[6],
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
-                PaletteState.CheckedTracking => _buttonBorderColors[4],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => BaseColors.ButtonNormalBorder,
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1491,10 +1478,10 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => BaseColors.ButtonNavigatorBorder,
@@ -3666,11 +3653,11 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[0];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color1);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[0];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color1);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[0];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3784,11 +3771,11 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[1];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color2);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[1];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color2);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[1];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3875,11 +3862,11 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[2];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color3);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[2];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color3);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[2];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color3);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3959,11 +3946,11 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[3];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color4);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[3];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color4);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[3];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color4);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4043,11 +4030,11 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[4];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color5);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[4];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color5);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[4];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color5);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4202,8 +4189,8 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.Light(BaseColors.ButtonNormalBorder),
                     PaletteState.Normal => BaseColors.ButtonNormalBorder,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBorderColors[1],
-                    PaletteState.Pressed => _buttonBorderColors[3],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                    PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4242,8 +4229,8 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
                         BaseColors.ButtonNormalBack1),
                     PaletteState.Normal => ControlPaint.Light(
                         BaseColors.ButtonNormalBack1),
-                    PaletteState.Tracking => ControlPaint.Light(_buttonBackColors[2]),
-                    PaletteState.Pressed => ControlPaint.Light(_buttonBackColors[4]),
+                    PaletteState.Tracking => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)),
+                    PaletteState.Pressed => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5)),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
 
@@ -4291,8 +4278,8 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors.ButtonNormalBack1,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[2],
-                    PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
 
@@ -4340,8 +4327,8 @@ public abstract class PaletteMicrosoft365SilverLightModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors.ButtonNormalBack2,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[3],
-                    PaletteState.Pressed => _buttonBackColors[5],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Bases/PaletteOffice2007Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Bases/PaletteOffice2007Base.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -18,6 +18,27 @@ namespace Krypton.Toolkit;
 public abstract class PaletteOffice2007Base : PaletteBase
 {
     #region Static Fields
+    static PaletteOffice2007Base()
+    {
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(221, 221, 221));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(236, 236, 236));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(255, 213,  77));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color4, Color.FromArgb(255, 239, 177));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color5, Color.FromArgb(235, 122,   5));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color6, Color.FromArgb(254, 195, 108));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color7, Color.FromArgb(254, 175,  77));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color8, Color.FromArgb(254, 230, 136));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color9, Color.FromArgb(232, 142,  49));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color10, Color.FromArgb(252, 207, 100));
+
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color1, Color.FromArgb(212, 212, 212));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color2, Color.FromArgb(221, 207, 155));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color3, Color.FromArgb(192, 167, 119));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color4, Color.FromArgb(147, 125,  90));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color5, Color.FromArgb(255, 196,  68));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color6, Color.FromArgb(158, 130,  85));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color7, Color.FromArgb(254, 218, 144));
+    }
 
     #region Padding
 
@@ -152,39 +173,6 @@ public abstract class PaletteOffice2007Base : PaletteBase
     private static readonly Color _contextMenuHeadingBorder = Color.FromArgb(197, 197, 197);
     private static readonly Color _contextMenuImageBackChecked = Color.FromArgb(255, 227, 149);
     private static readonly Color _contextMenuImageBorderChecked = Color.FromArgb(242, 149, 54);
-
-    private static readonly Color[] _ribbonGroupCollapsedBackContext = [Color.FromArgb(48, 255, 255, 255), Color.FromArgb(235, 235, 235)];
-    private static readonly Color[] _ribbonGroupCollapsedBackContextTracking = [Color.FromArgb(48, 255, 255, 255), Color.FromArgb(235, 235, 235)];
-    private static readonly Color[] _ribbonGroupCollapsedBorderContext = [Color.FromArgb(128, 199, 199, 199), Color.FromArgb(199, 199, 199), Color.FromArgb(48, 255, 255, 255), Color.FromArgb(235, 235, 235)];
-    private static readonly Color[] _ribbonGroupCollapsedBorderContextTracking = [Color.FromArgb(128, 168, 184, 196), Color.FromArgb(168, 184, 196), Color.FromArgb(48, 255, 255, 255), Color.FromArgb(192, 207, 220)];
-
-    private static readonly Color[] _appButtonNormal = [Color.FromArgb(243, 245, 248), Color.FromArgb(214, 220, 231), Color.FromArgb(188, 198, 211), Color.FromArgb(254, 254, 255), Color.FromArgb(206, 213, 225)];
-    private static readonly Color[] _appButtonTrack = [Color.FromArgb(255, 251, 230), Color.FromArgb(248, 230, 143), Color.FromArgb(238, 213, 126), Color.FromArgb(254, 247, 129), Color.FromArgb(240, 201, 41)];
-    private static readonly Color[] _appButtonPressed = [Color.FromArgb(235, 227, 196), Color.FromArgb(228, 198, 149), Color.FromArgb(166, 97, 7), Color.FromArgb(242, 155, 57), Color.FromArgb(236, 136, 9)];
-
-    private static readonly Color[] _buttonBorderColors =
-    [
-        Color.FromArgb(212, 212, 212), // Button, Disabled, Border
-        Color.FromArgb(221, 207, 155), // Button, Tracking, Border 1
-        Color.FromArgb(192, 167, 119), // Button, Tracking, Border 2
-        Color.FromArgb(147, 125,  90), // Button, Pressed, Border 1
-        Color.FromArgb(255, 196,  68), // Button, Pressed, Border 2
-        Color.FromArgb(158, 130,  85), // Button, Checked, Border 1
-        Color.FromArgb(254, 218, 144)  // Button, Checked, Border 2
-    ];
-    private static readonly Color[] _buttonBackColors =
-    [
-        Color.FromArgb(221, 221, 221), // Button, Disabled, Back 1
-        Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
-        Color.FromArgb(255, 213,  77), // Button, Tracking, Back 1
-        Color.FromArgb(255, 239, 177), // Button, Tracking, Back 2
-        Color.FromArgb(235, 122,   5), // Button, Pressed, Back 1
-        Color.FromArgb(254, 195, 108), // Button, Pressed, Back 2
-        Color.FromArgb(254, 175,  77), // Button, Checked, Back 1
-        Color.FromArgb(254, 230, 136), // Button, Checked, Back 2
-        Color.FromArgb(232, 142,  49), // Button, Checked Tracking, Back 1
-        Color.FromArgb(252, 207, 100)  // Button, Checked Tracking, Back 2
-    ];
 
     #endregion
 
@@ -513,7 +501,7 @@ public abstract class PaletteOffice2007Base : PaletteBase
                 return state == PaletteState.CheckedNormal ? _ribbonColors[(int)SchemeBaseColors.GridDataCellSelected] : SystemColors.Window;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[6] : SystemColors.Window;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7) : SystemColors.Window;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -536,8 +524,8 @@ public abstract class PaletteOffice2007Base : PaletteBase
                         {
                             PaletteBackStyle.TabLowProfile => GlobalStaticValues.EMPTY_COLOR,
                             PaletteBackStyle.TabHighProfile => state == PaletteState.Tracking
-                                ? _buttonBackColors[2]
-                                : _buttonBackColors[4],
+                                ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)
+                                : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                             _ => SystemColors.Window
                         };
 
@@ -548,9 +536,9 @@ public abstract class PaletteOffice2007Base : PaletteBase
                         {
                             return state switch
                             {
-                                PaletteState.CheckedNormal => _buttonBackColors[6],
-                                PaletteState.CheckedPressed => _buttonBackColors[4],
-                                _ => _buttonBackColors[8]
+                                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                                PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                                _ => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9)
                             };
                         }
                         else
@@ -587,7 +575,7 @@ public abstract class PaletteOffice2007Base : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeBaseColors.HeaderPrimaryBack1];
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[6];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeBaseColors.HeaderSecondaryBack1];
@@ -657,7 +645,7 @@ public abstract class PaletteOffice2007Base : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[2],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
                     _ => _contextMenuOuterBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -673,8 +661,8 @@ public abstract class PaletteOffice2007Base : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack1],
-                    PaletteState.Tracking or PaletteState.CheckedTracking => _buttonBackColors[2],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonForm:
@@ -719,12 +707,12 @@ public abstract class PaletteOffice2007Base : PaletteBase
                         _ => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]
                     },
                     PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack1],
-                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1] : _buttonBackColors[6],
-                    PaletteState.Tracking => _buttonBackColors[2],
+                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1] : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
                     PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBackStyle.ButtonAlternate
                         ? _ribbonColors[(int)SchemeBaseColors.AlternatePressedBack1]
-                        : _buttonBackColors[4],
-                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1] : _buttonBackColors[8],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1] : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -787,7 +775,7 @@ public abstract class PaletteOffice2007Base : PaletteBase
                 return state == PaletteState.CheckedNormal ? _ribbonColors[(int)SchemeBaseColors.GridDataCellSelected] : SystemColors.Window;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[7] : SystemColors.Window;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8) : SystemColors.Window;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -809,7 +797,7 @@ public abstract class PaletteOffice2007Base : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack2],
-                    PaletteState.Tracking or PaletteState.Pressed => _buttonBackColors[3],
+                    PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => SystemColors.Window,
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
@@ -818,7 +806,7 @@ public abstract class PaletteOffice2007Base : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack2],
-                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[3],
+                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.HeaderForm:
@@ -839,7 +827,7 @@ public abstract class PaletteOffice2007Base : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeBaseColors.HeaderPrimaryBack2];
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[7];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeBaseColors.HeaderSecondaryBack2];
@@ -907,7 +895,7 @@ public abstract class PaletteOffice2007Base : PaletteBase
                 return _contextMenuOuterBack;
             case PaletteBackStyle.ContextMenuSeparator:
             case PaletteBackStyle.ContextMenuItemSplit:
-                return state == PaletteState.Tracking ? _buttonBackColors[3] : _contextMenuOuterBack;
+                return state == PaletteState.Tracking ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4) : _contextMenuOuterBack;
             case PaletteBackStyle.ContextMenuInner:
                 return _contextMenuInnerBack;
             case PaletteBackStyle.ContextMenuHeading:
@@ -921,8 +909,8 @@ public abstract class PaletteOffice2007Base : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack2,
                     PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack2],
-                    PaletteState.Tracking or PaletteState.CheckedTracking => _buttonBackColors[2],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonForm:
@@ -955,7 +943,7 @@ public abstract class PaletteOffice2007Base : PaletteBase
             case PaletteBackStyle.ContextMenuItemHighlight:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Normal => style switch
                     {
                         PaletteBackStyle.ButtonNavigatorStack => _ribbonColors[
@@ -971,12 +959,12 @@ public abstract class PaletteOffice2007Base : PaletteBase
                         PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight => GlobalStaticValues.EMPTY_COLOR,
                         _ => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack2]
                     },
-                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack2] : _buttonBackColors[7],
-                    PaletteState.Tracking => _buttonBackColors[3],
+                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack2] : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBackStyle.ButtonAlternate
                         ? _ribbonColors[(int)SchemeBaseColors.AlternatePressedBack2]
-                        : _buttonBackColors[5],
-                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1] : _buttonBackColors[9],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
+                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1] : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color10),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -1854,7 +1842,7 @@ public abstract class PaletteOffice2007Base : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeBaseColors.ControlBorder],
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1862,7 +1850,7 @@ public abstract class PaletteOffice2007Base : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
@@ -1875,8 +1863,8 @@ public abstract class PaletteOffice2007Base : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1904,25 +1892,25 @@ public abstract class PaletteOffice2007Base : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBorder],
-                PaletteState.Tracking or PaletteState.CheckedTracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                PaletteState.Tracking or PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ButtonInputControl or PaletteBorderStyle.ContextMenuItemHighlight => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => style == PaletteBorderStyle.ButtonCluster
                     ? _ribbonColors[(int)SchemeBaseColors.ButtonClusterButtonBorder1]
                     : _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
                 PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
                     ? GlobalStaticValues.EMPTY_COLOR
                     : _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBorder],
-                PaletteState.CheckedNormal => _buttonBorderColors[5],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color6),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBorderStyle.ButtonAlternate
                     ? _ribbonColors[(int)SchemeBaseColors.AlternatePressedBorder1]
-                    : _buttonBorderColors[3],
-                PaletteState.CheckedTracking => _buttonBorderColors[3],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1930,10 +1918,10 @@ public abstract class PaletteOffice2007Base : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1],
                 PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack1],
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             _ => throw new ArgumentOutOfRangeException(nameof(style))
@@ -1976,7 +1964,7 @@ public abstract class PaletteOffice2007Base : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeBaseColors.ControlBorder],
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1984,7 +1972,7 @@ public abstract class PaletteOffice2007Base : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
@@ -1997,8 +1985,8 @@ public abstract class PaletteOffice2007Base : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -2026,23 +2014,23 @@ public abstract class PaletteOffice2007Base : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBorder],
-                PaletteState.Tracking or PaletteState.CheckedTracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                PaletteState.Tracking or PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ButtonInputControl or PaletteBorderStyle.ContextMenuItemHighlight => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => style == PaletteBorderStyle.ButtonCluster
                     ? _ribbonColors[(int)SchemeBaseColors.ButtonClusterButtonBorder2]
                     : _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
                 PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBorder],
-                PaletteState.CheckedNormal => _buttonBorderColors[6],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBorderStyle.ButtonAlternate
                     ? _ribbonColors[(int)SchemeBaseColors.AlternatePressedBorder2]
-                    : _buttonBorderColors[4],
-                PaletteState.CheckedTracking => _buttonBorderColors[4],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -2050,10 +2038,10 @@ public abstract class PaletteOffice2007Base : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1],
                 PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack1],
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             _ => throw new ArgumentOutOfRangeException(nameof(style))
@@ -4266,10 +4254,10 @@ public abstract class PaletteOffice2007Base : PaletteBase
                     case PaletteState.Tracking:
                         return _ribbonColors[(int)SchemeBaseColors.RibbonGroupCollapsedBorderT1];
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBorderContext[0];
+                        return GetArrayColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color1);
                     case PaletteState.ContextTracking:
                     case PaletteState.Pressed:
-                        return _ribbonGroupCollapsedBorderContextTracking[0];
+                        return GetArrayColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4292,9 +4280,9 @@ public abstract class PaletteOffice2007Base : PaletteBase
                     case PaletteState.Tracking:
                         return _ribbonColors[(int)SchemeBaseColors.RibbonGroupCollapsedBackT1];
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBackContext[0];
+                        return GetArrayColor<RibbonGroupCollapsedBack>(RibbonGroupCollapsedBack.Color1);
                     case PaletteState.ContextTracking:
-                        return _ribbonGroupCollapsedBackContextTracking[0];
+                        return GetArrayColor<RibbonGroupCollapsedBackT>(RibbonGroupCollapsedBackT.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4342,11 +4330,11 @@ public abstract class PaletteOffice2007Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[0];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color1);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[0];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color1);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[0];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4429,10 +4417,10 @@ public abstract class PaletteOffice2007Base : PaletteBase
                     case PaletteState.Tracking:
                         return _ribbonColors[(int)SchemeBaseColors.RibbonGroupCollapsedBorderT2];
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBorderContext[1];
+                        return GetArrayColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color2);
                     case PaletteState.ContextTracking:
                     case PaletteState.Pressed:
-                        return _ribbonGroupCollapsedBorderContextTracking[1];
+                        return GetArrayColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4455,9 +4443,9 @@ public abstract class PaletteOffice2007Base : PaletteBase
                     case PaletteState.Tracking:
                         return _ribbonColors[(int)SchemeBaseColors.RibbonGroupCollapsedBackT2];
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBackContext[1];
+                        return GetArrayColor<RibbonGroupCollapsedBack>(RibbonGroupCollapsedBack.Color2);
                     case PaletteState.ContextTracking:
-                        return _ribbonGroupCollapsedBackContextTracking[1];
+                        return GetArrayColor<RibbonGroupCollapsedBackT>(RibbonGroupCollapsedBackT.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4505,11 +4493,11 @@ public abstract class PaletteOffice2007Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[1];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color2);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[1];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color2);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[1];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4592,10 +4580,10 @@ public abstract class PaletteOffice2007Base : PaletteBase
                     case PaletteState.Tracking:
                         return _ribbonColors[(int)SchemeBaseColors.RibbonGroupCollapsedBorderT3];
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBorderContext[2];
+                        return GetArrayColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color3);
                     case PaletteState.ContextTracking:
                     case PaletteState.Pressed:
-                        return _ribbonGroupCollapsedBorderContextTracking[2];
+                        return GetArrayColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color3);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4641,11 +4629,11 @@ public abstract class PaletteOffice2007Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[2];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color3);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[2];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color3);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[2];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color3);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4715,10 +4703,10 @@ public abstract class PaletteOffice2007Base : PaletteBase
                     case PaletteState.Tracking:
                         return _ribbonColors[(int)SchemeBaseColors.RibbonGroupCollapsedBorderT4];
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBorderContext[3];
+                        return GetArrayColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color4);
                     case PaletteState.ContextTracking:
                     case PaletteState.Pressed:
-                        return _ribbonGroupCollapsedBorderContextTracking[3];
+                        return GetArrayColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color4);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4766,11 +4754,11 @@ public abstract class PaletteOffice2007Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[3];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color4);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[3];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color4);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[3];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color4);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4850,11 +4838,11 @@ public abstract class PaletteOffice2007Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[4];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color5);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[4];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color5);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[4];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color5);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -5012,8 +5000,8 @@ public abstract class PaletteOffice2007Base : PaletteBase
                     PaletteState.Disabled => ControlPaint.Light(
                         _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder]),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                    PaletteState.Tracking => _buttonBorderColors[1],
-                    PaletteState.Pressed => _buttonBorderColors[3],
+                    PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                    PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -5053,8 +5041,8 @@ public abstract class PaletteOffice2007Base : PaletteBase
                         _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
                     PaletteState.Normal => ControlPaint.Light(
                         _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
-                    PaletteState.Tracking => ControlPaint.Light(_buttonBackColors[2]),
-                    PaletteState.Pressed => ControlPaint.Light(_buttonBackColors[4]),
+                    PaletteState.Tracking => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)),
+                    PaletteState.Pressed => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5)),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
 
@@ -5103,8 +5091,8 @@ public abstract class PaletteOffice2007Base : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(_ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1],
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[2],
-                    PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -5152,8 +5140,8 @@ public abstract class PaletteOffice2007Base : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(_ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack2],
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[3],
-                    PaletteState.Pressed => _buttonBackColors[5],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Bases/PaletteOffice2007Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Bases/PaletteOffice2007Base.cs
@@ -18,8 +18,18 @@ namespace Krypton.Toolkit;
 public abstract class PaletteOffice2007Base : PaletteBase
 {
     #region Static Fields
+
+    // registration guard so default colours are initialised lazily only once
+    private static bool _defaultsRegistered;
+
     static PaletteOffice2007Base()
     {
+        if (_defaultsRegistered)
+        {
+            return;
+        }
+        _defaultsRegistered = true;
+
         RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(221, 221, 221));
         RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(236, 236, 236));
         RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(255, 213,  77));

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlackDarkMode.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -398,6 +398,61 @@ public class PaletteOffice2007BlackDarkMode : PaletteOffice2007BlackDarkModeBase
 public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
 {
     #region Static Fields
+    static PaletteOffice2007BlackDarkModeBase()
+    {
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color4, Color.FromArgb(254, 254, 255));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color5, Color.FromArgb(206, 213, 225));
+
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color1, Color.FromArgb(235, 227, 196));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color2, Color.FromArgb(185, 185, 185));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color3, Color.FromArgb(35, 35, 35));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color4, Color.FromArgb(50, 50, 50));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color5, Color.FromArgb(100, 100, 100));
+
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color1, Color.FromArgb(255, 251, 230));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color2, Color.FromArgb(178, 178, 178));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color3, Color.FromArgb(176, 176, 176));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color4, Color.FromArgb(179, 179, 179));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color5, Color.FromArgb(160, 160, 160));
+
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(250, 250, 250));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(250, 250, 250));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(91, 91, 91));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color4, Color.FromArgb(33, 33, 33));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color5, Color.FromArgb(121, 121, 121));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color6, Color.FromArgb(91, 91, 91));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color7, Color.FromArgb(91, 91, 91));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color8, Color.FromArgb(88, 88, 88));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color9, Color.FromArgb(41, 41, 41));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color10, Color.FromArgb(70, 70, 70));
+
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color1, Color.FromArgb(180, 180, 180));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color2, Color.FromArgb(187, 186, 186));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color3, Color.FromArgb(139, 139, 139));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color4, Color.FromArgb(30, 30, 30));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color5, Color.FromArgb(4, 3, 3));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color6, Color.FromArgb(30, 30, 30));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color7, Color.FromArgb(4, 3, 3));
+
+        RegisterColor<RibbonGroupCollapsedBack>(RibbonGroupCollapsedBack.Color1, Color.FromArgb(48, 255, 255, 255));
+        RegisterColor<RibbonGroupCollapsedBack>(RibbonGroupCollapsedBack.Color2, Color.FromArgb(235, 235, 235));
+
+        RegisterColor<RibbonGroupCollapsedBackT>(RibbonGroupCollapsedBackT.Color1, Color.FromArgb(48, 255, 255, 255));
+        RegisterColor<RibbonGroupCollapsedBackT>(RibbonGroupCollapsedBackT.Color2, Color.FromArgb(235, 235, 235));
+
+        RegisterColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color1, Color.FromArgb(128, 199, 199, 199));
+        RegisterColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color2, Color.FromArgb(199, 199, 199));
+        RegisterColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color3, Color.FromArgb(48, 255, 255, 255));
+        RegisterColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color4, Color.FromArgb(235, 235, 235));
+
+        RegisterColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color1, Color.FromArgb(128, 168, 184, 196));
+        RegisterColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color2, Color.FromArgb(168, 184, 196));
+        RegisterColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color3, Color.FromArgb(48, 255, 255, 255));
+        RegisterColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color4, Color.FromArgb(192, 207, 220));
+    }
 
     #region Padding
     private static readonly Padding _contentPaddingGrid = new Padding(2, 1, 2, 1);
@@ -532,86 +587,6 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
     #endregion
 
     #region Colour Arrays
-
-    private static readonly Color[] _ribbonGroupCollapsedBackContext =
-    [
-        Color.FromArgb(48, 255, 255, 255),
-        Color.FromArgb(235, 235, 235)
-    ];
-
-    private static readonly Color[] _ribbonGroupCollapsedBackContextTracking =
-    [
-        Color.FromArgb(48, 255, 255, 255),
-        Color.FromArgb(235, 235, 235)
-    ];
-
-    private static readonly Color[] _ribbonGroupCollapsedBorderContext =
-    [
-        Color.FromArgb(128, 199, 199, 199),
-        Color.FromArgb(199, 199, 199),
-        Color.FromArgb(48, 255, 255, 255),
-        Color.FromArgb(235, 235, 235)
-    ];
-
-    private static readonly Color[] _ribbonGroupCollapsedBorderContextTracking =
-    [
-        Color.FromArgb(128, 168, 184, 196),
-        Color.FromArgb(168, 184, 196),
-        Color.FromArgb(48, 255, 255, 255),
-        Color.FromArgb(192, 207, 220)
-    ];
-
-    private static readonly Color[] _appButtonNormal =
-    [
-        Color.FromArgb(243, 245, 248),
-        Color.FromArgb(214, 220, 231),
-        Color.FromArgb(188, 198, 211),
-        Color.FromArgb(254, 254, 255),
-        Color.FromArgb(206, 213, 225)
-    ];
-
-    private static readonly Color[] _appButtonTrack =
-    [
-        Color.FromArgb(255, 251, 230),
-        Color.FromArgb(178, 178, 178),
-        Color.FromArgb(176, 176, 176),
-        Color.FromArgb(179, 179, 179),
-        Color.FromArgb(160, 160, 160)
-    ];
-
-    private static readonly Color[] _appButtonPressed =
-    [
-        Color.FromArgb(235, 227, 196),
-        Color.FromArgb(185, 185, 185),
-        Color.FromArgb(35, 35, 35),
-        Color.FromArgb(50, 50, 50),
-        Color.FromArgb(100, 100, 100)
-    ];
-
-    private static readonly Color[] _buttonBorderColors =
-    [
-        Color.FromArgb(180, 180, 180), // Button, Disabled, Border
-        Color.FromArgb(187, 186, 186),  // Button, Tracking, Border 1
-        Color.FromArgb(139, 139, 139),  // Button, Tracking, Border 2
-        Color.FromArgb(30, 30, 30),  // Button, Pressed, Border 1
-        Color.FromArgb(4, 3, 3),  // Button, Pressed, Border 2
-        Color.FromArgb(30, 30, 30),  // Button, Checked, Border 1
-        Color.FromArgb(4, 3, 3)   // Button, Checked, Border 2
-    ];
-
-    private static readonly Color[] _buttonBackColors =
-    [
-        Color.FromArgb(250, 250, 250), // Button, Disabled, Back 1
-        Color.FromArgb(250, 250, 250), // Button, Disabled, Back 2
-        Color.FromArgb(91, 91, 91), // Button, Tracking, Back 1
-        Color.FromArgb(33, 33, 33), // Button, Tracking, Back 2
-        Color.FromArgb(121, 121, 121), // Button, Pressed, Back 1
-        Color.FromArgb(91, 91, 91),  // Button, Pressed, Back 2
-        Color.FromArgb(91, 91, 91), // Button, Checked, Back 1
-        Color.FromArgb(88, 88, 88), // Button, Checked, Back 2
-        Color.FromArgb(41, 41, 41), // Button, Checked Tracking, Back 1
-        Color.FromArgb(70, 70, 70)  // Button, Checked Tracking, Back 2
-    ];
 
     #endregion
 
@@ -916,7 +891,7 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
                 return state == PaletteState.CheckedNormal ? BaseColors!.GridDataCellSelected : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[6] : BaseColors!.PanelAlternative;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7) : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -939,8 +914,8 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
                         {
                             PaletteBackStyle.TabLowProfile => GlobalStaticValues.EMPTY_COLOR,
                             PaletteBackStyle.TabHighProfile => state == PaletteState.Tracking
-                                ? _buttonBackColors[2]
-                                : _buttonBackColors[4],
+                                ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)
+                                : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                             _ => SystemColors.Window
                         };
 
@@ -951,9 +926,9 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
                         {
                             return state switch
                             {
-                                PaletteState.CheckedNormal => _buttonBackColors[6],
-                                PaletteState.CheckedPressed => _buttonBackColors[4],
-                                _ => _buttonBackColors[8]
+                                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                                PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                                _ => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9)
                             };
                         }
                         else
@@ -990,7 +965,7 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderPrimaryBack1;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[6];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderSecondaryBack1;
@@ -1096,7 +1071,7 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[2],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
                     _ => _contextMenuOuterBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -1112,8 +1087,8 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal => BaseColors!.RibbonGalleryBack1,
-                    PaletteState.Tracking or PaletteState.CheckedTracking => _buttonBackColors[2],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonForm:
@@ -1163,12 +1138,12 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
                         _ => BaseColors!.ButtonNormalBack1
                     },
                     PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[6],
-                    PaletteState.Tracking => _buttonBackColors[2],
+                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
                     PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBackStyle.ButtonAlternate
                         ? BaseColors!.AlternatePressedBack1
-                        : _buttonBackColors[4],
-                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[8],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -1231,7 +1206,7 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
                 return state == PaletteState.CheckedNormal ? BaseColors!.GridDataCellSelected : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[7] : BaseColors!.PanelAlternative;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8) : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -1253,7 +1228,7 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal => BaseColors!.ButtonNormalBack2,
-                    PaletteState.Tracking or PaletteState.Pressed => _buttonBackColors[3],
+                    PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => SystemColors.Window,
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
@@ -1262,7 +1237,7 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.ButtonNormalBack2,
-                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[3],
+                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.HeaderForm:
@@ -1283,7 +1258,7 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderPrimaryBack2;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[7];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderSecondaryBack2;
@@ -1387,7 +1362,7 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
                 return _contextMenuOuterBack;
             case PaletteBackStyle.ContextMenuSeparator:
             case PaletteBackStyle.ContextMenuItemSplit:
-                return state == PaletteState.Tracking ? _buttonBackColors[3] : _contextMenuOuterBack;
+                return state == PaletteState.Tracking ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4) : _contextMenuOuterBack;
             case PaletteBackStyle.ContextMenuInner:
                 return _contextMenuInnerBack;
             case PaletteBackStyle.ContextMenuHeading:
@@ -1401,8 +1376,8 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack2,
                     PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal => BaseColors!.RibbonGalleryBack2,
-                    PaletteState.Tracking or PaletteState.CheckedTracking => _buttonBackColors[2],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonForm:
@@ -1443,7 +1418,7 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemHighlight:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Normal => style switch
                     {
                         PaletteBackStyle.ButtonNavigatorStack => BaseColors!.ButtonNormalNavigatorBack2,
@@ -1456,12 +1431,12 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
                         PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight => GlobalStaticValues.EMPTY_COLOR,
                         _ => BaseColors!.ButtonNormalDefaultBack2
                     },
-                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack2 : _buttonBackColors[7],
-                    PaletteState.Tracking => _buttonBackColors[3],
+                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack2 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBackStyle.ButtonAlternate
                         ? BaseColors!.AlternatePressedBack2
-                        : _buttonBackColors[5],
-                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[9],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
+                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color10),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -2338,7 +2313,7 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors!.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -2346,7 +2321,7 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
@@ -2359,8 +2334,8 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -2388,25 +2363,25 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal => BaseColors!.RibbonGalleryBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                PaletteState.Tracking or PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ButtonInputControl or PaletteBorderStyle.ContextMenuItemHighlight => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => style == PaletteBorderStyle.ButtonCluster
                     ? BaseColors!.ButtonClusterButtonBorder1
                     : BaseColors!.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
                     ? GlobalStaticValues.EMPTY_COLOR
                     : BaseColors!.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[5],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color6),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBorderStyle.ButtonAlternate
                     ? BaseColors!.AlternatePressedBorder1
-                    : _buttonBorderColors[3],
-                PaletteState.CheckedTracking => _buttonBorderColors[3],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -2414,10 +2389,10 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors!.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             _ => throw new ArgumentOutOfRangeException(nameof(style))
@@ -2460,7 +2435,7 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors!.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -2468,7 +2443,7 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
@@ -2481,8 +2456,8 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -2510,23 +2485,23 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal => BaseColors!.RibbonGalleryBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                PaletteState.Tracking or PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ButtonInputControl or PaletteBorderStyle.ContextMenuItemHighlight => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => style == PaletteBorderStyle.ButtonCluster
                     ? BaseColors!.ButtonClusterButtonBorder2
                     : BaseColors!.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[6],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBorderStyle.ButtonAlternate
                     ? BaseColors!.AlternatePressedBorder2
-                    : _buttonBorderColors[4],
-                PaletteState.CheckedTracking => _buttonBorderColors[4],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -2534,10 +2509,10 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors!.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             _ => throw new ArgumentOutOfRangeException(nameof(style))
@@ -4757,10 +4732,10 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
                     case PaletteState.Tracking:
                         return BaseColors!.RibbonGroupCollapsedBorderT1;
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBorderContext[0];
+                        return GetArrayColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color1);
                     case PaletteState.ContextTracking:
                     case PaletteState.Pressed:
-                        return _ribbonGroupCollapsedBorderContextTracking[0];
+                        return GetArrayColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4783,9 +4758,9 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
                     case PaletteState.Tracking:
                         return BaseColors!.RibbonGroupCollapsedBackT1;
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBackContext[0];
+                        return GetArrayColor<RibbonGroupCollapsedBack>(RibbonGroupCollapsedBack.Color1);
                     case PaletteState.ContextTracking:
-                        return _ribbonGroupCollapsedBackContextTracking[0];
+                        return GetArrayColor<RibbonGroupCollapsedBackT>(RibbonGroupCollapsedBackT.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4833,11 +4808,11 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[0];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color1);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[0];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color1);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[0];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4920,10 +4895,10 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
                     case PaletteState.Tracking:
                         return BaseColors!.RibbonGroupCollapsedBorderT2;
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBorderContext[1];
+                        return GetArrayColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color2);
                     case PaletteState.ContextTracking:
                     case PaletteState.Pressed:
-                        return _ribbonGroupCollapsedBorderContextTracking[1];
+                        return GetArrayColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4946,9 +4921,9 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
                     case PaletteState.Tracking:
                         return BaseColors!.RibbonGroupCollapsedBackT2;
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBackContext[1];
+                        return GetArrayColor<RibbonGroupCollapsedBack>(RibbonGroupCollapsedBack.Color2);
                     case PaletteState.ContextTracking:
-                        return _ribbonGroupCollapsedBackContextTracking[1];
+                        return GetArrayColor<RibbonGroupCollapsedBackT>(RibbonGroupCollapsedBackT.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4996,11 +4971,11 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[1];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color2);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[1];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color2);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[1];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -5083,10 +5058,10 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
                     case PaletteState.Tracking:
                         return BaseColors!.RibbonGroupCollapsedBorderT3;
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBorderContext[2];
+                        return GetArrayColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color3);
                     case PaletteState.ContextTracking:
                     case PaletteState.Pressed:
-                        return _ribbonGroupCollapsedBorderContextTracking[2];
+                        return GetArrayColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color3);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -5132,11 +5107,11 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[2];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color3);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[2];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color3);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[2];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color3);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -5206,10 +5181,10 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
                     case PaletteState.Tracking:
                         return BaseColors!.RibbonGroupCollapsedBorderT4;
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBorderContext[3];
+                        return GetArrayColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color4);
                     case PaletteState.ContextTracking:
                     case PaletteState.Pressed:
-                        return _ribbonGroupCollapsedBorderContextTracking[3];
+                        return GetArrayColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color4);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -5257,11 +5232,11 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[3];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color4);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[3];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color4);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[3];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color4);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -5341,11 +5316,11 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[4];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color5);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[4];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color5);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[4];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color5);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -5499,8 +5474,8 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
                     PaletteState.Disabled => ControlPaint.Light(
                         BaseColors!.ButtonNormalBorder),
                     PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                    PaletteState.Tracking => _buttonBorderColors[1],
-                    PaletteState.Pressed => _buttonBorderColors[3],
+                    PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                    PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -5540,8 +5515,8 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
                         BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => ControlPaint.Light(
                         BaseColors!.ButtonNormalBack1),
-                    PaletteState.Tracking => ControlPaint.Light(_buttonBackColors[2]),
-                    PaletteState.Pressed => ControlPaint.Light(_buttonBackColors[4]),
+                    PaletteState.Tracking => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)),
+                    PaletteState.Pressed => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5)),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
 
@@ -5590,8 +5565,8 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack1,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[2],
-                    PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -5639,8 +5614,8 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack2,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[3],
-                    PaletteState.Pressed => _buttonBackColors[5],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlackDarkMode.cs
@@ -398,8 +398,18 @@ public class PaletteOffice2007BlackDarkMode : PaletteOffice2007BlackDarkModeBase
 public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
 {
     #region Static Fields
+
+    // registration guard so default colours are initialised lazily only once
+    private static bool _defaultsRegistered;
+
     static PaletteOffice2007BlackDarkModeBase()
     {
+        if (_defaultsRegistered)
+        {
+            return;
+        }
+        _defaultsRegistered = true;
+
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
@@ -662,12 +672,36 @@ public abstract class PaletteOffice2007BlackDarkModeBase : PaletteBase
         [DisallowNull] ImageList checkBoxList,
         [DisallowNull] ImageList galleryButtonList,
         [DisallowNull] Image?[] radioButtonArray)
-        : this(scheme.ToArray(),
-               checkBoxList,
-               galleryButtonList,
-               radioButtonArray,
-               scheme.ToTrackBarArray())
     {
+        Debug.Assert(scheme != null);
+        Debug.Assert(checkBoxList != null);
+        Debug.Assert(galleryButtonList != null);
+        Debug.Assert(radioButtonArray != null);
+
+        // Remember incoming sets of values
+        ThemeName = nameof(PaletteOffice2007BlackDarkModeBase);
+
+        if (scheme != null)
+        {
+            _ribbonColors = scheme.ToArray();
+        }
+
+        if (checkBoxList != null)
+        {
+            _checkBoxList = checkBoxList;
+        }
+
+        if (galleryButtonList != null)
+        {
+            _galleryButtonList = galleryButtonList;
+        }
+
+        if (radioButtonArray != null)
+        {
+            _radioButtonArray = radioButtonArray;
+        }
+
+        DefineFonts();
         BaseColors = scheme;
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueDarkMode.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -242,6 +242,61 @@ public class PaletteOffice2007BlueDarkMode : PaletteOffice2007BlueDarkModeBase
 public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
 {
     #region Static Fields
+    static PaletteOffice2007BlueDarkModeBase()
+    {
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color4, Color.FromArgb(254, 254, 255));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color5, Color.FromArgb(206, 213, 225));
+
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color1, Color.FromArgb(185, 215, 250));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color2, Color.FromArgb(190, 220, 245));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color3, Color.FromArgb(98, 155, 230));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color4, Color.FromArgb(110, 160, 225));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color5, Color.FromArgb(120, 175, 240));
+
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color1, Color.FromArgb(255, 251, 230));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color2, Color.FromArgb(180, 210, 255));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color3, Color.FromArgb(96, 147, 235));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color4, Color.FromArgb(110, 150, 240));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color5, Color.FromArgb(115, 155, 245));
+
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(221, 221, 221));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(236, 236, 236));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(141, 168, 203));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color4, Color.FromArgb(95, 127, 169));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color5, Color.FromArgb(96, 150, 220));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color6, Color.FromArgb(179, 209, 247));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color7, Color.FromArgb(32, 98, 183));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color8, Color.FromArgb(141, 180, 230));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color9, Color.FromArgb(63, 122, 197));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color10, Color.FromArgb(96, 147, 213));
+
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color1, Color.FromArgb(212, 212, 212));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color2, Color.FromArgb(179, 209, 255));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color3, Color.FromArgb(179, 209, 249));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color4, Color.FromArgb(96, 147, 230));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color5, Color.FromArgb(32, 98, 200));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color6, Color.FromArgb(96, 147, 235));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color7, Color.FromArgb(63, 122, 220));
+
+        RegisterColor<RibbonGroupCollapsedBack>(RibbonGroupCollapsedBack.Color1, Color.FromArgb(48, 255, 255, 255));
+        RegisterColor<RibbonGroupCollapsedBack>(RibbonGroupCollapsedBack.Color2, Color.FromArgb(235, 235, 235));
+
+        RegisterColor<RibbonGroupCollapsedBackT>(RibbonGroupCollapsedBackT.Color1, Color.FromArgb(48, 255, 255, 255));
+        RegisterColor<RibbonGroupCollapsedBackT>(RibbonGroupCollapsedBackT.Color2, Color.FromArgb(235, 235, 235));
+
+        RegisterColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color1, Color.FromArgb(128, 199, 199, 199));
+        RegisterColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color2, Color.FromArgb(199, 199, 199));
+        RegisterColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color3, Color.FromArgb(48, 255, 255, 255));
+        RegisterColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color4, Color.FromArgb(235, 235, 235));
+
+        RegisterColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color1, Color.FromArgb(128, 168, 184, 196));
+        RegisterColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color2, Color.FromArgb(168, 184, 196));
+        RegisterColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color3, Color.FromArgb(48, 255, 255, 255));
+        RegisterColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color4, Color.FromArgb(192, 207, 220));
+    }
 
     #region Padding
 
@@ -381,85 +436,6 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
     #endregion
 
     #region Colour Arrays
-
-    private static readonly Color[] _ribbonGroupCollapsedBackContext =
-    [
-        Color.FromArgb(48, 255, 255, 255),
-        Color.FromArgb(235, 235, 235)
-    ];
-    private static readonly Color[] _ribbonGroupCollapsedBackContextTracking =
-    [
-        Color.FromArgb(48, 255, 255, 255),
-        Color.FromArgb(235, 235, 235)
-    ];
-
-    private static readonly Color[] _ribbonGroupCollapsedBorderContext =
-    [
-        Color.FromArgb(128, 199, 199, 199),
-        Color.FromArgb(199, 199, 199),
-        Color.FromArgb(48, 255, 255, 255),
-        Color.FromArgb(235, 235, 235)
-    ];
-
-    private static readonly Color[] _ribbonGroupCollapsedBorderContextTracking =
-    [
-        Color.FromArgb(128, 168, 184, 196),
-        Color.FromArgb(168, 184, 196),
-        Color.FromArgb(48, 255, 255, 255),
-        Color.FromArgb(192, 207, 220)
-    ];
-
-    private static readonly Color[] _appButtonNormal =
-    [
-        Color.FromArgb(243, 245, 248),
-        Color.FromArgb(214, 220, 231),
-        Color.FromArgb(188, 198, 211),
-        Color.FromArgb(254, 254, 255),
-        Color.FromArgb(206, 213, 225)
-    ];
-
-    private static readonly Color[] _appButtonTrack =
-    [
-        Color.FromArgb(255, 251, 230),
-        Color.FromArgb(180, 210, 255),
-        Color.FromArgb(96, 147, 235),
-        Color.FromArgb(110, 150, 240),
-        Color.FromArgb(115, 155, 245)
-    ];
-
-    private static readonly Color[] _appButtonPressed =
-    [
-        Color.FromArgb(185, 215, 250),
-        Color.FromArgb(190, 220, 245),
-        Color.FromArgb(98, 155, 230),
-        Color.FromArgb(110, 160, 225),
-        Color.FromArgb(120, 175, 240)
-    ];
-
-    private static readonly Color[] _buttonBorderColors =
-    [
-        Color.FromArgb(212, 212, 212), // Button, Disabled, Border
-        Color.FromArgb(179, 209, 255), // Button, Tracking, Border 1
-        Color.FromArgb(179, 209, 249), // Button, Tracking, Border 2
-        Color.FromArgb(96, 147, 230), // Button, Pressed, Border 1
-        Color.FromArgb(32, 98, 200), // Button, Pressed, Border 2
-        Color.FromArgb(96, 147, 235), // Button, Checked, Border 1
-        Color.FromArgb(63, 122, 220)  // Button, Checked, Border 2
-    ];
-
-    private static readonly Color[] _buttonBackColors =
-    [
-        Color.FromArgb(221, 221, 221), // Button, Disabled, Back 1
-        Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
-        Color.FromArgb(141, 168, 203), // Button, Tracking, Back 1
-        Color.FromArgb(95, 127, 169), // Button, Tracking, Back 2
-        Color.FromArgb(96, 150, 220), // Button, Pressed, Back 1
-        Color.FromArgb(179, 209, 247), // Button, Pressed, Back 2
-        Color.FromArgb(32, 98, 183), // Button, Checked, Back 1
-        Color.FromArgb(141, 180, 230), // Button, Checked, Back 2
-        Color.FromArgb(63, 122, 197), // Button, Checked Tracking, Back 1
-        Color.FromArgb(96, 147, 213)  // Button, Checked Tracking, Back 2
-    ];
 
     #endregion
 
@@ -761,7 +737,7 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
                 return state == PaletteState.CheckedNormal ? BaseColors!.GridDataCellSelected : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[6] : BaseColors!.PanelAlternative;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7) : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -784,8 +760,8 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
                         {
                             PaletteBackStyle.TabLowProfile => GlobalStaticValues.EMPTY_COLOR,
                             PaletteBackStyle.TabHighProfile => state == PaletteState.Tracking
-                                ? _buttonBackColors[2]
-                                : _buttonBackColors[4],
+                                ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)
+                                : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                             _ => SystemColors.Window
                         };
 
@@ -796,9 +772,9 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
                         {
                             return state switch
                             {
-                                PaletteState.CheckedNormal => _buttonBackColors[6],
-                                PaletteState.CheckedPressed => _buttonBackColors[4],
-                                _ => _buttonBackColors[8]
+                                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                                PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                                _ => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9)
                             };
                         }
                         else
@@ -835,7 +811,7 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderPrimaryBack1;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[6];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderSecondaryBack1;
@@ -941,7 +917,7 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[2],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
                     _ => _contextMenuOuterBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -957,8 +933,8 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal => BaseColors!.RibbonGalleryBack1,
-                    PaletteState.Tracking or PaletteState.CheckedTracking => _buttonBackColors[2],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonForm:
@@ -1000,12 +976,12 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
                         _ => BaseColors!.ButtonNormalBack1
                     },
                     PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[6],
-                    PaletteState.Tracking => _buttonBackColors[2],
+                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
                     PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBackStyle.ButtonAlternate
                         ? BaseColors!.AlternatePressedBack1
-                        : _buttonBackColors[4],
-                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[8],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -1068,7 +1044,7 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
                 return state == PaletteState.CheckedNormal ? BaseColors!.GridDataCellSelected : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[7] : BaseColors!.PanelAlternative;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8) : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -1090,7 +1066,7 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal => BaseColors!.ButtonNormalBack2,
-                    PaletteState.Tracking or PaletteState.Pressed => _buttonBackColors[3],
+                    PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => SystemColors.Window,
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
@@ -1099,7 +1075,7 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.ButtonNormalBack2,
-                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[3],
+                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.HeaderForm:
@@ -1120,7 +1096,7 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderPrimaryBack2;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[7];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderSecondaryBack2;
@@ -1224,7 +1200,7 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
                 return _contextMenuOuterBack;
             case PaletteBackStyle.ContextMenuSeparator:
             case PaletteBackStyle.ContextMenuItemSplit:
-                return state == PaletteState.Tracking ? _buttonBackColors[3] : _contextMenuOuterBack;
+                return state == PaletteState.Tracking ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4) : _contextMenuOuterBack;
             case PaletteBackStyle.ContextMenuInner:
                 return _contextMenuInnerBack;
             case PaletteBackStyle.ContextMenuHeading:
@@ -1238,8 +1214,8 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack2,
                     PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal => BaseColors!.RibbonGalleryBack2,
-                    PaletteState.Tracking or PaletteState.CheckedTracking => _buttonBackColors[2],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonForm:
@@ -1272,7 +1248,7 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemHighlight:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Normal => style switch
                     {
                         PaletteBackStyle.ButtonNavigatorStack => BaseColors!.ButtonNormalNavigatorBack2,
@@ -1285,12 +1261,12 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
                         PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight => GlobalStaticValues.EMPTY_COLOR,
                         _ => BaseColors!.ButtonNormalDefaultBack2
                     },
-                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack2 : _buttonBackColors[7],
-                    PaletteState.Tracking => _buttonBackColors[3],
+                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack2 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBackStyle.ButtonAlternate
                         ? BaseColors!.AlternatePressedBack2
-                        : _buttonBackColors[5],
-                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[9],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
+                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color10),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -1651,7 +1627,7 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors!.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1659,7 +1635,7 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
@@ -1672,8 +1648,8 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1701,25 +1677,25 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal => BaseColors!.RibbonGalleryBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                PaletteState.Tracking or PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ButtonInputControl or PaletteBorderStyle.ContextMenuItemHighlight => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => style == PaletteBorderStyle.ButtonCluster
                     ? BaseColors!.ButtonClusterButtonBorder1
                     : BaseColors!.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
                     ? GlobalStaticValues.EMPTY_COLOR
                     : BaseColors!.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[5],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color6),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBorderStyle.ButtonAlternate
                     ? BaseColors!.AlternatePressedBorder1
-                    : _buttonBorderColors[3],
-                PaletteState.CheckedTracking => _buttonBorderColors[3],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1727,10 +1703,10 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors!.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             _ => throw new ArgumentOutOfRangeException(nameof(style))
@@ -1773,7 +1749,7 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors!.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1781,7 +1757,7 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
@@ -1794,8 +1770,8 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1823,23 +1799,23 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal => BaseColors!.RibbonGalleryBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                PaletteState.Tracking or PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ButtonInputControl or PaletteBorderStyle.ContextMenuItemHighlight => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => style == PaletteBorderStyle.ButtonCluster
                     ? BaseColors!.ButtonClusterButtonBorder2
                     : BaseColors!.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[6],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBorderStyle.ButtonAlternate
                     ? BaseColors!.AlternatePressedBorder2
-                    : _buttonBorderColors[4],
-                PaletteState.CheckedTracking => _buttonBorderColors[4],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1847,10 +1823,10 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors!.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             _ => throw new ArgumentOutOfRangeException(nameof(style))
@@ -4050,10 +4026,10 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
                     case PaletteState.Tracking:
                         return BaseColors!.RibbonGroupCollapsedBorderT1;
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBorderContext[0];
+                        return GetArrayColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color1);
                     case PaletteState.ContextTracking:
                     case PaletteState.Pressed:
-                        return _ribbonGroupCollapsedBorderContextTracking[0];
+                        return GetArrayColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4076,9 +4052,9 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
                     case PaletteState.Tracking:
                         return BaseColors!.RibbonGroupCollapsedBackT1;
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBackContext[0];
+                        return GetArrayColor<RibbonGroupCollapsedBack>(RibbonGroupCollapsedBack.Color1);
                     case PaletteState.ContextTracking:
-                        return _ribbonGroupCollapsedBackContextTracking[0];
+                        return GetArrayColor<RibbonGroupCollapsedBackT>(RibbonGroupCollapsedBackT.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4126,11 +4102,11 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[0];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color1);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[0];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color1);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[0];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4213,10 +4189,10 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
                     case PaletteState.Tracking:
                         return BaseColors!.RibbonGroupCollapsedBorderT2;
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBorderContext[1];
+                        return GetArrayColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color2);
                     case PaletteState.ContextTracking:
                     case PaletteState.Pressed:
-                        return _ribbonGroupCollapsedBorderContextTracking[1];
+                        return GetArrayColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4239,9 +4215,9 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
                     case PaletteState.Tracking:
                         return BaseColors!.RibbonGroupCollapsedBackT2;
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBackContext[1];
+                        return GetArrayColor<RibbonGroupCollapsedBack>(RibbonGroupCollapsedBack.Color2);
                     case PaletteState.ContextTracking:
-                        return _ribbonGroupCollapsedBackContextTracking[1];
+                        return GetArrayColor<RibbonGroupCollapsedBackT>(RibbonGroupCollapsedBackT.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4289,11 +4265,11 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[1];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color2);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[1];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color2);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[1];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4376,10 +4352,10 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
                     case PaletteState.Tracking:
                         return BaseColors!.RibbonGroupCollapsedBorderT3;
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBorderContext[2];
+                        return GetArrayColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color3);
                     case PaletteState.ContextTracking:
                     case PaletteState.Pressed:
-                        return _ribbonGroupCollapsedBorderContextTracking[2];
+                        return GetArrayColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color3);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4425,11 +4401,11 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[2];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color3);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[2];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color3);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[2];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color3);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4499,10 +4475,10 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
                     case PaletteState.Tracking:
                         return BaseColors!.RibbonGroupCollapsedBorderT4;
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBorderContext[3];
+                        return GetArrayColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color4);
                     case PaletteState.ContextTracking:
                     case PaletteState.Pressed:
-                        return _ribbonGroupCollapsedBorderContextTracking[3];
+                        return GetArrayColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color4);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4550,11 +4526,11 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[3];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color4);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[3];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color4);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[3];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color4);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4634,11 +4610,11 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[4];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color5);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[4];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color5);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[4];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color5);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4792,8 +4768,8 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
                     PaletteState.Disabled => ControlPaint.Light(
                         BaseColors!.ButtonNormalBorder),
                     PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                    PaletteState.Tracking => _buttonBorderColors[1],
-                    PaletteState.Pressed => _buttonBorderColors[3],
+                    PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                    PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4833,8 +4809,8 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
                         BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => ControlPaint.Light(
                         BaseColors!.ButtonNormalBack1),
-                    PaletteState.Tracking => ControlPaint.Light(_buttonBackColors[2]),
-                    PaletteState.Pressed => ControlPaint.Light(_buttonBackColors[4]),
+                    PaletteState.Tracking => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)),
+                    PaletteState.Pressed => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5)),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
 
@@ -4883,8 +4859,8 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack1,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[2],
-                    PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4932,8 +4908,8 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack2,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[3],
-                    PaletteState.Pressed => _buttonBackColors[5],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueDarkMode.cs
@@ -242,8 +242,18 @@ public class PaletteOffice2007BlueDarkMode : PaletteOffice2007BlueDarkModeBase
 public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
 {
     #region Static Fields
+
+    // registration guard so default colours are initialised lazily only once
+    private static bool _defaultsRegistered;
+
     static PaletteOffice2007BlueDarkModeBase()
     {
+        if (_defaultsRegistered)
+        {
+            return;
+        }
+        _defaultsRegistered = true;
+
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
@@ -508,12 +518,34 @@ public abstract class PaletteOffice2007BlueDarkModeBase : PaletteBase
         [DisallowNull] ImageList checkBoxList,
         [DisallowNull] ImageList galleryButtonList,
         [DisallowNull] Image?[] radioButtonArray)
-        : this(scheme.ToArray(),
-               checkBoxList,
-               galleryButtonList,
-               radioButtonArray,
-               scheme.ToTrackBarArray())
     {
+        Debug.Assert(scheme != null);
+        Debug.Assert(checkBoxList != null);
+        Debug.Assert(galleryButtonList != null);
+        Debug.Assert(radioButtonArray != null);
+
+        // Remember incoming sets of values
+        ThemeName = nameof(PaletteOffice2007BlueDarkModeBase);
+
+        if (scheme != null)
+        {
+            _ribbonColors = scheme.ToArray();
+        }
+        if (checkBoxList != null)
+        {
+            _checkBoxList = checkBoxList;
+        }
+        if (galleryButtonList != null)
+        {
+            _galleryButtonList = galleryButtonList;
+        }
+        if (radioButtonArray != null)
+        {
+            _radioButtonArray = radioButtonArray;
+        }
+
+        // Get the font settings from the system
+        DefineFonts();
         BaseColors = scheme;
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueLightMode.cs
@@ -244,8 +244,18 @@ public class PaletteOffice2007BlueLightMode : PaletteOffice2007BlueLightModeBase
 public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
 {
     #region Static Fields
+
+    // registration guard so default colours are initialised lazily only once
+    private static bool _defaultsRegistered;
+
     static PaletteOffice2007BlueLightModeBase()
     {
+        if (_defaultsRegistered)
+        {
+            return;
+        }
+        _defaultsRegistered = true;
+
         RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(221, 221, 221));
         RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(236, 236, 236));
         RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(188, 213, 239));
@@ -475,12 +485,36 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
         [DisallowNull] ImageList checkBoxList,
         [DisallowNull] ImageList galleryButtonList,
         [DisallowNull] Image?[] radioButtonArray)
-        : this(scheme.ToArray(),
-               checkBoxList,
-               galleryButtonList,
-               radioButtonArray,
-               scheme.ToTrackBarArray())
     {
+        Debug.Assert(scheme != null);
+        Debug.Assert(checkBoxList != null);
+        Debug.Assert(galleryButtonList != null);
+        Debug.Assert(radioButtonArray != null);
+
+        // Remember incoming sets of values
+        ThemeName = nameof(PaletteOffice2007BlueLightModeBase);
+
+        if (scheme != null)
+        {
+            _ribbonColors = scheme.ToArray();
+        }
+
+        if (checkBoxList != null)
+        {
+            _checkBoxList = checkBoxList;
+        }
+
+        if (galleryButtonList != null)
+        {
+            _galleryButtonList = galleryButtonList;
+        }
+
+        if (radioButtonArray != null)
+        {
+            _radioButtonArray = radioButtonArray;
+        }
+
+        DefineFonts();
         BaseColors = scheme;
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007BlueLightMode.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -244,6 +244,27 @@ public class PaletteOffice2007BlueLightMode : PaletteOffice2007BlueLightModeBase
 public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
 {
     #region Static Fields
+    static PaletteOffice2007BlueLightModeBase()
+    {
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(221, 221, 221));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(236, 236, 236));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(188, 213, 239));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color4, Color.FromArgb(168, 200, 234));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color5, Color.FromArgb(209, 226, 244));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color6, Color.FromArgb(188, 213, 239));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color7, Color.FromArgb(189, 213, 233));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color8, Color.FromArgb(188, 213, 239));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color9, Color.FromArgb(209, 226, 244));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color10, Color.FromArgb(210, 226, 244));
+
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color1, Color.FromArgb(212, 212, 212));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color2, Color.FromArgb(168, 200, 234));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color3, Color.FromArgb(170, 210, 245));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color4, Color.FromArgb(155, 205, 230));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color5, Color.FromArgb(150, 200, 225));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color6, Color.FromArgb(148, 197,  220));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color7, Color.FromArgb(160, 205, 240));
+    }
 
     #region Padding
 
@@ -382,44 +403,6 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
     #endregion
 
     #region Colour Arrays
-
-    private static readonly Color[] _ribbonGroupCollapsedBackContext = [Color.FromArgb(48, 255, 255, 255), Color.FromArgb(235, 235, 235)
-    ];
-    private static readonly Color[] _ribbonGroupCollapsedBackContextTracking = [Color.FromArgb(48, 255, 255, 255), Color.FromArgb(235, 235, 235)
-    ];
-    private static readonly Color[] _ribbonGroupCollapsedBorderContext = [Color.FromArgb(128, 199, 199, 199), Color.FromArgb(199, 199, 199), Color.FromArgb(48, 255, 255, 255), Color.FromArgb(235, 235, 235)
-    ];
-    private static readonly Color[] _ribbonGroupCollapsedBorderContextTracking = [Color.FromArgb(128, 168, 184, 196), Color.FromArgb(168, 184, 196), Color.FromArgb(48, 255, 255, 255), Color.FromArgb(192, 207, 220)
-    ];
-    private static readonly Color[] _appButtonNormal = [Color.FromArgb(243, 245, 248), Color.FromArgb(214, 220, 231), Color.FromArgb(188, 198, 211), Color.FromArgb(254, 254, 255), Color.FromArgb(206, 213, 225)
-    ];
-    private static readonly Color[] _appButtonTrack = [Color.FromArgb(255, 251, 230), Color.FromArgb(248, 230, 143), Color.FromArgb(238, 213, 126), Color.FromArgb(254, 247, 129), Color.FromArgb(240, 201, 41)
-    ];
-    private static readonly Color[] _appButtonPressed = [Color.FromArgb(235, 227, 196), Color.FromArgb(228, 198, 149), Color.FromArgb(166, 97, 7), Color.FromArgb(242, 155, 57), Color.FromArgb(236, 136, 9)
-    ];
-    private static readonly Color[] _buttonBorderColors =
-    [
-        Color.FromArgb(212, 212, 212), // Button, Disabled, Border
-        Color.FromArgb(168, 200, 234), // Button, Tracking, Border 1
-        Color.FromArgb(170, 210, 245), // Button, Tracking, Border 2
-        Color.FromArgb(155, 205, 230), // Button, Pressed, Border 1
-        Color.FromArgb(150, 200, 225), // Button, Pressed, Border 2
-        Color.FromArgb(148, 197,  220), // Button, Checked, Border 1
-        Color.FromArgb(160, 205, 240)  // Button, Checked, Border 2
-    ];
-    private static readonly Color[] _buttonBackColors =
-    [
-        Color.FromArgb(221, 221, 221), // Button, Disabled, Back 1
-        Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
-        Color.FromArgb(188, 213, 239), // Button, Tracking, Back 1
-        Color.FromArgb(168, 200, 234), // Button, Tracking, Back 2
-        Color.FromArgb(209, 226, 244), // Button, Pressed, Back 1
-        Color.FromArgb(188, 213, 239), // Button, Pressed, Back 2
-        Color.FromArgb(189, 213, 233), // Button, Checked, Back 1
-        Color.FromArgb(188, 213, 239), // Button, Checked, Back 2
-        Color.FromArgb(209, 226, 244), // Button, Checked Tracking, Back 1
-        Color.FromArgb(210, 226, 244)  // Button, Checked Tracking, Back 2
-    ];
 
     #endregion
 
@@ -721,7 +704,7 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
                 return state == PaletteState.CheckedNormal ? BaseColors!.GridDataCellSelected : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[6] : BaseColors!.PanelAlternative;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7) : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -744,8 +727,8 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
                         {
                             PaletteBackStyle.TabLowProfile => GlobalStaticValues.EMPTY_COLOR,
                             PaletteBackStyle.TabHighProfile => state == PaletteState.Tracking
-                                ? _buttonBackColors[2]
-                                : _buttonBackColors[4],
+                                ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)
+                                : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                             _ => SystemColors.Window
                         };
 
@@ -756,9 +739,9 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
                         {
                             return state switch
                             {
-                                PaletteState.CheckedNormal => _buttonBackColors[6],
-                                PaletteState.CheckedPressed => _buttonBackColors[4],
-                                _ => _buttonBackColors[8]
+                                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                                PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                                _ => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9)
                             };
                         }
                         else
@@ -795,7 +778,7 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderPrimaryBack1;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[6];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderSecondaryBack1;
@@ -901,7 +884,7 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[2],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
                     _ => _contextMenuOuterBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -917,8 +900,8 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal => BaseColors!.RibbonGalleryBack1,
-                    PaletteState.Tracking or PaletteState.CheckedTracking => _buttonBackColors[2],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonForm:
@@ -960,12 +943,12 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
                         _ => BaseColors!.ButtonNormalBack1
                     },
                     PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[6],
-                    PaletteState.Tracking => _buttonBackColors[2],
+                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
                     PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBackStyle.ButtonAlternate
                         ? BaseColors!.AlternatePressedBack1
-                        : _buttonBackColors[4],
-                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[8],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -1028,7 +1011,7 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
                 return state == PaletteState.CheckedNormal ? BaseColors!.GridDataCellSelected : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[7] : BaseColors!.PanelAlternative;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8) : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -1050,7 +1033,7 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal => BaseColors!.ButtonNormalBack2,
-                    PaletteState.Tracking or PaletteState.Pressed => _buttonBackColors[3],
+                    PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => SystemColors.Window,
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
@@ -1059,7 +1042,7 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.ButtonNormalBack2,
-                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[3],
+                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.HeaderForm:
@@ -1080,7 +1063,7 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderPrimaryBack2;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[7];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderSecondaryBack2;
@@ -1184,7 +1167,7 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
                 return _contextMenuOuterBack;
             case PaletteBackStyle.ContextMenuSeparator:
             case PaletteBackStyle.ContextMenuItemSplit:
-                return state == PaletteState.Tracking ? _buttonBackColors[3] : _contextMenuOuterBack;
+                return state == PaletteState.Tracking ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4) : _contextMenuOuterBack;
             case PaletteBackStyle.ContextMenuInner:
                 return _contextMenuInnerBack;
             case PaletteBackStyle.ContextMenuHeading:
@@ -1198,8 +1181,8 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack2,
                     PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal => BaseColors!.RibbonGalleryBack2,
-                    PaletteState.Tracking or PaletteState.CheckedTracking => _buttonBackColors[2],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonForm:
@@ -1232,7 +1215,7 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemHighlight:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Normal => style switch
                     {
                         PaletteBackStyle.ButtonNavigatorStack => BaseColors!.ButtonNormalNavigatorBack2,
@@ -1245,12 +1228,12 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
                         PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight => GlobalStaticValues.EMPTY_COLOR,
                         _ => BaseColors!.ButtonNormalDefaultBack2
                     },
-                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack2 : _buttonBackColors[7],
-                    PaletteState.Tracking => _buttonBackColors[3],
+                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack2 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBackStyle.ButtonAlternate
                         ? BaseColors!.AlternatePressedBack2
-                        : _buttonBackColors[5],
-                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[9],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
+                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color10),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -2127,7 +2110,7 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors!.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -2135,7 +2118,7 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
@@ -2148,8 +2131,8 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -2177,25 +2160,25 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal => BaseColors!.RibbonGalleryBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                PaletteState.Tracking or PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ButtonInputControl or PaletteBorderStyle.ContextMenuItemHighlight => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => style == PaletteBorderStyle.ButtonCluster
                     ? BaseColors!.ButtonClusterButtonBorder1
                     : BaseColors!.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
                     ? GlobalStaticValues.EMPTY_COLOR
                     : BaseColors!.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[5],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color6),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBorderStyle.ButtonAlternate
                     ? BaseColors!.AlternatePressedBorder1
-                    : _buttonBorderColors[3],
-                PaletteState.CheckedTracking => _buttonBorderColors[3],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -2203,10 +2186,10 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors!.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             _ => throw new ArgumentOutOfRangeException(nameof(style))
@@ -2249,7 +2232,7 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors!.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -2257,7 +2240,7 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
@@ -2270,8 +2253,8 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -2299,23 +2282,23 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal => BaseColors!.RibbonGalleryBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                PaletteState.Tracking or PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ButtonInputControl or PaletteBorderStyle.ContextMenuItemHighlight => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => style == PaletteBorderStyle.ButtonCluster
                     ? BaseColors!.ButtonClusterButtonBorder2
                     : BaseColors!.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[6],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBorderStyle.ButtonAlternate
                     ? BaseColors!.AlternatePressedBorder2
-                    : _buttonBorderColors[4],
-                PaletteState.CheckedTracking => _buttonBorderColors[4],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -2323,10 +2306,10 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors!.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             _ => throw new ArgumentOutOfRangeException(nameof(style))
@@ -4526,10 +4509,10 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
                     case PaletteState.Tracking:
                         return BaseColors!.RibbonGroupCollapsedBorderT1;
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBorderContext[0];
+                        return GetArrayColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color1);
                     case PaletteState.ContextTracking:
                     case PaletteState.Pressed:
-                        return _ribbonGroupCollapsedBorderContextTracking[0];
+                        return GetArrayColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4552,9 +4535,9 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
                     case PaletteState.Tracking:
                         return BaseColors!.RibbonGroupCollapsedBackT1;
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBackContext[0];
+                        return GetArrayColor<RibbonGroupCollapsedBack>(RibbonGroupCollapsedBack.Color1);
                     case PaletteState.ContextTracking:
-                        return _ribbonGroupCollapsedBackContextTracking[0];
+                        return GetArrayColor<RibbonGroupCollapsedBackT>(RibbonGroupCollapsedBackT.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4602,11 +4585,11 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[0];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color1);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[0];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color1);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[0];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4689,10 +4672,10 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
                     case PaletteState.Tracking:
                         return BaseColors!.RibbonGroupCollapsedBorderT2;
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBorderContext[1];
+                        return GetArrayColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color2);
                     case PaletteState.ContextTracking:
                     case PaletteState.Pressed:
-                        return _ribbonGroupCollapsedBorderContextTracking[1];
+                        return GetArrayColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4715,9 +4698,9 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
                     case PaletteState.Tracking:
                         return BaseColors!.RibbonGroupCollapsedBackT2;
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBackContext[1];
+                        return GetArrayColor<RibbonGroupCollapsedBack>(RibbonGroupCollapsedBack.Color2);
                     case PaletteState.ContextTracking:
-                        return _ribbonGroupCollapsedBackContextTracking[1];
+                        return GetArrayColor<RibbonGroupCollapsedBackT>(RibbonGroupCollapsedBackT.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4765,11 +4748,11 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[1];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color2);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[1];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color2);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[1];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4852,10 +4835,10 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
                     case PaletteState.Tracking:
                         return BaseColors!.RibbonGroupCollapsedBorderT3;
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBorderContext[2];
+                        return GetArrayColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color3);
                     case PaletteState.ContextTracking:
                     case PaletteState.Pressed:
-                        return _ribbonGroupCollapsedBorderContextTracking[2];
+                        return GetArrayColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color3);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4901,11 +4884,11 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[2];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color3);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[2];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color3);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[2];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color3);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4975,10 +4958,10 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
                     case PaletteState.Tracking:
                         return BaseColors!.RibbonGroupCollapsedBorderT4;
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBorderContext[3];
+                        return GetArrayColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color4);
                     case PaletteState.ContextTracking:
                     case PaletteState.Pressed:
-                        return _ribbonGroupCollapsedBorderContextTracking[3];
+                        return GetArrayColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color4);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -5026,11 +5009,11 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[3];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color4);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[3];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color4);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[3];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color4);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -5110,11 +5093,11 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[4];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color5);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[4];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color5);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[4];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color5);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -5268,8 +5251,8 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
                     PaletteState.Disabled => ControlPaint.Light(
                         BaseColors!.ButtonNormalBorder),
                     PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                    PaletteState.Tracking => _buttonBorderColors[1],
-                    PaletteState.Pressed => _buttonBorderColors[3],
+                    PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                    PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -5309,8 +5292,8 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
                         BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => ControlPaint.Light(
                         BaseColors!.ButtonNormalBack1),
-                    PaletteState.Tracking => ControlPaint.Light(_buttonBackColors[2]),
-                    PaletteState.Pressed => ControlPaint.Light(_buttonBackColors[4]),
+                    PaletteState.Tracking => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)),
+                    PaletteState.Pressed => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5)),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
 
@@ -5359,8 +5342,8 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack1,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[2],
-                    PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -5408,8 +5391,8 @@ public abstract class PaletteOffice2007BlueLightModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack2,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[3],
-                    PaletteState.Pressed => _buttonBackColors[5],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverDarkMode.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -223,6 +223,27 @@ public class PaletteOffice2007SilverDarkMode : PaletteOffice2007SilverDarkModeBa
 public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
 {
     #region Static Fields
+    static PaletteOffice2007SilverDarkModeBase()
+    {
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(221, 221, 221));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(236, 236, 236));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(142,156,187));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color4, Color.FromArgb(106,123,164));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color5, Color.FromArgb(95, 107, 137));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color6, Color.FromArgb(54,64,88));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color7, Color.FromArgb(54,64,88));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color8, Color.FromArgb(122, 137, 174));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color9, Color.FromArgb(119, 134, 172));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color10, Color.FromArgb(135, 148, 182));
+
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color1, Color.FromArgb(212, 212, 212));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color2, Color.FromArgb(163, 179, 220));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color3, Color.FromArgb(128, 141, 173));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color4, Color.FromArgb(90, 99, 122));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color5, Color.FromArgb(118, 130, 160));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color6, Color.FromArgb(136, 150, 185));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color7, Color.FromArgb(174, 192, 236));
+    }
 
     #region Padding
 
@@ -361,44 +382,6 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
     #endregion
 
     #region Colour Arrays
-
-    private static readonly Color[] _ribbonGroupCollapsedBackContext = [Color.FromArgb(48, 255, 255, 255), Color.FromArgb(235, 235, 235)
-    ];
-    private static readonly Color[] _ribbonGroupCollapsedBackContextTracking = [Color.FromArgb(48, 255, 255, 255), Color.FromArgb(235, 235, 235)
-    ];
-    private static readonly Color[] _ribbonGroupCollapsedBorderContext = [Color.FromArgb(128, 199, 199, 199), Color.FromArgb(199, 199, 199), Color.FromArgb(48, 255, 255, 255), Color.FromArgb(235, 235, 235)
-    ];
-    private static readonly Color[] _ribbonGroupCollapsedBorderContextTracking = [Color.FromArgb(128, 168, 184, 196), Color.FromArgb(168, 184, 196), Color.FromArgb(48, 255, 255, 255), Color.FromArgb(192, 207, 220)
-    ];
-    private static readonly Color[] _appButtonNormal = [Color.FromArgb(243, 245, 248), Color.FromArgb(214, 220, 231), Color.FromArgb(188, 198, 211), Color.FromArgb(254, 254, 255), Color.FromArgb(206, 213, 225)
-    ];
-    private static readonly Color[] _appButtonTrack = [Color.FromArgb(255, 251, 230), Color.FromArgb(248, 230, 143), Color.FromArgb(238, 213, 126), Color.FromArgb(254, 247, 129), Color.FromArgb(240, 201, 41)
-    ];
-    private static readonly Color[] _appButtonPressed = [Color.FromArgb(235, 227, 196), Color.FromArgb(228, 198, 149), Color.FromArgb(166, 97, 7), Color.FromArgb(242, 155, 57), Color.FromArgb(236, 136, 9)
-    ];
-    private static readonly Color[] _buttonBorderColors =
-    [
-        Color.FromArgb(212, 212, 212), // Button, Disabled, Border
-        Color.FromArgb(163, 179, 220), // Button, Tracking, Border 1
-        Color.FromArgb(128, 141, 173), // Button, Tracking, Border 2
-        Color.FromArgb(90, 99, 122), // Button, Pressed, Border 1
-        Color.FromArgb(118, 130, 160), // Button, Pressed, Border 2
-        Color.FromArgb(136, 150, 185), // Button, Checked, Border 1
-        Color.FromArgb(174, 192, 236)  // Button, Checked, Border 2
-    ];
-    private static readonly Color[] _buttonBackColors =
-    [
-        Color.FromArgb(221, 221, 221), // Button, Disabled, Back 1
-        Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
-        Color.FromArgb(142,156,187), // Button, Tracking, Back 1
-        Color.FromArgb(106,123,164), // Button, Tracking, Back 2
-        Color.FromArgb(95, 107, 137), // Button, Pressed, Back 1
-        Color.FromArgb(54,64,88), // Button, Pressed, Back 2
-        Color.FromArgb(54,64,88), // Button, Checked, Back 1
-        Color.FromArgb(122, 137, 174), // Button, Checked, Back 2
-        Color.FromArgb(119, 134, 172), // Button, Checked Tracking, Back 1
-        Color.FromArgb(135, 148, 182)  // Button, Checked Tracking, Back 2
-    ];
 
     #endregion
 
@@ -701,7 +684,7 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
                     ? BaseColors!.GridDataCellSelected : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[6] : BaseColors!.PanelAlternative;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7) : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -724,8 +707,8 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
                         {
                             PaletteBackStyle.TabLowProfile => GlobalStaticValues.EMPTY_COLOR,
                             PaletteBackStyle.TabHighProfile => state == PaletteState.Tracking
-                                ? _buttonBackColors[2]
-                                : _buttonBackColors[4],
+                                ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)
+                                : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                             _ => SystemColors.Window
                         };
 
@@ -736,9 +719,9 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
                         {
                             return state switch
                             {
-                                PaletteState.CheckedNormal => _buttonBackColors[6],
-                                PaletteState.CheckedPressed => _buttonBackColors[4],
-                                _ => _buttonBackColors[8]
+                                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                                PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                                _ => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9)
                             };
                         }
                         else
@@ -775,7 +758,7 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderPrimaryBack1;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[6];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderSecondaryBack1;
@@ -881,7 +864,7 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[2],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
                     _ => _contextMenuOuterBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -897,8 +880,8 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal => BaseColors!.RibbonGalleryBack1,
-                    PaletteState.Tracking or PaletteState.CheckedTracking => _buttonBackColors[2],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonForm:
@@ -940,12 +923,12 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
                         _ => BaseColors!.ButtonNormalBack1
                     },
                     PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[6],
-                    PaletteState.Tracking => _buttonBackColors[2],
+                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
                     PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBackStyle.ButtonAlternate
                         ? BaseColors!.AlternatePressedBack1
-                        : _buttonBackColors[4],
-                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[8],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -1008,7 +991,7 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
                 return state == PaletteState.CheckedNormal ? BaseColors!.GridDataCellSelected : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[7] : BaseColors!.PanelAlternative;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8) : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -1030,7 +1013,7 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal => BaseColors!.ButtonNormalBack2,
-                    PaletteState.Tracking or PaletteState.Pressed => _buttonBackColors[3],
+                    PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => SystemColors.Window,
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
@@ -1039,7 +1022,7 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.ButtonNormalBack2,
-                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[3],
+                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.HeaderForm:
@@ -1060,7 +1043,7 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderPrimaryBack2;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[7];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderSecondaryBack2;
@@ -1164,7 +1147,7 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
                 return _contextMenuOuterBack;
             case PaletteBackStyle.ContextMenuSeparator:
             case PaletteBackStyle.ContextMenuItemSplit:
-                return state == PaletteState.Tracking ? _buttonBackColors[3] : _contextMenuOuterBack;
+                return state == PaletteState.Tracking ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4) : _contextMenuOuterBack;
             case PaletteBackStyle.ContextMenuInner:
                 return _contextMenuInnerBack;
             case PaletteBackStyle.ContextMenuHeading:
@@ -1178,8 +1161,8 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack2,
                     PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal => BaseColors!.RibbonGalleryBack2,
-                    PaletteState.Tracking or PaletteState.CheckedTracking => _buttonBackColors[2],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonForm:
@@ -1212,7 +1195,7 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemHighlight:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Normal => style switch
                     {
                         PaletteBackStyle.ButtonNavigatorStack => BaseColors!.ButtonNormalNavigatorBack2,
@@ -1225,12 +1208,12 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
                         PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight => GlobalStaticValues.EMPTY_COLOR,
                         _ => BaseColors!.ButtonNormalDefaultBack2
                     },
-                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack2 : _buttonBackColors[7],
-                    PaletteState.Tracking => _buttonBackColors[3],
+                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack2 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBackStyle.ButtonAlternate
                         ? BaseColors!.AlternatePressedBack2
-                        : _buttonBackColors[5],
-                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[9],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
+                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color10),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -2107,7 +2090,7 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors!.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -2115,7 +2098,7 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
@@ -2128,8 +2111,8 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -2157,25 +2140,25 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal => BaseColors!.RibbonGalleryBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                PaletteState.Tracking or PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ButtonInputControl or PaletteBorderStyle.ContextMenuItemHighlight => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => style == PaletteBorderStyle.ButtonCluster
                     ? BaseColors!.ButtonClusterButtonBorder1
                     : BaseColors!.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
                     ? GlobalStaticValues.EMPTY_COLOR
                     : BaseColors!.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[5],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color6),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBorderStyle.ButtonAlternate
                     ? BaseColors!.AlternatePressedBorder1
-                    : _buttonBorderColors[3],
-                PaletteState.CheckedTracking => _buttonBorderColors[3],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -2183,10 +2166,10 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors!.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             _ => throw new ArgumentOutOfRangeException(nameof(style))
@@ -2229,7 +2212,7 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors!.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -2237,7 +2220,7 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
@@ -2250,8 +2233,8 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -2279,23 +2262,23 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal => BaseColors!.RibbonGalleryBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                PaletteState.Tracking or PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ButtonInputControl or PaletteBorderStyle.ContextMenuItemHighlight => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => style == PaletteBorderStyle.ButtonCluster
                     ? BaseColors!.ButtonClusterButtonBorder2
                     : BaseColors!.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[6],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBorderStyle.ButtonAlternate
                     ? BaseColors!.AlternatePressedBorder2
-                    : _buttonBorderColors[4],
-                PaletteState.CheckedTracking => _buttonBorderColors[4],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -2303,10 +2286,10 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors!.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             _ => throw new ArgumentOutOfRangeException(nameof(style))
@@ -4505,10 +4488,10 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
                     case PaletteState.Tracking:
                         return BaseColors!.RibbonGroupCollapsedBorderT1;
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBorderContext[0];
+                        return GetArrayColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color1);
                     case PaletteState.ContextTracking:
                     case PaletteState.Pressed:
-                        return _ribbonGroupCollapsedBorderContextTracking[0];
+                        return GetArrayColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4531,9 +4514,9 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
                     case PaletteState.Tracking:
                         return BaseColors!.RibbonGroupCollapsedBackT1;
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBackContext[0];
+                        return GetArrayColor<RibbonGroupCollapsedBack>(RibbonGroupCollapsedBack.Color1);
                     case PaletteState.ContextTracking:
-                        return _ribbonGroupCollapsedBackContextTracking[0];
+                        return GetArrayColor<RibbonGroupCollapsedBackT>(RibbonGroupCollapsedBackT.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4581,11 +4564,11 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[0];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color1);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[0];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color1);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[0];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4668,10 +4651,10 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
                     case PaletteState.Tracking:
                         return BaseColors!.RibbonGroupCollapsedBorderT2;
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBorderContext[1];
+                        return GetArrayColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color2);
                     case PaletteState.ContextTracking:
                     case PaletteState.Pressed:
-                        return _ribbonGroupCollapsedBorderContextTracking[1];
+                        return GetArrayColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4694,9 +4677,9 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
                     case PaletteState.Tracking:
                         return BaseColors!.RibbonGroupCollapsedBackT2;
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBackContext[1];
+                        return GetArrayColor<RibbonGroupCollapsedBack>(RibbonGroupCollapsedBack.Color2);
                     case PaletteState.ContextTracking:
-                        return _ribbonGroupCollapsedBackContextTracking[1];
+                        return GetArrayColor<RibbonGroupCollapsedBackT>(RibbonGroupCollapsedBackT.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4743,11 +4726,11 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[1];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color2);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[1];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color2);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[1];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4828,10 +4811,10 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
                     case PaletteState.Tracking:
                         return BaseColors!.RibbonGroupCollapsedBorderT3;
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBorderContext[2];
+                        return GetArrayColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color3);
                     case PaletteState.ContextTracking:
                     case PaletteState.Pressed:
-                        return _ribbonGroupCollapsedBorderContextTracking[2];
+                        return GetArrayColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color3);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4875,11 +4858,11 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[2];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color3);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[2];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color3);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[2];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color3);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4947,10 +4930,10 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
                     case PaletteState.Tracking:
                         return BaseColors!.RibbonGroupCollapsedBorderT4;
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBorderContext[3];
+                        return GetArrayColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color4);
                     case PaletteState.ContextTracking:
                     case PaletteState.Pressed:
-                        return _ribbonGroupCollapsedBorderContextTracking[3];
+                        return GetArrayColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color4);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4996,11 +4979,11 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[3];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color4);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[3];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color4);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[3];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color4);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -5078,11 +5061,11 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[4];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color5);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[4];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color5);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[4];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color5);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -5234,8 +5217,8 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
                     PaletteState.Disabled => ControlPaint.Light(
                         BaseColors!.ButtonNormalBorder),
                     PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                    PaletteState.Tracking => _buttonBorderColors[1],
-                    PaletteState.Pressed => _buttonBorderColors[3],
+                    PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                    PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -5275,8 +5258,8 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
                         BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => ControlPaint.Light(
                         BaseColors!.ButtonNormalBack1),
-                    PaletteState.Tracking => ControlPaint.Light(_buttonBackColors[2]),
-                    PaletteState.Pressed => ControlPaint.Light(_buttonBackColors[4]),
+                    PaletteState.Tracking => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)),
+                    PaletteState.Pressed => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5)),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
 
@@ -5325,8 +5308,8 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack1,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[2],
-                    PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -5374,8 +5357,8 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack2,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[3],
-                    PaletteState.Pressed => _buttonBackColors[5],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverDarkMode.cs
@@ -223,8 +223,18 @@ public class PaletteOffice2007SilverDarkMode : PaletteOffice2007SilverDarkModeBa
 public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
 {
     #region Static Fields
+
+    // registration guard so default colours are initialised lazily only once
+    private static bool _defaultsRegistered;
+
     static PaletteOffice2007SilverDarkModeBase()
     {
+        if (_defaultsRegistered)
+        {
+            return;
+        }
+        _defaultsRegistered = true;
+
         RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(221, 221, 221));
         RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(236, 236, 236));
         RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(142,156,187));
@@ -454,12 +464,36 @@ public abstract class PaletteOffice2007SilverDarkModeBase : PaletteBase
         [DisallowNull] ImageList checkBoxList,
         [DisallowNull] ImageList galleryButtonList,
         [DisallowNull] Image?[] radioButtonArray)
-        : this(scheme.ToArray(),
-               checkBoxList,
-               galleryButtonList,
-               radioButtonArray,
-               scheme.ToTrackBarArray())
     {
+        Debug.Assert(scheme != null);
+        Debug.Assert(checkBoxList != null);
+        Debug.Assert(galleryButtonList != null);
+        Debug.Assert(radioButtonArray != null);
+
+        // Remember incoming sets of values
+        ThemeName = nameof(PaletteOffice2007SilverDarkModeBase);
+
+        if (scheme != null)
+        {
+            _ribbonColors = scheme.ToArray();
+        }
+
+        if (checkBoxList != null)
+        {
+            _checkBoxList = checkBoxList;
+        }
+
+        if (galleryButtonList != null)
+        {
+            _galleryButtonList = galleryButtonList;
+        }
+
+        if (radioButtonArray != null)
+        {
+            _radioButtonArray = radioButtonArray;
+        }
+
+        DefineFonts();
         BaseColors = scheme;
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverLightMode.cs
@@ -223,8 +223,18 @@ public class PaletteOffice2007SilverLightMode : PaletteOffice2007SilverLightMode
 public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
 {
     #region Static Fields
+
+    // registration guard so default colours are initialised lazily only once
+    private static bool _defaultsRegistered;
+
     static PaletteOffice2007SilverLightModeBase()
     {
+        if (_defaultsRegistered)
+        {
+            return;
+        }
+        _defaultsRegistered = true;
+
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
@@ -489,12 +499,36 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
         [DisallowNull] ImageList checkBoxList,
         [DisallowNull] ImageList galleryButtonList,
         [DisallowNull] Image?[] radioButtonArray)
-        : this(scheme.ToArray(),
-               checkBoxList,
-               galleryButtonList,
-               radioButtonArray,
-               scheme.ToTrackBarArray())
     {
+        Debug.Assert(scheme != null);
+        Debug.Assert(checkBoxList != null);
+        Debug.Assert(galleryButtonList != null);
+        Debug.Assert(radioButtonArray != null);
+
+        // Remember incoming sets of values
+        ThemeName = nameof(PaletteOffice2007SilverLightModeBase);
+
+        if (scheme != null)
+        {
+            _ribbonColors = scheme.ToArray();
+        }
+
+        if (checkBoxList != null)
+        {
+            _checkBoxList = checkBoxList;
+        }
+
+        if (galleryButtonList != null)
+        {
+            _galleryButtonList = galleryButtonList;
+        }
+
+        if (radioButtonArray != null)
+        {
+            _radioButtonArray = radioButtonArray;
+        }
+
+        DefineFonts();
         BaseColors = scheme;
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2007/Extra Themes/PaletteOffice2007SilverLightMode.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -223,6 +223,61 @@ public class PaletteOffice2007SilverLightMode : PaletteOffice2007SilverLightMode
 public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
 {
     #region Static Fields
+    static PaletteOffice2007SilverLightModeBase()
+    {
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color4, Color.FromArgb(254, 254, 255));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color5, Color.FromArgb(206, 213, 225));
+
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color1, Color.FromArgb(235, 227, 196));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color2, Color.FromArgb(228, 198, 149));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color3, Color.FromArgb(166, 97, 7));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color4, Color.FromArgb(242, 155, 57));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color5, Color.FromArgb(236, 136, 9));
+
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color1, Color.FromArgb(255, 251, 230));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color2, Color.FromArgb(248, 230, 143));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color3, Color.FromArgb(238, 213, 126));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color4, Color.FromArgb(254, 247, 129));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color5, Color.FromArgb(240, 201, 41));
+
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(221, 221, 221));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(236, 236, 236));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(214, 216, 221));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color4, Color.FromArgb(194, 197, 204));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color5, Color.FromArgb(196, 198, 206));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color6, Color.FromArgb(214, 216, 221));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color7, Color.FromArgb(214, 216, 221));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color8, Color.FromArgb(216, 220, 222));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color9, Color.FromArgb(219, 224, 222));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color10, Color.FromArgb(225, 228, 224));
+
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color1, Color.FromArgb(212, 212, 212));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color2, Color.FromArgb(232, 234, 244));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color3, Color.FromArgb(183, 185, 193));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color4, Color.FromArgb(134, 136, 142));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color5, Color.FromArgb(146, 148, 155));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color6, Color.FromArgb(121, 123, 129));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color7, Color.FromArgb(170, 172, 181));
+
+        RegisterColor<RibbonGroupCollapsedBack>(RibbonGroupCollapsedBack.Color1, Color.FromArgb(48, 255, 255, 255));
+        RegisterColor<RibbonGroupCollapsedBack>(RibbonGroupCollapsedBack.Color2, Color.FromArgb(235, 235, 235));
+
+        RegisterColor<RibbonGroupCollapsedBackT>(RibbonGroupCollapsedBackT.Color1, Color.FromArgb(48, 255, 255, 255));
+        RegisterColor<RibbonGroupCollapsedBackT>(RibbonGroupCollapsedBackT.Color2, Color.FromArgb(235, 235, 235));
+
+        RegisterColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color1, Color.FromArgb(128, 199, 199, 199));
+        RegisterColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color2, Color.FromArgb(199, 199, 199));
+        RegisterColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color3, Color.FromArgb(48, 255, 255, 255));
+        RegisterColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color4, Color.FromArgb(235, 235, 235));
+
+        RegisterColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color1, Color.FromArgb(128, 168, 184, 196));
+        RegisterColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color2, Color.FromArgb(168, 184, 196));
+        RegisterColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color3, Color.FromArgb(48, 255, 255, 255));
+        RegisterColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color4, Color.FromArgb(192, 207, 220));
+    }
 
     #region Padding
 
@@ -361,86 +416,6 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
     #endregion
 
     #region Colour Arrays
-
-    private static readonly Color[] _ribbonGroupCollapsedBackContext =
-    [
-        Color.FromArgb(48, 255, 255, 255),
-        Color.FromArgb(235, 235, 235)
-    ];
-
-    private static readonly Color[] _ribbonGroupCollapsedBackContextTracking =
-    [
-        Color.FromArgb(48, 255, 255, 255),
-        Color.FromArgb(235, 235, 235)
-    ];
-
-    private static readonly Color[] _ribbonGroupCollapsedBorderContext =
-    [
-        Color.FromArgb(128, 199, 199, 199),
-        Color.FromArgb(199, 199, 199),
-        Color.FromArgb(48, 255, 255, 255),
-        Color.FromArgb(235, 235, 235)
-    ];
-
-    private static readonly Color[] _ribbonGroupCollapsedBorderContextTracking =
-    [
-        Color.FromArgb(128, 168, 184, 196),
-        Color.FromArgb(168, 184, 196),
-        Color.FromArgb(48, 255, 255, 255),
-        Color.FromArgb(192, 207, 220)
-    ];
-
-    private static readonly Color[] _appButtonNormal =
-    [
-        Color.FromArgb(243, 245, 248),
-        Color.FromArgb(214, 220, 231),
-        Color.FromArgb(188, 198, 211),
-        Color.FromArgb(254, 254, 255),
-        Color.FromArgb(206, 213, 225)
-    ];
-
-    private static readonly Color[] _appButtonTrack =
-    [
-        Color.FromArgb(255, 251, 230),
-        Color.FromArgb(248, 230, 143),
-        Color.FromArgb(238, 213, 126),
-        Color.FromArgb(254, 247, 129),
-        Color.FromArgb(240, 201, 41)
-    ];
-
-    private static readonly Color[] _appButtonPressed =
-    [
-        Color.FromArgb(235, 227, 196),
-        Color.FromArgb(228, 198, 149),
-        Color.FromArgb(166, 97, 7),
-        Color.FromArgb(242, 155, 57),
-        Color.FromArgb(236, 136, 9)
-    ];
-
-    private static readonly Color[] _buttonBorderColors =
-    [
-        Color.FromArgb(212, 212, 212), // Button, Disabled, Border
-        Color.FromArgb(232, 234, 244), // Button, Tracking, Border 1
-        Color.FromArgb(183, 185, 193), // Button, Tracking, Border 2
-        Color.FromArgb(134, 136, 142), // Button, Pressed, Border 1
-        Color.FromArgb(146, 148, 155), // Button, Pressed, Border 2
-        Color.FromArgb(121, 123, 129), // Button, Checked, Border 1
-        Color.FromArgb(170, 172, 181) // Button, Checked, Border 2
-    ];
-
-    private static readonly Color[] _buttonBackColors =
-    [
-        Color.FromArgb(221, 221, 221), // Button, Disabled, Back 1
-        Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
-        Color.FromArgb(214, 216, 221), // Button, Tracking, Back 1
-        Color.FromArgb(194, 197, 204), // Button, Tracking, Back 2
-        Color.FromArgb(196, 198, 206), // Button, Pressed, Back 1
-        Color.FromArgb(214, 216, 221), // Button, Pressed, Back 2
-        Color.FromArgb(214, 216, 221), // Button, Checked, Back 1
-        Color.FromArgb(216, 220, 222), // Button, Checked, Back 2
-        Color.FromArgb(219, 224, 222), // Button, Checked Tracking, Back 1
-        Color.FromArgb(225, 228, 224) // Button, Checked Tracking, Back 2
-    ];
 
     #endregion
 
@@ -744,7 +719,7 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
                     ? BaseColors!.GridDataCellSelected : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[6] : BaseColors!.PanelAlternative;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7) : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -767,8 +742,8 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
                         {
                             PaletteBackStyle.TabLowProfile => GlobalStaticValues.EMPTY_COLOR,
                             PaletteBackStyle.TabHighProfile => state == PaletteState.Tracking
-                                ? _buttonBackColors[2]
-                                : _buttonBackColors[4],
+                                ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)
+                                : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                             _ => SystemColors.Window
                         };
 
@@ -779,9 +754,9 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
                         {
                             return state switch
                             {
-                                PaletteState.CheckedNormal => _buttonBackColors[6],
-                                PaletteState.CheckedPressed => _buttonBackColors[4],
-                                _ => _buttonBackColors[8]
+                                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                                PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                                _ => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9)
                             };
                         }
                         else
@@ -818,7 +793,7 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderPrimaryBack1;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[6];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderSecondaryBack1;
@@ -924,7 +899,7 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[2],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
                     _ => _contextMenuOuterBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -940,8 +915,8 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal => BaseColors!.RibbonGalleryBack1,
-                    PaletteState.Tracking or PaletteState.CheckedTracking => _buttonBackColors[2],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonForm:
@@ -983,12 +958,12 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
                         _ => BaseColors!.ButtonNormalBack1
                     },
                     PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[6],
-                    PaletteState.Tracking => _buttonBackColors[2],
+                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
                     PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBackStyle.ButtonAlternate
                         ? BaseColors!.AlternatePressedBack1
-                        : _buttonBackColors[4],
-                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[8],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -1051,7 +1026,7 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
                 return state == PaletteState.CheckedNormal ? BaseColors!.GridDataCellSelected : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[7] : BaseColors!.PanelAlternative;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8) : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -1073,7 +1048,7 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal => BaseColors!.ButtonNormalBack2,
-                    PaletteState.Tracking or PaletteState.Pressed => _buttonBackColors[3],
+                    PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => SystemColors.Window,
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
@@ -1082,7 +1057,7 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.ButtonNormalBack2,
-                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[3],
+                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.HeaderForm:
@@ -1103,7 +1078,7 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderPrimaryBack2;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[7];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderSecondaryBack2;
@@ -1207,7 +1182,7 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
                 return _contextMenuOuterBack;
             case PaletteBackStyle.ContextMenuSeparator:
             case PaletteBackStyle.ContextMenuItemSplit:
-                return state == PaletteState.Tracking ? _buttonBackColors[3] : _contextMenuOuterBack;
+                return state == PaletteState.Tracking ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4) : _contextMenuOuterBack;
             case PaletteBackStyle.ContextMenuInner:
                 return _contextMenuInnerBack;
             case PaletteBackStyle.ContextMenuHeading:
@@ -1221,8 +1196,8 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack2,
                     PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal => BaseColors!.RibbonGalleryBack2,
-                    PaletteState.Tracking or PaletteState.CheckedTracking => _buttonBackColors[2],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonForm:
@@ -1255,7 +1230,7 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemHighlight:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Normal => style switch
                     {
                         PaletteBackStyle.ButtonNavigatorStack => BaseColors!.ButtonNormalNavigatorBack2,
@@ -1268,12 +1243,12 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
                         PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight => GlobalStaticValues.EMPTY_COLOR,
                         _ => BaseColors!.ButtonNormalDefaultBack2
                     },
-                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack2 : _buttonBackColors[7],
-                    PaletteState.Tracking => _buttonBackColors[3],
+                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack2 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBackStyle.ButtonAlternate
                         ? BaseColors!.AlternatePressedBack2
-                        : _buttonBackColors[5],
-                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[9],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
+                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color10),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -2154,7 +2129,7 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors!.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -2162,7 +2137,7 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
@@ -2175,8 +2150,8 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -2204,25 +2179,25 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal => BaseColors!.RibbonGalleryBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                PaletteState.Tracking or PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ButtonInputControl or PaletteBorderStyle.ContextMenuItemHighlight => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => style == PaletteBorderStyle.ButtonCluster
                     ? BaseColors!.ButtonClusterButtonBorder1
                     : BaseColors!.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
                     ? GlobalStaticValues.EMPTY_COLOR
                     : BaseColors!.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[5],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color6),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBorderStyle.ButtonAlternate
                     ? BaseColors!.AlternatePressedBorder1
-                    : _buttonBorderColors[3],
-                PaletteState.CheckedTracking => _buttonBorderColors[3],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -2230,10 +2205,10 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors!.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             _ => throw new ArgumentOutOfRangeException(nameof(style))
@@ -2280,7 +2255,7 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors!.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -2288,7 +2263,7 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
@@ -2301,8 +2276,8 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -2330,23 +2305,23 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.NormalDefaultOverride or PaletteState.CheckedNormal => BaseColors!.RibbonGalleryBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                PaletteState.Tracking or PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ButtonInputControl or PaletteBorderStyle.ContextMenuItemHighlight => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => style == PaletteBorderStyle.ButtonCluster
                     ? BaseColors!.ButtonClusterButtonBorder2
                     : BaseColors!.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[6],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.Pressed or PaletteState.CheckedPressed => style == PaletteBorderStyle.ButtonAlternate
                     ? BaseColors!.AlternatePressedBorder2
-                    : _buttonBorderColors[4],
-                PaletteState.CheckedTracking => _buttonBorderColors[4],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -2354,10 +2329,10 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors!.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             _ => throw new ArgumentOutOfRangeException(nameof(style))
@@ -4552,10 +4527,10 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
                     case PaletteState.Tracking:
                         return BaseColors!.RibbonGroupCollapsedBorderT1;
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBorderContext[0];
+                        return GetArrayColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color1);
                     case PaletteState.ContextTracking:
                     case PaletteState.Pressed:
-                        return _ribbonGroupCollapsedBorderContextTracking[0];
+                        return GetArrayColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4577,9 +4552,9 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
                     case PaletteState.Tracking:
                         return BaseColors!.RibbonGroupCollapsedBackT1;
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBackContext[0];
+                        return GetArrayColor<RibbonGroupCollapsedBack>(RibbonGroupCollapsedBack.Color1);
                     case PaletteState.ContextTracking:
-                        return _ribbonGroupCollapsedBackContextTracking[0];
+                        return GetArrayColor<RibbonGroupCollapsedBackT>(RibbonGroupCollapsedBackT.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4624,11 +4599,11 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[0];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color1);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[0];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color1);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[0];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4709,10 +4684,10 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
                     case PaletteState.Tracking:
                         return BaseColors!.RibbonGroupCollapsedBorderT2;
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBorderContext[1];
+                        return GetArrayColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color2);
                     case PaletteState.ContextTracking:
                     case PaletteState.Pressed:
-                        return _ribbonGroupCollapsedBorderContextTracking[1];
+                        return GetArrayColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4734,9 +4709,9 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
                     case PaletteState.Tracking:
                         return BaseColors!.RibbonGroupCollapsedBackT2;
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBackContext[1];
+                        return GetArrayColor<RibbonGroupCollapsedBack>(RibbonGroupCollapsedBack.Color2);
                     case PaletteState.ContextTracking:
-                        return _ribbonGroupCollapsedBackContextTracking[1];
+                        return GetArrayColor<RibbonGroupCollapsedBackT>(RibbonGroupCollapsedBackT.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4781,11 +4756,11 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[1];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color2);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[1];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color2);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[1];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4866,10 +4841,10 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
                     case PaletteState.Tracking:
                         return BaseColors!.RibbonGroupCollapsedBorderT3;
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBorderContext[2];
+                        return GetArrayColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color3);
                     case PaletteState.ContextTracking:
                     case PaletteState.Pressed:
-                        return _ribbonGroupCollapsedBorderContextTracking[2];
+                        return GetArrayColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color3);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4913,11 +4888,11 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[2];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color3);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[2];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color3);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[2];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color3);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4985,10 +4960,10 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
                     case PaletteState.Tracking:
                         return BaseColors!.RibbonGroupCollapsedBorderT4;
                     case PaletteState.ContextNormal:
-                        return _ribbonGroupCollapsedBorderContext[3];
+                        return GetArrayColor<RibbonGroupCollapsedBorder>(RibbonGroupCollapsedBorder.Color4);
                     case PaletteState.ContextTracking:
                     case PaletteState.Pressed:
-                        return _ribbonGroupCollapsedBorderContextTracking[3];
+                        return GetArrayColor<RibbonGroupCollapsedBorderT>(RibbonGroupCollapsedBorderT.Color4);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -5034,11 +5009,11 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[3];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color4);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[3];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color4);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[3];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color4);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -5116,11 +5091,11 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[4];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color5);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[4];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color5);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[4];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color5);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -5272,8 +5247,8 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
                     PaletteState.Disabled => ControlPaint.Light(
                         BaseColors!.ButtonNormalBorder),
                     PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                    PaletteState.Tracking => _buttonBorderColors[1],
-                    PaletteState.Pressed => _buttonBorderColors[3],
+                    PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                    PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -5313,8 +5288,8 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
                         BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => ControlPaint.Light(
                         BaseColors!.ButtonNormalBack1),
-                    PaletteState.Tracking => ControlPaint.Light(_buttonBackColors[2]),
-                    PaletteState.Pressed => ControlPaint.Light(_buttonBackColors[4]),
+                    PaletteState.Tracking => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)),
+                    PaletteState.Pressed => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5)),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
 
@@ -5363,8 +5338,8 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack1,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[2],
-                    PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -5412,8 +5387,8 @@ public abstract class PaletteOffice2007SilverLightModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack2,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[3],
-                    PaletteState.Pressed => _buttonBackColors[5],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Bases/PaletteOffice2010Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Bases/PaletteOffice2010Base.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -18,6 +18,45 @@ namespace Krypton.Toolkit;
 public abstract class PaletteOffice2010Base : PaletteBase
 {
     #region Static Fields
+    static PaletteOffice2010Base()
+    {
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color4, Color.FromArgb(254, 254, 255));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color5, Color.FromArgb(206, 213, 225));
+
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color1, Color.FromArgb(235, 227, 196));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color2, Color.FromArgb(228, 198, 149));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color3, Color.FromArgb(166, 97, 7));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color4, Color.FromArgb(242, 155, 57));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color5, Color.FromArgb(236, 136, 9));
+
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color1, Color.FromArgb(255, 251, 230));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color2, Color.FromArgb(248, 230, 143));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color3, Color.FromArgb(238, 213, 126));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color4, Color.FromArgb(254, 247, 129));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color5, Color.FromArgb(240, 201, 41));
+
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(250, 250, 250));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(250, 250, 250));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(248, 225, 135));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color4, Color.FromArgb(251, 248, 224));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color5, Color.FromArgb(255, 228, 138));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color6, Color.FromArgb(194, 118, 43));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color7, Color.FromArgb(255, 216, 108));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color8, Color.FromArgb(255, 244, 128));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color9, Color.FromArgb(255, 225, 104));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color10, Color.FromArgb(255, 249, 196));
+
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color1, Color.FromArgb(180, 180, 180));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color2, Color.FromArgb(237, 201, 88));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color3, Color.FromArgb(243, 213, 73));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color4, Color.FromArgb(194, 118, 43));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color5, Color.FromArgb(194, 158, 71));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color6, Color.FromArgb(194, 138, 48));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color7, Color.FromArgb(194, 164, 77));
+    }
 
     #region Padding
 
@@ -161,57 +200,6 @@ public abstract class PaletteOffice2010Base : PaletteBase
 
     #region Color Arrays
 
-    private static readonly Color[] _appButtonNormal =
-    [
-        Color.FromArgb(243, 245, 248),
-        Color.FromArgb(214, 220, 231),
-        Color.FromArgb(188, 198, 211),
-        Color.FromArgb(254, 254, 255),
-        Color.FromArgb(206, 213, 225)
-    ];
-
-    private static readonly Color[] _appButtonTrack =
-    [
-        Color.FromArgb(255, 251, 230),
-        Color.FromArgb(248, 230, 143),
-        Color.FromArgb(238, 213, 126),
-        Color.FromArgb(254, 247, 129),
-        Color.FromArgb(240, 201, 41)
-    ];
-
-    private static readonly Color[] _appButtonPressed =
-    [
-        Color.FromArgb(235, 227, 196),
-        Color.FromArgb(228, 198, 149),
-        Color.FromArgb(166, 97, 7),
-        Color.FromArgb(242, 155, 57),
-        Color.FromArgb(236, 136, 9)
-    ];
-
-    private static readonly Color[] _buttonBorderColors =
-    [
-        Color.FromArgb(180, 180, 180), // Button, Disabled, Border
-        Color.FromArgb(237, 201, 88), // Button, Tracking, Border 1
-        Color.FromArgb(243, 213, 73), // Button, Tracking, Border 2
-        Color.FromArgb(194, 118, 43), // Button, Pressed, Border 1
-        Color.FromArgb(194, 158, 71), // Button, Pressed, Border 2
-        Color.FromArgb(194, 138, 48), // Button, Checked, Border 1
-        Color.FromArgb(194, 164, 77) // Button, Checked, Border 2
-    ];
-
-    private static readonly Color[] _buttonBackColors =
-    [
-        Color.FromArgb(250, 250, 250), // Button, Disabled, Back 1
-        Color.FromArgb(250, 250, 250), // Button, Disabled, Back 2
-        Color.FromArgb(248, 225, 135), // Button, Tracking, Back 1
-        Color.FromArgb(251, 248, 224), // Button, Tracking, Back 2
-        Color.FromArgb(255, 228, 138), // Button, Pressed, Back 1
-        Color.FromArgb(194, 118, 43), // Button, Pressed, Back 2
-        Color.FromArgb(255, 216, 108), // Button, Checked, Back 1
-        Color.FromArgb(255, 244, 128), // Button, Checked, Back 2
-        Color.FromArgb(255, 225, 104), // Button, Checked Tracking, Back 1
-        Color.FromArgb(255, 249, 196) // Button, Checked Tracking, Back 2
-    ];
     #endregion
 
     #endregion
@@ -453,7 +441,7 @@ public abstract class PaletteOffice2010Base : PaletteBase
                 return state == PaletteState.CheckedNormal ? _ribbonColors[(int)SchemeBaseColors.GridDataCellSelected] : SystemColors.Window;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[6] : SystemColors.Window;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7) : SystemColors.Window;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -476,8 +464,8 @@ public abstract class PaletteOffice2010Base : PaletteBase
                         {
                             PaletteBackStyle.TabLowProfile => GlobalStaticValues.EMPTY_COLOR,
                             PaletteBackStyle.TabHighProfile => state == PaletteState.Tracking
-                                ? _buttonBackColors[2]
-                                : _buttonBackColors[4],
+                                ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)
+                                : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                             _ => SystemColors.Window
                         };
 
@@ -488,9 +476,9 @@ public abstract class PaletteOffice2010Base : PaletteBase
                         {
                             return state switch
                             {
-                                PaletteState.CheckedNormal => _buttonBackColors[6],
-                                PaletteState.CheckedPressed => _buttonBackColors[4],
-                                _ => _buttonBackColors[8]
+                                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                                PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                                _ => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9)
                             };
                         }
                         else
@@ -529,7 +517,7 @@ public abstract class PaletteOffice2010Base : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeBaseColors.HeaderDockInactiveBack1];
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[6];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeBaseColors.HeaderSecondaryBack1];
@@ -600,7 +588,7 @@ public abstract class PaletteOffice2010Base : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[2],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -652,10 +640,10 @@ public abstract class PaletteOffice2010Base : PaletteBase
                     PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack1] : _disabledBack,
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1],
                     PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack1],
-                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1] : _buttonBackColors[6],
-                    PaletteState.Tracking => _buttonBackColors[2],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1] : _buttonBackColors[8],
+                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1] : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1] : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -663,7 +651,7 @@ public abstract class PaletteOffice2010Base : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorTrack1],
                     PaletteState.Pressed => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorPressed1],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorChecked1],
@@ -728,7 +716,7 @@ public abstract class PaletteOffice2010Base : PaletteBase
                 return state == PaletteState.CheckedNormal ? _ribbonColors[(int)SchemeBaseColors.GridDataCellSelected] : SystemColors.Window;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[7] : SystemColors.Window;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8) : SystemColors.Window;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -750,7 +738,7 @@ public abstract class PaletteOffice2010Base : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.HeaderDockInactiveBack1],
-                    PaletteState.Tracking or PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => SystemColors.Window,
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
@@ -759,7 +747,7 @@ public abstract class PaletteOffice2010Base : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeBaseColors.HeaderDockInactiveBack1],
-                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.HeaderForm:
@@ -782,7 +770,7 @@ public abstract class PaletteOffice2010Base : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeBaseColors.HeaderDockInactiveBack2];
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[7];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeBaseColors.HeaderSecondaryBack2];
@@ -853,7 +841,7 @@ public abstract class PaletteOffice2010Base : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[3],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -901,15 +889,15 @@ public abstract class PaletteOffice2010Base : PaletteBase
             case PaletteBackStyle.ContextMenuItemHighlight:
                 return state switch
                 {
-                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack1] : _buttonBackColors[1],
+                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack1] : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack2],
                     PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
                         ? GlobalStaticValues.EMPTY_COLOR
                         : _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack2],
-                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack2] : _buttonBackColors[7],
-                    PaletteState.Tracking => _buttonBackColors[3],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
-                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1] : _buttonBackColors[9],
+                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack2] : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
+                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1] : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color10),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -917,7 +905,7 @@ public abstract class PaletteOffice2010Base : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorTrack2],
                     PaletteState.Pressed => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorPressed2],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorChecked2],
@@ -1337,7 +1325,7 @@ public abstract class PaletteOffice2010Base : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking =>
                     _ribbonColors[(int)SchemeBaseColors.ControlBorder],
                 _ => throw DebugTools.NotImplemented(state.ToString())
@@ -1347,7 +1335,7 @@ public abstract class PaletteOffice2010Base : PaletteBase
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
                 PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed
-                    or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                    or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
@@ -1360,8 +1348,8 @@ public abstract class PaletteOffice2010Base : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1395,23 +1383,23 @@ public abstract class PaletteOffice2010Base : PaletteBase
             },
             PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
             {
-                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack2] : _buttonBorderColors[0],
+                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack2] : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
                 PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
                     ? GlobalStaticValues.EMPTY_COLOR
                     : _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBorder],
-                PaletteState.CheckedNormal => _buttonBorderColors[5],
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
-                PaletteState.CheckedTracking => _buttonBorderColors[3],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color6),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1419,10 +1407,10 @@ public abstract class PaletteOffice2010Base : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1],
                 PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack1],
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorBorder],
@@ -1465,7 +1453,7 @@ public abstract class PaletteOffice2010Base : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeBaseColors.ControlBorder],
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1473,7 +1461,7 @@ public abstract class PaletteOffice2010Base : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
@@ -1486,8 +1474,8 @@ public abstract class PaletteOffice2010Base : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1521,21 +1509,21 @@ public abstract class PaletteOffice2010Base : PaletteBase
             },
             PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
             {
-                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack2] : _buttonBorderColors[0],
+                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack2] : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
                 PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBorder],
-                PaletteState.CheckedNormal => _buttonBorderColors[6],
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
-                PaletteState.CheckedTracking => _buttonBorderColors[4],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1543,10 +1531,10 @@ public abstract class PaletteOffice2010Base : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1],
                 PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack1],
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorBorder],
@@ -4047,11 +4035,11 @@ public abstract class PaletteOffice2010Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[0];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color1);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[0];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color1);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[0];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4162,11 +4150,11 @@ public abstract class PaletteOffice2010Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[1];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color2);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[1];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color2);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[1];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4251,11 +4239,11 @@ public abstract class PaletteOffice2010Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[2];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color3);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[2];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color3);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[2];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color3);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4333,11 +4321,11 @@ public abstract class PaletteOffice2010Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[3];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color4);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[3];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color4);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[3];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color4);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4415,11 +4403,11 @@ public abstract class PaletteOffice2010Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[4];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color5);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[4];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color5);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[4];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color5);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4571,8 +4559,8 @@ public abstract class PaletteOffice2010Base : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.Light(_ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder]),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBorderColors[1],
-                    PaletteState.Pressed => _buttonBorderColors[3],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                    PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4611,8 +4599,8 @@ public abstract class PaletteOffice2010Base : PaletteBase
                         _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
                     PaletteState.Normal => ControlPaint.Light(
                         _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
-                    PaletteState.Tracking => ControlPaint.Light(_buttonBackColors[2]),
-                    PaletteState.Pressed => ControlPaint.Light(_buttonBackColors[4]),
+                    PaletteState.Tracking => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)),
+                    PaletteState.Pressed => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5)),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
 
@@ -4660,8 +4648,8 @@ public abstract class PaletteOffice2010Base : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(_ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1],
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[2],
-                    PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4708,8 +4696,8 @@ public abstract class PaletteOffice2010Base : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(_ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack2],
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[3],
-                    PaletteState.Pressed => _buttonBackColors[5],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Bases/PaletteOffice2010Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Bases/PaletteOffice2010Base.cs
@@ -18,8 +18,18 @@ namespace Krypton.Toolkit;
 public abstract class PaletteOffice2010Base : PaletteBase
 {
     #region Static Fields
+
+    // registration guard so default colours are initialised lazily only once
+    private static bool _defaultsRegistered;
+
     static PaletteOffice2010Base()
     {
+        if (_defaultsRegistered)
+        {
+            return;
+        }
+        _defaultsRegistered = true;
+
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
@@ -271,12 +281,36 @@ public abstract class PaletteOffice2010Base : PaletteBase
         [DisallowNull] ImageList checkBoxList,
         [DisallowNull] ImageList galleryButtonList,
         [DisallowNull] Image?[] radioButtonArray)
-        : this(scheme.ToArray(),
-               checkBoxList,
-               galleryButtonList,
-               radioButtonArray,
-               scheme.ToTrackBarArray())
     {
+        Debug.Assert(scheme != null);
+        Debug.Assert(checkBoxList != null);
+        Debug.Assert(galleryButtonList != null);
+        Debug.Assert(radioButtonArray != null);
+
+        // Remember incoming sets of values
+        ThemeName = nameof(PaletteOffice2010Base);
+
+        if (scheme != null)
+        {
+            _ribbonColors = scheme.ToArray();
+        }
+
+        if (checkBoxList != null)
+        {
+            _checkBoxList = checkBoxList;
+        }
+
+        if (galleryButtonList != null)
+        {
+            _galleryButtonList = galleryButtonList;
+        }
+
+        if (radioButtonArray != null)
+        {
+            _radioButtonArray = radioButtonArray;
+        }
+
+        DefineFonts();
         BaseColors = scheme;
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Bases/PaletteOffice2010BlackBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Bases/PaletteOffice2010BlackBase.cs
@@ -18,8 +18,18 @@ namespace Krypton.Toolkit;
 public abstract class PaletteOffice2010BlackBase : PaletteBase
 {
     #region Static Fields
+
+    // registration guard so default colours are initialised lazily only once
+    private static bool _defaultsRegistered;
+
     static PaletteOffice2010BlackBase()
     {
+        if (_defaultsRegistered)
+        {
+            return;
+        }
+        _defaultsRegistered = true;
+
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
@@ -274,12 +284,34 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
         [DisallowNull] ImageList checkBoxList,
         [DisallowNull] ImageList galleryButtonList,
         [DisallowNull] Image?[] radioButtonArray)
-        : this(scheme.ToArray(),
-               checkBoxList,
-               galleryButtonList,
-               radioButtonArray,
-               scheme.ToTrackBarArray())
     {
+        Debug.Assert(scheme != null);
+        Debug.Assert(checkBoxList != null);
+        Debug.Assert(galleryButtonList != null);
+        Debug.Assert(radioButtonArray != null);
+
+        // Remember incoming sets of values
+        ThemeName = nameof(PaletteOffice2010BlackBase);
+
+        if (scheme != null)
+        {
+            _ribbonColors = scheme.ToArray();
+        }
+        if (checkBoxList != null)
+        {
+            _checkBoxList = checkBoxList;
+        }
+        if (galleryButtonList != null)
+        {
+            _galleryButtonList = galleryButtonList;
+        }
+        if (radioButtonArray != null)
+        {
+            _radioButtonArray = radioButtonArray;
+        }
+
+        // Get the font settings from the system
+        DefineFonts();
         BaseColors = scheme;
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Bases/PaletteOffice2010BlackBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Bases/PaletteOffice2010BlackBase.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -18,6 +18,45 @@ namespace Krypton.Toolkit;
 public abstract class PaletteOffice2010BlackBase : PaletteBase
 {
     #region Static Fields
+    static PaletteOffice2010BlackBase()
+    {
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color4, Color.FromArgb(254, 254, 255));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color5, Color.FromArgb(206, 213, 225));
+
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color1, Color.FromArgb(235, 227, 196));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color2, Color.FromArgb(228, 198, 149));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color3, Color.FromArgb(166, 97, 7));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color4, Color.FromArgb(242, 155, 57));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color5, Color.FromArgb(236, 136, 9));
+
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color1, Color.FromArgb(255, 251, 230));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color2, Color.FromArgb(248, 230, 143));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color3, Color.FromArgb(238, 213, 126));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color4, Color.FromArgb(254, 247, 129));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color5, Color.FromArgb(240, 201, 41));
+
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(250, 250, 250));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(250, 250, 250));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(248, 225, 135));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color4, Color.FromArgb(251, 248, 224));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color5, Color.FromArgb(255, 228, 138));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color6, Color.FromArgb(194, 118, 43));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color7, Color.FromArgb(255, 216, 108));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color8, Color.FromArgb(255, 244, 128));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color9, Color.FromArgb(255, 225, 104));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color10, Color.FromArgb(255, 249, 196));
+
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color1, Color.FromArgb(180, 180, 180));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color2, Color.FromArgb(237, 201, 88));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color3, Color.FromArgb(243, 213, 73));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color4, Color.FromArgb(194, 118, 43));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color5, Color.FromArgb(194, 158, 71));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color6, Color.FromArgb(194, 138, 48));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color7, Color.FromArgb(194, 164, 77));
+    }
 
     #region Padding
 
@@ -160,58 +199,6 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
     #endregion
 
     #region Color Arrays
-
-    private static readonly Color[] _appButtonNormal =
-    [
-        Color.FromArgb(243, 245, 248),
-        Color.FromArgb(214, 220, 231),
-        Color.FromArgb(188, 198, 211),
-        Color.FromArgb(254, 254, 255),
-        Color.FromArgb(206, 213, 225)
-    ];
-
-    private static readonly Color[] _appButtonTrack =
-    [
-        Color.FromArgb(255, 251, 230),
-        Color.FromArgb(248, 230, 143),
-        Color.FromArgb(238, 213, 126),
-        Color.FromArgb(254, 247, 129),
-        Color.FromArgb(240, 201, 41)
-    ];
-
-    private static readonly Color[] _appButtonPressed =
-    [
-        Color.FromArgb(235, 227, 196),
-        Color.FromArgb(228, 198, 149),
-        Color.FromArgb(166, 97, 7),
-        Color.FromArgb(242, 155, 57),
-        Color.FromArgb(236, 136, 9)
-    ];
-
-    private static readonly Color[] _buttonBorderColors =
-    [
-        Color.FromArgb(180, 180, 180), // Button, Disabled, Border
-        Color.FromArgb(237, 201, 88), // Button, Tracking, Border 1
-        Color.FromArgb(243, 213, 73), // Button, Tracking, Border 2
-        Color.FromArgb(194, 118, 43), // Button, Pressed, Border 1
-        Color.FromArgb(194, 158, 71), // Button, Pressed, Border 2
-        Color.FromArgb(194, 138, 48), // Button, Checked, Border 1
-        Color.FromArgb(194, 164, 77) // Button, Checked, Border 2
-    ];
-
-    private static readonly Color[] _buttonBackColors =
-    [
-        Color.FromArgb(250, 250, 250), // Button, Disabled, Back 1
-        Color.FromArgb(250, 250, 250), // Button, Disabled, Back 2
-        Color.FromArgb(248, 225, 135), // Button, Tracking, Back 1
-        Color.FromArgb(251, 248, 224), // Button, Tracking, Back 2
-        Color.FromArgb(255, 228, 138), // Button, Pressed, Back 1
-        Color.FromArgb(194, 118, 43), // Button, Pressed, Back 2
-        Color.FromArgb(255, 216, 108), // Button, Checked, Back 1
-        Color.FromArgb(255, 244, 128), // Button, Checked, Back 2
-        Color.FromArgb(255, 225, 104), // Button, Checked Tracking, Back 1
-        Color.FromArgb(255, 249, 196) // Button, Checked Tracking, Back 2
-    ];
 
     #endregion
 
@@ -460,7 +447,7 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
                 return state == PaletteState.CheckedNormal ? BaseColors!.GridDataCellSelected : SystemColors.Window;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[6] : SystemColors.Window;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7) : SystemColors.Window;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -483,8 +470,8 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
                         {
                             PaletteBackStyle.TabLowProfile => GlobalStaticValues.EMPTY_COLOR,
                             PaletteBackStyle.TabHighProfile => state == PaletteState.Tracking
-                                ? _buttonBackColors[2]
-                                : _buttonBackColors[4],
+                                ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)
+                                : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                             _ => SystemColors.Window
                         };
 
@@ -495,9 +482,9 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
                         {
                             return state switch
                             {
-                                PaletteState.CheckedNormal => _buttonBackColors[6],
-                                PaletteState.CheckedPressed => _buttonBackColors[4],
-                                _ => _buttonBackColors[8]
+                                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                                PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                                _ => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9)
                             };
                         }
                         else
@@ -536,7 +523,7 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderDockInactiveBack1;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[6];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderSecondaryBack1;
@@ -607,7 +594,7 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[2],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -659,10 +646,10 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
                     PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack1 : _disabledBack,
                     PaletteState.Normal => BaseColors!.ButtonNormalBack1,
                     PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[6],
-                    PaletteState.Tracking => _buttonBackColors[2],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[8],
+                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -670,7 +657,7 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => BaseColors!.ButtonNavigatorTrack1,
                     PaletteState.Pressed => BaseColors!.ButtonNavigatorPressed1,
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => BaseColors!.ButtonNavigatorChecked1,
@@ -735,7 +722,7 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
                 return state == PaletteState.CheckedNormal ? BaseColors!.GridDataCellSelected : SystemColors.Window;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[7] : SystemColors.Window;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8) : SystemColors.Window;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -757,7 +744,7 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal => BaseColors!.HeaderDockInactiveBack1,
-                    PaletteState.Tracking or PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => SystemColors.Window,
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
@@ -766,7 +753,7 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.HeaderDockInactiveBack1,
-                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.HeaderForm:
@@ -789,7 +776,7 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderDockInactiveBack2;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[7];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderSecondaryBack2;
@@ -860,7 +847,7 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[3],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -908,15 +895,15 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemHighlight:
                 return state switch
                 {
-                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack1 : _buttonBackColors[1],
+                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack2,
                     PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
                         ? GlobalStaticValues.EMPTY_COLOR
                         : BaseColors!.ButtonNormalDefaultBack2,
-                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack2 : _buttonBackColors[7],
-                    PaletteState.Tracking => _buttonBackColors[3],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
-                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[9],
+                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack2 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
+                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color10),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -924,7 +911,7 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => BaseColors!.ButtonNavigatorTrack2,
                     PaletteState.Pressed => BaseColors!.ButtonNavigatorPressed2,
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => BaseColors!.ButtonNavigatorChecked2,
@@ -1257,7 +1244,7 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors!.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1265,7 +1252,7 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
@@ -1278,8 +1265,8 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1313,23 +1300,23 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
             },
             PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
             {
-                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack2 : _buttonBorderColors[0],
+                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack2 : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
                     ? GlobalStaticValues.EMPTY_COLOR
                     : BaseColors!.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[5],
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
-                PaletteState.CheckedTracking => _buttonBorderColors[3],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color6),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1337,10 +1324,10 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors!.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => BaseColors!.ButtonNavigatorBorder,
@@ -1383,7 +1370,7 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors!.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1391,7 +1378,7 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
@@ -1404,8 +1391,8 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1439,21 +1426,21 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
             },
             PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
             {
-                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack2 : _buttonBorderColors[0],
+                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack2 : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[6],
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
-                PaletteState.CheckedTracking => _buttonBorderColors[4],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1461,10 +1448,10 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors!.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => BaseColors!.ButtonNavigatorBorder,
@@ -3740,11 +3727,11 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[0];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color1);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[0];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color1);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[0];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3855,11 +3842,11 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[1];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color2);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[1];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color2);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[1];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3944,11 +3931,11 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[2];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color3);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[2];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color3);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[2];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color3);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4026,11 +4013,11 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[3];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color4);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[3];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color4);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[3];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color4);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4108,11 +4095,11 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[4];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color5);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[4];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color5);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[4];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color5);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4266,8 +4253,8 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.Light(BaseColors!.ButtonNormalBorder),
                     PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBorderColors[1],
-                    PaletteState.Pressed => _buttonBorderColors[3],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                    PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4306,8 +4293,8 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
                         BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => ControlPaint.Light(
                         BaseColors!.ButtonNormalBack1),
-                    PaletteState.Tracking => ControlPaint.Light(_buttonBackColors[2]),
-                    PaletteState.Pressed => ControlPaint.Light(_buttonBackColors[4]),
+                    PaletteState.Tracking => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)),
+                    PaletteState.Pressed => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5)),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
 
@@ -4355,8 +4342,8 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack1,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[2],
-                    PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4403,8 +4390,8 @@ public abstract class PaletteOffice2010BlackBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack2,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[3],
-                    PaletteState.Pressed => _buttonBackColors[5],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlackDarkMode.cs
@@ -580,8 +580,18 @@ public class PaletteOffice2010BlackDarkMode : PaletteOffice2010BlackDarkModeBase
 public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
 {
     #region Static Fields
+
+    // registration guard so default colours are initialised lazily only once
+    private static bool _defaultsRegistered;
+
     static PaletteOffice2010BlackDarkModeBase()
     {
+        if (_defaultsRegistered)
+        {
+            return;
+        }
+        _defaultsRegistered = true;
+
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
@@ -834,12 +844,35 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
         [DisallowNull] ImageList checkBoxList,
         [DisallowNull] ImageList galleryButtonList,
         [DisallowNull] Image?[] radioButtonArray)
-        : this(scheme.ToArray(),
-               checkBoxList,
-               galleryButtonList,
-               radioButtonArray,
-               scheme.ToTrackBarArray())
     {
+        Debug.Assert(scheme != null);
+        Debug.Assert(checkBoxList != null);
+        Debug.Assert(galleryButtonList != null);
+        Debug.Assert(radioButtonArray != null);
+
+        // Remember incoming sets of values
+        ThemeName = nameof(PaletteOffice2010BlackDarkModeBase);
+
+        if (scheme != null)
+        {
+            _ribbonColors = scheme.ToArray();
+        }
+
+        if (checkBoxList != null)
+        {
+            _checkBoxList = checkBoxList;
+        }
+        if (galleryButtonList != null)
+        {
+            _galleryButtonList = galleryButtonList;
+        }
+        if (radioButtonArray != null)
+        {
+            _radioButtonArray = radioButtonArray;
+        }
+
+        // Get the font settings from the system
+        DefineFonts();
         BaseColors = scheme;
     }
 
@@ -5041,7 +5074,6 @@ public class KryptonColorTable2010BlackDarkMode : KryptonColorTable
     /// <param name="colors">Source of </param>
     /// <param name="roundedEdges">Should have rounded edges.</param>
     /// <param name="palette">Associated palette instance.</param>
-    [System.Obsolete("Color[] constructor is deprecated and will be removed in V110. Use KryptonColorSchemeBase overload.", false)]
     public KryptonColorTable2010BlackDarkMode([DisallowNull] Color[] colors,
         InheritBool roundedEdges,
         PaletteBase palette)

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlackDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlackDarkMode.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -580,6 +580,45 @@ public class PaletteOffice2010BlackDarkMode : PaletteOffice2010BlackDarkModeBase
 public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
 {
     #region Static Fields
+    static PaletteOffice2010BlackDarkModeBase()
+    {
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color4, Color.FromArgb(254, 254, 255));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color5, Color.FromArgb(206, 213, 225));
+
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color1, Color.FromArgb(235, 227, 196));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color2, Color.FromArgb(185, 185, 185));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color3, Color.FromArgb(35, 35, 35));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color4, Color.FromArgb(50, 50, 50));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color5, Color.FromArgb(100, 100, 100));
+
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color1, Color.FromArgb(255, 251, 230));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color2, Color.FromArgb(178, 178, 178));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color3, Color.FromArgb(176, 176, 176));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color4, Color.FromArgb(179, 179, 179));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color5, Color.FromArgb(160, 160, 160));
+
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(250, 250, 250));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(250, 250, 250));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(129, 129, 129));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color4, Color.FromArgb(89, 89, 89));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color5, Color.FromArgb(91, 91, 91));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color6, Color.FromArgb(89, 89, 89));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color7, Color.FromArgb(91, 91, 91));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color8, Color.FromArgb(88, 88, 88));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color9, Color.FromArgb(41, 41, 41));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color10, Color.FromArgb(70, 70, 70));
+
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color1, Color.FromArgb(180, 180, 180));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color2, Color.FromArgb(187, 186, 186));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color3, Color.FromArgb(139, 139, 139));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color4, Color.FromArgb(30, 30, 30));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color5, Color.FromArgb(4, 3, 3));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color6, Color.FromArgb(30, 30, 30));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color7, Color.FromArgb(4, 3, 3));
+    }
 
     #region Padding
     private static readonly Padding _contentPaddingGrid = new Padding(2, 1, 2, 1);
@@ -722,58 +761,6 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
     #endregion
 
     #region Colour Arrays
-
-    private static readonly Color[] _appButtonNormal =
-    [
-        Color.FromArgb(243, 245, 248),
-        Color.FromArgb(214, 220, 231),
-        Color.FromArgb(188, 198, 211),
-        Color.FromArgb(254, 254, 255),
-        Color.FromArgb(206, 213, 225)
-    ];
-
-    private static readonly Color[] _appButtonTrack =
-    [
-        Color.FromArgb(255, 251, 230),
-        Color.FromArgb(178, 178, 178),
-        Color.FromArgb(176, 176, 176),
-        Color.FromArgb(179, 179, 179),
-        Color.FromArgb(160, 160, 160)
-    ];
-
-    private static readonly Color[] _appButtonPressed =
-    [
-        Color.FromArgb(235, 227, 196),
-        Color.FromArgb(185, 185, 185),
-        Color.FromArgb(35, 35, 35),
-        Color.FromArgb(50, 50, 50),
-        Color.FromArgb(100, 100, 100)
-    ];
-
-    private static readonly Color[] _buttonBorderColors =
-    [
-        Color.FromArgb(180, 180, 180), // Button, Disabled, Border
-        Color.FromArgb(187, 186, 186),  // Button, Tracking, Border 1
-        Color.FromArgb(139, 139, 139),  // Button, Tracking, Border 2
-        Color.FromArgb(30, 30, 30),  // Button, Pressed, Border 1
-        Color.FromArgb(4, 3, 3),  // Button, Pressed, Border 2
-        Color.FromArgb(30, 30, 30),  // Button, Checked, Border 1
-        Color.FromArgb(4, 3, 3)   // Button, Checked, Border 2
-    ];
-
-    private static readonly Color[] _buttonBackColors =
-    [
-        Color.FromArgb(250, 250, 250), // Button, Disabled, Back 1
-        Color.FromArgb(250, 250, 250), // Button, Disabled, Back 2
-        Color.FromArgb(129, 129, 129), // Button, Tracking, Back 1
-        Color.FromArgb(89, 89, 89), // Button, Tracking, Back 2
-        Color.FromArgb(91, 91, 91), // Button, Pressed, Back 1
-        Color.FromArgb(89, 89, 89),  // Button, Pressed, Back 2
-        Color.FromArgb(91, 91, 91), // Button, Checked, Back 1
-        Color.FromArgb(88, 88, 88), // Button, Checked, Back 2
-        Color.FromArgb(41, 41, 41), // Button, Checked Tracking, Back 1
-        Color.FromArgb(70, 70, 70)  // Button, Checked Tracking, Back 2
-    ];
 
     #endregion
 
@@ -980,7 +967,7 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
                 return state == PaletteState.CheckedNormal ? BaseColors!.GridDataCellSelected : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[6] : BaseColors!.PanelAlternative;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7) : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -1003,8 +990,8 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
                         {
                             PaletteBackStyle.TabLowProfile => GlobalStaticValues.EMPTY_COLOR,
                             PaletteBackStyle.TabHighProfile => state == PaletteState.Tracking
-                                ? _buttonBackColors[2]
-                                : _buttonBackColors[4],
+                                ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)
+                                : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                             _ => SystemColors.Window
                         };
 
@@ -1015,9 +1002,9 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
                         {
                             return state switch
                             {
-                                PaletteState.CheckedNormal => _buttonBackColors[6],
-                                PaletteState.CheckedPressed => _buttonBackColors[4],
-                                _ => _buttonBackColors[8]
+                                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                                PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                                _ => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9)
                             };
                         }
                         else
@@ -1056,7 +1043,7 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderDockInactiveBack1;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[6];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderSecondaryBack1;
@@ -1163,7 +1150,7 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[2],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -1214,10 +1201,10 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
                     PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack1 : _disabledBack,
                     PaletteState.Normal => BaseColors!.ButtonNormalBack1,
                     PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[6],
-                    PaletteState.Tracking => _buttonBackColors[2],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[8],
+                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -1225,7 +1212,7 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => BaseColors!.ButtonNavigatorTrack1,
                     PaletteState.Pressed => BaseColors!.ButtonNavigatorPressed1,
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => BaseColors!.ButtonNavigatorChecked1,
@@ -1290,7 +1277,7 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
                 return state == PaletteState.CheckedNormal ? BaseColors!.GridDataCellSelected : SystemColors.Window;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[7] : SystemColors.Window;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8) : SystemColors.Window;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -1312,7 +1299,7 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal => BaseColors!.HeaderDockInactiveBack1,
-                    PaletteState.Tracking or PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => SystemColors.Window,
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
@@ -1321,7 +1308,7 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.HeaderDockInactiveBack1,
-                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.HeaderForm:
@@ -1344,7 +1331,7 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderDockInactiveBack2;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[7];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderSecondaryBack2;
@@ -1451,7 +1438,7 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[3],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -1499,15 +1486,15 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemHighlight:
                 return state switch
                 {
-                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack1 : _buttonBackColors[1],
+                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack2,
                     PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
                         ? GlobalStaticValues.EMPTY_COLOR
                         : BaseColors!.ButtonNormalDefaultBack2,
-                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack2 : _buttonBackColors[7],
-                    PaletteState.Tracking => _buttonBackColors[3],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
-                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[9],
+                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack2 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
+                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color10),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -1515,7 +1502,7 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => BaseColors!.ButtonNavigatorTrack2,
                     PaletteState.Pressed => BaseColors!.ButtonNavigatorPressed2,
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => Color.FromArgb(73, 73, 73), // ToDo: Find out why this is a problem... BaseColors!.ButtonNavigatorChecked2,
@@ -1846,7 +1833,7 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors!.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1854,7 +1841,7 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
@@ -1867,8 +1854,8 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1902,23 +1889,23 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
             },
             PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
             {
-                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack2 : _buttonBorderColors[0],
+                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack2 : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
                     ? GlobalStaticValues.EMPTY_COLOR
                     : BaseColors!.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[5],
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
-                PaletteState.CheckedTracking => _buttonBorderColors[3],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color6),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1926,10 +1913,10 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors!.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => BaseColors!.ButtonNavigatorBorder,
@@ -1972,7 +1959,7 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors!.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1980,7 +1967,7 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
@@ -1993,8 +1980,8 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -2028,21 +2015,21 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
             },
             PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
             {
-                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack2 : _buttonBorderColors[0],
+                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack2 : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[6],
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
-                PaletteState.CheckedTracking => _buttonBorderColors[4],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -2050,10 +2037,10 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors!.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => BaseColors!.ButtonNavigatorBorder,
@@ -4312,11 +4299,11 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[0];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color1);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[0];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color1);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[0];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4427,11 +4414,11 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[1];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color2);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[1];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color2);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[1];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4516,11 +4503,11 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[2];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color3);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[2];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color3);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[2];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color3);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4598,11 +4585,11 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[3];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color4);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[3];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color4);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[3];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color4);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4680,11 +4667,11 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[4];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color5);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[4];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color5);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[4];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color5);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4836,8 +4823,8 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.Light(BaseColors!.ButtonNormalBorder),
                     PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBorderColors[1],
-                    PaletteState.Pressed => _buttonBorderColors[3],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                    PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4876,8 +4863,8 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
                         BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => ControlPaint.Light(
                         BaseColors!.ButtonNormalBack1),
-                    PaletteState.Tracking => ControlPaint.Light(_buttonBackColors[2]),
-                    PaletteState.Pressed => ControlPaint.Light(_buttonBackColors[4]),
+                    PaletteState.Tracking => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)),
+                    PaletteState.Pressed => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5)),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
 
@@ -4925,8 +4912,8 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack1,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[2],
-                    PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4973,8 +4960,8 @@ public abstract class PaletteOffice2010BlackDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack2,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[3],
-                    PaletteState.Pressed => _buttonBackColors[5],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueDarkMode.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -229,6 +229,45 @@ public class PaletteOffice2010BlueDarkMode : PaletteOffice2010BlueDarkModeBase
 public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
 {
     #region Static Fields
+    static PaletteOffice2010BlueDarkModeBase()
+    {
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color4, Color.FromArgb(254, 254, 255));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color5, Color.FromArgb(206, 213, 225));
+
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color1, Color.FromArgb(185, 215, 250));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color2, Color.FromArgb(190, 220, 245));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color3, Color.FromArgb(98, 155, 230));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color4, Color.FromArgb(110, 160, 225));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color5, Color.FromArgb(120, 175, 240));
+
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color1, Color.FromArgb(255, 251, 230));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color2, Color.FromArgb(180, 210, 255));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color3, Color.FromArgb(96, 147, 235));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color4, Color.FromArgb(110, 150, 240));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color5, Color.FromArgb(115, 155, 245));
+
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(221, 221, 221));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(236, 236, 236));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(141, 168, 203));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color4, Color.FromArgb(95, 127, 169));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color5, Color.FromArgb(96, 150, 220));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color6, Color.FromArgb(179, 209, 247));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color7, Color.FromArgb(32, 98, 183));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color8, Color.FromArgb(141, 180, 230));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color9, Color.FromArgb(63, 122, 197));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color10, Color.FromArgb(96, 147, 213));
+
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color1, Color.FromArgb(212, 212, 212));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color2, Color.FromArgb(179, 209, 255));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color3, Color.FromArgb(179, 209, 249));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color4, Color.FromArgb(96, 147, 230));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color5, Color.FromArgb(32, 98, 200));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color6, Color.FromArgb(96, 147, 235));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color7, Color.FromArgb(63, 122, 220));
+    }
 
     #region Padding
 
@@ -371,58 +410,6 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
     #endregion
 
     #region Colour Arrays
-
-    private static readonly Color[] _appButtonNormal =
-    [
-        Color.FromArgb(243, 245, 248),
-        Color.FromArgb(214, 220, 231),
-        Color.FromArgb(188, 198, 211),
-        Color.FromArgb(254, 254, 255),
-        Color.FromArgb(206, 213, 225)
-    ];
-
-    private static readonly Color[] _appButtonTrack =
-    [
-        Color.FromArgb(255, 251, 230),
-        Color.FromArgb(180, 210, 255),
-        Color.FromArgb(96, 147, 235),
-        Color.FromArgb(110, 150, 240),
-        Color.FromArgb(115, 155, 245)
-    ];
-
-    private static readonly Color[] _appButtonPressed =
-    [
-        Color.FromArgb(185, 215, 250),
-        Color.FromArgb(190, 220, 245),
-        Color.FromArgb(98, 155, 230),
-        Color.FromArgb(110, 160, 225),
-        Color.FromArgb(120, 175, 240)
-    ];
-
-    private static readonly Color[] _buttonBorderColors =
-    [
-        Color.FromArgb(212, 212, 212), // Button, Disabled, Border
-        Color.FromArgb(179, 209, 255), // Button, Tracking, Border 1
-        Color.FromArgb(179, 209, 249), // Button, Tracking, Border 2
-        Color.FromArgb(96, 147, 230), // Button, Pressed, Border 1
-        Color.FromArgb(32, 98, 200), // Button, Pressed, Border 2
-        Color.FromArgb(96, 147, 235), // Button, Checked, Border 1
-        Color.FromArgb(63, 122, 220)  // Button, Checked, Border 2
-    ];
-
-    private static readonly Color[] _buttonBackColors =
-    [
-        Color.FromArgb(221, 221, 221), // Button, Disabled, Back 1
-        Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
-        Color.FromArgb(141, 168, 203), // Button, Tracking, Back 1
-        Color.FromArgb(95, 127, 169), // Button, Tracking, Back 2
-        Color.FromArgb(96, 150, 220), // Button, Pressed, Back 1
-        Color.FromArgb(179, 209, 247), // Button, Pressed, Back 2
-        Color.FromArgb(32, 98, 183), // Button, Checked, Back 1
-        Color.FromArgb(141, 180, 230), // Button, Checked, Back 2
-        Color.FromArgb(63, 122, 197), // Button, Checked Tracking, Back 1
-        Color.FromArgb(96, 147, 213)  // Button, Checked Tracking, Back 2
-    ];
 
     #endregion
 
@@ -628,7 +615,7 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
                 return state == PaletteState.CheckedNormal ? BaseColors!.GridDataCellSelected : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[6] : BaseColors!.PanelAlternative;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7) : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -651,8 +638,8 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
                         {
                             PaletteBackStyle.TabLowProfile => GlobalStaticValues.EMPTY_COLOR,
                             PaletteBackStyle.TabHighProfile => state == PaletteState.Tracking
-                                ? _buttonBackColors[2]
-                                : _buttonBackColors[4],
+                                ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)
+                                : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                             _ => SystemColors.Window
                         };
 
@@ -663,9 +650,9 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
                         {
                             return state switch
                             {
-                                PaletteState.CheckedNormal => _buttonBackColors[6],
-                                PaletteState.CheckedPressed => _buttonBackColors[4],
-                                _ => _buttonBackColors[8]
+                                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                                PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                                _ => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9)
                             };
                         }
                         else
@@ -704,7 +691,7 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderDockInactiveBack1;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[6];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderSecondaryBack1;
@@ -811,7 +798,7 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[2],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -862,10 +849,10 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
                     PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack1 : _disabledBack,
                     PaletteState.Normal => BaseColors!.ButtonNormalBack1,
                     PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[6],
-                    PaletteState.Tracking => _buttonBackColors[2],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[8],
+                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -873,7 +860,7 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => BaseColors!.ButtonNavigatorTrack1,
                     PaletteState.Pressed => BaseColors!.ButtonNavigatorPressed1,
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => BaseColors!.ButtonNavigatorChecked1,
@@ -938,7 +925,7 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
                 return state == PaletteState.CheckedNormal ? BaseColors!.GridDataCellSelected : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[7] : BaseColors!.PanelAlternative;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8) : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -960,7 +947,7 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal => BaseColors!.HeaderDockInactiveBack1,
-                    PaletteState.Tracking or PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => SystemColors.Window,
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
@@ -969,7 +956,7 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.HeaderDockInactiveBack1,
-                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.HeaderForm:
@@ -992,7 +979,7 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderDockInactiveBack2;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[7];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderSecondaryBack2;
@@ -1099,7 +1086,7 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[3],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -1147,15 +1134,15 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemHighlight:
                 return state switch
                 {
-                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack1 : _buttonBackColors[1],
+                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack2,
                     PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
                         ? GlobalStaticValues.EMPTY_COLOR
                         : BaseColors!.ButtonNormalDefaultBack2,
-                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack2 : _buttonBackColors[7],
-                    PaletteState.Tracking => _buttonBackColors[3],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
-                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[9],
+                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack2 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
+                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color10),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -1163,7 +1150,7 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => BaseColors!.ButtonNavigatorTrack2,
                     PaletteState.Pressed => BaseColors!.ButtonNavigatorPressed2,
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => BaseColors!.ButtonNavigatorChecked2,
@@ -1494,7 +1481,7 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors!.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1502,7 +1489,7 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
@@ -1515,8 +1502,8 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1550,23 +1537,23 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
             },
             PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
             {
-                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack2 : _buttonBorderColors[0],
+                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack2 : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
                     ? GlobalStaticValues.EMPTY_COLOR
                     : BaseColors!.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[5],
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
-                PaletteState.CheckedTracking => _buttonBorderColors[3],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color6),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1574,10 +1561,10 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors!.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => BaseColors!.ButtonNavigatorBorder,
@@ -1620,7 +1607,7 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors!.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1628,7 +1615,7 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
@@ -1641,8 +1628,8 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1676,21 +1663,21 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
             },
             PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
             {
-                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack2 : _buttonBorderColors[0],
+                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack2 : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[6],
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
-                PaletteState.CheckedTracking => _buttonBorderColors[4],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1698,10 +1685,10 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors!.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => BaseColors!.ButtonNavigatorBorder,
@@ -3938,11 +3925,11 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[0];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color1);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[0];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color1);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[0];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4053,11 +4040,11 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[1];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color2);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[1];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color2);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[1];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4142,11 +4129,11 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[2];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color3);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[2];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color3);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[2];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color3);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4224,11 +4211,11 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[3];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color4);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[3];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color4);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[3];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color4);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4306,11 +4293,11 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[4];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color5);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[4];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color5);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[4];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color5);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4462,8 +4449,8 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.Light(BaseColors!.ButtonNormalBorder),
                     PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBorderColors[1],
-                    PaletteState.Pressed => _buttonBorderColors[3],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                    PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4502,8 +4489,8 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
                         BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => ControlPaint.Light(
                         BaseColors!.ButtonNormalBack1),
-                    PaletteState.Tracking => ControlPaint.Light(_buttonBackColors[2]),
-                    PaletteState.Pressed => ControlPaint.Light(_buttonBackColors[4]),
+                    PaletteState.Tracking => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)),
+                    PaletteState.Pressed => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5)),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
 
@@ -4551,8 +4538,8 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack1,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[2],
-                    PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4599,8 +4586,8 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack2,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[3],
-                    PaletteState.Pressed => _buttonBackColors[5],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueDarkMode.cs
@@ -229,8 +229,18 @@ public class PaletteOffice2010BlueDarkMode : PaletteOffice2010BlueDarkModeBase
 public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
 {
     #region Static Fields
+
+    // registration guard so default colours are initialised lazily only once
+    private static bool _defaultsRegistered;
+
     static PaletteOffice2010BlueDarkModeBase()
     {
+        if (_defaultsRegistered)
+        {
+            return;
+        }
+        _defaultsRegistered = true;
+
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
@@ -482,12 +492,34 @@ public abstract class PaletteOffice2010BlueDarkModeBase : PaletteBase
         [DisallowNull] ImageList checkBoxList,
         [DisallowNull] ImageList galleryButtonList,
         [DisallowNull] Image?[] radioButtonArray)
-        : this(scheme.ToArray(),
-               checkBoxList,
-               galleryButtonList,
-               radioButtonArray,
-               scheme.ToTrackBarArray())
     {
+        Debug.Assert(scheme != null);
+        Debug.Assert(checkBoxList != null);
+        Debug.Assert(galleryButtonList != null);
+        Debug.Assert(radioButtonArray != null);
+
+        // Remember incoming sets of values
+        ThemeName = nameof(PaletteOffice2010BlueDarkModeBase);
+
+        if (scheme != null)
+        {
+            _ribbonColors = scheme.ToArray();
+        }
+        if (checkBoxList != null)
+        {
+            _checkBoxList = checkBoxList;
+        }
+        if (galleryButtonList != null)
+        {
+            _galleryButtonList = galleryButtonList;
+        }
+        if (radioButtonArray != null)
+        {
+            _radioButtonArray = radioButtonArray;
+        }
+
+        // Get the font settings from the system
+        DefineFonts();
         BaseColors = scheme;
     }
 
@@ -4667,7 +4699,6 @@ public class KryptonColorTable2010BlueDarkMode : KryptonColorTable
     /// <param name="colors">Source of </param>
     /// <param name="roundedEdges">Should have rounded edges.</param>
     /// <param name="palette">Associated palette instance.</param>
-    [System.Obsolete("Color[] constructor is deprecated and will be removed in V110. Use KryptonColorSchemeBase overload.", false)]
     public KryptonColorTable2010BlueDarkMode([DisallowNull] Color[] colors,
         InheritBool roundedEdges,
         PaletteBase palette)

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueLightMode.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -234,6 +234,27 @@ public class PaletteOffice2010BlueLightMode : PaletteOffice2010BlueLightModeBase
 public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
 {
     #region Static Fields
+    static PaletteOffice2010BlueLightModeBase()
+    {
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(221, 221, 221));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(236, 236, 236));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(188, 213, 239));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color4, Color.FromArgb(168, 200, 234));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color5, Color.FromArgb(209, 226, 244));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color6, Color.FromArgb(188, 213, 239));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color7, Color.FromArgb(189, 213, 233));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color8, Color.FromArgb(188, 213, 239));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color9, Color.FromArgb(209, 226, 244));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color10, Color.FromArgb(210, 226, 244));
+
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color1, Color.FromArgb(212, 212, 212));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color2, Color.FromArgb(168, 200, 234));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color3, Color.FromArgb(170, 210, 245));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color4, Color.FromArgb(155, 205, 230));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color5, Color.FromArgb(150, 200, 225));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color6, Color.FromArgb(148, 197,  220));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color7, Color.FromArgb(160, 205, 240));
+    }
 
     #region Padding
 
@@ -376,36 +397,6 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
     #endregion
 
     #region Colour Arrays
-
-    private static readonly Color[] _appButtonNormal = [Color.FromArgb(243, 245, 248), Color.FromArgb(214, 220, 231), Color.FromArgb(188, 198, 211), Color.FromArgb(254, 254, 255), Color.FromArgb(206, 213, 225)
-    ];
-    private static readonly Color[] _appButtonTrack = [Color.FromArgb(255, 251, 230), Color.FromArgb(248, 230, 143), Color.FromArgb(238, 213, 126), Color.FromArgb(254, 247, 129), Color.FromArgb(240, 201, 41)
-    ];
-    private static readonly Color[] _appButtonPressed = [Color.FromArgb(235, 227, 196), Color.FromArgb(228, 198, 149), Color.FromArgb(166, 97, 7), Color.FromArgb(242, 155, 57), Color.FromArgb(236, 136, 9)
-    ];
-    private static readonly Color[] _buttonBorderColors =
-    [
-        Color.FromArgb(212, 212, 212), // Button, Disabled, Border
-        Color.FromArgb(168, 200, 234), // Button, Tracking, Border 1
-        Color.FromArgb(170, 210, 245), // Button, Tracking, Border 2
-        Color.FromArgb(155, 205, 230), // Button, Pressed, Border 1
-        Color.FromArgb(150, 200, 225), // Button, Pressed, Border 2
-        Color.FromArgb(148, 197,  220), // Button, Checked, Border 1
-        Color.FromArgb(160, 205, 240)  // Button, Checked, Border 2
-    ];
-    private static readonly Color[] _buttonBackColors =
-    [
-        Color.FromArgb(221, 221, 221), // Button, Disabled, Back 1
-        Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
-        Color.FromArgb(188, 213, 239), // Button, Tracking, Back 1
-        Color.FromArgb(168, 200, 234), // Button, Tracking, Back 2
-        Color.FromArgb(209, 226, 244), // Button, Pressed, Back 1
-        Color.FromArgb(188, 213, 239), // Button, Pressed, Back 2
-        Color.FromArgb(189, 213, 233), // Button, Checked, Back 1
-        Color.FromArgb(188, 213, 239), // Button, Checked, Back 2
-        Color.FromArgb(209, 226, 244), // Button, Checked Tracking, Back 1
-        Color.FromArgb(210, 226, 244)  // Button, Checked Tracking, Back 2
-    ];
 
     #endregion
 
@@ -611,7 +602,7 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
                 return state == PaletteState.CheckedNormal ? BaseColors!.GridDataCellSelected : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[6] : BaseColors!.PanelAlternative;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7) : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -634,8 +625,8 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
                         {
                             PaletteBackStyle.TabLowProfile => GlobalStaticValues.EMPTY_COLOR,
                             PaletteBackStyle.TabHighProfile => state == PaletteState.Tracking
-                                ? _buttonBackColors[2]
-                                : _buttonBackColors[4],
+                                ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)
+                                : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                             _ => SystemColors.Window
                         };
 
@@ -646,9 +637,9 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
                         {
                             return state switch
                             {
-                                PaletteState.CheckedNormal => _buttonBackColors[6],
-                                PaletteState.CheckedPressed => _buttonBackColors[4],
-                                _ => _buttonBackColors[8]
+                                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                                PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                                _ => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9)
                             };
                         }
                         else
@@ -687,7 +678,7 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderDockInactiveBack1;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[6];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderSecondaryBack1;
@@ -794,7 +785,7 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[2],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -845,10 +836,10 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
                     PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack1 : _disabledBack,
                     PaletteState.Normal => BaseColors!.ButtonNormalBack1,
                     PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[6],
-                    PaletteState.Tracking => _buttonBackColors[2],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[8],
+                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -856,7 +847,7 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => BaseColors!.ButtonNavigatorTrack1,
                     PaletteState.Pressed => BaseColors!.ButtonNavigatorPressed1,
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => BaseColors!.ButtonNavigatorChecked1,
@@ -921,7 +912,7 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
                 return state == PaletteState.CheckedNormal ? BaseColors!.GridDataCellSelected : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[7] : BaseColors!.PanelAlternative;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8) : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -943,7 +934,7 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal => BaseColors!.HeaderDockInactiveBack1,
-                    PaletteState.Tracking or PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => SystemColors.Window,
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
@@ -952,7 +943,7 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.HeaderDockInactiveBack1,
-                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.HeaderForm:
@@ -975,7 +966,7 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderDockInactiveBack2;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[7];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderSecondaryBack2;
@@ -1082,7 +1073,7 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[3],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -1130,15 +1121,15 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemHighlight:
                 return state switch
                 {
-                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack1 : _buttonBackColors[1],
+                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack2,
                     PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
                         ? GlobalStaticValues.EMPTY_COLOR
                         : BaseColors!.ButtonNormalDefaultBack2,
-                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack2 : _buttonBackColors[7],
-                    PaletteState.Tracking => _buttonBackColors[3],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
-                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[9],
+                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack2 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
+                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color10),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -1146,7 +1137,7 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => BaseColors!.ButtonNavigatorTrack2,
                     PaletteState.Pressed => BaseColors!.ButtonNavigatorPressed2,
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => BaseColors!.ButtonNavigatorChecked2,
@@ -1477,7 +1468,7 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors!.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1485,7 +1476,7 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
@@ -1498,8 +1489,8 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1533,23 +1524,23 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
             },
             PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
             {
-                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack2 : _buttonBorderColors[0],
+                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack2 : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
                     ? GlobalStaticValues.EMPTY_COLOR
                     : BaseColors!.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[5],
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
-                PaletteState.CheckedTracking => _buttonBorderColors[3],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color6),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1557,10 +1548,10 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors!.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => BaseColors!.ButtonNavigatorBorder,
@@ -1603,7 +1594,7 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors!.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1611,7 +1602,7 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
@@ -1624,8 +1615,8 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1659,21 +1650,21 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
             },
             PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
             {
-                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack2 : _buttonBorderColors[0],
+                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack2 : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[6],
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
-                PaletteState.CheckedTracking => _buttonBorderColors[4],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1681,10 +1672,10 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors!.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => BaseColors!.ButtonNavigatorBorder,
@@ -3921,11 +3912,11 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[0];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color1);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[0];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color1);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[0];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4036,11 +4027,11 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[1];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color2);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[1];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color2);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[1];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4125,11 +4116,11 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[2];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color3);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[2];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color3);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[2];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color3);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4207,11 +4198,11 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[3];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color4);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[3];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color4);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[3];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color4);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4289,11 +4280,11 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[4];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color5);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[4];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color5);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[4];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color5);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4445,8 +4436,8 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.Light(BaseColors!.ButtonNormalBorder),
                     PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBorderColors[1],
-                    PaletteState.Pressed => _buttonBorderColors[3],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                    PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4485,8 +4476,8 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
                         BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => ControlPaint.Light(
                         BaseColors!.ButtonNormalBack1),
-                    PaletteState.Tracking => ControlPaint.Light(_buttonBackColors[2]),
-                    PaletteState.Pressed => ControlPaint.Light(_buttonBackColors[4]),
+                    PaletteState.Tracking => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)),
+                    PaletteState.Pressed => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5)),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
 
@@ -4534,8 +4525,8 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack1,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[2],
-                    PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4582,8 +4573,8 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack2,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[3],
-                    PaletteState.Pressed => _buttonBackColors[5],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010BlueLightMode.cs
@@ -234,8 +234,18 @@ public class PaletteOffice2010BlueLightMode : PaletteOffice2010BlueLightModeBase
 public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
 {
     #region Static Fields
+
+    // registration guard so default colours are initialised lazily only once
+    private static bool _defaultsRegistered;
+
     static PaletteOffice2010BlueLightModeBase()
     {
+        if (_defaultsRegistered)
+        {
+            return;
+        }
+        _defaultsRegistered = true;
+
         RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(221, 221, 221));
         RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(236, 236, 236));
         RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(188, 213, 239));
@@ -469,12 +479,34 @@ public abstract class PaletteOffice2010BlueLightModeBase : PaletteBase
         [DisallowNull] ImageList checkBoxList,
         [DisallowNull] ImageList galleryButtonList,
         [DisallowNull] Image?[] radioButtonArray)
-        : this(scheme.ToArray(),
-               checkBoxList,
-               galleryButtonList,
-               radioButtonArray,
-               scheme.ToTrackBarArray())
     {
+        Debug.Assert(scheme != null);
+        Debug.Assert(checkBoxList != null);
+        Debug.Assert(galleryButtonList != null);
+        Debug.Assert(radioButtonArray != null);
+
+        // Remember incoming sets of values
+        ThemeName = nameof(PaletteOffice2010BlueLightModeBase);
+
+        if (scheme != null)
+        {
+            _ribbonColors = scheme.ToArray();
+        }
+        if (checkBoxList != null)
+        {
+            _checkBoxList = checkBoxList;
+        }
+        if (galleryButtonList != null)
+        {
+            _galleryButtonList = galleryButtonList;
+        }
+        if (radioButtonArray != null)
+        {
+            _radioButtonArray = radioButtonArray;
+        }
+
+        // Get the font settings from the system
+        DefineFonts();
         BaseColors = scheme;
     }
 
@@ -4654,7 +4686,6 @@ public class KryptonColorTable2010BlueLightMode : KryptonColorTable
     /// <param name="colors">Source of </param>
     /// <param name="roundedEdges">Should have rounded edges.</param>
     /// <param name="palette">Associated palette instance.</param>
-    [System.Obsolete("Color[] constructor is deprecated and will be removed in V110. Use KryptonColorSchemeBase overload.", false)]
     public KryptonColorTable2010BlueLightMode([DisallowNull] Color[] colors,
         InheritBool roundedEdges,
         PaletteBase palette)

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverDarkMode.cs
@@ -229,8 +229,18 @@ public class PaletteOffice2010SilverDarkMode : PaletteOffice2010SilverDarkModeBa
 public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
 {
     #region Static Fields
+
+    // registration guard so default colours are initialised lazily only once
+    private static bool _defaultsRegistered;
+
     static PaletteOffice2010SilverDarkModeBase()
     {
+        if (_defaultsRegistered)
+        {
+            return;
+        }
+        _defaultsRegistered = true;
+
         RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(221, 221, 221));
         RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(236, 236, 236));
         RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(142,156,187));
@@ -466,12 +476,35 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
         [DisallowNull] ImageList checkBoxList,
         [DisallowNull] ImageList galleryButtonList,
         [DisallowNull] Image?[] radioButtonArray)
-        : this(scheme.ToArray(),
-               checkBoxList,
-               galleryButtonList,
-               radioButtonArray,
-               scheme.ToTrackBarArray())
     {
+        Debug.Assert(scheme != null);
+        Debug.Assert(checkBoxList != null);
+        Debug.Assert(galleryButtonList != null);
+        Debug.Assert(radioButtonArray != null);
+
+        // Remember incoming sets of values
+        ThemeName = nameof(PaletteOffice2010SilverDarkModeBase);
+
+        if (scheme != null)
+        {
+            _ribbonColors = scheme.ToArray();
+        }
+
+        if (checkBoxList != null)
+        {
+            _checkBoxList = checkBoxList;
+        }
+        if (galleryButtonList != null)
+        {
+            _galleryButtonList = galleryButtonList;
+        }
+        if (radioButtonArray != null)
+        {
+            _radioButtonArray = radioButtonArray;
+        }
+
+        // Get the font settings from the system
+        DefineFonts();
         BaseColors = scheme;
     }
 
@@ -4757,7 +4790,6 @@ public class KryptonColorTable2010SilverDarkMode : KryptonColorTable
     /// <param name="colors">Source of </param>
     /// <param name="roundedEdges">Should have rounded edges.</param>
     /// <param name="palette">Associated palette instance.</param>
-    [System.Obsolete("Color[] constructor is deprecated and will be removed in V110. Use KryptonColorSchemeBase overload.", false)]
     public KryptonColorTable2010SilverDarkMode([DisallowNull] Color[] colors,
         InheritBool roundedEdges,
         PaletteBase palette)

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverDarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverDarkMode.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -229,6 +229,27 @@ public class PaletteOffice2010SilverDarkMode : PaletteOffice2010SilverDarkModeBa
 public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
 {
     #region Static Fields
+    static PaletteOffice2010SilverDarkModeBase()
+    {
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(221, 221, 221));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(236, 236, 236));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(142,156,187));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color4, Color.FromArgb(106,123,164));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color5, Color.FromArgb(73, 84, 113));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color6, Color.FromArgb(54,64,88));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color7, Color.FromArgb(54,64,88));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color8, Color.FromArgb(122, 137, 174));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color9, Color.FromArgb(119, 134, 172));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color10, Color.FromArgb(135, 148, 182));
+
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color1, Color.FromArgb(212, 212, 212));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color2, Color.FromArgb(163, 179, 220));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color3, Color.FromArgb(128, 141, 173));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color4, Color.FromArgb(90, 99, 122));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color5, Color.FromArgb(118, 130, 160));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color6, Color.FromArgb(136, 150, 185));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color7, Color.FromArgb(174, 192, 236));
+    }
 
     #region Padding
 
@@ -372,36 +393,6 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
     #endregion
 
     #region Colour Arrays
-
-    private static readonly Color[] _appButtonNormal = [Color.FromArgb(243, 245, 248), Color.FromArgb(214, 220, 231), Color.FromArgb(188, 198, 211), Color.FromArgb(254, 254, 255), Color.FromArgb(206, 213, 225)
-    ];
-    private static readonly Color[] _appButtonTrack = [Color.FromArgb(255, 251, 230), Color.FromArgb(248, 230, 143), Color.FromArgb(238, 213, 126), Color.FromArgb(254, 247, 129), Color.FromArgb(240, 201, 41)
-    ];
-    private static readonly Color[] _appButtonPressed = [Color.FromArgb(235, 227, 196), Color.FromArgb(228, 198, 149), Color.FromArgb(166, 97, 7), Color.FromArgb(242, 155, 57), Color.FromArgb(236, 136, 9)
-    ];
-    private static readonly Color[] _buttonBorderColors =
-    [
-        Color.FromArgb(212, 212, 212), // Button, Disabled, Border
-        Color.FromArgb(163, 179, 220), // Button, Tracking, Border 1
-        Color.FromArgb(128, 141, 173), // Button, Tracking, Border 2
-        Color.FromArgb(90, 99, 122), // Button, Pressed, Border 1
-        Color.FromArgb(118, 130, 160), // Button, Pressed, Border 2
-        Color.FromArgb(136, 150, 185), // Button, Checked, Border 1
-        Color.FromArgb(174, 192, 236)  // Button, Checked, Border 2
-    ];
-    private static readonly Color[] _buttonBackColors =
-    [
-        Color.FromArgb(221, 221, 221), // Button, Disabled, Back 1
-        Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
-        Color.FromArgb(142,156,187), // Button, Tracking, Back 1
-        Color.FromArgb(106,123,164), // Button, Tracking, Back 2
-        Color.FromArgb(73, 84, 113), // Button, Pressed, Back 1
-        Color.FromArgb(54,64,88), // Button, Pressed, Back 2
-        Color.FromArgb(54,64,88), // Button, Checked, Back 1
-        Color.FromArgb(122, 137, 174), // Button, Checked, Back 2
-        Color.FromArgb(119, 134, 172), // Button, Checked Tracking, Back 1
-        Color.FromArgb(135, 148, 182)  // Button, Checked Tracking, Back 2
-    ];
 
     #endregion
 
@@ -608,7 +599,7 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
                 return state == PaletteState.CheckedNormal ? BaseColors!.GridDataCellSelected : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[6] : BaseColors!.PanelAlternative;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7) : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -631,8 +622,8 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
                         {
                             PaletteBackStyle.TabLowProfile => GlobalStaticValues.EMPTY_COLOR,
                             PaletteBackStyle.TabHighProfile => state == PaletteState.Tracking
-                                ? _buttonBackColors[2]
-                                : _buttonBackColors[4],
+                                ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)
+                                : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                             _ => SystemColors.Window
                         };
 
@@ -643,9 +634,9 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
                         {
                             return state switch
                             {
-                                PaletteState.CheckedNormal => _buttonBackColors[6],
-                                PaletteState.CheckedPressed => _buttonBackColors[4],
-                                _ => _buttonBackColors[8]
+                                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                                PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                                _ => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9)
                             };
                         }
                         else
@@ -684,7 +675,7 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderDockInactiveBack1;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[6];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderSecondaryBack1;
@@ -791,7 +782,7 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[2],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -842,10 +833,10 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
                     PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack1 : _disabledBack,
                     PaletteState.Normal => BaseColors!.ButtonNormalBack1,
                     PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[6],
-                    PaletteState.Tracking => _buttonBackColors[2],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[8],
+                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -853,7 +844,7 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => BaseColors!.ButtonNavigatorTrack1,
                     PaletteState.Pressed => BaseColors!.ButtonNavigatorPressed1,
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => BaseColors!.ButtonNavigatorChecked1,
@@ -918,7 +909,7 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
                 return state == PaletteState.CheckedNormal ? BaseColors!.GridDataCellSelected : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[7] : BaseColors!.PanelAlternative;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8) : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -940,7 +931,7 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal => BaseColors!.HeaderDockInactiveBack1,
-                    PaletteState.Tracking or PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => SystemColors.Window,
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
@@ -949,7 +940,7 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.HeaderDockInactiveBack1,
-                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.HeaderForm:
@@ -972,7 +963,7 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderDockInactiveBack2;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[7];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderSecondaryBack2;
@@ -1079,7 +1070,7 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[3],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -1127,15 +1118,15 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemHighlight:
                 return state switch
                 {
-                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack1 : _buttonBackColors[1],
+                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack2,
                     PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
                         ? GlobalStaticValues.EMPTY_COLOR
                         : BaseColors!.ButtonNormalDefaultBack2,
-                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack2 : _buttonBackColors[7],
-                    PaletteState.Tracking => _buttonBackColors[3],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
-                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[9],
+                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack2 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
+                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color10),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -1143,7 +1134,7 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => BaseColors!.ButtonNavigatorTrack2,
                     PaletteState.Pressed => BaseColors!.ButtonNavigatorPressed2,
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => BaseColors!.ButtonNavigatorChecked2,
@@ -1474,7 +1465,7 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors!.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1482,7 +1473,7 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
@@ -1495,8 +1486,8 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1530,23 +1521,23 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
             },
             PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
             {
-                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack2 : _buttonBorderColors[0],
+                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack2 : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
                     ? GlobalStaticValues.EMPTY_COLOR
                     : BaseColors!.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[5],
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
-                PaletteState.CheckedTracking => _buttonBorderColors[3],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color6),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1554,10 +1545,10 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors!.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => BaseColors!.ButtonNavigatorBorder,
@@ -1600,7 +1591,7 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors!.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1608,7 +1599,7 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
@@ -1621,8 +1612,8 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1656,21 +1647,21 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
             },
             PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
             {
-                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack2 : _buttonBorderColors[0],
+                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack2 : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[6],
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
-                PaletteState.CheckedTracking => _buttonBorderColors[4],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1678,10 +1669,10 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors!.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => BaseColors!.ButtonNavigatorBorder,
@@ -3969,11 +3960,11 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[0];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color1);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[0];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color1);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[0];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4090,11 +4081,11 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[1];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color2);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[1];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color2);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[1];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4185,11 +4176,11 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[2];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color3);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[2];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color3);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[2];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color3);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4273,11 +4264,11 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[3];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color4);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[3];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color4);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[3];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color4);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4361,11 +4352,11 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[4];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color5);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[4];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color5);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[4];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color5);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4529,8 +4520,8 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.Light(BaseColors!.ButtonNormalBorder),
                     PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBorderColors[1],
-                    PaletteState.Pressed => _buttonBorderColors[3],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                    PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4575,8 +4566,8 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
                         BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => ControlPaint.Light(
                         BaseColors!.ButtonNormalBack1),
-                    PaletteState.Tracking => ControlPaint.Light(_buttonBackColors[2]),
-                    PaletteState.Pressed => ControlPaint.Light(_buttonBackColors[4]),
+                    PaletteState.Tracking => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)),
+                    PaletteState.Pressed => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5)),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
 
@@ -4630,8 +4621,8 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack1,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[2],
-                    PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4684,8 +4675,8 @@ public abstract class PaletteOffice2010SilverDarkModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack2,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[3],
-                    PaletteState.Pressed => _buttonBackColors[5],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverLightMode.cs
@@ -229,8 +229,18 @@ public class PaletteOffice2010SilverLightMode : PaletteOffice2010SilverLightMode
 public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
 {
     #region Static Fields
+
+    // registration guard so default colours are initialised lazily only once
+    private static bool _defaultsRegistered;
+
     static PaletteOffice2010SilverLightModeBase()
     {
+        if (_defaultsRegistered)
+        {
+            return;
+        }
+        _defaultsRegistered = true;
+
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
@@ -485,12 +495,36 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
         [DisallowNull] ImageList checkBoxList,
         [DisallowNull] ImageList galleryButtonList,
         [DisallowNull] Image?[] radioButtonArray)
-        : this(scheme.ToArray(),
-               checkBoxList,
-               galleryButtonList,
-               radioButtonArray,
-               scheme.ToTrackBarArray())
     {
+        Debug.Assert(scheme != null);
+        Debug.Assert(checkBoxList != null);
+        Debug.Assert(galleryButtonList != null);
+        Debug.Assert(radioButtonArray != null);
+
+        // Remember incoming sets of values
+        ThemeName = nameof(PaletteOffice2010SilverLightModeBase);
+
+        if (scheme != null)
+        {
+            _ribbonColors = scheme.ToArray();
+        }
+
+        if (checkBoxList != null)
+        {
+            _checkBoxList = checkBoxList;
+        }
+
+        if (galleryButtonList != null)
+        {
+            _galleryButtonList = galleryButtonList;
+        }
+        if (radioButtonArray != null)
+        {
+            _radioButtonArray = radioButtonArray;
+        }
+
+        // Get the font settings from the system
+        DefineFonts();
         BaseColors = scheme;
     }
 
@@ -4671,7 +4705,6 @@ public class KryptonColorTable2010SilverLightMode : KryptonColorTable
     /// <param name="colors">Source of </param>
     /// <param name="roundedEdges">Should have rounded edges.</param>
     /// <param name="palette">Associated palette instance.</param>
-    [System.Obsolete("Color[] constructor is deprecated and will be removed in V110. Use KryptonColorSchemeBase overload.", false)]
     public KryptonColorTable2010SilverLightMode([DisallowNull] Color[] colors,
         InheritBool roundedEdges,
         PaletteBase palette)

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverLightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2010/Extra Themes/PaletteOffice2010SilverLightMode.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -229,6 +229,45 @@ public class PaletteOffice2010SilverLightMode : PaletteOffice2010SilverLightMode
 public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
 {
     #region Static Fields
+    static PaletteOffice2010SilverLightModeBase()
+    {
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color4, Color.FromArgb(254, 254, 255));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color5, Color.FromArgb(206, 213, 225));
+
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color1, Color.FromArgb(235, 227, 196));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color2, Color.FromArgb(228, 198, 149));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color3, Color.FromArgb(166, 97, 7));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color4, Color.FromArgb(242, 155, 57));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color5, Color.FromArgb(236, 136, 9));
+
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color1, Color.FromArgb(255, 251, 230));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color2, Color.FromArgb(248, 230, 143));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color3, Color.FromArgb(238, 213, 126));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color4, Color.FromArgb(254, 247, 129));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color5, Color.FromArgb(240, 201, 41));
+
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(221, 221, 221));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(236, 236, 236));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(214, 216, 221));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color4, Color.FromArgb(194, 197, 204));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color5, Color.FromArgb(196, 198, 206));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color6, Color.FromArgb(214, 216, 221));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color7, Color.FromArgb(214, 216, 221));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color8, Color.FromArgb(216, 220, 222));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color9, Color.FromArgb(219, 224, 222));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color10, Color.FromArgb(225, 228, 224));
+
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color1, Color.FromArgb(212, 212, 212));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color2, Color.FromArgb(232, 234, 244));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color3, Color.FromArgb(183, 185, 193));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color4, Color.FromArgb(134, 136, 142));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color5, Color.FromArgb(146, 148, 155));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color6, Color.FromArgb(121, 123, 129));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color7, Color.FromArgb(170, 172, 181));
+    }
 
     #region Padding
 
@@ -372,58 +411,6 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
     #endregion
 
     #region Colour Arrays
-
-    private static readonly Color[] _appButtonNormal =
-    [
-        Color.FromArgb(243, 245, 248),
-        Color.FromArgb(214, 220, 231),
-        Color.FromArgb(188, 198, 211),
-        Color.FromArgb(254, 254, 255),
-        Color.FromArgb(206, 213, 225)
-    ];
-
-    private static readonly Color[] _appButtonTrack =
-    [
-        Color.FromArgb(255, 251, 230),
-        Color.FromArgb(248, 230, 143),
-        Color.FromArgb(238, 213, 126),
-        Color.FromArgb(254, 247, 129),
-        Color.FromArgb(240, 201, 41)
-    ];
-
-    private static readonly Color[] _appButtonPressed =
-    [
-        Color.FromArgb(235, 227, 196),
-        Color.FromArgb(228, 198, 149),
-        Color.FromArgb(166, 97, 7),
-        Color.FromArgb(242, 155, 57),
-        Color.FromArgb(236, 136, 9)
-    ];
-
-    private static readonly Color[] _buttonBorderColors =
-    [
-        Color.FromArgb(212, 212, 212), // Button, Disabled, Border
-        Color.FromArgb(232, 234, 244), // Button, Tracking, Border 1
-        Color.FromArgb(183, 185, 193), // Button, Tracking, Border 2
-        Color.FromArgb(134, 136, 142), // Button, Pressed, Border 1
-        Color.FromArgb(146, 148, 155), // Button, Pressed, Border 2
-        Color.FromArgb(121, 123, 129), // Button, Checked, Border 1
-        Color.FromArgb(170, 172, 181) // Button, Checked, Border 2
-    ];
-
-    private static readonly Color[] _buttonBackColors =
-    [
-        Color.FromArgb(221, 221, 221), // Button, Disabled, Back 1
-        Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
-        Color.FromArgb(214, 216, 221), // Button, Tracking, Back 1
-        Color.FromArgb(194, 197, 204), // Button, Tracking, Back 2
-        Color.FromArgb(196, 198, 206), // Button, Pressed, Back 1
-        Color.FromArgb(214, 216, 221), // Button, Pressed, Back 2
-        Color.FromArgb(214, 216, 221), // Button, Checked, Back 1
-        Color.FromArgb(216, 220, 222), // Button, Checked, Back 2
-        Color.FromArgb(219, 224, 222), // Button, Checked Tracking, Back 1
-        Color.FromArgb(225, 228, 224) // Button, Checked Tracking, Back 2
-    ];
 
     #endregion
 
@@ -631,7 +618,7 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
                 return state == PaletteState.CheckedNormal ? BaseColors!.GridDataCellSelected : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[6] : BaseColors!.PanelAlternative;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7) : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -654,8 +641,8 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
                         {
                             PaletteBackStyle.TabLowProfile => GlobalStaticValues.EMPTY_COLOR,
                             PaletteBackStyle.TabHighProfile => state == PaletteState.Tracking
-                                ? _buttonBackColors[2]
-                                : _buttonBackColors[4],
+                                ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)
+                                : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                             _ => SystemColors.Window
                         };
 
@@ -666,9 +653,9 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
                         {
                             return state switch
                             {
-                                PaletteState.CheckedNormal => _buttonBackColors[6],
-                                PaletteState.CheckedPressed => _buttonBackColors[4],
-                                _ => _buttonBackColors[8]
+                                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                                PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                                _ => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9)
                             };
                         }
                         else
@@ -707,7 +694,7 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderDockInactiveBack1;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[6];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderSecondaryBack1;
@@ -814,7 +801,7 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[2],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -865,10 +852,10 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
                     PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack1 : _disabledBack,
                     PaletteState.Normal => BaseColors!.ButtonNormalBack1,
                     PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[6],
-                    PaletteState.Tracking => _buttonBackColors[2],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[8],
+                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -876,7 +863,7 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => BaseColors!.ButtonNavigatorTrack1,
                     PaletteState.Pressed => BaseColors!.ButtonNavigatorPressed1,
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => BaseColors!.ButtonNavigatorChecked1,
@@ -941,7 +928,7 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
                 return state == PaletteState.CheckedNormal ? BaseColors!.GridDataCellSelected : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[7] : BaseColors!.PanelAlternative;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8) : BaseColors!.PanelAlternative;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -963,7 +950,7 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal => BaseColors!.HeaderDockInactiveBack1,
-                    PaletteState.Tracking or PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => SystemColors.Window,
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
@@ -972,7 +959,7 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.HeaderDockInactiveBack1,
-                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.HeaderForm:
@@ -995,7 +982,7 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderDockInactiveBack2;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[7];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderSecondaryBack2;
@@ -1102,7 +1089,7 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[3],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -1150,15 +1137,15 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemHighlight:
                 return state switch
                 {
-                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack1 : _buttonBackColors[1],
+                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack2,
                     PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
                         ? GlobalStaticValues.EMPTY_COLOR
                         : BaseColors!.ButtonNormalDefaultBack2,
-                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack2 : _buttonBackColors[7],
-                    PaletteState.Tracking => _buttonBackColors[3],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
-                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[9],
+                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack2 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
+                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color10),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -1166,7 +1153,7 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => BaseColors!.ButtonNavigatorTrack2,
                     PaletteState.Pressed => BaseColors!.ButtonNavigatorPressed2,
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => BaseColors!.ButtonNavigatorChecked2,
@@ -1497,7 +1484,7 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors!.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1505,7 +1492,7 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
@@ -1518,8 +1505,8 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1553,23 +1540,23 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
             },
             PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
             {
-                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack2 : _buttonBorderColors[0],
+                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack2 : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
                     ? GlobalStaticValues.EMPTY_COLOR
                     : BaseColors!.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[5],
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
-                PaletteState.CheckedTracking => _buttonBorderColors[3],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color6),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1577,10 +1564,10 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors!.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => BaseColors!.ButtonNavigatorBorder,
@@ -1623,7 +1610,7 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors!.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1631,7 +1618,7 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
@@ -1644,8 +1631,8 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1679,21 +1666,21 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
             },
             PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
             {
-                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack2 : _buttonBorderColors[0],
+                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack2 : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[6],
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
-                PaletteState.CheckedTracking => _buttonBorderColors[4],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1701,10 +1688,10 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors!.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => BaseColors!.ButtonNavigatorBorder,
@@ -3941,11 +3928,11 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[0];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color1);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[0];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color1);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[0];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4056,11 +4043,11 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[1];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color2);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[1];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color2);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[1];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4145,11 +4132,11 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[2];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color3);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[2];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color3);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[2];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color3);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4227,11 +4214,11 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[3];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color4);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[3];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color4);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[3];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color4);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4309,11 +4296,11 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[4];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color5);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[4];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color5);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[4];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color5);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4465,8 +4452,8 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.Light(BaseColors!.ButtonNormalBorder),
                     PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBorderColors[1],
-                    PaletteState.Pressed => _buttonBorderColors[3],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                    PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4505,8 +4492,8 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
                         BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => ControlPaint.Light(
                         BaseColors!.ButtonNormalBack1),
-                    PaletteState.Tracking => ControlPaint.Light(_buttonBackColors[2]),
-                    PaletteState.Pressed => ControlPaint.Light(_buttonBackColors[4]),
+                    PaletteState.Tracking => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)),
+                    PaletteState.Pressed => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5)),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
 
@@ -4554,8 +4541,8 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack1,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[2],
-                    PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4602,8 +4589,8 @@ public abstract class PaletteOffice2010SilverLightModeBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack2,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[3],
-                    PaletteState.Pressed => _buttonBackColors[5],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Bases/PaletteOffice2013Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Bases/PaletteOffice2013Base.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -18,6 +18,45 @@ namespace Krypton.Toolkit;
 public abstract class PaletteOffice2013Base : PaletteBase
 {
     #region Static Fields
+    static PaletteOffice2013Base()
+    {
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color4, Color.FromArgb(254, 254, 255));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color5, Color.FromArgb(206, 213, 225));
+
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color1, Color.FromArgb(235, 227, 196));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color2, Color.FromArgb(228, 198, 149));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color3, Color.FromArgb(166, 97, 7));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color4, Color.FromArgb(242, 155, 57));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color5, Color.FromArgb(236, 136, 9));
+
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color1, Color.FromArgb(255, 251, 230));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color2, Color.FromArgb(248, 230, 143));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color3, Color.FromArgb(238, 213, 126));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color4, Color.FromArgb(254, 247, 129));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color5, Color.FromArgb(240, 201, 41));
+
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(250, 250, 250));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(250, 250, 250));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(248, 225, 135));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color4, Color.FromArgb(251, 248, 224));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color5, Color.FromArgb(255, 228, 138));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color6, Color.FromArgb(194, 118, 43));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color7, Color.FromArgb(255, 216, 108));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color8, Color.FromArgb(255, 244, 128));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color9, Color.FromArgb(255, 225, 104));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color10, Color.FromArgb(255, 249, 196));
+
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color1, Color.FromArgb(180, 180, 180));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color2, Color.FromArgb(237, 201, 88));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color3, Color.FromArgb(243, 213, 73));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color4, Color.FromArgb(194, 118, 43));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color5, Color.FromArgb(194, 158, 71));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color6, Color.FromArgb(194, 138, 48));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color7, Color.FromArgb(194, 164, 77));
+    }
 
     #region Padding
 
@@ -160,58 +199,6 @@ public abstract class PaletteOffice2013Base : PaletteBase
     #endregion
 
     #region Color Arrays
-
-    private static readonly Color[] _appButtonNormal =
-    [
-        Color.FromArgb(243, 245, 248),
-        Color.FromArgb(214, 220, 231),
-        Color.FromArgb(188, 198, 211),
-        Color.FromArgb(254, 254, 255),
-        Color.FromArgb(206, 213, 225)
-    ];
-
-    private static readonly Color[] _appButtonTrack =
-    [
-        Color.FromArgb(255, 251, 230),
-        Color.FromArgb(248, 230, 143),
-        Color.FromArgb(238, 213, 126),
-        Color.FromArgb(254, 247, 129),
-        Color.FromArgb(240, 201, 41)
-    ];
-
-    private static readonly Color[] _appButtonPressed =
-    [
-        Color.FromArgb(235, 227, 196),
-        Color.FromArgb(228, 198, 149),
-        Color.FromArgb(166, 97, 7),
-        Color.FromArgb(242, 155, 57),
-        Color.FromArgb(236, 136, 9)
-    ];
-
-    private static readonly Color[] _buttonBorderColors =
-    [
-        Color.FromArgb(180, 180, 180), // Button, Disabled, Border
-        Color.FromArgb(237, 201, 88),  // Button, Tracking, Border 1
-        Color.FromArgb(243, 213, 73),  // Button, Tracking, Border 2
-        Color.FromArgb(194, 118, 43),  // Button, Pressed, Border 1
-        Color.FromArgb(194, 158, 71),  // Button, Pressed, Border 2
-        Color.FromArgb(194, 138, 48),  // Button, Checked, Border 1
-        Color.FromArgb(194, 164, 77)   // Button, Checked, Border 2
-    ];
-
-    private static readonly Color[] _buttonBackColors =
-    [
-        Color.FromArgb(250, 250, 250), // Button, Disabled, Back 1
-        Color.FromArgb(250, 250, 250), // Button, Disabled, Back 2
-        Color.FromArgb(248, 225, 135), // Button, Tracking, Back 1
-        Color.FromArgb(251, 248, 224), // Button, Tracking, Back 2
-        Color.FromArgb(255, 228, 138), // Button, Pressed, Back 1
-        Color.FromArgb(194, 118, 43),  // Button, Pressed, Back 2
-        Color.FromArgb(255, 216, 108), // Button, Checked, Back 1
-        Color.FromArgb(255, 244, 128), // Button, Checked, Back 2
-        Color.FromArgb(255, 225, 104), // Button, Checked Tracking, Back 1
-        Color.FromArgb(255, 249, 196)  // Button, Checked Tracking, Back 2
-    ];
 
     /*private static readonly Color[] _appButtonNormal = new Color[] { Color.FromArgb(243, 245, 248), Color.FromArgb(214, 220, 231), Color.FromArgb(188, 198, 211), Color.FromArgb(254, 254, 255), Color.FromArgb(206, 213, 225) };
     private static readonly Color[] _appButtonTrack = new Color[] { Color.FromArgb(255, 251, 230), Color.FromArgb(248, 230, 143), Color.FromArgb(238, 213, 126), Color.FromArgb(254, 247, 129), Color.FromArgb(240, 201, 41) };
@@ -476,7 +463,7 @@ public abstract class PaletteOffice2013Base : PaletteBase
                 return state == PaletteState.CheckedNormal ? _ribbonColors[(int)SchemeBaseColors.GridDataCellSelected] : SystemColors.Window;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[6] : SystemColors.Window;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7) : SystemColors.Window;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -500,7 +487,7 @@ public abstract class PaletteOffice2013Base : PaletteBase
                             case PaletteBackStyle.TabLowProfile:
                                 return GlobalStaticValues.EMPTY_COLOR;
                             case PaletteBackStyle.TabHighProfile:
-                                return state == PaletteState.Tracking ? _buttonBackColors[2] : _buttonBackColors[4];
+                                return state == PaletteState.Tracking ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3) : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5);
                             default:
                                 return SystemColors.Window;
                         }
@@ -512,11 +499,11 @@ public abstract class PaletteOffice2013Base : PaletteBase
                         {
                             if (state == PaletteState.CheckedNormal)
                             {
-                                return _buttonBackColors[6];
+                                return GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
                             }
                             else
                             {
-                                return state == PaletteState.CheckedPressed ? _buttonBackColors[4] : _buttonBackColors[8];
+                                return state == PaletteState.CheckedPressed ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5) : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9);
                             }
                         }
                         else
@@ -555,7 +542,7 @@ public abstract class PaletteOffice2013Base : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeBaseColors.HeaderDockInactiveBack1];
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[6];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeBaseColors.HeaderSecondaryBack1];
@@ -626,7 +613,7 @@ public abstract class PaletteOffice2013Base : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[2],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -677,10 +664,10 @@ public abstract class PaletteOffice2013Base : PaletteBase
                     PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack1] : _disabledBack,
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1],
                     PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack1],
-                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1] : _buttonBackColors[6],
-                    PaletteState.Tracking => _buttonBackColors[2],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1] : _buttonBackColors[8],
+                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1] : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1] : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -688,7 +675,7 @@ public abstract class PaletteOffice2013Base : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorTrack1],
                     PaletteState.Pressed => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorPressed1],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorChecked1],
@@ -753,7 +740,7 @@ public abstract class PaletteOffice2013Base : PaletteBase
                 return state == PaletteState.CheckedNormal ? _ribbonColors[(int)SchemeBaseColors.GridDataCellSelected] : SystemColors.Window;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[7] : SystemColors.Window;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8) : SystemColors.Window;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -775,7 +762,7 @@ public abstract class PaletteOffice2013Base : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.HeaderDockInactiveBack1],
-                    PaletteState.Tracking or PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => SystemColors.Window,
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
@@ -784,7 +771,7 @@ public abstract class PaletteOffice2013Base : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeBaseColors.HeaderDockInactiveBack1],
-                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.HeaderForm:
@@ -807,7 +794,7 @@ public abstract class PaletteOffice2013Base : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeBaseColors.HeaderDockInactiveBack2];
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[7];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeBaseColors.HeaderSecondaryBack2];
@@ -878,7 +865,7 @@ public abstract class PaletteOffice2013Base : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[3],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -926,15 +913,15 @@ public abstract class PaletteOffice2013Base : PaletteBase
             case PaletteBackStyle.ContextMenuItemHighlight:
                 return state switch
                 {
-                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack1] : _buttonBackColors[1],
+                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack1] : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack2],
                     PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
                         ? GlobalStaticValues.EMPTY_COLOR
                         : _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack2],
-                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack2] : _buttonBackColors[7],
-                    PaletteState.Tracking => _buttonBackColors[3],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
-                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1] : _buttonBackColors[9],
+                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack2] : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
+                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1] : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color10),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -942,7 +929,7 @@ public abstract class PaletteOffice2013Base : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorTrack2],
                     PaletteState.Pressed => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorPressed2],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorChecked2],
@@ -1273,7 +1260,7 @@ public abstract class PaletteOffice2013Base : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeBaseColors.ControlBorder],
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1281,7 +1268,7 @@ public abstract class PaletteOffice2013Base : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
@@ -1294,8 +1281,8 @@ public abstract class PaletteOffice2013Base : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1329,23 +1316,23 @@ public abstract class PaletteOffice2013Base : PaletteBase
             },
             PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
             {
-                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack2] : _buttonBorderColors[0],
+                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack2] : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
                 PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
                     ? GlobalStaticValues.EMPTY_COLOR
                     : _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBorder],
-                PaletteState.CheckedNormal => _buttonBorderColors[5],
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
-                PaletteState.CheckedTracking => _buttonBorderColors[3],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color6),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1353,10 +1340,10 @@ public abstract class PaletteOffice2013Base : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1],
                 PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack1],
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorBorder],
@@ -1399,7 +1386,7 @@ public abstract class PaletteOffice2013Base : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeBaseColors.ControlBorder],
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1407,7 +1394,7 @@ public abstract class PaletteOffice2013Base : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
@@ -1420,8 +1407,8 @@ public abstract class PaletteOffice2013Base : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1455,21 +1442,21 @@ public abstract class PaletteOffice2013Base : PaletteBase
             },
             PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
             {
-                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack2] : _buttonBorderColors[0],
+                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack2] : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
                 PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBorder],
-                PaletteState.CheckedNormal => _buttonBorderColors[6],
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
-                PaletteState.CheckedTracking => _buttonBorderColors[4],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1477,10 +1464,10 @@ public abstract class PaletteOffice2013Base : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1],
                 PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack1],
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorBorder],
@@ -3649,11 +3636,11 @@ public abstract class PaletteOffice2013Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[0];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color1);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[0];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color1);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[0];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3764,11 +3751,11 @@ public abstract class PaletteOffice2013Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[1];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color2);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[1];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color2);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[1];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3853,11 +3840,11 @@ public abstract class PaletteOffice2013Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[2];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color3);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[2];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color3);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[2];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color3);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3935,11 +3922,11 @@ public abstract class PaletteOffice2013Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[3];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color4);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[3];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color4);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[3];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color4);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4017,11 +4004,11 @@ public abstract class PaletteOffice2013Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[4];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color5);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[4];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color5);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[4];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color5);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4173,8 +4160,8 @@ public abstract class PaletteOffice2013Base : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.Light(_ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder]),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBorderColors[1],
-                    PaletteState.Pressed => _buttonBorderColors[3],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                    PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4211,8 +4198,8 @@ public abstract class PaletteOffice2013Base : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(_ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
                     PaletteState.Normal => ControlPaint.Light(_ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
-                    PaletteState.Tracking => ControlPaint.Light(_buttonBackColors[2]),
-                    PaletteState.Pressed => ControlPaint.Light(_buttonBackColors[4]),
+                    PaletteState.Tracking => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)),
+                    PaletteState.Pressed => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5)),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4259,8 +4246,8 @@ public abstract class PaletteOffice2013Base : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(_ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1],
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[2],
-                    PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4307,8 +4294,8 @@ public abstract class PaletteOffice2013Base : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(_ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack2],
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[3],
-                    PaletteState.Pressed => _buttonBackColors[5],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Bases/PaletteOffice2013Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Bases/PaletteOffice2013Base.cs
@@ -18,8 +18,18 @@ namespace Krypton.Toolkit;
 public abstract class PaletteOffice2013Base : PaletteBase
 {
     #region Static Fields
+
+    // registration guard so default colours are initialised lazily only once
+    private static bool _defaultsRegistered;
+
     static PaletteOffice2013Base()
     {
+        if (_defaultsRegistered)
+        {
+            return;
+        }
+        _defaultsRegistered = true;
+
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
@@ -297,12 +307,34 @@ public abstract class PaletteOffice2013Base : PaletteBase
         [DisallowNull] ImageList checkBoxList,
         [DisallowNull] ImageList galleryButtonList,
         [DisallowNull] Image?[] radioButtonArray)
-        : this(scheme.ToArray(),
-               checkBoxList,
-               galleryButtonList,
-               radioButtonArray,
-               scheme.ToTrackBarArray())
     {
+        Debug.Assert(scheme != null);
+        Debug.Assert(checkBoxList != null);
+        Debug.Assert(galleryButtonList != null);
+        Debug.Assert(radioButtonArray != null);
+
+        // Remember incoming sets of values
+        ThemeName = nameof(PaletteOffice2013Base);
+
+        if (scheme != null)
+        {
+            _ribbonColors = scheme.ToArray();
+        }
+        if (checkBoxList != null)
+        {
+            _checkBoxList = checkBoxList;
+        }
+        if (galleryButtonList != null)
+        {
+            _galleryButtonList = galleryButtonList;
+        }
+        if (radioButtonArray != null)
+        {
+            _radioButtonArray = radioButtonArray;
+        }
+
+        // Get the font settings from the system
+        DefineFonts();
         BaseColors = scheme;
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Bases/PaletteOffice2013WhiteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Bases/PaletteOffice2013WhiteBase.cs
@@ -18,8 +18,18 @@ namespace Krypton.Toolkit;
 public abstract class PaletteOffice2013WhiteBase : PaletteBase
 {
     #region Static Fields
+
+    // registration guard so default colours are initialised lazily only once
+    private static bool _defaultsRegistered;
+
     static PaletteOffice2013WhiteBase()
     {
+        if (_defaultsRegistered)
+        {
+            return;
+        }
+        _defaultsRegistered = true;
+
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
@@ -264,12 +274,34 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
         [DisallowNull] ImageList checkBoxList,
         [DisallowNull] ImageList galleryButtonList,
         [DisallowNull] Image?[] radioButtonArray)
-        : this(scheme.ToArray(),
-               checkBoxList,
-               galleryButtonList,
-               radioButtonArray,
-               scheme.ToTrackBarArray())
     {
+        Debug.Assert(scheme is not null);
+        Debug.Assert(checkBoxList is not null);
+        Debug.Assert(galleryButtonList is not null);
+        Debug.Assert(radioButtonArray is not null);
+
+        // Remember incoming sets of values
+        ThemeName = nameof(PaletteOffice2013WhiteBase);
+
+        if (scheme != null)
+        {
+            _ribbonColors = scheme.ToArray();
+        }
+        if (checkBoxList != null)
+        {
+            _checkBoxList = checkBoxList;
+        }
+        if (galleryButtonList != null)
+        {
+            _galleryButtonList = galleryButtonList;
+        }
+        if (radioButtonArray != null)
+        {
+            _radioButtonArray = radioButtonArray;
+        }
+
+        // Get the font settings from the system
+        DefineFonts();
         BaseColors = scheme;
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Bases/PaletteOffice2013WhiteBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Bases/PaletteOffice2013WhiteBase.cs
@@ -1,4 +1,4 @@
-#region BSD License
+﻿#region BSD License
 /*
  *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
@@ -18,6 +18,45 @@ namespace Krypton.Toolkit;
 public abstract class PaletteOffice2013WhiteBase : PaletteBase
 {
     #region Static Fields
+    static PaletteOffice2013WhiteBase()
+    {
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color4, Color.FromArgb(254, 254, 255));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color5, Color.FromArgb(206, 213, 225));
+
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color1, Color.FromArgb(235, 227, 196));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color2, Color.FromArgb(228, 198, 149));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color3, Color.FromArgb(166, 97, 7));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color4, Color.FromArgb(242, 155, 57));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color5, Color.FromArgb(236, 136, 9));
+
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color1, Color.FromArgb(255, 251, 230));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color2, Color.FromArgb(248, 230, 143));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color3, Color.FromArgb(238, 213, 126));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color4, Color.FromArgb(254, 247, 129));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color5, Color.FromArgb(240, 201, 41));
+
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(250, 250, 250));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(250, 250, 250));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(205, 230, 247));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color4, Color.FromArgb(205, 230, 247));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color5, Color.FromArgb(146, 192, 244));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color6, Color.FromArgb(146, 192, 244));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color7, Color.FromArgb(146, 192, 244));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color8, Color.FromArgb(146, 192, 244));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color9, Color.FromArgb(255, 225, 104));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color10, Color.FromArgb(255, 249, 196));
+
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color1, Color.FromArgb(180, 180, 180));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color2, Color.FromArgb(205, 230, 247));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color3, Color.FromArgb(205, 230, 247));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color4, Color.FromArgb(146, 192, 244));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color5, Color.FromArgb(146, 192, 244));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color6, Color.FromArgb(146, 192, 244));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color7, Color.FromArgb(146, 192, 244));
+    }
 
     #region Padding
 
@@ -161,57 +200,6 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
 
     #region Colour Arrays
 
-    private static readonly Color[] _appButtonNormal =
-    [
-        Color.FromArgb(243, 245, 248),
-        Color.FromArgb(214, 220, 231),
-        Color.FromArgb(188, 198, 211),
-        Color.FromArgb(254, 254, 255),
-        Color.FromArgb(206, 213, 225)
-    ];
-
-    private static readonly Color[] _appButtonTrack =
-    [
-        Color.FromArgb(255, 251, 230),
-        Color.FromArgb(248, 230, 143),
-        Color.FromArgb(238, 213, 126),
-        Color.FromArgb(254, 247, 129),
-        Color.FromArgb(240, 201, 41)
-    ];
-
-    private static readonly Color[] _appButtonPressed =
-    [
-        Color.FromArgb(235, 227, 196),
-        Color.FromArgb(228, 198, 149),
-        Color.FromArgb(166, 97, 7),
-        Color.FromArgb(242, 155, 57),
-        Color.FromArgb(236, 136, 9)
-    ];
-
-    private static readonly Color[] _buttonBorderColors =
-    [
-        Color.FromArgb(180, 180, 180), // Button, Disabled, Border
-        Color.FromArgb(205, 230, 247), // Button, Tracking, Border 1
-        Color.FromArgb(205, 230, 247), // Button, Tracking, Border 2
-        Color.FromArgb(146, 192, 244), // Button, Pressed, Border 1
-        Color.FromArgb(146, 192, 244), // Button, Pressed, Border 2
-        Color.FromArgb(146, 192, 244), // Button, Checked, Border 1
-        Color.FromArgb(146, 192, 244) // Button, Checked, Border 2
-    ];
-
-    private static readonly Color[] _buttonBackColors =
-    [
-        Color.FromArgb(250, 250, 250), // Button, Disabled, Back 1
-        Color.FromArgb(250, 250, 250), // Button, Disabled, Back 2
-        Color.FromArgb(205, 230, 247), // Button, Tracking, Back 1
-        Color.FromArgb(205, 230, 247), // Button, Tracking, Back 2
-        Color.FromArgb(146, 192, 244), // Button, Pressed, Back 1
-        Color.FromArgb(146, 192, 244), // Button, Pressed, Back 2
-        Color.FromArgb(146, 192, 244), // Button, Checked, Back 1
-        Color.FromArgb(146, 192, 244), // Button, Checked, Back 2
-        Color.FromArgb(255, 225, 104), // Button, Checked Tracking, Back 1
-        Color.FromArgb(255, 249, 196)  // Button, Checked Tracking, Back 2
-    ];
     #endregion
 
     #endregion Static Fields
@@ -411,7 +399,7 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
                 return state == PaletteState.CheckedNormal ? BaseColors!.GridDataCellSelected : SystemColors.Window;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[6] : SystemColors.Window;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7) : SystemColors.Window;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -435,7 +423,7 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
                             case PaletteBackStyle.TabLowProfile:
                                 return GlobalStaticValues.EMPTY_COLOR;
                             case PaletteBackStyle.TabHighProfile:
-                                return state == PaletteState.Tracking ? _buttonBackColors[2] : _buttonBackColors[4];
+                                return state == PaletteState.Tracking ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3) : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5);
                             default:
                                 return SystemColors.Window;
                         }
@@ -447,11 +435,11 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
                         {
                             if (state == PaletteState.CheckedNormal)
                             {
-                                return _buttonBackColors[6];
+                                return GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
                             }
                             else
                             {
-                                return state == PaletteState.CheckedPressed ? _buttonBackColors[4] : _buttonBackColors[8];
+                                return state == PaletteState.CheckedPressed ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5) : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9);
                             }
                         }
                         else
@@ -490,7 +478,7 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderDockInactiveBack1;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[6];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderSecondaryBack1;
@@ -561,7 +549,7 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[2],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -612,10 +600,10 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
                     PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack1 : _disabledBack,
                     PaletteState.Normal => BaseColors!.ButtonNormalBack1,
                     PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[6],
-                    PaletteState.Tracking => _buttonBackColors[2],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[8],
+                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -623,7 +611,7 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => BaseColors!.ButtonNavigatorTrack1,
                     PaletteState.Pressed => BaseColors!.ButtonNavigatorPressed1,
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => BaseColors!.ButtonNavigatorChecked1,
@@ -688,7 +676,7 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
                 return state == PaletteState.CheckedNormal ? BaseColors!.GridDataCellSelected : SystemColors.Window;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[7] : SystemColors.Window;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8) : SystemColors.Window;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -710,7 +698,7 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal => BaseColors!.HeaderDockInactiveBack1,
-                    PaletteState.Tracking or PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => SystemColors.Window,
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
@@ -719,7 +707,7 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.HeaderDockInactiveBack1,
-                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.HeaderForm:
@@ -742,7 +730,7 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderDockInactiveBack2;
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[7];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : BaseColors!.HeaderSecondaryBack2;
@@ -813,7 +801,7 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[3],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -861,15 +849,15 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
             case PaletteBackStyle.ContextMenuItemHighlight:
                 return state switch
                 {
-                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack1 : _buttonBackColors[1],
+                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack2,
                     PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
                         ? GlobalStaticValues.EMPTY_COLOR
                         : BaseColors!.ButtonNormalDefaultBack2,
-                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack2 : _buttonBackColors[7],
-                    PaletteState.Tracking => _buttonBackColors[3],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
-                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : _buttonBackColors[9],
+                    PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack2 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
+                    PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl ? BaseColors!.ButtonNormalBack1 : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color10),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -877,7 +865,7 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => BaseColors!.ButtonNavigatorTrack2,
                     PaletteState.Pressed => BaseColors!.ButtonNavigatorPressed2,
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => BaseColors!.ButtonNavigatorChecked2,
@@ -1210,7 +1198,7 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors!.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1218,7 +1206,7 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
@@ -1231,8 +1219,8 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1266,23 +1254,23 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
             },
             PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
             {
-                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack2 : _buttonBorderColors[0],
+                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack2 : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
                     ? GlobalStaticValues.EMPTY_COLOR
                     : BaseColors!.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[5],
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
-                PaletteState.CheckedTracking => _buttonBorderColors[3],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color6),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1290,10 +1278,10 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors!.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => BaseColors!.ButtonNavigatorBorder,
@@ -1336,7 +1324,7 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => BaseColors!.ControlBorder,
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1344,7 +1332,7 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
@@ -1357,8 +1345,8 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1392,21 +1380,21 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
             },
             PaletteBorderStyle.ButtonGallery or PaletteBorderStyle.ButtonStandalone or PaletteBorderStyle.ButtonAlternate or PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ButtonCluster or PaletteBorderStyle.ButtonCustom1 or PaletteBorderStyle.ButtonCustom2 or PaletteBorderStyle.ButtonCustom3 or PaletteBorderStyle.ContextMenuItemHighlight => state switch
             {
-                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack2 : _buttonBorderColors[0],
+                PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery ? BaseColors!.RibbonGalleryBack2 : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => BaseColors!.ButtonNormalBorder,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBorder,
-                PaletteState.CheckedNormal => _buttonBorderColors[6],
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
-                PaletteState.CheckedTracking => _buttonBorderColors[4],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => BaseColors!.ButtonNormalBorder,
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1414,10 +1402,10 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => BaseColors!.ButtonNormalBack1,
                 PaletteState.NormalDefaultOverride => BaseColors!.ButtonNormalDefaultBack1,
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => BaseColors!.ButtonNavigatorBorder,
@@ -3593,11 +3581,11 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[0];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color1);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[0];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color1);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[0];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3708,11 +3696,11 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[1];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color2);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[1];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color2);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[1];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3797,11 +3785,11 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[2];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color3);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[2];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color3);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[2];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color3);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3879,11 +3867,11 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[3];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color4);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[3];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color4);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[3];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color4);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3961,11 +3949,11 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[4];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color5);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[4];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color5);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[4];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color5);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4119,8 +4107,8 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.Light(BaseColors!.ButtonNormalBorder),
                     PaletteState.Normal => BaseColors!.ButtonNormalBorder,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBorderColors[1],
-                    PaletteState.Pressed => _buttonBorderColors[3],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                    PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4157,8 +4145,8 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => ControlPaint.Light(BaseColors!.ButtonNormalBack1),
-                    PaletteState.Tracking => ControlPaint.Light(_buttonBackColors[2]),
-                    PaletteState.Pressed => ControlPaint.Light(_buttonBackColors[4]),
+                    PaletteState.Tracking => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)),
+                    PaletteState.Pressed => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5)),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4205,8 +4193,8 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack1,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[2],
-                    PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4253,8 +4241,8 @@ public abstract class PaletteOffice2013WhiteBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(BaseColors!.ButtonNormalBack1),
                     PaletteState.Normal => BaseColors!.ButtonNormalBack2,
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[3],
-                    PaletteState.Pressed => _buttonBackColors[5],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013DarkGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013DarkGray.cs
@@ -69,20 +69,6 @@ public class PaletteOffice2013DarkGray : PaletteOffice2013Base
     private static readonly Image _formHelpDisabled = Office2010ControlBoxResources.Office2010HelpIconDisabled;
 
     #endregion
-
-    #region Colour Arrays
-
-    private static readonly Color[]? _trackBarColors =
-    [
-        Color.FromArgb(170, 170, 170), // Tick marks
-        Color.FromArgb(166, 170, 175), // Top track
-        Color.FromArgb(226, 220, 235), // Bottom track
-        Color.FromArgb(206, 200, 215), // Fill track
-        Color.FromArgb(64, Color.White), // Outside position
-        Color.FromArgb(80, 81, 82) // Border (normal) position
-    ];
-
-    #endregion
     #endregion
 
     #region Identity

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013LightGray.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Office 2013/Official Themes/PaletteOffice2013LightGray.cs
@@ -69,20 +69,6 @@ public class PaletteOffice2013LightGray : PaletteOffice2013Base
     private static readonly Image _formHelpDisabled = Office2010ControlBoxResources.Office2010HelpIconDisabled;
 
     #endregion
-
-    #region Colour Arrays
-
-    private static readonly Color[]? _trackBarColors =
-    [
-        Color.FromArgb(170, 170, 170), // Tick marks
-        Color.FromArgb(166, 170, 175), // Top track
-        Color.FromArgb(226, 220, 235), // Bottom track
-        Color.FromArgb(206, 200, 215), // Fill track
-        Color.FromArgb(64, Color.White), // Outside position
-        Color.FromArgb(80, 81, 82) // Border (normal) position
-    ];
-
-    #endregion
     #endregion
 
     #region Identity

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Professional/PaletteProfessionalOffice2003.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Professional/PaletteProfessionalOffice2003.cs
@@ -38,7 +38,6 @@ public class PaletteProfessionalOffice2003 : PaletteOffice2003Base
     #endregion
 
     #region Instance Fields
-    protected readonly KryptonColorSchemeBase? BaseColors;
     private bool _usingOffice2003;
     #endregion
 
@@ -4586,8 +4585,10 @@ public class PaletteOffice2003Base : PaletteBase
         Color highlight4 = MergeColors(Color.White, 0.25f, ColorTable.ButtonPressedGradientMiddle, 0.75f);
         //Color pressed3 = MergeColors(Color.White, 0.50f, ColorTable.CheckBackground, 0.50f);
         Color pressed4 = MergeColors(Color.White, 0.25f, ColorTable.CheckPressedBackground, 0.75f);
-        _appButtonNormal = [ColorTable.SeparatorLight, ColorTable.ImageMarginGradientBegin, ColorTable.ImageMarginGradientMiddle, ColorTable.GripLight, ColorTable.ImageMarginGradientBegin
-        ];
+        _appButtonNormal = [
+            ColorTable.SeparatorLight, ColorTable.ImageMarginGradientBegin,
+            ColorTable.ImageMarginGradientMiddle, ColorTable.GripLight,
+            ColorTable.ImageMarginGradientBegin];
         _appButtonTrack = [highlight1, highlight2, ColorTable.ButtonSelectedGradientEnd, highlight3, highlight4];
         _appButtonPressed = [highlight1, pressed4, ColorTable.CheckPressedBackground, highlight2, pressed4];
 
@@ -4682,7 +4683,7 @@ public class PaletteOffice2003Base : PaletteBase
 
     /// <inheritdoc />
     public override Color GetRibbonTabRowGradientColor1(PaletteState state) =>
-	    GlobalStaticValues.EMPTY_COLOR;
+        GlobalStaticValues.EMPTY_COLOR;
 
     /// <inheritdoc />
     public override Color GetRibbonTabRowBackgroundGradientRaftingDark(PaletteState state) =>
@@ -4694,7 +4695,7 @@ public class PaletteOffice2003Base : PaletteBase
 
     /// <inheritdoc />
     public override Color GetRibbonTabRowBackgroundSolidColor(PaletteState state) =>
-	    GlobalStaticValues.EMPTY_COLOR;
+        GlobalStaticValues.EMPTY_COLOR;
 
     /// <inheritdoc />
     public override float GetRibbonTabRowGradientRaftingAngle(PaletteState state) => -1;

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/Base/PaletteSparkleBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/Base/PaletteSparkleBase.cs
@@ -191,14 +191,6 @@ public class PaletteSparkleBase : PaletteBase
     #region Instance Fields
     /// <inheritdoc/>
     protected override Color[] SchemeColors => _ribbonColors;
-    private Color[] _trackBarColors = [
-        Color.FromArgb(180, 180, 180),
-        Color.FromArgb(33, 37, 50),
-        Color.FromArgb(126, 131, 142),
-        Color.FromArgb(99, 99, 99),
-        Color.FromArgb(32, Color.White),
-        Color.FromArgb(35, 35, 35)
-    ];
 
     protected readonly KryptonColorSchemeBase? BaseColors;
     private KryptonColorTableSparkle? _table;
@@ -241,7 +233,6 @@ public class PaletteSparkleBase : PaletteBase
         {
             _ribbonColors = ribbonColors;
         }
-
         if (sparkleColors != null)
         {
             _sparkleColors = sparkleColors;
@@ -273,6 +264,8 @@ public class PaletteSparkleBase : PaletteBase
 
         // Get the font settings from the system
         DefineFonts();
+
+        SetTrackBarColors();
     }
 
     /// <summary>
@@ -294,9 +287,7 @@ public class PaletteSparkleBase : PaletteBase
         if (scheme != null)
         {
             _ribbonColors = scheme.ToArray();
-            _trackBarColors = scheme.ToTrackBarArray();
         }
-
         if (sparkleColors != null)
         {
             _sparkleColors = sparkleColors;
@@ -330,6 +321,20 @@ public class PaletteSparkleBase : PaletteBase
         DefineFonts();
 
         BaseColors = scheme;
+
+        SetTrackBarColors();
+    }
+
+    protected void SetTrackBarColors()
+    {
+        // Sparkle themes do NOT have own TrackBar colors in themes!
+        // Those are solely defined in this base class, so overwrite here:
+        _ribbonColors[(int)SchemeBaseColors.TrackBarTickMarks] = Color.FromArgb(180, 180, 180);
+        _ribbonColors[(int)SchemeBaseColors.TrackBarTopTrack] = Color.FromArgb(33, 37, 50);
+        _ribbonColors[(int)SchemeBaseColors.TrackBarBottomTrack] = Color.FromArgb(126, 131, 142);
+        _ribbonColors[(int)SchemeBaseColors.TrackBarFillTrack] = Color.FromArgb(99, 99, 99);
+        _ribbonColors[(int)SchemeBaseColors.TrackBarOutsidePosition] =  Color.FromArgb(32, Color.White);
+        _ribbonColors[(int)SchemeBaseColors.TrackBarBorderPosition] = Color.FromArgb(35, 35, 35);
     }
 
     #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/Base/PaletteSparkleBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/Base/PaletteSparkleBase.cs
@@ -287,17 +287,49 @@ public class PaletteSparkleBase : PaletteBase
         [DisallowNull] Color[] ribbonGroupCollapsedBorderContextTracking,
         [DisallowNull] ImageList checkBoxList,
         [DisallowNull] Image?[] radioButtonArray)
-        : this(scheme.ToArray(),
-            sparkleColors,
-            appButtonNormal,
-            appButtonTrack,
-            appButtonPressed,
-            ribbonGroupCollapsedBorderContextTracking,
-            checkBoxList,
-            radioButtonArray)
     {
+        // Save colors for use in the color table
+        ThemeName = nameof(PaletteSparkleBase);
+
+        if (scheme != null)
+        {
+            _ribbonColors = scheme.ToArray();
+            _trackBarColors = scheme.ToTrackBarArray();
+        }
+
+        if (sparkleColors != null)
+        {
+            _sparkleColors = sparkleColors;
+        }
+        if (appButtonNormal != null)
+        {
+            _appButtonNormal = appButtonNormal;
+        }
+        if (appButtonTrack != null)
+        {
+            _appButtonTrack = appButtonTrack;
+        }
+        if (appButtonPressed != null)
+        {
+            _appButtonPressed = appButtonPressed;
+        }
+        if (ribbonGroupCollapsedBorderContextTracking != null)
+        {
+            _ribbonGroupCollapsedBorderContextTracking = ribbonGroupCollapsedBorderContextTracking;
+        }
+        if (checkBoxList != null)
+        {
+            _checkBoxList = checkBoxList;
+        }
+        if (radioButtonArray != null)
+        {
+            _radioButtonArray = radioButtonArray;
+        }
+
+        // Get the font settings from the system
+        DefineFonts();
+
         BaseColors = scheme;
-        _trackBarColors = scheme.ToTrackBarArray();
     }
 
     #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/Base/PaletteSparkleBlueDarkModeBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/Base/PaletteSparkleBlueDarkModeBase.cs
@@ -149,14 +149,6 @@ public abstract class PaletteSparkleBlueDarkModeBase : PaletteBase
     protected override Color[] SchemeColors => _ribbonColors;
     private readonly Color[] _ribbonColors;
 
-    private readonly Color[] _trackBarColors = [
-        Color.FromArgb(180, 180, 180),
-        Color.FromArgb(33, 37, 50),
-        Color.FromArgb(126, 131, 142),
-        Color.FromArgb(99, 99, 99),
-        Color.FromArgb(32, Color.White),
-        Color.FromArgb(35, 35, 35)];
-
     protected readonly KryptonColorSchemeBase? BaseColors;
     private KryptonColorTableSparkle? _table;
     private readonly Color[] _sparkleColors;
@@ -206,6 +198,8 @@ public abstract class PaletteSparkleBlueDarkModeBase : PaletteBase
 
         // Get the font settings from the system
         DefineFonts();
+
+        SetTrackBarColors();
     }
 
     /// <summary>
@@ -227,7 +221,6 @@ public abstract class PaletteSparkleBlueDarkModeBase : PaletteBase
         if (scheme != null)
         {
             _ribbonColors = scheme.ToArray();
-            _trackBarColors = scheme.ToTrackBarArray();
         }
         _sparkleColors = sparkleColors;
         _appButtonNormal = appButtonNormal;
@@ -241,6 +234,20 @@ public abstract class PaletteSparkleBlueDarkModeBase : PaletteBase
         DefineFonts();
 
         BaseColors = scheme;
+
+        SetTrackBarColors();
+    }
+
+    private void SetTrackBarColors()
+    {
+        // Sparkle themes do NOT have own TrackBar colors in themes!
+        // Those are solely defined in this base class, so overwrite here:
+        _ribbonColors[(int)SchemeBaseColors.TrackBarTickMarks] = Color.FromArgb(180, 180, 180);
+        _ribbonColors[(int)SchemeBaseColors.TrackBarTopTrack] = Color.FromArgb(33, 37, 50);
+        _ribbonColors[(int)SchemeBaseColors.TrackBarBottomTrack] = Color.FromArgb(126, 131, 142);
+        _ribbonColors[(int)SchemeBaseColors.TrackBarFillTrack] = Color.FromArgb(99, 99, 99);
+        _ribbonColors[(int)SchemeBaseColors.TrackBarOutsidePosition] =  Color.FromArgb(32, Color.White);
+        _ribbonColors[(int)SchemeBaseColors.TrackBarBorderPosition] = Color.FromArgb(35, 35, 35);
     }
 
     #endregion Identity

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/Base/PaletteSparkleBlueDarkModeBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Sparkle/Base/PaletteSparkleBlueDarkModeBase.cs
@@ -193,6 +193,7 @@ public abstract class PaletteSparkleBlueDarkModeBase : PaletteBase
         Image?[] radioButtonArray)
     {
         ThemeName = nameof(PaletteSparkleBlueDarkModeBase);
+
         // Save colors for use in the color table
         _ribbonColors = ribbonColors;
         _sparkleColors = sparkleColors;
@@ -219,17 +220,27 @@ public abstract class PaletteSparkleBlueDarkModeBase : PaletteBase
         [DisallowNull] Color[] ribbonGroupCollapsedBorderContextTracking,
         [DisallowNull] ImageList checkBoxList,
         [DisallowNull] Image?[] radioButtonArray)
-        : this(scheme.ToArray(),
-            sparkleColors,
-            appButtonNormal,
-            appButtonTrack,
-            appButtonPressed,
-            ribbonGroupCollapsedBorderContextTracking,
-            checkBoxList,
-            radioButtonArray)
     {
+        ThemeName = nameof(PaletteSparkleBlueDarkModeBase);
+
+        // Save colors for use in the color table
+        if (scheme != null)
+        {
+            _ribbonColors = scheme.ToArray();
+            _trackBarColors = scheme.ToTrackBarArray();
+        }
+        _sparkleColors = sparkleColors;
+        _appButtonNormal = appButtonNormal;
+        _appButtonTrack = appButtonTrack;
+        _appButtonPressed = appButtonPressed;
+        _ribbonGroupCollapsedBorderContextTracking = ribbonGroupCollapsedBorderContextTracking;
+        _checkBoxList = checkBoxList;
+        _radioButtonArray = radioButtonArray;
+
+        // Get the font settings from the system
+        DefineFonts();
+
         BaseColors = scheme;
-        _trackBarColors = scheme.ToTrackBarArray();
     }
 
     #endregion Identity

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/PaletteVisualStudioBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/PaletteVisualStudioBase.cs
@@ -17,8 +17,18 @@ namespace Krypton.Toolkit;
 public abstract class PaletteVisualStudioBase : PaletteBase
 {
     #region Static Fields
+
+    // registration guard so default colours are initialised lazily only once
+    private static bool _defaultsRegistered;
+
     static PaletteVisualStudioBase()
     {
+        if (_defaultsRegistered)
+        {
+            return;
+        }
+        _defaultsRegistered = true;
+
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
@@ -226,7 +236,6 @@ public abstract class PaletteVisualStudioBase : PaletteBase
     /// <param name="galleryButtonList">The gallery button list.</param>
     /// <param name="radioButtonArray">The radio button array.</param>
     /// <param name="trackBarColors">The track bar colours.</param>
-    [System.Obsolete("Color[] constructor is deprecated and will be removed in V110. Use KryptonColorSchemeBase overload.", false)]
     public PaletteVisualStudioBase([DisallowNull] Color[] schemeColors,
         [DisallowNull] ImageList checkBoxList,
         [DisallowNull] ImageList galleryButtonList,
@@ -273,12 +282,35 @@ public abstract class PaletteVisualStudioBase : PaletteBase
         [DisallowNull] ImageList checkBoxList,
         [DisallowNull] ImageList galleryButtonList,
         [DisallowNull] Image?[] radioButtonArray)
-        : this(scheme.ToArray(),
-               checkBoxList,
-               galleryButtonList,
-               radioButtonArray,
-               scheme.ToTrackBarArray())
     {
+        Debug.Assert(scheme != null);
+        Debug.Assert(checkBoxList != null);
+        Debug.Assert(galleryButtonList != null);
+        Debug.Assert(radioButtonArray != null);
+
+        ThemeName = nameof(PaletteVisualStudioBase);
+
+        if (scheme != null)
+        {
+            _ribbonColors = scheme.ToArray();
+        }
+
+        if (checkBoxList != null)
+        {
+            _checkBoxList = checkBoxList;
+        }
+
+        if (galleryButtonList != null)
+        {
+            _galleryButtonList = galleryButtonList;
+        }
+
+        if (radioButtonArray != null)
+        {
+            _radioButtonArray = radioButtonArray;
+        }
+
+        DefineFonts();
         BaseColors = scheme;
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/PaletteVisualStudioBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/PaletteVisualStudioBase.cs
@@ -17,6 +17,45 @@ namespace Krypton.Toolkit;
 public abstract class PaletteVisualStudioBase : PaletteBase
 {
     #region Static Fields
+    static PaletteVisualStudioBase()
+    {
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color4, Color.FromArgb(254, 254, 255));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color5, Color.FromArgb(206, 213, 225));
+
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color1, Color.FromArgb(235, 227, 196));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color2, Color.FromArgb(228, 198, 149));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color3, Color.FromArgb(166, 97, 7));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color4, Color.FromArgb(242, 155, 57));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color5, Color.FromArgb(236, 136, 9));
+
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color1, Color.FromArgb(255, 251, 230));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color2, Color.FromArgb(248, 230, 143));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color3, Color.FromArgb(238, 213, 126));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color4, Color.FromArgb(254, 247, 129));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color5, Color.FromArgb(240, 201, 41));
+
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(250, 250, 250));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(250, 250, 250));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(205, 230, 247));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color4, Color.FromArgb(205, 230, 247));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color5, Color.FromArgb(146, 192, 244));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color6, Color.FromArgb(146, 192, 244));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color7, Color.FromArgb(146, 192, 244));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color8, Color.FromArgb(146, 192, 244));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color9, Color.FromArgb(255, 225, 104));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color10, Color.FromArgb(255, 249, 196));
+
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color1, Color.FromArgb(180, 180, 180));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color2, Color.FromArgb(205, 230, 247));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color3, Color.FromArgb(205, 230, 247));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color4, Color.FromArgb(146, 192, 244));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color5, Color.FromArgb(146, 192, 244));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color6, Color.FromArgb(146, 192, 244));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color7, Color.FromArgb(146, 192, 244));
+    }
 
     #region Padding
 
@@ -159,58 +198,6 @@ public abstract class PaletteVisualStudioBase : PaletteBase
     #endregion
 
     #region Color Arrays
-
-    private static readonly Color[] _appButtonNormal =
-    [
-        Color.FromArgb(243, 245, 248),
-        Color.FromArgb(214, 220, 231),
-        Color.FromArgb(188, 198, 211),
-        Color.FromArgb(254, 254, 255),
-        Color.FromArgb(206, 213, 225)
-    ];
-
-    private static readonly Color[] _appButtonTrack =
-    [
-        Color.FromArgb(255, 251, 230),
-        Color.FromArgb(248, 230, 143),
-        Color.FromArgb(238, 213, 126),
-        Color.FromArgb(254, 247, 129),
-        Color.FromArgb(240, 201, 41)
-    ];
-
-    private static readonly Color[] _appButtonPressed =
-    [
-        Color.FromArgb(235, 227, 196),
-        Color.FromArgb(228, 198, 149),
-        Color.FromArgb(166, 97, 7),
-        Color.FromArgb(242, 155, 57),
-        Color.FromArgb(236, 136, 9)
-    ];
-
-    private static readonly Color[] _buttonBorderColors =
-    [
-        Color.FromArgb(180, 180, 180), // Button, Disabled, Border
-        Color.FromArgb(205, 230, 247), // Button, Tracking, Border 1
-        Color.FromArgb(205, 230, 247), // Button, Tracking, Border 2
-        Color.FromArgb(146, 192, 244), // Button, Pressed, Border 1
-        Color.FromArgb(146, 192, 244), // Button, Pressed, Border 2
-        Color.FromArgb(146, 192, 244), // Button, Checked, Border 1
-        Color.FromArgb(146, 192, 244) // Button, Checked, Border 2
-    ];
-
-    private static readonly Color[] _buttonBackColors =
-    [
-        Color.FromArgb(250, 250, 250), // Button, Disabled, Back 1
-        Color.FromArgb(250, 250, 250), // Button, Disabled, Back 2
-        Color.FromArgb(205, 230, 247), // Button, Tracking, Back 1
-        Color.FromArgb(205, 230, 247), // Button, Tracking, Back 2
-        Color.FromArgb(146, 192, 244), // Button, Pressed, Back 1
-        Color.FromArgb(146, 192, 244), // Button, Pressed, Back 2
-        Color.FromArgb(146, 192, 244), // Button, Checked, Back 1
-        Color.FromArgb(146, 192, 244), // Button, Checked, Back 2
-        Color.FromArgb(255, 225, 104), // Button, Checked Tracking, Back 1
-        Color.FromArgb(255, 249, 196) // Button, Checked Tracking, Back 2
-    ];
 
     #endregion
 
@@ -429,7 +416,7 @@ public abstract class PaletteVisualStudioBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeBaseColors.ControlBorder],
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -437,7 +424,7 @@ public abstract class PaletteVisualStudioBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
@@ -450,8 +437,8 @@ public abstract class PaletteVisualStudioBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -487,23 +474,23 @@ public abstract class PaletteVisualStudioBase : PaletteBase
             {
                 PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
                     ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack2]
-                    : _buttonBorderColors[0],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
                 PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
                     ? GlobalStaticValues.EMPTY_COLOR
                     : _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBorder],
-                PaletteState.CheckedNormal => _buttonBorderColors[5],
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
-                PaletteState.CheckedTracking => _buttonBorderColors[3],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color6),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -511,10 +498,10 @@ public abstract class PaletteVisualStudioBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1],
                 PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack1],
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorBorder],
@@ -557,7 +544,7 @@ public abstract class PaletteVisualStudioBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeBaseColors.ControlBorder],
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -565,7 +552,7 @@ public abstract class PaletteVisualStudioBase : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
@@ -578,8 +565,8 @@ public abstract class PaletteVisualStudioBase : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -615,21 +602,21 @@ public abstract class PaletteVisualStudioBase : PaletteBase
             {
                 PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
                     ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack2]
-                    : _buttonBorderColors[0],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
                 PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBorder],
-                PaletteState.CheckedNormal => _buttonBorderColors[6],
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
-                PaletteState.CheckedTracking => _buttonBorderColors[4],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -637,10 +624,10 @@ public abstract class PaletteVisualStudioBase : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1],
                 PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack1],
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorBorder],
@@ -2812,11 +2799,11 @@ public abstract class PaletteVisualStudioBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[0];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color1);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[0];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color1);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[0];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -2927,11 +2914,11 @@ public abstract class PaletteVisualStudioBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[1];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color2);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[1];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color2);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[1];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3016,11 +3003,11 @@ public abstract class PaletteVisualStudioBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[2];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color3);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[2];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color3);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[2];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color3);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3098,11 +3085,11 @@ public abstract class PaletteVisualStudioBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[3];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color4);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[3];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color4);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[3];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color4);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3180,11 +3167,11 @@ public abstract class PaletteVisualStudioBase : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[4];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color5);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[4];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color5);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[4];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color5);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3336,8 +3323,8 @@ public abstract class PaletteVisualStudioBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.Light(_ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder]),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBorderColors[1],
-                    PaletteState.Pressed => _buttonBorderColors[3],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                    PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -3376,8 +3363,8 @@ public abstract class PaletteVisualStudioBase : PaletteBase
                         _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
                     PaletteState.Normal => ControlPaint.Light(
                         _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
-                    PaletteState.Tracking => ControlPaint.Light(_buttonBackColors[2]),
-                    PaletteState.Pressed => ControlPaint.Light(_buttonBackColors[4]),
+                    PaletteState.Tracking => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)),
+                    PaletteState.Pressed => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5)),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
 
@@ -3425,8 +3412,8 @@ public abstract class PaletteVisualStudioBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(_ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1],
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[2],
-                    PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -3473,8 +3460,8 @@ public abstract class PaletteVisualStudioBase : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(_ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack2],
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[3],
-                    PaletteState.Pressed => _buttonBackColors[5],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2007/PaletteVisualStudio2010With2007Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2007/PaletteVisualStudio2010With2007Base.cs
@@ -14,6 +14,45 @@ namespace Krypton.Toolkit;
 public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
 {
     #region Static Fields
+    static PaletteVisualStudio2010With2007Base()
+    {
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color4, Color.FromArgb(254, 254, 255));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color5, Color.FromArgb(206, 213, 225));
+
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color1, Color.FromArgb(235, 227, 196));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color2, Color.FromArgb(228, 198, 149));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color3, Color.FromArgb(166, 97, 7));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color4, Color.FromArgb(242, 155, 57));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color5, Color.FromArgb(236, 136, 9));
+
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color1, Color.FromArgb(255, 251, 230));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color2, Color.FromArgb(248, 230, 143));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color3, Color.FromArgb(238, 213, 126));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color4, Color.FromArgb(254, 247, 129));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color5, Color.FromArgb(240, 201, 41));
+
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(221, 221, 221));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(236, 236, 236));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(255, 246, 217));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color4, Color.FromArgb(255, 236, 181));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color5, Color.FromArgb(235, 122, 5));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color6, Color.FromArgb(254, 195, 108));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color7, Color.FromArgb(254, 175, 77));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color8, Color.FromArgb(254, 230, 136));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color9, Color.FromArgb(232, 142, 49));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color10, Color.FromArgb(252, 207, 100));
+
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color1, Color.FromArgb(212, 212, 212));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color2, Color.FromArgb(229, 195, 101));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color3, Color.FromArgb(255, 226, 112));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color4, Color.FromArgb(147, 125, 90));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color5, Color.FromArgb(255, 196, 68));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color6, Color.FromArgb(158, 130, 85));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color7, Color.FromArgb(254, 218, 144));
+    }
 
     #region Padding
 
@@ -156,58 +195,6 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
     #endregion
 
     #region Color Arrays
-
-    private static readonly Color[] _appButtonNormal =
-    [
-        Color.FromArgb(243, 245, 248),
-        Color.FromArgb(214, 220, 231),
-        Color.FromArgb(188, 198, 211),
-        Color.FromArgb(254, 254, 255),
-        Color.FromArgb(206, 213, 225)
-    ];
-
-    private static readonly Color[] _appButtonTrack =
-    [
-        Color.FromArgb(255, 251, 230),
-        Color.FromArgb(248, 230, 143),
-        Color.FromArgb(238, 213, 126),
-        Color.FromArgb(254, 247, 129),
-        Color.FromArgb(240, 201, 41)
-    ];
-
-    private static readonly Color[] _appButtonPressed =
-    [
-        Color.FromArgb(235, 227, 196),
-        Color.FromArgb(228, 198, 149),
-        Color.FromArgb(166, 97, 7),
-        Color.FromArgb(242, 155, 57),
-        Color.FromArgb(236, 136, 9)
-    ];
-
-    private static readonly Color[] _buttonBorderColors =
-    [
-        Color.FromArgb(212, 212, 212), // Button, Disabled, Border
-        Color.FromArgb(229, 195, 101), // Button, Tracking, Border 1
-        Color.FromArgb(255, 226, 112), // Button, Tracking, Border 2
-        Color.FromArgb(147, 125, 90), // Button, Pressed, Border 1
-        Color.FromArgb(255, 196, 68), // Button, Pressed, Border 2
-        Color.FromArgb(158, 130, 85), // Button, Checked, Border 1
-        Color.FromArgb(254, 218, 144) // Button, Checked, Border 2
-    ];
-
-    private static readonly Color[] _buttonBackColors =
-    [
-        Color.FromArgb(221, 221, 221), // Button, Disabled, Back 1
-        Color.FromArgb(236, 236, 236), // Button, Disabled, Back 2
-        Color.FromArgb(255, 246, 217), // Button, Tracking, Back 1
-        Color.FromArgb(255, 236, 181), // Button, Tracking, Back 2
-        Color.FromArgb(235, 122, 5), // Button, Pressed, Back 1
-        Color.FromArgb(254, 195, 108), // Button, Pressed, Back 2
-        Color.FromArgb(254, 175, 77), // Button, Checked, Back 1
-        Color.FromArgb(254, 230, 136), // Button, Checked, Back 2
-        Color.FromArgb(232, 142, 49), // Button, Checked Tracking, Back 1
-        Color.FromArgb(252, 207, 100) // Button, Checked Tracking, Back 2
-    ];
 
     #endregion
 
@@ -412,7 +399,7 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
                 return state == PaletteState.CheckedNormal ? _ribbonColors[(int)SchemeBaseColors.GridDataCellSelected] : SystemColors.Window;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[6] : SystemColors.Window;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7) : SystemColors.Window;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -436,7 +423,7 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
                             case PaletteBackStyle.TabLowProfile:
                                 return GlobalStaticValues.EMPTY_COLOR;
                             case PaletteBackStyle.TabHighProfile:
-                                return state == PaletteState.Tracking ? _buttonBackColors[2] : _buttonBackColors[4];
+                                return state == PaletteState.Tracking ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3) : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5);
                             default:
                                 return SystemColors.Window;
                         }
@@ -448,11 +435,11 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
                         {
                             if (state == PaletteState.CheckedNormal)
                             {
-                                return _buttonBackColors[6];
+                                return GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
                             }
                             else
                             {
-                                return state == PaletteState.CheckedPressed ? _buttonBackColors[4] : _buttonBackColors[8];
+                                return state == PaletteState.CheckedPressed ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5) : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9);
                             }
                         }
                         else
@@ -491,7 +478,7 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeBaseColors.HeaderDockInactiveBack1];
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[6];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeBaseColors.HeaderSecondaryBack1];
@@ -562,7 +549,7 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[2],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -615,12 +602,12 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
                     PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack1],
                     PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
                         ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]
-                        : _buttonBackColors[6],
-                    PaletteState.Tracking => _buttonBackColors[2],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
                         ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]
-                        : _buttonBackColors[8],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -628,7 +615,7 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorTrack1],
                     PaletteState.Pressed => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorPressed1],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorChecked1],
@@ -693,7 +680,7 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
                 return state == PaletteState.CheckedNormal ? _ribbonColors[(int)SchemeBaseColors.GridDataCellSelected] : SystemColors.Window;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[7] : SystemColors.Window;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8) : SystemColors.Window;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -715,7 +702,7 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.HeaderDockInactiveBack1],
-                    PaletteState.Tracking or PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => SystemColors.Window,
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
@@ -724,7 +711,7 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeBaseColors.HeaderDockInactiveBack1],
-                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.HeaderForm:
@@ -747,7 +734,7 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeBaseColors.HeaderDockInactiveBack2];
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[7];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeBaseColors.HeaderSecondaryBack2];
@@ -818,7 +805,7 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[3],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -866,19 +853,19 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
             case PaletteBackStyle.ContextMenuItemHighlight:
                 return state switch
                 {
-                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack1] : _buttonBackColors[1],
+                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack1] : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack2],
                     PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
                         ? GlobalStaticValues.EMPTY_COLOR
                         : _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack2],
                     PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
                         ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack2]
-                        : _buttonBackColors[7],
-                    PaletteState.Tracking => _buttonBackColors[3],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
                         ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]
-                        : _buttonBackColors[9],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color10),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -886,7 +873,7 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorTrack2],
                     PaletteState.Pressed => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorPressed2],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorChecked2],
@@ -1217,7 +1204,7 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeBaseColors.ControlBorder],
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1225,7 +1212,7 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
@@ -1238,8 +1225,8 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1275,23 +1262,23 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
             {
                 PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
                     ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack2]
-                    : _buttonBorderColors[0],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
                 PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
                     ? GlobalStaticValues.EMPTY_COLOR
                     : _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBorder],
-                PaletteState.CheckedNormal => _buttonBorderColors[5],
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
-                PaletteState.CheckedTracking => _buttonBorderColors[3],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color6),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1299,10 +1286,10 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1],
                 PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack1],
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorBorder],
@@ -1345,7 +1332,7 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeBaseColors.ControlBorder],
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1353,7 +1340,7 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
@@ -1366,8 +1353,8 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1403,21 +1390,21 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
             {
                 PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
                     ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack2]
-                    : _buttonBorderColors[0],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
                 PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBorder],
-                PaletteState.CheckedNormal => _buttonBorderColors[6],
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
-                PaletteState.CheckedTracking => _buttonBorderColors[4],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1425,10 +1412,10 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1],
                 PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack1],
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorBorder],
@@ -3602,11 +3589,11 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[0];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color1);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[0];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color1);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[0];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3717,11 +3704,11 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[1];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color2);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[1];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color2);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[1];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3806,11 +3793,11 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[2];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color3);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[2];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color3);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[2];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color3);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3888,11 +3875,11 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[3];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color4);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[3];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color4);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[3];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color4);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3970,11 +3957,11 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[4];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color5);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[4];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color5);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[4];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color5);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4126,8 +4113,8 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.Light(_ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder]),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBorderColors[1],
-                    PaletteState.Pressed => _buttonBorderColors[3],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                    PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4166,8 +4153,8 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
                         _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
                     PaletteState.Normal => ControlPaint.Light(
                         _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
-                    PaletteState.Tracking => ControlPaint.Light(_buttonBackColors[2]),
-                    PaletteState.Pressed => ControlPaint.Light(_buttonBackColors[4]),
+                    PaletteState.Tracking => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)),
+                    PaletteState.Pressed => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5)),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
 
@@ -4215,8 +4202,8 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(_ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1],
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[2],
-                    PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4263,8 +4250,8 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(_ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack2],
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[3],
-                    PaletteState.Pressed => _buttonBackColors[5],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2007/PaletteVisualStudio2010With2007Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2007/PaletteVisualStudio2010With2007Base.cs
@@ -14,8 +14,18 @@ namespace Krypton.Toolkit;
 public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
 {
     #region Static Fields
+
+    // registration guard so default colours are initialised lazily only once
+    private static bool _defaultsRegistered;
+
     static PaletteVisualStudio2010With2007Base()
     {
+        if (_defaultsRegistered)
+        {
+            return;
+        }
+        _defaultsRegistered = true;
+
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
@@ -269,12 +279,35 @@ public abstract class PaletteVisualStudio2010With2007Base : PaletteBase
         [DisallowNull] ImageList checkBoxList,
         [DisallowNull] ImageList galleryButtonList,
         [DisallowNull] Image?[] radioButtonArray)
-        : this(scheme.ToArray(),
-               checkBoxList,
-               galleryButtonList,
-               radioButtonArray,
-               scheme.ToTrackBarArray())
     {
+        Debug.Assert(scheme != null);
+        Debug.Assert(checkBoxList != null);
+        Debug.Assert(galleryButtonList != null);
+        Debug.Assert(radioButtonArray != null);
+
+        ThemeName = nameof(PaletteVisualStudio2010With2007Base);
+
+        if (scheme != null)
+        {
+            _ribbonColors = scheme.ToArray();
+        }
+
+        if (checkBoxList != null)
+        {
+            _checkBoxList = checkBoxList;
+        }
+
+        if (galleryButtonList != null)
+        {
+            _galleryButtonList = galleryButtonList;
+        }
+
+        if (radioButtonArray != null)
+        {
+            _radioButtonArray = radioButtonArray;
+        }
+
+        DefineFonts();
         BaseColors = scheme;
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2010/PaletteVisualStudio2010With2010Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2010/PaletteVisualStudio2010With2010Base.cs
@@ -14,6 +14,45 @@ namespace Krypton.Toolkit;
 public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
 {
     #region Static Fields
+    static PaletteVisualStudio2010With2010Base()
+    {
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color4, Color.FromArgb(254, 254, 255));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color5, Color.FromArgb(206, 213, 225));
+
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color1, Color.FromArgb(235, 227, 196));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color2, Color.FromArgb(228, 198, 149));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color3, Color.FromArgb(166, 97, 7));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color4, Color.FromArgb(242, 155, 57));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color5, Color.FromArgb(236, 136, 9));
+
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color1, Color.FromArgb(255, 251, 230));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color2, Color.FromArgb(248, 230, 143));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color3, Color.FromArgb(238, 213, 126));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color4, Color.FromArgb(254, 247, 129));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color5, Color.FromArgb(240, 201, 41));
+
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(250, 250, 250));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(250, 250, 250));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(248, 225, 135));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color4, Color.FromArgb(251, 248, 224));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color5, Color.FromArgb(255, 228, 138));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color6, Color.FromArgb(194, 118, 43));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color7, Color.FromArgb(255, 216, 108));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color8, Color.FromArgb(255, 244, 128));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color9, Color.FromArgb(255, 225, 104));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color10, Color.FromArgb(255, 249, 196));
+
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color1, Color.FromArgb(180, 180, 180));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color2, Color.FromArgb(237, 201, 88));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color3, Color.FromArgb(243, 213, 73));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color4, Color.FromArgb(194, 118, 43));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color5, Color.FromArgb(194, 158, 71));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color6, Color.FromArgb(194, 138, 48));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color7, Color.FromArgb(194, 164, 77));
+    }
 
     #region Padding
 
@@ -156,58 +195,6 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
     #endregion
 
     #region Color Arrays
-
-    private static readonly Color[] _appButtonNormal =
-    [
-        Color.FromArgb(243, 245, 248),
-        Color.FromArgb(214, 220, 231),
-        Color.FromArgb(188, 198, 211),
-        Color.FromArgb(254, 254, 255),
-        Color.FromArgb(206, 213, 225)
-    ];
-
-    private static readonly Color[] _appButtonTrack =
-    [
-        Color.FromArgb(255, 251, 230),
-        Color.FromArgb(248, 230, 143),
-        Color.FromArgb(238, 213, 126),
-        Color.FromArgb(254, 247, 129),
-        Color.FromArgb(240, 201, 41)
-    ];
-
-    private static readonly Color[] _appButtonPressed =
-    [
-        Color.FromArgb(235, 227, 196),
-        Color.FromArgb(228, 198, 149),
-        Color.FromArgb(166, 97, 7),
-        Color.FromArgb(242, 155, 57),
-        Color.FromArgb(236, 136, 9)
-    ];
-
-    private static readonly Color[] _buttonBorderColors =
-    [
-        Color.FromArgb(180, 180, 180), // Button, Disabled, Border
-        Color.FromArgb(237, 201, 88), // Button, Tracking, Border 1
-        Color.FromArgb(243, 213, 73), // Button, Tracking, Border 2
-        Color.FromArgb(194, 118, 43), // Button, Pressed, Border 1
-        Color.FromArgb(194, 158, 71), // Button, Pressed, Border 2
-        Color.FromArgb(194, 138, 48), // Button, Checked, Border 1
-        Color.FromArgb(194, 164, 77) // Button, Checked, Border 2
-    ];
-
-    private static readonly Color[] _buttonBackColors =
-    [
-        Color.FromArgb(250, 250, 250), // Button, Disabled, Back 1
-        Color.FromArgb(250, 250, 250), // Button, Disabled, Back 2
-        Color.FromArgb(248, 225, 135), // Button, Tracking, Back 1
-        Color.FromArgb(251, 248, 224), // Button, Tracking, Back 2
-        Color.FromArgb(255, 228, 138), // Button, Pressed, Back 1
-        Color.FromArgb(194, 118, 43), // Button, Pressed, Back 2
-        Color.FromArgb(255, 216, 108), // Button, Checked, Back 1
-        Color.FromArgb(255, 244, 128), // Button, Checked, Back 2
-        Color.FromArgb(255, 225, 104), // Button, Checked Tracking, Back 1
-        Color.FromArgb(255, 249, 196) // Button, Checked Tracking, Back 2
-    ];
 
     #endregion
 
@@ -412,7 +399,7 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
                 return state == PaletteState.CheckedNormal ? _ribbonColors[(int)SchemeBaseColors.GridDataCellSelected] : SystemColors.Window;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[6] : SystemColors.Window;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7) : SystemColors.Window;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -436,7 +423,7 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
                             case PaletteBackStyle.TabLowProfile:
                                 return GlobalStaticValues.EMPTY_COLOR;
                             case PaletteBackStyle.TabHighProfile:
-                                return state == PaletteState.Tracking ? _buttonBackColors[2] : _buttonBackColors[4];
+                                return state == PaletteState.Tracking ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3) : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5);
                             default:
                                 return SystemColors.Window;
                         }
@@ -448,11 +435,11 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
                         {
                             if (state == PaletteState.CheckedNormal)
                             {
-                                return _buttonBackColors[6];
+                                return GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
                             }
                             else
                             {
-                                return state == PaletteState.CheckedPressed ? _buttonBackColors[4] : _buttonBackColors[8];
+                                return state == PaletteState.CheckedPressed ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5) : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9);
                             }
                         }
                         else
@@ -491,7 +478,7 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeBaseColors.HeaderDockInactiveBack1];
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[6];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeBaseColors.HeaderSecondaryBack1];
@@ -562,7 +549,7 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[2],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -615,12 +602,12 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
                     PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack1],
                     PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
                         ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]
-                        : _buttonBackColors[6],
-                    PaletteState.Tracking => _buttonBackColors[2],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
                         ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]
-                        : _buttonBackColors[8],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -628,7 +615,7 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorTrack1],
                     PaletteState.Pressed => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorPressed1],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorChecked1],
@@ -693,7 +680,7 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
                 return state == PaletteState.CheckedNormal ? _ribbonColors[(int)SchemeBaseColors.GridDataCellSelected] : SystemColors.Window;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[7] : SystemColors.Window;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8) : SystemColors.Window;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -715,7 +702,7 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.HeaderDockInactiveBack1],
-                    PaletteState.Tracking or PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => SystemColors.Window,
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
@@ -724,7 +711,7 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeBaseColors.HeaderDockInactiveBack1],
-                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.HeaderForm:
@@ -747,7 +734,7 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeBaseColors.HeaderDockInactiveBack2];
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[7];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeBaseColors.HeaderSecondaryBack2];
@@ -818,7 +805,7 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[3],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -866,19 +853,19 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
             case PaletteBackStyle.ContextMenuItemHighlight:
                 return state switch
                 {
-                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack1] : _buttonBackColors[1],
+                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack1] : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack2],
                     PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
                         ? GlobalStaticValues.EMPTY_COLOR
                         : _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack2],
                     PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
                         ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack2]
-                        : _buttonBackColors[7],
-                    PaletteState.Tracking => _buttonBackColors[3],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
                         ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]
-                        : _buttonBackColors[9],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color10),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -886,7 +873,7 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorTrack2],
                     PaletteState.Pressed => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorPressed2],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorChecked2],
@@ -1217,7 +1204,7 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeBaseColors.ControlBorder],
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1225,7 +1212,7 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
@@ -1238,8 +1225,8 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1275,23 +1262,23 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
             {
                 PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
                     ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack2]
-                    : _buttonBorderColors[0],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
                 PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
                     ? GlobalStaticValues.EMPTY_COLOR
                     : _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBorder],
-                PaletteState.CheckedNormal => _buttonBorderColors[5],
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
-                PaletteState.CheckedTracking => _buttonBorderColors[3],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color6),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1299,10 +1286,10 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1],
                 PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack1],
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorBorder],
@@ -1345,7 +1332,7 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeBaseColors.ControlBorder],
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1353,7 +1340,7 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
@@ -1366,8 +1353,8 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1403,21 +1390,21 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
             {
                 PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
                     ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack2]
-                    : _buttonBorderColors[0],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
                 PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBorder],
-                PaletteState.CheckedNormal => _buttonBorderColors[6],
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
-                PaletteState.CheckedTracking => _buttonBorderColors[4],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1425,10 +1412,10 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1],
                 PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack1],
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorBorder],
@@ -3602,11 +3589,11 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[0];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color1);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[0];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color1);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[0];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3717,11 +3704,11 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[1];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color2);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[1];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color2);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[1];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3806,11 +3793,11 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[2];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color3);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[2];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color3);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[2];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color3);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3888,11 +3875,11 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[3];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color4);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[3];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color4);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[3];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color4);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3970,11 +3957,11 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[4];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color5);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[4];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color5);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[4];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color5);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4126,8 +4113,8 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.Light(_ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder]),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBorderColors[1],
-                    PaletteState.Pressed => _buttonBorderColors[3],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                    PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4166,8 +4153,8 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
                         _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
                     PaletteState.Normal => ControlPaint.Light(
                         _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
-                    PaletteState.Tracking => ControlPaint.Light(_buttonBackColors[2]),
-                    PaletteState.Pressed => ControlPaint.Light(_buttonBackColors[4]),
+                    PaletteState.Tracking => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)),
+                    PaletteState.Pressed => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5)),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
 
@@ -4215,8 +4202,8 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(_ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1],
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[2],
-                    PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4263,8 +4250,8 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(_ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack2],
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[3],
-                    PaletteState.Pressed => _buttonBackColors[5],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2010/PaletteVisualStudio2010With2010Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2010/PaletteVisualStudio2010With2010Base.cs
@@ -14,8 +14,18 @@ namespace Krypton.Toolkit;
 public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
 {
     #region Static Fields
+
+    // registration guard so default colours are initialised lazily only once
+    private static bool _defaultsRegistered;
+
     static PaletteVisualStudio2010With2010Base()
     {
+        if (_defaultsRegistered)
+        {
+            return;
+        }
+        _defaultsRegistered = true;
+
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
@@ -269,12 +279,36 @@ public abstract class PaletteVisualStudio2010With2010Base : PaletteBase
         [DisallowNull] ImageList checkBoxList,
         [DisallowNull] ImageList galleryButtonList,
         [DisallowNull] Image?[] radioButtonArray)
-        : this(scheme.ToArray(),
-               checkBoxList,
-               galleryButtonList,
-               radioButtonArray,
-               scheme.ToTrackBarArray())
     {
+        Debug.Assert(scheme != null);
+        Debug.Assert(checkBoxList != null);
+        Debug.Assert(galleryButtonList != null);
+        Debug.Assert(radioButtonArray != null);
+
+        ThemeName = nameof(PaletteVisualStudio2010With2010Base);
+
+        if (scheme != null)
+        {
+            _ribbonColors = scheme.ToArray();
+        }
+
+        if (checkBoxList != null)
+        {
+            _checkBoxList = checkBoxList;
+        }
+
+        if (galleryButtonList != null)
+        {
+            _galleryButtonList = galleryButtonList;
+        }
+
+        if (radioButtonArray != null)
+        {
+            _radioButtonArray = radioButtonArray;
+        }
+
+        DefineFonts();
+
         BaseColors = scheme;
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2013/PaletteVisualStudio2010With2013Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2013/PaletteVisualStudio2010With2013Base.cs
@@ -14,6 +14,45 @@ namespace Krypton.Toolkit;
 public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
 {
     #region Static Fields
+    static PaletteVisualStudio2010With2013Base()
+    {
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color4, Color.FromArgb(254, 254, 255));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color5, Color.FromArgb(206, 213, 225));
+
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color1, Color.FromArgb(235, 227, 196));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color2, Color.FromArgb(228, 198, 149));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color3, Color.FromArgb(166, 97, 7));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color4, Color.FromArgb(242, 155, 57));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color5, Color.FromArgb(236, 136, 9));
+
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color1, Color.FromArgb(255, 251, 230));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color2, Color.FromArgb(248, 230, 143));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color3, Color.FromArgb(238, 213, 126));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color4, Color.FromArgb(254, 247, 129));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color5, Color.FromArgb(240, 201, 41));
+
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(250, 250, 250));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(250, 250, 250));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(205, 230, 247));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color4, Color.FromArgb(205, 230, 247));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color5, Color.FromArgb(146, 192, 244));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color6, Color.FromArgb(146, 192, 244));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color7, Color.FromArgb(146, 192, 244));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color8, Color.FromArgb(146, 192, 244));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color9, Color.FromArgb(255, 225, 104));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color10, Color.FromArgb(255, 249, 196));
+
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color1, Color.FromArgb(180, 180, 180));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color2, Color.FromArgb(205, 230, 247));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color3, Color.FromArgb(205, 230, 247));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color4, Color.FromArgb(146, 192, 244));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color5, Color.FromArgb(146, 192, 244));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color6, Color.FromArgb(146, 192, 244));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color7, Color.FromArgb(146, 192, 244));
+    }
 
     #region Padding
 
@@ -156,58 +195,6 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
     #endregion
 
     #region Color Arrays
-
-    private static readonly Color[] _appButtonNormal =
-    [
-        Color.FromArgb(243, 245, 248),
-        Color.FromArgb(214, 220, 231),
-        Color.FromArgb(188, 198, 211),
-        Color.FromArgb(254, 254, 255),
-        Color.FromArgb(206, 213, 225)
-    ];
-
-    private static readonly Color[] _appButtonTrack =
-    [
-        Color.FromArgb(255, 251, 230),
-        Color.FromArgb(248, 230, 143),
-        Color.FromArgb(238, 213, 126),
-        Color.FromArgb(254, 247, 129),
-        Color.FromArgb(240, 201, 41)
-    ];
-
-    private static readonly Color[] _appButtonPressed =
-    [
-        Color.FromArgb(235, 227, 196),
-        Color.FromArgb(228, 198, 149),
-        Color.FromArgb(166, 97, 7),
-        Color.FromArgb(242, 155, 57),
-        Color.FromArgb(236, 136, 9)
-    ];
-
-    private static readonly Color[] _buttonBorderColors =
-    [
-        Color.FromArgb(180, 180, 180), // Button, Disabled, Border
-        Color.FromArgb(205, 230, 247), // Button, Tracking, Border 1
-        Color.FromArgb(205, 230, 247), // Button, Tracking, Border 2
-        Color.FromArgb(146, 192, 244), // Button, Pressed, Border 1
-        Color.FromArgb(146, 192, 244), // Button, Pressed, Border 2
-        Color.FromArgb(146, 192, 244), // Button, Checked, Border 1
-        Color.FromArgb(146, 192, 244) // Button, Checked, Border 2
-    ];
-
-    private static readonly Color[] _buttonBackColors =
-    [
-        Color.FromArgb(250, 250, 250), // Button, Disabled, Back 1
-        Color.FromArgb(250, 250, 250), // Button, Disabled, Back 2
-        Color.FromArgb(205, 230, 247), // Button, Tracking, Back 1
-        Color.FromArgb(205, 230, 247), // Button, Tracking, Back 2
-        Color.FromArgb(146, 192, 244), // Button, Pressed, Back 1
-        Color.FromArgb(146, 192, 244), // Button, Pressed, Back 2
-        Color.FromArgb(146, 192, 244), // Button, Checked, Back 1
-        Color.FromArgb(146, 192, 244), // Button, Checked, Back 2
-        Color.FromArgb(255, 225, 104), // Button, Checked Tracking, Back 1
-        Color.FromArgb(255, 249, 196) // Button, Checked Tracking, Back 2
-    ];
 
     #endregion
 
@@ -411,7 +398,7 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
                 return state == PaletteState.CheckedNormal ? _ribbonColors[(int)SchemeBaseColors.GridDataCellSelected] : SystemColors.Window;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[6] : SystemColors.Window;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7) : SystemColors.Window;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -435,7 +422,7 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
                             case PaletteBackStyle.TabLowProfile:
                                 return GlobalStaticValues.EMPTY_COLOR;
                             case PaletteBackStyle.TabHighProfile:
-                                return state == PaletteState.Tracking ? _buttonBackColors[2] : _buttonBackColors[4];
+                                return state == PaletteState.Tracking ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3) : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5);
                             default:
                                 return SystemColors.Window;
                         }
@@ -447,11 +434,11 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
                         {
                             if (state == PaletteState.CheckedNormal)
                             {
-                                return _buttonBackColors[6];
+                                return GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
                             }
                             else
                             {
-                                return state == PaletteState.CheckedPressed ? _buttonBackColors[4] : _buttonBackColors[8];
+                                return state == PaletteState.CheckedPressed ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5) : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9);
                             }
                         }
                         else
@@ -490,7 +477,7 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeBaseColors.HeaderDockInactiveBack1];
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[6];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeBaseColors.HeaderSecondaryBack1];
@@ -561,7 +548,7 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[2],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -614,12 +601,12 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
                     PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack1],
                     PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
                         ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]
-                        : _buttonBackColors[6],
-                    PaletteState.Tracking => _buttonBackColors[2],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
                         ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]
-                        : _buttonBackColors[8],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -627,7 +614,7 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorTrack1],
                     PaletteState.Pressed => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorPressed1],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorChecked1],
@@ -692,7 +679,7 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
                 return state == PaletteState.CheckedNormal ? _ribbonColors[(int)SchemeBaseColors.GridDataCellSelected] : SystemColors.Window;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[7] : SystemColors.Window;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8) : SystemColors.Window;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -714,7 +701,7 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.HeaderDockInactiveBack1],
-                    PaletteState.Tracking or PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => SystemColors.Window,
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
@@ -723,7 +710,7 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeBaseColors.HeaderDockInactiveBack1],
-                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.HeaderForm:
@@ -746,7 +733,7 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeBaseColors.HeaderDockInactiveBack2];
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[7];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeBaseColors.HeaderSecondaryBack2];
@@ -817,7 +804,7 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[3],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -865,19 +852,19 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
             case PaletteBackStyle.ContextMenuItemHighlight:
                 return state switch
                 {
-                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack1] : _buttonBackColors[1],
+                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack1] : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack2],
                     PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
                         ? GlobalStaticValues.EMPTY_COLOR
                         : _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack2],
                     PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
                         ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack2]
-                        : _buttonBackColors[7],
-                    PaletteState.Tracking => _buttonBackColors[3],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
                         ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]
-                        : _buttonBackColors[9],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color10),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -885,7 +872,7 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorTrack2],
                     PaletteState.Pressed => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorPressed2],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorChecked2],
@@ -1216,7 +1203,7 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeBaseColors.ControlBorder],
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1224,7 +1211,7 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
@@ -1237,8 +1224,8 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1274,23 +1261,23 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
             {
                 PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
                     ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack2]
-                    : _buttonBorderColors[0],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
                 PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
                     ? GlobalStaticValues.EMPTY_COLOR
                     : _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBorder],
-                PaletteState.CheckedNormal => _buttonBorderColors[5],
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
-                PaletteState.CheckedTracking => _buttonBorderColors[3],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color6),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1298,10 +1285,10 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1],
                 PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack1],
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorBorder],
@@ -1344,7 +1331,7 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeBaseColors.ControlBorder],
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1352,7 +1339,7 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
@@ -1365,8 +1352,8 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1402,21 +1389,21 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
             {
                 PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
                     ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack2]
-                    : _buttonBorderColors[0],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
                 PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBorder],
-                PaletteState.CheckedNormal => _buttonBorderColors[6],
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
-                PaletteState.CheckedTracking => _buttonBorderColors[4],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1424,10 +1411,10 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1],
                 PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack1],
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorBorder],
@@ -3601,11 +3588,11 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[0];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color1);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[0];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color1);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[0];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3716,11 +3703,11 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[1];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color2);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[1];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color2);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[1];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3805,11 +3792,11 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[2];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color3);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[2];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color3);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[2];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color3);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3887,11 +3874,11 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[3];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color4);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[3];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color4);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[3];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color4);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3969,11 +3956,11 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[4];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color5);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[4];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color5);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[4];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color5);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4125,8 +4112,8 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.Light(_ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder]),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBorderColors[1],
-                    PaletteState.Pressed => _buttonBorderColors[3],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                    PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4165,8 +4152,8 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
                         _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
                     PaletteState.Normal => ControlPaint.Light(
                         _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
-                    PaletteState.Tracking => ControlPaint.Light(_buttonBackColors[2]),
-                    PaletteState.Pressed => ControlPaint.Light(_buttonBackColors[4]),
+                    PaletteState.Tracking => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)),
+                    PaletteState.Pressed => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5)),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
 
@@ -4214,8 +4201,8 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(_ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1],
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[2],
-                    PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4262,8 +4249,8 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(_ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack2],
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[3],
-                    PaletteState.Pressed => _buttonBackColors[5],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2013/PaletteVisualStudio2010With2013Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/2013/PaletteVisualStudio2010With2013Base.cs
@@ -14,8 +14,18 @@ namespace Krypton.Toolkit;
 public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
 {
     #region Static Fields
+
+    // registration guard so default colours are initialised lazily only once
+    private static bool _defaultsRegistered;
+
     static PaletteVisualStudio2010With2013Base()
     {
+        if (_defaultsRegistered)
+        {
+            return;
+        }
+        _defaultsRegistered = true;
+
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
@@ -269,12 +279,36 @@ public abstract class PaletteVisualStudio2010With2013Base : PaletteBase
         [DisallowNull] ImageList checkBoxList,
         [DisallowNull] ImageList galleryButtonList,
         [DisallowNull] Image?[] radioButtonArray)
-        : this(scheme.ToArray(),
-               checkBoxList,
-               galleryButtonList,
-               radioButtonArray,
-               scheme.ToTrackBarArray())
     {
+        Debug.Assert(scheme != null);
+        Debug.Assert(checkBoxList != null);
+        Debug.Assert(galleryButtonList != null);
+        Debug.Assert(radioButtonArray != null);
+
+        ThemeName = nameof(PaletteVisualStudio2010With2013Base);
+
+        if (scheme != null)
+        {
+            _ribbonColors = scheme.ToArray();
+        }
+
+        if (checkBoxList != null)
+        {
+            _checkBoxList = checkBoxList;
+        }
+
+        if (galleryButtonList != null)
+        {
+            _galleryButtonList = galleryButtonList;
+        }
+
+        if (radioButtonArray != null)
+        {
+            _radioButtonArray = radioButtonArray;
+        }
+
+        DefineFonts();
+
         BaseColors = scheme;
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/365/PaletteVisualStudio2010With365Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/365/PaletteVisualStudio2010With365Base.cs
@@ -14,8 +14,18 @@ namespace Krypton.Toolkit;
 public abstract class PaletteVisualStudio2010With365Base : PaletteBase
 {
     #region Static Fields
+
+    // registration guard so default colours are initialised lazily only once
+    private static bool _defaultsRegistered;
+
     static PaletteVisualStudio2010With365Base()
     {
+        if (_defaultsRegistered)
+        {
+            return;
+        }
+        _defaultsRegistered = true;
+
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
         RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
@@ -269,12 +279,35 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
         [DisallowNull] ImageList checkBoxList,
         [DisallowNull] ImageList galleryButtonList,
         [DisallowNull] Image?[] radioButtonArray)
-        : this(scheme.ToArray(),
-               checkBoxList,
-               galleryButtonList,
-               radioButtonArray,
-               scheme.ToTrackBarArray())
     {
+        Debug.Assert(scheme != null);
+        Debug.Assert(checkBoxList != null);
+        Debug.Assert(galleryButtonList != null);
+        Debug.Assert(radioButtonArray != null);
+
+        ThemeName = nameof(PaletteVisualStudio2010With365Base);
+
+        if (scheme != null)
+        {
+            _ribbonColors = scheme.ToArray();
+        }
+
+        if (checkBoxList != null)
+        {
+            _checkBoxList = checkBoxList;
+        }
+
+        if (galleryButtonList != null)
+        {
+            _galleryButtonList = galleryButtonList;
+        }
+
+        if (radioButtonArray != null)
+        {
+            _radioButtonArray = radioButtonArray;
+        }
+
+        DefineFonts();
         BaseColors = scheme;
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/365/PaletteVisualStudio2010With365Base.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Base/Visual Studio 2010/Renderers/365/PaletteVisualStudio2010With365Base.cs
@@ -14,6 +14,45 @@ namespace Krypton.Toolkit;
 public abstract class PaletteVisualStudio2010With365Base : PaletteBase
 {
     #region Static Fields
+    static PaletteVisualStudio2010With365Base()
+    {
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color2, Color.FromArgb(214, 220, 231));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color3, Color.FromArgb(188, 198, 211));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color4, Color.FromArgb(254, 254, 255));
+        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color5, Color.FromArgb(206, 213, 225));
+
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color1, Color.FromArgb(235, 227, 196));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color2, Color.FromArgb(228, 198, 149));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color3, Color.FromArgb(166, 97, 7));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color4, Color.FromArgb(242, 155, 57));
+        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color5, Color.FromArgb(236, 136, 9));
+
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color1, Color.FromArgb(255, 251, 230));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color2, Color.FromArgb(248, 230, 143));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color3, Color.FromArgb(238, 213, 126));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color4, Color.FromArgb(254, 247, 129));
+        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color5, Color.FromArgb(240, 201, 41));
+
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color1, Color.FromArgb(250, 250, 250));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color2, Color.FromArgb(250, 250, 250));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color3, Color.FromArgb(248, 225, 135));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color4, Color.FromArgb(251, 248, 224));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color5, Color.FromArgb(255, 228, 138));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color6, Color.FromArgb(194, 118, 43));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color7, Color.FromArgb(255, 216, 108));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color8, Color.FromArgb(255, 244, 128));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color9, Color.FromArgb(255, 225, 104));
+        RegisterColor<ButtonBackColor>(ButtonBackColor.Color10, Color.FromArgb(255, 249, 196));
+
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color1, Color.FromArgb(180, 180, 180));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color2, Color.FromArgb(237, 201, 88));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color3, Color.FromArgb(243, 213, 73));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color4, Color.FromArgb(194, 118, 43));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color5, Color.FromArgb(194, 158, 71));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color6, Color.FromArgb(194, 138, 48));
+        RegisterColor<ButtonBorderColor>(ButtonBorderColor.Color7, Color.FromArgb(194, 164, 77));
+    }
 
     #region Padding
 
@@ -156,58 +195,6 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
     #endregion
 
     #region Color Arrays
-
-    private static readonly Color[] _appButtonNormal =
-    [
-        Color.FromArgb(243, 245, 248),
-        Color.FromArgb(214, 220, 231),
-        Color.FromArgb(188, 198, 211),
-        Color.FromArgb(254, 254, 255),
-        Color.FromArgb(206, 213, 225)
-    ];
-
-    private static readonly Color[] _appButtonTrack =
-    [
-        Color.FromArgb(255, 251, 230),
-        Color.FromArgb(248, 230, 143),
-        Color.FromArgb(238, 213, 126),
-        Color.FromArgb(254, 247, 129),
-        Color.FromArgb(240, 201, 41)
-    ];
-
-    private static readonly Color[] _appButtonPressed =
-    [
-        Color.FromArgb(235, 227, 196),
-        Color.FromArgb(228, 198, 149),
-        Color.FromArgb(166, 97, 7),
-        Color.FromArgb(242, 155, 57),
-        Color.FromArgb(236, 136, 9)
-    ];
-
-    private static readonly Color[] _buttonBorderColors =
-    [
-        Color.FromArgb(180, 180, 180), // Button, Disabled, Border
-        Color.FromArgb(237, 201, 88), // Button, Tracking, Border 1
-        Color.FromArgb(243, 213, 73), // Button, Tracking, Border 2
-        Color.FromArgb(194, 118, 43), // Button, Pressed, Border 1
-        Color.FromArgb(194, 158, 71), // Button, Pressed, Border 2
-        Color.FromArgb(194, 138, 48), // Button, Checked, Border 1
-        Color.FromArgb(194, 164, 77) // Button, Checked, Border 2
-    ];
-
-    private static readonly Color[] _buttonBackColors =
-    [
-        Color.FromArgb(250, 250, 250), // Button, Disabled, Back 1
-        Color.FromArgb(250, 250, 250), // Button, Disabled, Back 2
-        Color.FromArgb(248, 225, 135), // Button, Tracking, Back 1
-        Color.FromArgb(251, 248, 224), // Button, Tracking, Back 2
-        Color.FromArgb(255, 228, 138), // Button, Pressed, Back 1
-        Color.FromArgb(194, 118, 43), // Button, Pressed, Back 2
-        Color.FromArgb(255, 216, 108), // Button, Checked, Back 1
-        Color.FromArgb(255, 244, 128), // Button, Checked, Back 2
-        Color.FromArgb(255, 225, 104), // Button, Checked Tracking, Back 1
-        Color.FromArgb(255, 249, 196) // Button, Checked Tracking, Back 2
-    ];
 
     #endregion
 
@@ -412,7 +399,7 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
                 return state == PaletteState.CheckedNormal ? _ribbonColors[(int)SchemeBaseColors.GridDataCellSelected] : SystemColors.Window;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[6] : SystemColors.Window;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7) : SystemColors.Window;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -436,7 +423,7 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
                             case PaletteBackStyle.TabLowProfile:
                                 return GlobalStaticValues.EMPTY_COLOR;
                             case PaletteBackStyle.TabHighProfile:
-                                return state == PaletteState.Tracking ? _buttonBackColors[2] : _buttonBackColors[4];
+                                return state == PaletteState.Tracking ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3) : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5);
                             default:
                                 return SystemColors.Window;
                         }
@@ -448,11 +435,11 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
                         {
                             if (state == PaletteState.CheckedNormal)
                             {
-                                return _buttonBackColors[6];
+                                return GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
                             }
                             else
                             {
-                                return state == PaletteState.CheckedPressed ? _buttonBackColors[4] : _buttonBackColors[8];
+                                return state == PaletteState.CheckedPressed ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5) : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9);
                             }
                         }
                         else
@@ -491,7 +478,7 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeBaseColors.HeaderDockInactiveBack1];
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[6];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeBaseColors.HeaderSecondaryBack1];
@@ -562,7 +549,7 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[2],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -615,12 +602,12 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
                     PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack1],
                     PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
                         ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]
-                        : _buttonBackColors[6],
-                    PaletteState.Tracking => _buttonBackColors[2],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
                         ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]
-                        : _buttonBackColors[8],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -628,7 +615,7 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorTrack1],
                     PaletteState.Pressed => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorPressed1],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorChecked1],
@@ -693,7 +680,7 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
                 return state == PaletteState.CheckedNormal ? _ribbonColors[(int)SchemeBaseColors.GridDataCellSelected] : SystemColors.Window;
 
             case PaletteBackStyle.GridDataCellSheet:
-                return state == PaletteState.CheckedNormal ? _buttonBackColors[7] : SystemColors.Window;
+                return state == PaletteState.CheckedNormal ? GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8) : SystemColors.Window;
 
             case PaletteBackStyle.TabHighProfile:
             case PaletteBackStyle.TabStandardProfile:
@@ -715,7 +702,7 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.HeaderDockInactiveBack1],
-                    PaletteState.Tracking or PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => SystemColors.Window,
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
@@ -724,7 +711,7 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
                 {
                     PaletteState.Disabled => _disabledBack,
                     PaletteState.Normal or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeBaseColors.HeaderDockInactiveBack1],
-                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.HeaderForm:
@@ -747,7 +734,7 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
                 return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeBaseColors.HeaderDockInactiveBack2];
 
             case PaletteBackStyle.HeaderDockActive:
-                return state == PaletteState.Disabled ? _disabledBack : _buttonBackColors[7];
+                return state == PaletteState.Disabled ? _disabledBack : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8);
 
             case PaletteBackStyle.HeaderSecondary:
                 return state == PaletteState.Disabled ? _disabledBack : _ribbonColors[(int)SchemeBaseColors.HeaderSecondaryBack2];
@@ -818,7 +805,7 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
             case PaletteBackStyle.ContextMenuItemSplit:
                 return state switch
                 {
-                    PaletteState.Tracking => _buttonBackColors[3],
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
                     _ => _contextMenuBack
                 };
             case PaletteBackStyle.ContextMenuInner:
@@ -866,19 +853,19 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
             case PaletteBackStyle.ContextMenuItemHighlight:
                 return state switch
                 {
-                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack1] : _buttonBackColors[1],
+                    PaletteState.Disabled => style == PaletteBackStyle.ButtonGallery ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack1] : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack2],
                     PaletteState.NormalDefaultOverride => style is PaletteBackStyle.ButtonLowProfile or PaletteBackStyle.ButtonBreadCrumb or PaletteBackStyle.ButtonListItem or PaletteBackStyle.ButtonCommand or PaletteBackStyle.ButtonButtonSpec or PaletteBackStyle.ContextMenuItemHighlight
                         ? GlobalStaticValues.EMPTY_COLOR
                         : _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack2],
                     PaletteState.CheckedNormal => style == PaletteBackStyle.ButtonInputControl
                         ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack2]
-                        : _buttonBackColors[7],
-                    PaletteState.Tracking => _buttonBackColors[3],
-                    PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[5],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color8),
+                    PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     PaletteState.CheckedTracking => style == PaletteBackStyle.ButtonInputControl
                         ? _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]
-                        : _buttonBackColors[9],
+                        : GetArrayColor<ButtonBackColor>(ButtonBackColor.Color10),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             case PaletteBackStyle.ButtonNavigatorStack:
@@ -886,7 +873,7 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
             case PaletteBackStyle.ButtonNavigatorMini:
                 return state switch
                 {
-                    PaletteState.Disabled => _buttonBackColors[1],
+                    PaletteState.Disabled => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color2),
                     PaletteState.Tracking => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorTrack2],
                     PaletteState.Pressed => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorPressed2],
                     PaletteState.CheckedNormal or PaletteState.CheckedTracking or PaletteState.CheckedPressed => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorChecked2],
@@ -1217,7 +1204,7 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeBaseColors.ControlBorder],
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1225,7 +1212,7 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderCalendar => state == PaletteState.Disabled
@@ -1238,8 +1225,8 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[1],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1275,23 +1262,23 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
             {
                 PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
                     ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack2]
-                    : _buttonBorderColors[0],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
                 PaletteState.NormalDefaultOverride => style is PaletteBorderStyle.ButtonLowProfile or PaletteBorderStyle.ButtonBreadCrumb or PaletteBorderStyle.ButtonListItem or PaletteBorderStyle.ButtonCommand or PaletteBorderStyle.ButtonButtonSpec or PaletteBorderStyle.ContextMenuItemHighlight
                     ? GlobalStaticValues.EMPTY_COLOR
                     : _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBorder],
-                PaletteState.CheckedNormal => _buttonBorderColors[5],
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
-                PaletteState.CheckedTracking => _buttonBorderColors[3],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color6),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking => _buttonBorderColors[1],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[3],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1299,10 +1286,10 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1],
                 PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack1],
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorBorder],
@@ -1345,7 +1332,7 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.Pressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 PaletteState.CheckedNormal or PaletteState.CheckedPressed or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeBaseColors.ControlBorder],
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
@@ -1353,7 +1340,7 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
             {
                 PaletteState.Disabled => _disabledBorder,
                 PaletteState.Normal or PaletteState.CheckedNormal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[2],
+                PaletteState.Tracking or PaletteState.CheckedTracking or PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.HeaderForm => state == PaletteState.Disabled
@@ -1366,8 +1353,8 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
             PaletteBorderStyle.ContextMenuHeading or PaletteBorderStyle.ContextMenuItemImageColumn => _contextMenuHeadingBorder,
             PaletteBorderStyle.ContextMenuSeparator or PaletteBorderStyle.ContextMenuItemSplit => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
-                PaletteState.Tracking => _buttonBorderColors[2],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
                 _ => _contextMenuHeadingBorder
             },
             PaletteBorderStyle.ContextMenuItemImage => _contextMenuImageBorderChecked,
@@ -1403,21 +1390,21 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
             {
                 PaletteState.Disabled => style == PaletteBorderStyle.ButtonGallery
                     ? _ribbonColors[(int)SchemeBaseColors.RibbonGalleryBack2]
-                    : _buttonBorderColors[0],
+                    : GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
                 PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBorder],
-                PaletteState.CheckedNormal => _buttonBorderColors[6],
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
-                PaletteState.CheckedTracking => _buttonBorderColors[4],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonInputControl => state switch
             {
-                PaletteState.Disabled => _buttonBorderColors[0],
+                PaletteState.Disabled => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color1),
                 PaletteState.Normal or PaletteState.CheckedNormal or PaletteState.CheckedTracking => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                PaletteState.Tracking => _buttonBorderColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBorderColors[4],
+                PaletteState.Tracking => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color5),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonCalendarDay => state switch
@@ -1425,10 +1412,10 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
                 PaletteState.Disabled => _disabledBack,
                 PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1],
                 PaletteState.NormalDefaultOverride => _ribbonColors[(int)SchemeBaseColors.ButtonNormalDefaultBack1],
-                PaletteState.CheckedNormal => _buttonBackColors[6],
-                PaletteState.Tracking => _buttonBackColors[2],
-                PaletteState.Pressed or PaletteState.CheckedPressed => _buttonBackColors[4],
-                PaletteState.CheckedTracking => _buttonBackColors[8],
+                PaletteState.CheckedNormal => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color7),
+                PaletteState.Tracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                PaletteState.Pressed or PaletteState.CheckedPressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
+                PaletteState.CheckedTracking => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color9),
                 _ => throw DebugTools.NotImplemented(state.ToString())
             },
             PaletteBorderStyle.ButtonNavigatorStack or PaletteBorderStyle.ButtonNavigatorOverflow or PaletteBorderStyle.ButtonNavigatorMini => _ribbonColors[(int)SchemeBaseColors.ButtonNavigatorBorder],
@@ -3602,11 +3589,11 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[0];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color1);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[0];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color1);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[0];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color1);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3717,11 +3704,11 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[1];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color2);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[1];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color2);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[1];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color2);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3806,11 +3793,11 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[2];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color3);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[2];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color3);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[2];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color3);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3888,11 +3875,11 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[3];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color4);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[3];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color4);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[3];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color4);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -3970,11 +3957,11 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
                 switch (state)
                 {
                     case PaletteState.Normal:
-                        return _appButtonNormal[4];
+                        return GetArrayColor<AppButtonNormalColor>(AppButtonNormalColor.Color5);
                     case PaletteState.Tracking:
-                        return _appButtonTrack[4];
+                        return GetArrayColor<AppButtonTrackColor>(AppButtonTrackColor.Color5);
                     case PaletteState.Pressed:
-                        return _appButtonPressed[4];
+                        return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color5);
                     default:
                         // Should never happen!
                         Debug.Assert(false);
@@ -4126,8 +4113,8 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.Light(_ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder]),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBorder],
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBorderColors[1],
-                    PaletteState.Pressed => _buttonBorderColors[3],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color2),
+                    PaletteState.Pressed => GetArrayColor<ButtonBorderColor>(ButtonBorderColor.Color4),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4166,8 +4153,8 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
                         _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
                     PaletteState.Normal => ControlPaint.Light(
                         _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
-                    PaletteState.Tracking => ControlPaint.Light(_buttonBackColors[2]),
-                    PaletteState.Pressed => ControlPaint.Light(_buttonBackColors[4]),
+                    PaletteState.Tracking => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3)),
+                    PaletteState.Pressed => ControlPaint.Light(GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5)),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
 
@@ -4215,8 +4202,8 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(_ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1],
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[2],
-                    PaletteState.Pressed => _buttonBackColors[4],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color3),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color5),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:
@@ -4263,8 +4250,8 @@ public abstract class PaletteVisualStudio2010With365Base : PaletteBase
                 {
                     PaletteState.Disabled => ControlPaint.LightLight(_ribbonColors[(int)SchemeBaseColors.ButtonNormalBack1]),
                     PaletteState.Normal => _ribbonColors[(int)SchemeBaseColors.ButtonNormalBack2],
-                    PaletteState.Tracking or PaletteState.FocusOverride => _buttonBackColors[3],
-                    PaletteState.Pressed => _buttonBackColors[5],
+                    PaletteState.Tracking or PaletteState.FocusOverride => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color4),
+                    PaletteState.Pressed => GetArrayColor<ButtonBackColor>(ButtonBackColor.Color6),
                     _ => throw DebugTools.NotImplemented(state.ToString())
                 };
             default:

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Official Themes/2012/PaletteVisualStudio2012DarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Official Themes/2012/PaletteVisualStudio2012DarkMode.cs
@@ -1,9 +1,9 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -11,7 +11,8 @@ namespace Krypton.Toolkit;
 
 public abstract class PaletteVisualStudio2012DarkMode : PaletteVisualStudioBase
 {
-    protected PaletteVisualStudio2012DarkMode(Color[] schemeColors, ImageList checkBoxList, ImageList galleryButtonList, Image?[] radioButtonArray, Color[] trackBarColors) 
+    [System.Obsolete("Color[] constructor is deprecated and will be removed in V110. Use KryptonColorSchemeBase overload.", false)]
+    protected PaletteVisualStudio2012DarkMode(Color[] schemeColors, ImageList checkBoxList, ImageList galleryButtonList, Image?[] radioButtonArray, Color[] trackBarColors)
         : base(schemeColors, checkBoxList, galleryButtonList, radioButtonArray, trackBarColors)
     {
         ThemeName = nameof(PaletteVisualStudio2012DarkMode);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Official Themes/2012/PaletteVisualStudio2012LightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Official Themes/2012/PaletteVisualStudio2012LightMode.cs
@@ -1,9 +1,9 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -11,7 +11,8 @@ namespace Krypton.Toolkit;
 
 public abstract class PaletteVisualStudio2012LightMode : PaletteVisualStudioBase
 {
-    protected PaletteVisualStudio2012LightMode(Color[] schemeColors, ImageList checkBoxList, ImageList galleryButtonList, Image?[] radioButtonArray, Color[] trackBarColors) 
+    [System.Obsolete("Color[] constructor is deprecated and will be removed in V110. Use KryptonColorSchemeBase overload.", false)]
+    protected PaletteVisualStudio2012LightMode(Color[] schemeColors, ImageList checkBoxList, ImageList galleryButtonList, Image?[] radioButtonArray, Color[] trackBarColors)
         : base(schemeColors, checkBoxList, galleryButtonList, radioButtonArray, trackBarColors)
     {
         ThemeName = nameof(PaletteVisualStudio2012LightMode);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Official Themes/2013/PaletteVisualStudio2013DarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Official Themes/2013/PaletteVisualStudio2013DarkMode.cs
@@ -1,9 +1,9 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -11,7 +11,8 @@ namespace Krypton.Toolkit;
 
 public abstract class PaletteVisualStudio2013DarkMode : PaletteVisualStudioBase
 {
-    protected PaletteVisualStudio2013DarkMode(Color[] schemeColors, ImageList checkBoxList, ImageList galleryButtonList, Image?[] radioButtonArray, Color[] trackBarColors) 
+    [System.Obsolete("Color[] constructor is deprecated and will be removed in V110. Use KryptonColorSchemeBase overload.", false)]
+    protected PaletteVisualStudio2013DarkMode(Color[] schemeColors, ImageList checkBoxList, ImageList galleryButtonList, Image?[] radioButtonArray, Color[] trackBarColors)
         : base(schemeColors, checkBoxList, galleryButtonList, radioButtonArray, trackBarColors)
     {
         ThemeName = nameof(PaletteVisualStudio2013DarkMode);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Official Themes/2013/PaletteVisualStudio2013LightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Official Themes/2013/PaletteVisualStudio2013LightMode.cs
@@ -1,9 +1,9 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -11,7 +11,8 @@ namespace Krypton.Toolkit;
 
 public abstract class PaletteVisualStudio2013LightMode : PaletteVisualStudioBase
 {
-    protected PaletteVisualStudio2013LightMode(Color[] schemeColors, ImageList checkBoxList, ImageList galleryButtonList, Image?[] radioButtonArray, Color[] trackBarColors) 
+    [System.Obsolete("Color[] constructor is deprecated and will be removed in V110. Use KryptonColorSchemeBase overload.", false)]
+    protected PaletteVisualStudio2013LightMode(Color[] schemeColors, ImageList checkBoxList, ImageList galleryButtonList, Image?[] radioButtonArray, Color[] trackBarColors)
         : base(schemeColors, checkBoxList, galleryButtonList, radioButtonArray, trackBarColors)
     {
         ThemeName = nameof(PaletteVisualStudio2013LightMode);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Official Themes/2015/PaletteVisualStudio2015DarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Official Themes/2015/PaletteVisualStudio2015DarkMode.cs
@@ -1,9 +1,9 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -11,7 +11,8 @@ namespace Krypton.Toolkit;
 
 public abstract class PaletteVisualStudio2015DarkMode : PaletteVisualStudioBase
 {
-    protected PaletteVisualStudio2015DarkMode(Color[] schemeColors, ImageList checkBoxList, ImageList galleryButtonList, Image?[] radioButtonArray, Color[] trackBarColors) 
+    [System.Obsolete("Color[] constructor is deprecated and will be removed in V110. Use KryptonColorSchemeBase overload.", false)]
+    protected PaletteVisualStudio2015DarkMode(Color[] schemeColors, ImageList checkBoxList, ImageList galleryButtonList, Image?[] radioButtonArray, Color[] trackBarColors)
         : base(schemeColors, checkBoxList, galleryButtonList, radioButtonArray, trackBarColors)
     {
         ThemeName = nameof(PaletteVisualStudio2015DarkMode);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Official Themes/2015/PaletteVisualStudio2015LightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Official Themes/2015/PaletteVisualStudio2015LightMode.cs
@@ -1,9 +1,9 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -11,7 +11,8 @@ namespace Krypton.Toolkit;
 
 public abstract class PaletteVisualStudio2015LightMode : PaletteVisualStudioBase
 {
-    protected PaletteVisualStudio2015LightMode(Color[] schemeColors, ImageList checkBoxList, ImageList galleryButtonList, Image?[] radioButtonArray, Color[] trackBarColors) 
+    [System.Obsolete("Color[] constructor is deprecated and will be removed in V110. Use KryptonColorSchemeBase overload.", false)]
+    protected PaletteVisualStudio2015LightMode(Color[] schemeColors, ImageList checkBoxList, ImageList galleryButtonList, Image?[] radioButtonArray, Color[] trackBarColors)
         : base(schemeColors, checkBoxList, galleryButtonList, radioButtonArray, trackBarColors)
     {
         ThemeName = nameof(PaletteVisualStudio2015LightMode);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Official Themes/2017/PaletteVisualStudio2017DarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Official Themes/2017/PaletteVisualStudio2017DarkMode.cs
@@ -1,9 +1,9 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -11,6 +11,7 @@ namespace Krypton.Toolkit;
 
 public abstract class PaletteVisualStudio2017DarkMode : PaletteVisualStudioBase
 {
+    [System.Obsolete("Color[] constructor is deprecated and will be removed in V110. Use KryptonColorSchemeBase overload.", false)]
     protected PaletteVisualStudio2017DarkMode(Color[] schemeColors, ImageList checkBoxList, ImageList galleryButtonList, Image?[] radioButtonArray, Color[] trackBarColors)
         : base(schemeColors, checkBoxList, galleryButtonList, radioButtonArray, trackBarColors)
     {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Official Themes/2017/PaletteVisualStudio2017LightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Official Themes/2017/PaletteVisualStudio2017LightMode.cs
@@ -1,9 +1,9 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -11,7 +11,8 @@ namespace Krypton.Toolkit;
 
 public abstract class PaletteVisualStudio2017LightMode : PaletteVisualStudioBase
 {
-    protected PaletteVisualStudio2017LightMode(Color[] schemeColors, ImageList checkBoxList, ImageList galleryButtonList, Image?[] radioButtonArray, Color[] trackBarColors) 
+    [System.Obsolete("Color[] constructor is deprecated and will be removed in V110. Use KryptonColorSchemeBase overload.", false)]
+    protected PaletteVisualStudio2017LightMode(Color[] schemeColors, ImageList checkBoxList, ImageList galleryButtonList, Image?[] radioButtonArray, Color[] trackBarColors)
         : base(schemeColors, checkBoxList, galleryButtonList, radioButtonArray, trackBarColors)
     {
         ThemeName = nameof(PaletteVisualStudio2017LightMode);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Official Themes/2019/PaletteVisualStudio2019DarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Official Themes/2019/PaletteVisualStudio2019DarkMode.cs
@@ -1,9 +1,9 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -11,7 +11,8 @@ namespace Krypton.Toolkit;
 
 public abstract class PaletteVisualStudio2019DarkMode : PaletteVisualStudioBase
 {
-    protected PaletteVisualStudio2019DarkMode(Color[] schemeColors, ImageList checkBoxList, ImageList galleryButtonList, Image?[] radioButtonArray, Color[] trackBarColors) 
+    [System.Obsolete("Color[] constructor is deprecated and will be removed in V110. Use KryptonColorSchemeBase overload.", false)]
+    protected PaletteVisualStudio2019DarkMode(Color[] schemeColors, ImageList checkBoxList, ImageList galleryButtonList, Image?[] radioButtonArray, Color[] trackBarColors)
         : base(schemeColors, checkBoxList, galleryButtonList, radioButtonArray, trackBarColors)
     {
         ThemeName = nameof(PaletteVisualStudio2019DarkMode);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Official Themes/2019/PaletteVisualStudio2019LightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Official Themes/2019/PaletteVisualStudio2019LightMode.cs
@@ -1,9 +1,9 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -11,6 +11,7 @@ namespace Krypton.Toolkit;
 
 public abstract class PaletteVisualStudio2019LightMode : PaletteVisualStudioBase
 {
+    [System.Obsolete("Color[] constructor is deprecated and will be removed in V110. Use KryptonColorSchemeBase overload.", false)]
     protected PaletteVisualStudio2019LightMode(Color[] schemeColors, ImageList checkBoxList, ImageList galleryButtonList, Image?[] radioButtonArray, Color[] trackBarColors)
         : base(schemeColors, checkBoxList, galleryButtonList, radioButtonArray, trackBarColors)
     {

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Official Themes/2022/PaletteVisualStudio2022DarkMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Official Themes/2022/PaletteVisualStudio2022DarkMode.cs
@@ -1,9 +1,9 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -11,7 +11,8 @@ namespace Krypton.Toolkit;
 
 public abstract class PaletteVisualStudio2022DarkMode : PaletteVisualStudioBase
 {
-    protected PaletteVisualStudio2022DarkMode(Color[] schemeColors, ImageList checkBoxList, ImageList galleryButtonList, Image?[] radioButtonArray, Color[] trackBarColors) 
+    [System.Obsolete("Color[] constructor is deprecated and will be removed in V110. Use KryptonColorSchemeBase overload.", false)]
+    protected PaletteVisualStudio2022DarkMode(Color[] schemeColors, ImageList checkBoxList, ImageList galleryButtonList, Image?[] radioButtonArray, Color[] trackBarColors)
         : base(schemeColors, checkBoxList, galleryButtonList, radioButtonArray, trackBarColors)
     {
         ThemeName = nameof(PaletteVisualStudio2022DarkMode);

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Official Themes/2022/PaletteVisualStudio2022LightMode.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Builtin/Visual Studio/Official Themes/2022/PaletteVisualStudio2022LightMode.cs
@@ -1,9 +1,9 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -11,7 +11,8 @@ namespace Krypton.Toolkit;
 
 public abstract class PaletteVisualStudio2022LightMode : PaletteVisualStudioBase
 {
-    protected PaletteVisualStudio2022LightMode(Color[] schemeColors, ImageList checkBoxList, ImageList galleryButtonList, Image?[] radioButtonArray, Color[] trackBarColors) 
+    [System.Obsolete("Color[] constructor is deprecated and will be removed in V110. Use KryptonColorSchemeBase overload.", false)]
+    protected PaletteVisualStudio2022LightMode(Color[] schemeColors, ImageList checkBoxList, ImageList galleryButtonList, Image?[] radioButtonArray, Color[] trackBarColors)
         : base(schemeColors, checkBoxList, galleryButtonList, radioButtonArray, trackBarColors)
     {
         ThemeName = nameof(PaletteVisualStudio2022LightMode);


### PR DESCRIPTION
Fixes #2389 

With this PR we finally get rid of private, inaccessible color arrays for most of the built-in themes (except Pro and Sparkle for now).
These could now finally be customized at runtime, too, if implemented in e.g. the `PaletteDesigner` and could later be included in save/load XML operations in the `KryptonCustomPaletteBase` class.
Changing any of these colors at runtime will immediately be seen on next paint cycle.

Attempts to incorporate these into the existing (huge) `SchemeBaseColors` enum posed severe problems and a lot of extra code changes and thus were dropped again.

- Refactor color management in palette classes by introducing static constructors for up to 10 color array registrations across various palette bases.
- Added proper enums for color arrays in `PaletteEnumerations.cs`.
- Added helper classes to `PaletteBase.cs` for get/set of new color arrays.
- Base classes access these colors now via `GetArrayColor<enum>` calls instead of "magic numbers".
- Removed interim tools from .gitignore again.

Example for `PaletteMicrosoft365Base.cs` how old, private arrays were changed to static color registrations:
```cs
    static PaletteMicrosoft365Base()
    {
        RegisterColor<AppButtonNormalColor>(AppButtonNormalColor.Color1, Color.FromArgb(243, 245, 248));
        ...
        RegisterColor<AppButtonPressedColor>(AppButtonPressedColor.Color1, Color.FromArgb(235, 227, 196));
        ...
        RegisterColor<AppButtonTrackColor>(AppButtonTrackColor.Color1, Color.FromArgb(255, 251, 230));
        ...
    }
```

Retrieval of any of these color values is via the new method like:
```cs
    return GetArrayColor<AppButtonPressedColor>(AppButtonPressedColor.Color4);
```