### PR TITLE
2397-V95-Kform-Parent-control-is-null

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2025-08-25 - Build 2508 (Patch 8) - August 2025
+* Resolved [#2397](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2397), `KryptonForm` throws and exception on CTRL+F1.
 * Resolved [#2331](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2331), Correction of edges, 3D effect and color adjustment in `KryptonRibbon` in Office 2010 themes.
 * Implemented [#2374](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2374), Fix exception in `VisualForm` invalidation
 * Implemented [#2368](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2368), Fix 2 themes-related exceptions in `KryptonCustomPaletteBase`, `PaletteRedirectGrids`.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -1763,7 +1763,8 @@ namespace Krypton.Toolkit
                     }
                 }
 
-                control = control.Parent ?? throw new InvalidOperationException("Parent control is null.");
+                // If the parent is null then the caller did not find a help provider.
+                control = control.Parent;
             }
 
             return null;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
@@ -729,7 +729,7 @@ namespace Krypton.Toolkit
                     PI.RedrawWindow(Handle, IntPtr.Zero, hRgn.Value,
                         PI.RDW_FRAME | PI.RDW_UPDATENOW | PI.RDW_INVALIDATE);
                 }
-                catch (InvalidOperationException ioEx)
+                catch (InvalidOperationException)
                 {
                     // Object is currently in use elsewhere. Fallback to full non-client redraw.
                     PI.RedrawWindow(Handle, IntPtr.Zero, IntPtr.Zero,


### PR DESCRIPTION
- Issue #2397
- Return statement adjusted
- Warning removed: Krypton.Toolkit\Controls Visuals\VisualForm.cs(732,50): warning CS0168: The variable 'ioEx' is declared but never used
- And the changelog

<img width="260" height="141" alt="compile-results" src="https://github.com/user-attachments/assets/2011eecf-6652-47da-99a8-743bfdf510af" />
