### PR TITLE
2048 V100 KStatusStrip with per-control theming

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 ====
 
 ## 2025-11-xx - Build 2511 (V10 - alpha) - November 2025
+* Implemented [#2048](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2048), `KryptonStatusStrip` control theming.
 * Resolved [#2397](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2397), `KryptonForm` throws and exception on CTRL+F1.
 * Implemented [#2392](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2392), Fix `KryptonPropertyGrid` theme switching
 * Implemented [#2389](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2389), Transform private color arrays in base palettes.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonStatusStrip.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonStatusStrip.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -15,15 +15,29 @@ namespace Krypton.Toolkit;
 [ToolboxBitmap(typeof(StatusStrip)), Description(@"A Krypton based status strip."), ToolboxItem(true)]
 public class KryptonStatusStrip : StatusStrip
 {
+    #region Instance Fields
+    private readonly PaletteBack _stateCommon;
+    private readonly PaletteBack _stateDisabled;
+    private readonly PaletteBack _stateNormal;
+    #endregion
+
     #region Properties
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
     public ToolStripProgressBar[] ProgressBars { get; set; }
     #endregion
 
     #region Constructor
-    public KryptonStatusStrip() =>
+    public KryptonStatusStrip()
+    {
         // Use Krypton
         RenderMode = ToolStripRenderMode.ManagerRenderMode;
+
+        // Create palette storage for per-control overrides, inheriting defaults from current palette ColorTable
+        var inherit = new PaletteBackInheritStatusStrip();
+        _stateCommon = new PaletteBack(inherit, OnNeedPaint);
+        _stateDisabled = new PaletteBack(_stateCommon, OnNeedPaint);
+        _stateNormal = new PaletteBack(_stateCommon, OnNeedPaint);
+    }
 
     #endregion
 
@@ -42,6 +56,53 @@ public class KryptonStatusStrip : StatusStrip
         }
 
         base.OnRendererChanged(e);
+        Invalidate();
+    }
+    #endregion
+
+    #region Visual States
+    /// <summary>
+    /// Gets access to the common status strip appearance that other states can override.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Overrides for defining common status strip appearance that other states can override.")]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    public PaletteBack StateCommon => _stateCommon;
+
+    private bool ShouldSerializeStateCommon() => !_stateCommon.IsDefault;
+
+    /// <summary>
+    /// Gets access to the disabled status strip appearance.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Overrides for defining disabled status strip appearance.")]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    public PaletteBack StateDisabled => _stateDisabled;
+
+    private bool ShouldSerializeStateDisabled() => !_stateDisabled.IsDefault;
+
+    /// <summary>
+    /// Gets access to the normal status strip appearance.
+    /// </summary>
+    [Category(@"Visuals")]
+    [Description(@"Overrides for defining normal status strip appearance.")]
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Content)]
+    public PaletteBack StateNormal => _stateNormal;
+
+    private bool ShouldSerializeStateNormal() => !_stateNormal.IsDefault;
+    #endregion
+
+    #region Implementation
+    private void OnNeedPaint(object? sender, NeedLayoutEventArgs e)
+    {
+        if (!IsDisposed)
+        {
+            if (e != null && e.NeedLayout)
+            {
+                PerformLayout();
+            }
+            Invalidate();
+        }
     }
     #endregion
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteBackInheritStatusStrip.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteBackInheritStatusStrip.cs
@@ -1,0 +1,65 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+/// <summary>
+/// Provides palette-backed inheritance for StatusStrip background values by adapting the current global palette ColorTable.
+/// </summary>
+public sealed class PaletteBackInheritStatusStrip : PaletteBackInherit
+{
+    public PaletteBackInheritStatusStrip()
+    {
+    }
+
+    private static KryptonColorTable? CurrentColorTable
+    {
+        get
+        {
+            PaletteBase? palette = KryptonManager.CurrentGlobalPalette;
+            return palette?.ColorTable;
+        }
+    }
+
+    public override InheritBool GetBackDraw(PaletteState state) => InheritBool.True;
+
+    public override PaletteGraphicsHint GetBackGraphicsHint(PaletteState state) => PaletteGraphicsHint.Inherit;
+
+    public override Color GetBackColor1(PaletteState state)
+    {
+        var ct = CurrentColorTable;
+        if (ct is not null && ct.StatusStripGradientBegin != GlobalStaticValues.EMPTY_COLOR)
+        {
+            return ct.StatusStripGradientBegin;
+        }
+        return GlobalStaticValues.EMPTY_COLOR;
+    }
+
+    public override Color GetBackColor2(PaletteState state)
+    {
+        var ct = CurrentColorTable;
+        if (ct is not null && ct.StatusStripGradientEnd != GlobalStaticValues.EMPTY_COLOR)
+        {
+            return ct.StatusStripGradientEnd;
+        }
+        return GlobalStaticValues.EMPTY_COLOR;
+    }
+
+    public override PaletteColorStyle GetBackColorStyle(PaletteState state) => PaletteColorStyle.Inherit;
+
+    public override PaletteRectangleAlign GetBackColorAlign(PaletteState state) => PaletteRectangleAlign.Inherit;
+
+    public override float GetBackColorAngle(PaletteState state) => -1f;
+
+    public override Image? GetBackImage(PaletteState state) => null;
+
+    public override PaletteImageStyle GetBackImageStyle(PaletteState state) => PaletteImageStyle.Inherit;
+
+    public override PaletteRectangleAlign GetBackImageAlign(PaletteState state) => PaletteRectangleAlign.Inherit;
+}

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteBackInheritStatusStrip.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteBackInheritStatusStrip.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed, tobitege et al. 2025 - 2025. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonMicrosoft365Renderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonMicrosoft365Renderer.cs
@@ -1,19 +1,19 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
+ *
  */
 #endregion
 
 namespace Krypton.Toolkit;
 
 /// <summary>
-/// 
+///
 /// </summary>
 /// <seealso cref="KryptonProfessionalRenderer" />
 public class KryptonMicrosoft365Renderer : KryptonProfessionalRenderer
@@ -361,7 +361,7 @@ public class KryptonMicrosoft365Renderer : KryptonProfessionalRenderer
 
     #region OnRenderArrow
     /// <summary>
-    /// Raises the RenderArrow event. 
+    /// Raises the RenderArrow event.
     /// </summary>
     /// <param name="e">An ToolStripArrowRenderEventArgs containing the event data.</param>
     protected override void OnRenderArrow(ToolStripArrowRenderEventArgs e)
@@ -417,7 +417,7 @@ public class KryptonMicrosoft365Renderer : KryptonProfessionalRenderer
 
     #region OnRenderButtonBackground
     /// <summary>
-    /// Raises the RenderButtonBackground event. 
+    /// Raises the RenderButtonBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderButtonBackground(ToolStripItemRenderEventArgs e)
@@ -436,7 +436,7 @@ public class KryptonMicrosoft365Renderer : KryptonProfessionalRenderer
 
     #region OnRenderDropDownButtonBackground
     /// <summary>
-    /// Raises the RenderDropDownButtonBackground event. 
+    /// Raises the RenderDropDownButtonBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderDropDownButtonBackground(ToolStripItemRenderEventArgs e)
@@ -452,7 +452,7 @@ public class KryptonMicrosoft365Renderer : KryptonProfessionalRenderer
 
     #region OnRenderItemCheck
     /// <summary>
-    /// Raises the RenderItemCheck event. 
+    /// Raises the RenderItemCheck event.
     /// </summary>
     /// <param name="e">An ToolStripItemImageRenderEventArgs containing the event data.</param>
     protected override void OnRenderItemCheck(ToolStripItemImageRenderEventArgs e)
@@ -538,7 +538,7 @@ public class KryptonMicrosoft365Renderer : KryptonProfessionalRenderer
 
     #region OnRenderItemText
     /// <summary>
-    /// Raises the RenderItemText event. 
+    /// Raises the RenderItemText event.
     /// </summary>
     /// <param name="e">A ToolStripItemTextRenderEventArgs that contains the event data.</param>
     protected override void OnRenderItemText(ToolStripItemTextRenderEventArgs e)
@@ -613,7 +613,7 @@ public class KryptonMicrosoft365Renderer : KryptonProfessionalRenderer
 
     #region OnRenderItemImage
     /// <summary>
-    /// Raises the RenderItemImage event. 
+    /// Raises the RenderItemImage event.
     /// </summary>
     /// <param name="e">An ToolStripItemImageRenderEventArgs containing the event data.</param>
     protected override void OnRenderItemImage(ToolStripItemImageRenderEventArgs e)
@@ -648,7 +648,7 @@ public class KryptonMicrosoft365Renderer : KryptonProfessionalRenderer
 
     #region OnRenderMenuItemBackground
     /// <summary>
-    /// Raises the RenderMenuItemBackground event. 
+    /// Raises the RenderMenuItemBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderMenuItemBackground(ToolStripItemRenderEventArgs e)
@@ -711,7 +711,7 @@ public class KryptonMicrosoft365Renderer : KryptonProfessionalRenderer
 
     #region OnRenderSeparator
     /// <summary>
-    /// Raises the RenderSeparator event. 
+    /// Raises the RenderSeparator event.
     /// </summary>
     /// <param name="e">An ToolStripSeparatorRenderEventArgs containing the event data.</param>
     protected override void OnRenderSeparator(ToolStripSeparatorRenderEventArgs e)
@@ -731,7 +731,7 @@ public class KryptonMicrosoft365Renderer : KryptonProfessionalRenderer
 
     #region OnRenderSplitButtonBackground
     /// <summary>
-    /// Raises the RenderSplitButtonBackground event. 
+    /// Raises the RenderSplitButtonBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderSplitButtonBackground(ToolStripItemRenderEventArgs e)
@@ -765,7 +765,7 @@ public class KryptonMicrosoft365Renderer : KryptonProfessionalRenderer
 
     #region OnRenderStatusStripSizingGrip
     /// <summary>
-    /// Raises the RenderStatusStripSizingGrip event. 
+    /// Raises the RenderStatusStripSizingGrip event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderStatusStripSizingGrip(ToolStripRenderEventArgs e)
@@ -803,7 +803,7 @@ public class KryptonMicrosoft365Renderer : KryptonProfessionalRenderer
 
     #region OnRenderToolStripContentPanelBackground
     /// <summary>
-    /// Raises the RenderToolStripContentPanelBackground event. 
+    /// Raises the RenderToolStripContentPanelBackground event.
     /// </summary>
     /// <param name="e">An ToolStripContentPanelRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripContentPanelBackground(ToolStripContentPanelRenderEventArgs e)
@@ -823,7 +823,7 @@ public class KryptonMicrosoft365Renderer : KryptonProfessionalRenderer
 
     #region OnRenderToolStripBackground
     /// <summary>
-    /// Raises the RenderToolStripBackground event. 
+    /// Raises the RenderToolStripBackground event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripBackground(ToolStripRenderEventArgs e)
@@ -850,6 +850,10 @@ public class KryptonMicrosoft365Renderer : KryptonProfessionalRenderer
             }
             case StatusStrip:
             {
+                if (TryRenderStatusStripOverride(e, e.Graphics))
+                {
+                    break;
+                }
                 // Make sure the font is current
                 if (e.ToolStrip.Font != KCT.StatusStripFont)
                 {
@@ -942,7 +946,7 @@ public class KryptonMicrosoft365Renderer : KryptonProfessionalRenderer
 
     #region OnRenderToolStripBorder
     /// <summary>
-    /// Raises the RenderToolStripBorder event. 
+    /// Raises the RenderToolStripBorder event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripBorder(ToolStripRenderEventArgs e)
@@ -1000,7 +1004,7 @@ public class KryptonMicrosoft365Renderer : KryptonProfessionalRenderer
 
     #region OnRenderImageMargin
     /// <summary>
-    /// Raises the RenderImageMargin event. 
+    /// Raises the RenderImageMargin event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderImageMargin(ToolStripRenderEventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonOffice2007Renderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonOffice2007Renderer.cs
@@ -1,19 +1,19 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
+ *
  */
 #endregion
 
 namespace Krypton.Toolkit;
 
 /// <summary>
-/// 
+///
 /// </summary>
 public class KryptonOffice2007Renderer : KryptonProfessionalRenderer
 {
@@ -252,7 +252,7 @@ public class KryptonOffice2007Renderer : KryptonProfessionalRenderer
 
     #region OnRenderArrow
     /// <summary>
-    /// Raises the RenderArrow event. 
+    /// Raises the RenderArrow event.
     /// </summary>
     /// <param name="e">An ToolStripArrowRenderEventArgs containing the event data.</param>
     protected override void OnRenderArrow(ToolStripArrowRenderEventArgs e)
@@ -291,7 +291,7 @@ public class KryptonOffice2007Renderer : KryptonProfessionalRenderer
 
     #region OnRenderButtonBackground
     /// <summary>
-    /// Raises the RenderButtonBackground event. 
+    /// Raises the RenderButtonBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderButtonBackground(ToolStripItemRenderEventArgs e)
@@ -310,7 +310,7 @@ public class KryptonOffice2007Renderer : KryptonProfessionalRenderer
 
     #region OnRenderDropDownButtonBackground
     /// <summary>
-    /// Raises the RenderDropDownButtonBackground event. 
+    /// Raises the RenderDropDownButtonBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderDropDownButtonBackground(ToolStripItemRenderEventArgs e)
@@ -326,7 +326,7 @@ public class KryptonOffice2007Renderer : KryptonProfessionalRenderer
 
     #region OnRenderItemCheck
     /// <summary>
-    /// Raises the RenderItemCheck event. 
+    /// Raises the RenderItemCheck event.
     /// </summary>
     /// <param name="e">An ToolStripItemImageRenderEventArgs containing the event data.</param>
     protected override void OnRenderItemCheck(ToolStripItemImageRenderEventArgs e)
@@ -414,7 +414,7 @@ public class KryptonOffice2007Renderer : KryptonProfessionalRenderer
 
     #region OnRenderItemText
     /// <summary>
-    /// Raises the RenderItemText event. 
+    /// Raises the RenderItemText event.
     /// </summary>
     /// <param name="e">A ToolStripItemTextRenderEventArgs that contains the event data.</param>
     protected override void OnRenderItemText(ToolStripItemTextRenderEventArgs e)
@@ -459,7 +459,7 @@ public class KryptonOffice2007Renderer : KryptonProfessionalRenderer
 
     #region OnRenderItemImage
     /// <summary>
-    /// Raises the RenderItemImage event. 
+    /// Raises the RenderItemImage event.
     /// </summary>
     /// <param name="e">An ToolStripItemImageRenderEventArgs containing the event data.</param>
     protected override void OnRenderItemImage(ToolStripItemImageRenderEventArgs e)
@@ -494,7 +494,7 @@ public class KryptonOffice2007Renderer : KryptonProfessionalRenderer
 
     #region OnRenderMenuItemBackground
     /// <summary>
-    /// Raises the RenderMenuItemBackground event. 
+    /// Raises the RenderMenuItemBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderMenuItemBackground(ToolStripItemRenderEventArgs e)
@@ -557,7 +557,7 @@ public class KryptonOffice2007Renderer : KryptonProfessionalRenderer
 
     #region OnRenderSplitButtonBackground
     /// <summary>
-    /// Raises the RenderSplitButtonBackground event. 
+    /// Raises the RenderSplitButtonBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderSplitButtonBackground(ToolStripItemRenderEventArgs e)
@@ -591,7 +591,7 @@ public class KryptonOffice2007Renderer : KryptonProfessionalRenderer
 
     #region OnRenderStatusStripSizingGrip
     /// <summary>
-    /// Raises the RenderStatusStripSizingGrip event. 
+    /// Raises the RenderStatusStripSizingGrip event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderStatusStripSizingGrip(ToolStripRenderEventArgs e)
@@ -629,7 +629,7 @@ public class KryptonOffice2007Renderer : KryptonProfessionalRenderer
 
     #region OnRenderToolStripContentPanelBackground
     /// <summary>
-    /// Raises the RenderToolStripContentPanelBackground event. 
+    /// Raises the RenderToolStripContentPanelBackground event.
     /// </summary>
     /// <param name="e">An ToolStripContentPanelRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripContentPanelBackground(ToolStripContentPanelRenderEventArgs e)
@@ -649,7 +649,7 @@ public class KryptonOffice2007Renderer : KryptonProfessionalRenderer
 
     #region OnRenderSeparator
     /// <summary>
-    /// Raises the RenderSeparator event. 
+    /// Raises the RenderSeparator event.
     /// </summary>
     /// <param name="e">An ToolStripSeparatorRenderEventArgs containing the event data.</param>
     protected override void OnRenderSeparator(ToolStripSeparatorRenderEventArgs e)
@@ -687,7 +687,7 @@ public class KryptonOffice2007Renderer : KryptonProfessionalRenderer
 
     #region OnRenderToolStripBackground
     /// <summary>
-    /// Raises the RenderToolStripBackground event. 
+    /// Raises the RenderToolStripBackground event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripBackground(ToolStripRenderEventArgs e)
@@ -716,6 +716,10 @@ public class KryptonOffice2007Renderer : KryptonProfessionalRenderer
                 break;
             case StatusStrip _:
             {
+                if (TryRenderStatusStripOverride(e, e.Graphics))
+                {
+                    break;
+                }
                 // Make sure the font is current
                 e.ToolStrip.Font = KCT.StatusStripFont;
 
@@ -724,7 +728,7 @@ public class KryptonOffice2007Renderer : KryptonProfessionalRenderer
 
                 Form? owner = e.ToolStrip.FindForm();
 
-                // Check if the status strip is inside a KryptonForm and using the Office 2007 renderer, in 
+                // Check if the status strip is inside a KryptonForm and using the Office 2007 renderer, in
                 // which case we want to extend the drawing down into the border area for an integrated look
                 if (e.ToolStrip.Visible
                     && e.ToolStrip is { Dock: DockStyle.Bottom, RenderMode: ToolStripRenderMode.ManagerRenderMode }
@@ -774,7 +778,7 @@ public class KryptonOffice2007Renderer : KryptonProfessionalRenderer
 
     #region OnRenderImageMargin
     /// <summary>
-    /// Raises the RenderImageMargin event. 
+    /// Raises the RenderImageMargin event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderImageMargin(ToolStripRenderEventArgs e)
@@ -835,7 +839,7 @@ public class KryptonOffice2007Renderer : KryptonProfessionalRenderer
 
     #region OnRenderToolStripBorder
     /// <summary>
-    /// Raises the RenderToolStripBorder event. 
+    /// Raises the RenderToolStripBorder event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripBorder(ToolStripRenderEventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonOffice2010Renderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonOffice2010Renderer.cs
@@ -1,19 +1,19 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
+ *
  */
 #endregion
 
 namespace Krypton.Toolkit;
 
 /// <summary>
-/// 
+///
 /// </summary>
 public class KryptonOffice2010Renderer : KryptonProfessionalRenderer
 {
@@ -365,7 +365,7 @@ public class KryptonOffice2010Renderer : KryptonProfessionalRenderer
 
     #region OnRenderArrow
     /// <summary>
-    /// Raises the RenderArrow event. 
+    /// Raises the RenderArrow event.
     /// </summary>
     /// <param name="e">An ToolStripArrowRenderEventArgs containing the event data.</param>
     protected override void OnRenderArrow(ToolStripArrowRenderEventArgs e)
@@ -421,7 +421,7 @@ public class KryptonOffice2010Renderer : KryptonProfessionalRenderer
 
     #region OnRenderButtonBackground
     /// <summary>
-    /// Raises the RenderButtonBackground event. 
+    /// Raises the RenderButtonBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderButtonBackground(ToolStripItemRenderEventArgs e)
@@ -440,7 +440,7 @@ public class KryptonOffice2010Renderer : KryptonProfessionalRenderer
 
     #region OnRenderDropDownButtonBackground
     /// <summary>
-    /// Raises the RenderDropDownButtonBackground event. 
+    /// Raises the RenderDropDownButtonBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderDropDownButtonBackground(ToolStripItemRenderEventArgs e)
@@ -456,7 +456,7 @@ public class KryptonOffice2010Renderer : KryptonProfessionalRenderer
 
     #region OnRenderItemCheck
     /// <summary>
-    /// Raises the RenderItemCheck event. 
+    /// Raises the RenderItemCheck event.
     /// </summary>
     /// <param name="e">An ToolStripItemImageRenderEventArgs containing the event data.</param>
     protected override void OnRenderItemCheck(ToolStripItemImageRenderEventArgs e)
@@ -544,7 +544,7 @@ public class KryptonOffice2010Renderer : KryptonProfessionalRenderer
 
     #region OnRenderItemText
     /// <summary>
-    /// Raises the RenderItemText event. 
+    /// Raises the RenderItemText event.
     /// </summary>
     /// <param name="e">A ToolStripItemTextRenderEventArgs that contains the event data.</param>
     protected override void OnRenderItemText(ToolStripItemTextRenderEventArgs e)
@@ -595,7 +595,7 @@ public class KryptonOffice2010Renderer : KryptonProfessionalRenderer
             }
 
             // Status strips under XP cannot use clear type because it ends up being cut off at edges
-            if ((e.ToolStrip is StatusStrip) 
+            if ((e.ToolStrip is StatusStrip)
                 // TODO: Remove checks for Below Vista as no longer supporting old TFM's
                 && (Environment.OSVersion.Version.Major < 6))
             {
@@ -617,7 +617,7 @@ public class KryptonOffice2010Renderer : KryptonProfessionalRenderer
 
     #region OnRenderItemImage
     /// <summary>
-    /// Raises the RenderItemImage event. 
+    /// Raises the RenderItemImage event.
     /// </summary>
     /// <param name="e">An ToolStripItemImageRenderEventArgs containing the event data.</param>
     protected override void OnRenderItemImage(ToolStripItemImageRenderEventArgs e)
@@ -652,7 +652,7 @@ public class KryptonOffice2010Renderer : KryptonProfessionalRenderer
 
     #region OnRenderMenuItemBackground
     /// <summary>
-    /// Raises the RenderMenuItemBackground event. 
+    /// Raises the RenderMenuItemBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderMenuItemBackground(ToolStripItemRenderEventArgs e)
@@ -715,7 +715,7 @@ public class KryptonOffice2010Renderer : KryptonProfessionalRenderer
 
     #region OnRenderSeparator
     /// <summary>
-    /// Raises the RenderSeparator event. 
+    /// Raises the RenderSeparator event.
     /// </summary>
     /// <param name="e">An ToolStripSeparatorRenderEventArgs containing the event data.</param>
     protected override void OnRenderSeparator(ToolStripSeparatorRenderEventArgs e)
@@ -735,7 +735,7 @@ public class KryptonOffice2010Renderer : KryptonProfessionalRenderer
 
     #region OnRenderSplitButtonBackground
     /// <summary>
-    /// Raises the RenderSplitButtonBackground event. 
+    /// Raises the RenderSplitButtonBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderSplitButtonBackground(ToolStripItemRenderEventArgs e)
@@ -769,7 +769,7 @@ public class KryptonOffice2010Renderer : KryptonProfessionalRenderer
 
     #region OnRenderStatusStripSizingGrip
     /// <summary>
-    /// Raises the RenderStatusStripSizingGrip event. 
+    /// Raises the RenderStatusStripSizingGrip event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderStatusStripSizingGrip(ToolStripRenderEventArgs e)
@@ -807,7 +807,7 @@ public class KryptonOffice2010Renderer : KryptonProfessionalRenderer
 
     #region OnRenderToolStripContentPanelBackground
     /// <summary>
-    /// Raises the RenderToolStripContentPanelBackground event. 
+    /// Raises the RenderToolStripContentPanelBackground event.
     /// </summary>
     /// <param name="e">An ToolStripContentPanelRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripContentPanelBackground(ToolStripContentPanelRenderEventArgs e)
@@ -827,7 +827,7 @@ public class KryptonOffice2010Renderer : KryptonProfessionalRenderer
 
     #region OnRenderToolStripBackground
     /// <summary>
-    /// Raises the RenderToolStripBackground event. 
+    /// Raises the RenderToolStripBackground event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripBackground(ToolStripRenderEventArgs e)
@@ -859,6 +859,10 @@ public class KryptonOffice2010Renderer : KryptonProfessionalRenderer
                 break;
             case StatusStrip _:
             {
+                if (TryRenderStatusStripOverride(e, e.Graphics))
+                {
+                    break;
+                }
                 // Make sure the font is current
                 if (e.ToolStrip.Font != KCT.StatusStripFont)
                 {
@@ -940,7 +944,7 @@ public class KryptonOffice2010Renderer : KryptonProfessionalRenderer
 
     #region OnRenderToolStripBorder
     /// <summary>
-    /// Raises the RenderToolStripBorder event. 
+    /// Raises the RenderToolStripBorder event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripBorder(ToolStripRenderEventArgs e)
@@ -1003,7 +1007,7 @@ public class KryptonOffice2010Renderer : KryptonProfessionalRenderer
 
     #region OnRenderImageMargin
     /// <summary>
-    /// Raises the RenderImageMargin event. 
+    /// Raises the RenderImageMargin event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderImageMargin(ToolStripRenderEventArgs e)
@@ -1222,7 +1226,7 @@ public class KryptonOffice2010Renderer : KryptonProfessionalRenderer
 
                 // Draw the border of the entire item
                 colorsButton.DrawBorder(g, backRect);
-            } 
+            }
         }
     }
 

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonOffice2013Renderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonOffice2013Renderer.cs
@@ -1,19 +1,19 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
+ *
  */
 #endregion
 
 namespace Krypton.Toolkit;
 
 /// <summary>
-/// 
+///
 /// </summary>
 public class KryptonOffice2013Renderer : KryptonProfessionalRenderer
 {
@@ -364,7 +364,7 @@ public class KryptonOffice2013Renderer : KryptonProfessionalRenderer
 
     #region OnRenderArrow
     /// <summary>
-    /// Raises the RenderArrow event. 
+    /// Raises the RenderArrow event.
     /// </summary>
     /// <param name="e">An ToolStripArrowRenderEventArgs containing the event data.</param>
     protected override void OnRenderArrow(ToolStripArrowRenderEventArgs e)
@@ -420,7 +420,7 @@ public class KryptonOffice2013Renderer : KryptonProfessionalRenderer
 
     #region OnRenderButtonBackground
     /// <summary>
-    /// Raises the RenderButtonBackground event. 
+    /// Raises the RenderButtonBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderButtonBackground(ToolStripItemRenderEventArgs e)
@@ -439,7 +439,7 @@ public class KryptonOffice2013Renderer : KryptonProfessionalRenderer
 
     #region OnRenderDropDownButtonBackground
     /// <summary>
-    /// Raises the RenderDropDownButtonBackground event. 
+    /// Raises the RenderDropDownButtonBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderDropDownButtonBackground(ToolStripItemRenderEventArgs e)
@@ -455,7 +455,7 @@ public class KryptonOffice2013Renderer : KryptonProfessionalRenderer
 
     #region OnRenderItemCheck
     /// <summary>
-    /// Raises the RenderItemCheck event. 
+    /// Raises the RenderItemCheck event.
     /// </summary>
     /// <param name="e">An ToolStripItemImageRenderEventArgs containing the event data.</param>
     protected override void OnRenderItemCheck(ToolStripItemImageRenderEventArgs e)
@@ -543,7 +543,7 @@ public class KryptonOffice2013Renderer : KryptonProfessionalRenderer
 
     #region OnRenderItemText
     /// <summary>
-    /// Raises the RenderItemText event. 
+    /// Raises the RenderItemText event.
     /// </summary>
     /// <param name="e">A ToolStripItemTextRenderEventArgs that contains the event data.</param>
     protected override void OnRenderItemText(ToolStripItemTextRenderEventArgs e)
@@ -618,7 +618,7 @@ public class KryptonOffice2013Renderer : KryptonProfessionalRenderer
 
     #region OnRenderItemImage
     /// <summary>
-    /// Raises the RenderItemImage event. 
+    /// Raises the RenderItemImage event.
     /// </summary>
     /// <param name="e">An ToolStripItemImageRenderEventArgs containing the event data.</param>
     protected override void OnRenderItemImage(ToolStripItemImageRenderEventArgs e)
@@ -653,7 +653,7 @@ public class KryptonOffice2013Renderer : KryptonProfessionalRenderer
 
     #region OnRenderMenuItemBackground
     /// <summary>
-    /// Raises the RenderMenuItemBackground event. 
+    /// Raises the RenderMenuItemBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderMenuItemBackground(ToolStripItemRenderEventArgs e)
@@ -716,7 +716,7 @@ public class KryptonOffice2013Renderer : KryptonProfessionalRenderer
 
     #region OnRenderSeparator
     /// <summary>
-    /// Raises the RenderSeparator event. 
+    /// Raises the RenderSeparator event.
     /// </summary>
     /// <param name="e">An ToolStripSeparatorRenderEventArgs containing the event data.</param>
     protected override void OnRenderSeparator(ToolStripSeparatorRenderEventArgs e)
@@ -736,7 +736,7 @@ public class KryptonOffice2013Renderer : KryptonProfessionalRenderer
 
     #region OnRenderSplitButtonBackground
     /// <summary>
-    /// Raises the RenderSplitButtonBackground event. 
+    /// Raises the RenderSplitButtonBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderSplitButtonBackground(ToolStripItemRenderEventArgs e)
@@ -770,7 +770,7 @@ public class KryptonOffice2013Renderer : KryptonProfessionalRenderer
 
     #region OnRenderStatusStripSizingGrip
     /// <summary>
-    /// Raises the RenderStatusStripSizingGrip event. 
+    /// Raises the RenderStatusStripSizingGrip event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderStatusStripSizingGrip(ToolStripRenderEventArgs e)
@@ -808,7 +808,7 @@ public class KryptonOffice2013Renderer : KryptonProfessionalRenderer
 
     #region OnRenderToolStripContentPanelBackground
     /// <summary>
-    /// Raises the RenderToolStripContentPanelBackground event. 
+    /// Raises the RenderToolStripContentPanelBackground event.
     /// </summary>
     /// <param name="e">An ToolStripContentPanelRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripContentPanelBackground(ToolStripContentPanelRenderEventArgs e)
@@ -828,7 +828,7 @@ public class KryptonOffice2013Renderer : KryptonProfessionalRenderer
 
     #region OnRenderToolStripBackground
     /// <summary>
-    /// Raises the RenderToolStripBackground event. 
+    /// Raises the RenderToolStripBackground event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripBackground(ToolStripRenderEventArgs e)
@@ -855,6 +855,10 @@ public class KryptonOffice2013Renderer : KryptonProfessionalRenderer
             }
             case StatusStrip:
             {
+                if (TryRenderStatusStripOverride(e, e.Graphics))
+                {
+                    break;
+                }
                 // Make sure the font is current
                 if (e.ToolStrip.Font != KCT.StatusStripFont)
                 {
@@ -947,7 +951,7 @@ public class KryptonOffice2013Renderer : KryptonProfessionalRenderer
 
     #region OnRenderToolStripBorder
     /// <summary>
-    /// Raises the RenderToolStripBorder event. 
+    /// Raises the RenderToolStripBorder event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripBorder(ToolStripRenderEventArgs e)
@@ -1005,7 +1009,7 @@ public class KryptonOffice2013Renderer : KryptonProfessionalRenderer
 
     #region OnRenderImageMargin
     /// <summary>
-    /// Raises the RenderImageMargin event. 
+    /// Raises the RenderImageMargin event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderImageMargin(ToolStripRenderEventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonProfessionalRenderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonProfessionalRenderer.cs
@@ -1,19 +1,19 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
+ *
  */
 #endregion
 
 namespace Krypton.Toolkit;
 
 /// <summary>
-/// 
+///
 /// </summary>
 public class KryptonProfessionalRenderer : ToolStripProfessionalRenderer
 {
@@ -40,7 +40,7 @@ public class KryptonProfessionalRenderer : ToolStripProfessionalRenderer
 
     #region OnRenderItemImage
     /// <summary>
-    /// Raises the RenderItemImage event. 
+    /// Raises the RenderItemImage event.
     /// </summary>
     /// <param name="e">An ToolStripItemImageRenderEventArgs containing the event data.</param>
     protected override void OnRenderItemImage(ToolStripItemImageRenderEventArgs e)
@@ -126,9 +126,101 @@ public class KryptonProfessionalRenderer : ToolStripProfessionalRenderer
     }
     #endregion
 
+    #region StatusStrip Overrides Helper
+    /// <summary>
+    /// Resolves per-control StatusStrip background overrides (Color1/Color2/Style/Angle) if present.
+    /// Returns true if an override was applied and the caller should skip default painting.
+    /// </summary>
+    /// <param name="e">Render event args.</param>
+    /// <param name="graphics">Graphics to draw on.</param>
+    /// <returns>True if painted using per-control overrides; otherwise false.</returns>
+    protected bool TryRenderStatusStripOverride(ToolStripRenderEventArgs e, Graphics graphics)
+    {
+        if (e.ToolStrip is not StatusStrip statusStrip)
+        {
+            return false;
+        }
+
+        // Only KryptonStatusStrip exposes PaletteBack overrides
+        if (statusStrip is not KryptonStatusStrip kryptonStatus)
+        {
+            return false;
+        }
+
+        // Determine state palette to use
+        PaletteBack state = kryptonStatus.Enabled ? kryptonStatus.StateNormal : kryptonStatus.StateDisabled;
+
+        // Consider overrides present if any state has non-default values, or Draw is explicitly disabled
+        bool hasAnyOverride = !kryptonStatus.StateCommon.IsDefault ||
+                              !kryptonStatus.StateNormal.IsDefault ||
+                              !kryptonStatus.StateDisabled.IsDefault ||
+                              state.Draw == InheritBool.False;
+        if (state.Draw == InheritBool.False)
+        {
+            // Explicitly suppress painting and skip default renderer
+            return true;
+        }
+
+        if (!hasAnyOverride)
+        {
+            return false;
+        }
+
+        // Establish drawing rect: skip top 2px to respect border line drawing (as existing renderers do)
+        RectangleF backRect = new RectangleF(0, 1.5f, e.ToolStrip.Width, e.ToolStrip.Height - 2);
+        if (!(backRect.Width > 0 && backRect.Height > 0))
+        {
+            return false;
+        }
+
+        // Resolve effective settings using inheritance (so StateCommon overrides are honored)
+        var effectiveStyle = state.GetBackColorStyle(PaletteState.Normal);
+        var angle = state.GetBackColorAngle(PaletteState.Normal);
+        var color1 = state.GetBackColor1(PaletteState.Normal);
+        var color2 = state.GetBackColor2(PaletteState.Normal);
+
+        // Default style when the user provides one color only: Solid
+        if (effectiveStyle == PaletteColorStyle.Inherit)
+        {
+            effectiveStyle = (color2 == GlobalStaticValues.EMPTY_COLOR || color2.IsEmpty)
+                ? PaletteColorStyle.Solid
+                : PaletteColorStyle.Linear;
+        }
+
+        if (Math.Abs(angle - (-1f)) <= float.Epsilon)
+        {
+            angle = 90f;
+        }
+
+        // Paint according to style
+        Rectangle rect = Rectangle.Truncate(backRect);
+
+        switch (effectiveStyle)
+        {
+            case PaletteColorStyle.Solid:
+            {
+                using var brush = new SolidBrush((color1 == GlobalStaticValues.EMPTY_COLOR || color1.IsEmpty)
+                    ? KCT.StatusStripGradientEnd : color1);
+                graphics.FillRectangle(brush, rect);
+                break;
+            }
+            default:
+            {
+                Color a = (color1 == GlobalStaticValues.EMPTY_COLOR || color1.IsEmpty) ? KCT.StatusStripGradientBegin : color1;
+                Color b = (color2 == GlobalStaticValues.EMPTY_COLOR || color2.IsEmpty) ? KCT.StatusStripGradientEnd : color2;
+                using var brush = new LinearGradientBrush(rect, a, b, angle);
+                graphics.FillRectangle(brush, rect);
+                break;
+            }
+        }
+
+        return true;
+    }
+    #endregion
+
     #region OnRenderToolStripBorder
     /// <summary>
-    /// Raises the RenderToolStripBorder event. 
+    /// Raises the RenderToolStripBorder event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripBorder(ToolStripRenderEventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonSparkleRenderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonSparkleRenderer.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -16,7 +16,7 @@
 namespace Krypton.Toolkit;
 
 /// <summary>
-/// 
+///
 /// </summary>
 public class KryptonSparkleRenderer : KryptonProfessionalRenderer
 {
@@ -125,7 +125,7 @@ public class KryptonSparkleRenderer : KryptonProfessionalRenderer
 
     #region OnRenderArrow
     /// <summary>
-    /// Raises the RenderArrow event. 
+    /// Raises the RenderArrow event.
     /// </summary>
     /// <param name="e">An ToolStripArrowRenderEventArgs containing the event data.</param>
     protected override void OnRenderArrow(ToolStripArrowRenderEventArgs e)
@@ -203,7 +203,7 @@ public class KryptonSparkleRenderer : KryptonProfessionalRenderer
 
     #region OnRenderButtonBackground
     /// <summary>
-    /// Raises the RenderButtonBackground event. 
+    /// Raises the RenderButtonBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderButtonBackground(ToolStripItemRenderEventArgs e)
@@ -222,7 +222,7 @@ public class KryptonSparkleRenderer : KryptonProfessionalRenderer
 
     #region OnRenderDropDownButtonBackground
     /// <summary>
-    /// Raises the RenderDropDownButtonBackground event. 
+    /// Raises the RenderDropDownButtonBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderDropDownButtonBackground(ToolStripItemRenderEventArgs e)
@@ -238,7 +238,7 @@ public class KryptonSparkleRenderer : KryptonProfessionalRenderer
 
     #region OnRenderItemCheck
     /// <summary>
-    /// Raises the RenderItemCheck event. 
+    /// Raises the RenderItemCheck event.
     /// </summary>
     /// <param name="e">An ToolStripItemImageRenderEventArgs containing the event data.</param>
     protected override void OnRenderItemCheck(ToolStripItemImageRenderEventArgs e)
@@ -337,7 +337,7 @@ public class KryptonSparkleRenderer : KryptonProfessionalRenderer
 
     #region OnRenderItemText
     /// <summary>
-    /// Raises the RenderItemText event. 
+    /// Raises the RenderItemText event.
     /// </summary>
     /// <param name="e">A ToolStripItemTextRenderEventArgs that contains the event data.</param>
     protected override void OnRenderItemText(ToolStripItemTextRenderEventArgs e)
@@ -406,7 +406,7 @@ public class KryptonSparkleRenderer : KryptonProfessionalRenderer
 
     #region OnRenderItemImage
     /// <summary>
-    /// Raises the RenderItemImage event. 
+    /// Raises the RenderItemImage event.
     /// </summary>
     /// <param name="e">An ToolStripItemImageRenderEventArgs containing the event data.</param>
     protected override void OnRenderItemImage(ToolStripItemImageRenderEventArgs e)
@@ -441,7 +441,7 @@ public class KryptonSparkleRenderer : KryptonProfessionalRenderer
 
     #region OnRenderMenuItemBackground
     /// <summary>
-    /// Raises the RenderMenuItemBackground event. 
+    /// Raises the RenderMenuItemBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderMenuItemBackground(ToolStripItemRenderEventArgs e)
@@ -494,7 +494,7 @@ public class KryptonSparkleRenderer : KryptonProfessionalRenderer
 
     #region OnRenderSplitButtonBackground
     /// <summary>
-    /// Raises the RenderSplitButtonBackground event. 
+    /// Raises the RenderSplitButtonBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderSplitButtonBackground(ToolStripItemRenderEventArgs e)
@@ -528,7 +528,7 @@ public class KryptonSparkleRenderer : KryptonProfessionalRenderer
 
     #region OnRenderStatusStripSizingGrip
     /// <summary>
-    /// Raises the RenderStatusStripSizingGrip event. 
+    /// Raises the RenderStatusStripSizingGrip event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderStatusStripSizingGrip(ToolStripRenderEventArgs e)
@@ -566,7 +566,7 @@ public class KryptonSparkleRenderer : KryptonProfessionalRenderer
 
     #region OnRenderToolStripContentPanelBackground
     /// <summary>
-    /// Raises the RenderToolStripContentPanelBackground event. 
+    /// Raises the RenderToolStripContentPanelBackground event.
     /// </summary>
     /// <param name="e">An ToolStripContentPanelRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripContentPanelBackground(ToolStripContentPanelRenderEventArgs e)
@@ -586,7 +586,7 @@ public class KryptonSparkleRenderer : KryptonProfessionalRenderer
 
     #region OnRenderSeparator
     /// <summary>
-    /// Raises the RenderSeparator event. 
+    /// Raises the RenderSeparator event.
     /// </summary>
     /// <param name="e">An ToolStripSeparatorRenderEventArgs containing the event data.</param>
     protected override void OnRenderSeparator(ToolStripSeparatorRenderEventArgs e)
@@ -622,7 +622,7 @@ public class KryptonSparkleRenderer : KryptonProfessionalRenderer
 
     #region OnRenderToolStripBackground
     /// <summary>
-    /// Raises the RenderToolStripBackground event. 
+    /// Raises the RenderToolStripBackground event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripBackground(ToolStripRenderEventArgs e)
@@ -653,12 +653,16 @@ public class KryptonSparkleRenderer : KryptonProfessionalRenderer
                 }
                 break;
             case StatusStrip _:
+                if (TryRenderStatusStripOverride(e, e.Graphics))
+                {
+                    break;
+                }
                 // Create rectangle that covers the status strip area
                 var backRect = new RectangleF(0, 0, e.ToolStrip.Width, e.ToolStrip.Height);
 
                 Form? owner = e.ToolStrip.FindForm();
 
-                // Check if the status strip is inside a KryptonForm and using the Sparkle renderer, in 
+                // Check if the status strip is inside a KryptonForm and using the Sparkle renderer, in
                 // which case we want to extend the drawing down into the border area for an integrated look
                 if (e.ToolStrip.Visible
                     && e.ToolStrip is { Dock: DockStyle.Bottom, RenderMode: ToolStripRenderMode.ManagerRenderMode }
@@ -723,7 +727,7 @@ public class KryptonSparkleRenderer : KryptonProfessionalRenderer
 
     #region OnRenderImageMargin
     /// <summary>
-    /// Raises the RenderImageMargin event. 
+    /// Raises the RenderImageMargin event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderImageMargin(ToolStripRenderEventArgs e)
@@ -782,7 +786,7 @@ public class KryptonSparkleRenderer : KryptonProfessionalRenderer
 
     #region OnRenderToolStripBorder
     /// <summary>
-    /// Raises the RenderToolStripBorder event. 
+    /// Raises the RenderToolStripBorder event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripBorder(ToolStripRenderEventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonStandardRenderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonStandardRenderer.cs
@@ -1,19 +1,19 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
+ *
  */
 #endregion
 
 namespace Krypton.Toolkit;
 
 /// <summary>
-/// 
+///
 /// </summary>
 public class KryptonStandardRenderer : KryptonProfessionalRenderer
 {
@@ -30,7 +30,7 @@ public class KryptonStandardRenderer : KryptonProfessionalRenderer
 
     #region OnRenderItemText
     /// <summary>
-    /// Raises the RenderItemText event. 
+    /// Raises the RenderItemText event.
     /// </summary>
     /// <param name="e">A ToolStripItemTextRenderEventArgs that contains the event data.</param>
     protected override void OnRenderItemText(ToolStripItemTextRenderEventArgs e)
@@ -58,7 +58,7 @@ public class KryptonStandardRenderer : KryptonProfessionalRenderer
 
     #region OnRenderToolStripBackground
     /// <summary>
-    /// Raises the RenderToolStripBackground event. 
+    /// Raises the RenderToolStripBackground event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripBackground(ToolStripRenderEventArgs e)
@@ -75,6 +75,10 @@ public class KryptonStandardRenderer : KryptonProfessionalRenderer
                 }
                 break;
             case StatusStrip _:
+                if (TryRenderStatusStripOverride(e, e.Graphics))
+                {
+                    return;
+                }
                 if (e.ToolStrip.Font != KCT.StatusStripFont)
                 {
                     e.ToolStrip.Font = KCT.StatusStripFont;

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonVisualStudio2010With2007Renderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonVisualStudio2010With2007Renderer.cs
@@ -1,15 +1,14 @@
 ﻿#region BSD License
 /*
- *   BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved. 
- *  
+ *  BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed, tobitege et al. 2023 - 2025. All rights reserved. *
  */
 #endregion
 
 namespace Krypton.Toolkit;
 
 /// <summary>
-/// 
+///
 /// </summary>
 public class KryptonVisualStudio2010With2007Renderer : KryptonProfessionalRenderer
 {
@@ -248,7 +247,7 @@ public class KryptonVisualStudio2010With2007Renderer : KryptonProfessionalRender
 
     #region OnRenderArrow
     /// <summary>
-    /// Raises the RenderArrow event. 
+    /// Raises the RenderArrow event.
     /// </summary>
     /// <param name="e">An ToolStripArrowRenderEventArgs containing the event data.</param>
     protected override void OnRenderArrow(ToolStripArrowRenderEventArgs e)
@@ -263,12 +262,12 @@ public class KryptonVisualStudio2010With2007Renderer : KryptonProfessionalRender
             RectangleF boundsF = arrowPath.GetBounds();
             boundsF.Inflate(1f, 1f);
 
-            Color color1 = e.Item!.Enabled 
-                ? KCT.ToolStripText 
+            Color color1 = e.Item!.Enabled
+                ? KCT.ToolStripText
                 : _disabled;
-                
-            Color color2 = e.Item.Enabled 
-                ? CommonHelper.WhitenColor(KCT.ToolStripText, 0.7f, 0.7f, 0.7f) 
+
+            Color color2 = e.Item.Enabled
+                ? CommonHelper.WhitenColor(KCT.ToolStripText, 0.7f, 0.7f, 0.7f)
                 : _disabled;
 
             // Use gradient angle to match the arrow direction
@@ -290,7 +289,7 @@ public class KryptonVisualStudio2010With2007Renderer : KryptonProfessionalRender
 
     #region OnRenderButtonBackground
     /// <summary>
-    /// Raises the RenderButtonBackground event. 
+    /// Raises the RenderButtonBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderButtonBackground(ToolStripItemRenderEventArgs e)
@@ -309,7 +308,7 @@ public class KryptonVisualStudio2010With2007Renderer : KryptonProfessionalRender
 
     #region OnRenderDropDownButtonBackground
     /// <summary>
-    /// Raises the RenderDropDownButtonBackground event. 
+    /// Raises the RenderDropDownButtonBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderDropDownButtonBackground(ToolStripItemRenderEventArgs e)
@@ -325,7 +324,7 @@ public class KryptonVisualStudio2010With2007Renderer : KryptonProfessionalRender
 
     #region OnRenderItemCheck
     /// <summary>
-    /// Raises the RenderItemCheck event. 
+    /// Raises the RenderItemCheck event.
     /// </summary>
     /// <param name="e">An ToolStripItemImageRenderEventArgs containing the event data.</param>
     protected override void OnRenderItemCheck(ToolStripItemImageRenderEventArgs e)
@@ -413,7 +412,7 @@ public class KryptonVisualStudio2010With2007Renderer : KryptonProfessionalRender
 
     #region OnRenderItemText
     /// <summary>
-    /// Raises the RenderItemText event. 
+    /// Raises the RenderItemText event.
     /// </summary>
     /// <param name="e">A ToolStripItemTextRenderEventArgs that contains the event data.</param>
     protected override void OnRenderItemText(ToolStripItemTextRenderEventArgs e)
@@ -458,7 +457,7 @@ public class KryptonVisualStudio2010With2007Renderer : KryptonProfessionalRender
 
     #region OnRenderItemImage
     /// <summary>
-    /// Raises the RenderItemImage event. 
+    /// Raises the RenderItemImage event.
     /// </summary>
     /// <param name="e">An ToolStripItemImageRenderEventArgs containing the event data.</param>
     protected override void OnRenderItemImage(ToolStripItemImageRenderEventArgs e)
@@ -493,7 +492,7 @@ public class KryptonVisualStudio2010With2007Renderer : KryptonProfessionalRender
 
     #region OnRenderMenuItemBackground
     /// <summary>
-    /// Raises the RenderMenuItemBackground event. 
+    /// Raises the RenderMenuItemBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderMenuItemBackground(ToolStripItemRenderEventArgs e)
@@ -556,7 +555,7 @@ public class KryptonVisualStudio2010With2007Renderer : KryptonProfessionalRender
 
     #region OnRenderSplitButtonBackground
     /// <summary>
-    /// Raises the RenderSplitButtonBackground event. 
+    /// Raises the RenderSplitButtonBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderSplitButtonBackground(ToolStripItemRenderEventArgs e)
@@ -590,7 +589,7 @@ public class KryptonVisualStudio2010With2007Renderer : KryptonProfessionalRender
 
     #region OnRenderStatusStripSizingGrip
     /// <summary>
-    /// Raises the RenderStatusStripSizingGrip event. 
+    /// Raises the RenderStatusStripSizingGrip event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderStatusStripSizingGrip(ToolStripRenderEventArgs e)
@@ -628,7 +627,7 @@ public class KryptonVisualStudio2010With2007Renderer : KryptonProfessionalRender
 
     #region OnRenderToolStripContentPanelBackground
     /// <summary>
-    /// Raises the RenderToolStripContentPanelBackground event. 
+    /// Raises the RenderToolStripContentPanelBackground event.
     /// </summary>
     /// <param name="e">An ToolStripContentPanelRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripContentPanelBackground(ToolStripContentPanelRenderEventArgs e)
@@ -648,7 +647,7 @@ public class KryptonVisualStudio2010With2007Renderer : KryptonProfessionalRender
 
     #region OnRenderSeparator
     /// <summary>
-    /// Raises the RenderSeparator event. 
+    /// Raises the RenderSeparator event.
     /// </summary>
     /// <param name="e">An ToolStripSeparatorRenderEventArgs containing the event data.</param>
     protected override void OnRenderSeparator(ToolStripSeparatorRenderEventArgs e)
@@ -686,7 +685,7 @@ public class KryptonVisualStudio2010With2007Renderer : KryptonProfessionalRender
 
     #region OnRenderToolStripBackground
     /// <summary>
-    /// Raises the RenderToolStripBackground event. 
+    /// Raises the RenderToolStripBackground event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripBackground(ToolStripRenderEventArgs e)
@@ -715,6 +714,10 @@ public class KryptonVisualStudio2010With2007Renderer : KryptonProfessionalRender
                 break;
             case StatusStrip _:
             {
+                if (TryRenderStatusStripOverride(e, e.Graphics))
+                {
+                    break;
+                }
                 // Make sure the font is current
                 e.ToolStrip.Font = KCT.StatusStripFont;
 
@@ -723,7 +726,7 @@ public class KryptonVisualStudio2010With2007Renderer : KryptonProfessionalRender
 
                 Form? owner = e.ToolStrip.FindForm();
 
-                // Check if the status strip is inside a KryptonForm and using the Office 2007 renderer, in 
+                // Check if the status strip is inside a KryptonForm and using the Office 2007 renderer, in
                 // which case we want to extend the drawing down into the border area for an integrated look
                 if (e.ToolStrip.Visible
                     && e.ToolStrip is { Dock: DockStyle.Bottom, RenderMode: ToolStripRenderMode.ManagerRenderMode }
@@ -773,7 +776,7 @@ public class KryptonVisualStudio2010With2007Renderer : KryptonProfessionalRender
 
     #region OnRenderImageMargin
     /// <summary>
-    /// Raises the RenderImageMargin event. 
+    /// Raises the RenderImageMargin event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderImageMargin(ToolStripRenderEventArgs e)
@@ -834,7 +837,7 @@ public class KryptonVisualStudio2010With2007Renderer : KryptonProfessionalRender
 
     #region OnRenderToolStripBorder
     /// <summary>
-    /// Raises the RenderToolStripBorder event. 
+    /// Raises the RenderToolStripBorder event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripBorder(ToolStripRenderEventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonVisualStudio2010With2010Renderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonVisualStudio2010With2010Renderer.cs
@@ -1,15 +1,15 @@
 ﻿#region BSD License
 /*
- *   BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved. 
- *  
+ *  BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed, tobitege et al. 2023 - 2025. All rights reserved. *
+ *
  */
 #endregion
 
 namespace Krypton.Toolkit;
 
 /// <summary>
-/// 
+///
 /// </summary>
 public class KryptonVisualStudio2010With2010Renderer : KryptonProfessionalRenderer
 {
@@ -361,7 +361,7 @@ public class KryptonVisualStudio2010With2010Renderer : KryptonProfessionalRender
 
     #region OnRenderArrow
     /// <summary>
-    /// Raises the RenderArrow event. 
+    /// Raises the RenderArrow event.
     /// </summary>
     /// <param name="e">An ToolStripArrowRenderEventArgs containing the event data.</param>
     protected override void OnRenderArrow(ToolStripArrowRenderEventArgs e)
@@ -417,7 +417,7 @@ public class KryptonVisualStudio2010With2010Renderer : KryptonProfessionalRender
 
     #region OnRenderButtonBackground
     /// <summary>
-    /// Raises the RenderButtonBackground event. 
+    /// Raises the RenderButtonBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderButtonBackground(ToolStripItemRenderEventArgs e)
@@ -436,7 +436,7 @@ public class KryptonVisualStudio2010With2010Renderer : KryptonProfessionalRender
 
     #region OnRenderDropDownButtonBackground
     /// <summary>
-    /// Raises the RenderDropDownButtonBackground event. 
+    /// Raises the RenderDropDownButtonBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderDropDownButtonBackground(ToolStripItemRenderEventArgs e)
@@ -452,7 +452,7 @@ public class KryptonVisualStudio2010With2010Renderer : KryptonProfessionalRender
 
     #region OnRenderItemCheck
     /// <summary>
-    /// Raises the RenderItemCheck event. 
+    /// Raises the RenderItemCheck event.
     /// </summary>
     /// <param name="e">An ToolStripItemImageRenderEventArgs containing the event data.</param>
     protected override void OnRenderItemCheck(ToolStripItemImageRenderEventArgs e)
@@ -540,7 +540,7 @@ public class KryptonVisualStudio2010With2010Renderer : KryptonProfessionalRender
 
     #region OnRenderItemText
     /// <summary>
-    /// Raises the RenderItemText event. 
+    /// Raises the RenderItemText event.
     /// </summary>
     /// <param name="e">A ToolStripItemTextRenderEventArgs that contains the event data.</param>
     protected override void OnRenderItemText(ToolStripItemTextRenderEventArgs e)
@@ -613,7 +613,7 @@ public class KryptonVisualStudio2010With2010Renderer : KryptonProfessionalRender
 
     #region OnRenderItemImage
     /// <summary>
-    /// Raises the RenderItemImage event. 
+    /// Raises the RenderItemImage event.
     /// </summary>
     /// <param name="e">An ToolStripItemImageRenderEventArgs containing the event data.</param>
     protected override void OnRenderItemImage(ToolStripItemImageRenderEventArgs e)
@@ -648,7 +648,7 @@ public class KryptonVisualStudio2010With2010Renderer : KryptonProfessionalRender
 
     #region OnRenderMenuItemBackground
     /// <summary>
-    /// Raises the RenderMenuItemBackground event. 
+    /// Raises the RenderMenuItemBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderMenuItemBackground(ToolStripItemRenderEventArgs e)
@@ -711,7 +711,7 @@ public class KryptonVisualStudio2010With2010Renderer : KryptonProfessionalRender
 
     #region OnRenderSeparator
     /// <summary>
-    /// Raises the RenderSeparator event. 
+    /// Raises the RenderSeparator event.
     /// </summary>
     /// <param name="e">An ToolStripSeparatorRenderEventArgs containing the event data.</param>
     protected override void OnRenderSeparator(ToolStripSeparatorRenderEventArgs e)
@@ -731,7 +731,7 @@ public class KryptonVisualStudio2010With2010Renderer : KryptonProfessionalRender
 
     #region OnRenderSplitButtonBackground
     /// <summary>
-    /// Raises the RenderSplitButtonBackground event. 
+    /// Raises the RenderSplitButtonBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderSplitButtonBackground(ToolStripItemRenderEventArgs e)
@@ -765,7 +765,7 @@ public class KryptonVisualStudio2010With2010Renderer : KryptonProfessionalRender
 
     #region OnRenderStatusStripSizingGrip
     /// <summary>
-    /// Raises the RenderStatusStripSizingGrip event. 
+    /// Raises the RenderStatusStripSizingGrip event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderStatusStripSizingGrip(ToolStripRenderEventArgs e)
@@ -803,7 +803,7 @@ public class KryptonVisualStudio2010With2010Renderer : KryptonProfessionalRender
 
     #region OnRenderToolStripContentPanelBackground
     /// <summary>
-    /// Raises the RenderToolStripContentPanelBackground event. 
+    /// Raises the RenderToolStripContentPanelBackground event.
     /// </summary>
     /// <param name="e">An ToolStripContentPanelRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripContentPanelBackground(ToolStripContentPanelRenderEventArgs e)
@@ -823,7 +823,7 @@ public class KryptonVisualStudio2010With2010Renderer : KryptonProfessionalRender
 
     #region OnRenderToolStripBackground
     /// <summary>
-    /// Raises the RenderToolStripBackground event. 
+    /// Raises the RenderToolStripBackground event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripBackground(ToolStripRenderEventArgs e)
@@ -855,6 +855,10 @@ public class KryptonVisualStudio2010With2010Renderer : KryptonProfessionalRender
                 break;
             case StatusStrip _:
             {
+                if (TryRenderStatusStripOverride(e, e.Graphics))
+                {
+                    break;
+                }
                 // Make sure the font is current
                 if (e.ToolStrip.Font != KCT.StatusStripFont)
                 {
@@ -936,7 +940,7 @@ public class KryptonVisualStudio2010With2010Renderer : KryptonProfessionalRender
 
     #region OnRenderToolStripBorder
     /// <summary>
-    /// Raises the RenderToolStripBorder event. 
+    /// Raises the RenderToolStripBorder event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripBorder(ToolStripRenderEventArgs e)
@@ -999,7 +1003,7 @@ public class KryptonVisualStudio2010With2010Renderer : KryptonProfessionalRender
 
     #region OnRenderImageMargin
     /// <summary>
-    /// Raises the RenderImageMargin event. 
+    /// Raises the RenderImageMargin event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderImageMargin(ToolStripRenderEventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonVisualStudio2010With2013Renderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonVisualStudio2010With2013Renderer.cs
@@ -1,15 +1,15 @@
 ﻿#region BSD License
 /*
- *   BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *  BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved. *
+ *
  */
 #endregion
 
 namespace Krypton.Toolkit;
 
 /// <summary>
-/// 
+///
 /// </summary>
 public class KryptonVisualStudio2010With2013Renderer : KryptonProfessionalRenderer
 {
@@ -360,7 +360,7 @@ public class KryptonVisualStudio2010With2013Renderer : KryptonProfessionalRender
 
     #region OnRenderArrow
     /// <summary>
-    /// Raises the RenderArrow event. 
+    /// Raises the RenderArrow event.
     /// </summary>
     /// <param name="e">An ToolStripArrowRenderEventArgs containing the event data.</param>
     protected override void OnRenderArrow(ToolStripArrowRenderEventArgs e)
@@ -416,7 +416,7 @@ public class KryptonVisualStudio2010With2013Renderer : KryptonProfessionalRender
 
     #region OnRenderButtonBackground
     /// <summary>
-    /// Raises the RenderButtonBackground event. 
+    /// Raises the RenderButtonBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderButtonBackground(ToolStripItemRenderEventArgs e)
@@ -435,7 +435,7 @@ public class KryptonVisualStudio2010With2013Renderer : KryptonProfessionalRender
 
     #region OnRenderDropDownButtonBackground
     /// <summary>
-    /// Raises the RenderDropDownButtonBackground event. 
+    /// Raises the RenderDropDownButtonBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderDropDownButtonBackground(ToolStripItemRenderEventArgs e)
@@ -451,7 +451,7 @@ public class KryptonVisualStudio2010With2013Renderer : KryptonProfessionalRender
 
     #region OnRenderItemCheck
     /// <summary>
-    /// Raises the RenderItemCheck event. 
+    /// Raises the RenderItemCheck event.
     /// </summary>
     /// <param name="e">An ToolStripItemImageRenderEventArgs containing the event data.</param>
     protected override void OnRenderItemCheck(ToolStripItemImageRenderEventArgs e)
@@ -539,7 +539,7 @@ public class KryptonVisualStudio2010With2013Renderer : KryptonProfessionalRender
 
     #region OnRenderItemText
     /// <summary>
-    /// Raises the RenderItemText event. 
+    /// Raises the RenderItemText event.
     /// </summary>
     /// <param name="e">A ToolStripItemTextRenderEventArgs that contains the event data.</param>
     protected override void OnRenderItemText(ToolStripItemTextRenderEventArgs e)
@@ -614,7 +614,7 @@ public class KryptonVisualStudio2010With2013Renderer : KryptonProfessionalRender
 
     #region OnRenderItemImage
     /// <summary>
-    /// Raises the RenderItemImage event. 
+    /// Raises the RenderItemImage event.
     /// </summary>
     /// <param name="e">An ToolStripItemImageRenderEventArgs containing the event data.</param>
     protected override void OnRenderItemImage(ToolStripItemImageRenderEventArgs e)
@@ -649,7 +649,7 @@ public class KryptonVisualStudio2010With2013Renderer : KryptonProfessionalRender
 
     #region OnRenderMenuItemBackground
     /// <summary>
-    /// Raises the RenderMenuItemBackground event. 
+    /// Raises the RenderMenuItemBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderMenuItemBackground(ToolStripItemRenderEventArgs e)
@@ -712,7 +712,7 @@ public class KryptonVisualStudio2010With2013Renderer : KryptonProfessionalRender
 
     #region OnRenderSeparator
     /// <summary>
-    /// Raises the RenderSeparator event. 
+    /// Raises the RenderSeparator event.
     /// </summary>
     /// <param name="e">An ToolStripSeparatorRenderEventArgs containing the event data.</param>
     protected override void OnRenderSeparator(ToolStripSeparatorRenderEventArgs e)
@@ -732,7 +732,7 @@ public class KryptonVisualStudio2010With2013Renderer : KryptonProfessionalRender
 
     #region OnRenderSplitButtonBackground
     /// <summary>
-    /// Raises the RenderSplitButtonBackground event. 
+    /// Raises the RenderSplitButtonBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderSplitButtonBackground(ToolStripItemRenderEventArgs e)
@@ -766,7 +766,7 @@ public class KryptonVisualStudio2010With2013Renderer : KryptonProfessionalRender
 
     #region OnRenderStatusStripSizingGrip
     /// <summary>
-    /// Raises the RenderStatusStripSizingGrip event. 
+    /// Raises the RenderStatusStripSizingGrip event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderStatusStripSizingGrip(ToolStripRenderEventArgs e)
@@ -804,7 +804,7 @@ public class KryptonVisualStudio2010With2013Renderer : KryptonProfessionalRender
 
     #region OnRenderToolStripContentPanelBackground
     /// <summary>
-    /// Raises the RenderToolStripContentPanelBackground event. 
+    /// Raises the RenderToolStripContentPanelBackground event.
     /// </summary>
     /// <param name="e">An ToolStripContentPanelRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripContentPanelBackground(ToolStripContentPanelRenderEventArgs e)
@@ -824,7 +824,7 @@ public class KryptonVisualStudio2010With2013Renderer : KryptonProfessionalRender
 
     #region OnRenderToolStripBackground
     /// <summary>
-    /// Raises the RenderToolStripBackground event. 
+    /// Raises the RenderToolStripBackground event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripBackground(ToolStripRenderEventArgs e)
@@ -851,6 +851,10 @@ public class KryptonVisualStudio2010With2013Renderer : KryptonProfessionalRender
             }
             case StatusStrip:
             {
+                if (TryRenderStatusStripOverride(e, e.Graphics))
+                {
+                    break;
+                }
                 // Make sure the font is current
                 if (e.ToolStrip.Font != KCT.StatusStripFont)
                 {
@@ -943,7 +947,7 @@ public class KryptonVisualStudio2010With2013Renderer : KryptonProfessionalRender
 
     #region OnRenderToolStripBorder
     /// <summary>
-    /// Raises the RenderToolStripBorder event. 
+    /// Raises the RenderToolStripBorder event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripBorder(ToolStripRenderEventArgs e)
@@ -1001,7 +1005,7 @@ public class KryptonVisualStudio2010With2013Renderer : KryptonProfessionalRender
 
     #region OnRenderImageMargin
     /// <summary>
-    /// Raises the RenderImageMargin event. 
+    /// Raises the RenderImageMargin event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderImageMargin(ToolStripRenderEventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonVisualStudio2010WithMicrosoft365Renderer.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonVisualStudio2010WithMicrosoft365Renderer.cs
@@ -1,15 +1,15 @@
 ﻿#region BSD License
 /*
  *   BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed, tobitege et al. 2023 - 2025. All rights reserved. *
+ *
  */
 #endregion
 
 namespace Krypton.Toolkit;
 
 /// <summary>
-/// 
+///
 /// </summary>
 /// <seealso cref="KryptonProfessionalRenderer" />
 public class KryptonVisualStudio2010WithMicrosoft365Renderer : KryptonProfessionalRenderer
@@ -357,7 +357,7 @@ public class KryptonVisualStudio2010WithMicrosoft365Renderer : KryptonProfession
 
     #region OnRenderArrow
     /// <summary>
-    /// Raises the RenderArrow event. 
+    /// Raises the RenderArrow event.
     /// </summary>
     /// <param name="e">An ToolStripArrowRenderEventArgs containing the event data.</param>
     protected override void OnRenderArrow(ToolStripArrowRenderEventArgs e)
@@ -413,7 +413,7 @@ public class KryptonVisualStudio2010WithMicrosoft365Renderer : KryptonProfession
 
     #region OnRenderButtonBackground
     /// <summary>
-    /// Raises the RenderButtonBackground event. 
+    /// Raises the RenderButtonBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderButtonBackground(ToolStripItemRenderEventArgs e)
@@ -432,7 +432,7 @@ public class KryptonVisualStudio2010WithMicrosoft365Renderer : KryptonProfession
 
     #region OnRenderDropDownButtonBackground
     /// <summary>
-    /// Raises the RenderDropDownButtonBackground event. 
+    /// Raises the RenderDropDownButtonBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderDropDownButtonBackground(ToolStripItemRenderEventArgs e)
@@ -448,7 +448,7 @@ public class KryptonVisualStudio2010WithMicrosoft365Renderer : KryptonProfession
 
     #region OnRenderItemCheck
     /// <summary>
-    /// Raises the RenderItemCheck event. 
+    /// Raises the RenderItemCheck event.
     /// </summary>
     /// <param name="e">An ToolStripItemImageRenderEventArgs containing the event data.</param>
     protected override void OnRenderItemCheck(ToolStripItemImageRenderEventArgs e)
@@ -534,7 +534,7 @@ public class KryptonVisualStudio2010WithMicrosoft365Renderer : KryptonProfession
 
     #region OnRenderItemText
     /// <summary>
-    /// Raises the RenderItemText event. 
+    /// Raises the RenderItemText event.
     /// </summary>
     /// <param name="e">A ToolStripItemTextRenderEventArgs that contains the event data.</param>
     protected override void OnRenderItemText(ToolStripItemTextRenderEventArgs e)
@@ -609,7 +609,7 @@ public class KryptonVisualStudio2010WithMicrosoft365Renderer : KryptonProfession
 
     #region OnRenderItemImage
     /// <summary>
-    /// Raises the RenderItemImage event. 
+    /// Raises the RenderItemImage event.
     /// </summary>
     /// <param name="e">An ToolStripItemImageRenderEventArgs containing the event data.</param>
     protected override void OnRenderItemImage(ToolStripItemImageRenderEventArgs e)
@@ -644,7 +644,7 @@ public class KryptonVisualStudio2010WithMicrosoft365Renderer : KryptonProfession
 
     #region OnRenderMenuItemBackground
     /// <summary>
-    /// Raises the RenderMenuItemBackground event. 
+    /// Raises the RenderMenuItemBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderMenuItemBackground(ToolStripItemRenderEventArgs e)
@@ -707,7 +707,7 @@ public class KryptonVisualStudio2010WithMicrosoft365Renderer : KryptonProfession
 
     #region OnRenderSeparator
     /// <summary>
-    /// Raises the RenderSeparator event. 
+    /// Raises the RenderSeparator event.
     /// </summary>
     /// <param name="e">An ToolStripSeparatorRenderEventArgs containing the event data.</param>
     protected override void OnRenderSeparator(ToolStripSeparatorRenderEventArgs e)
@@ -727,7 +727,7 @@ public class KryptonVisualStudio2010WithMicrosoft365Renderer : KryptonProfession
 
     #region OnRenderSplitButtonBackground
     /// <summary>
-    /// Raises the RenderSplitButtonBackground event. 
+    /// Raises the RenderSplitButtonBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderSplitButtonBackground(ToolStripItemRenderEventArgs e)
@@ -761,7 +761,7 @@ public class KryptonVisualStudio2010WithMicrosoft365Renderer : KryptonProfession
 
     #region OnRenderStatusStripSizingGrip
     /// <summary>
-    /// Raises the RenderStatusStripSizingGrip event. 
+    /// Raises the RenderStatusStripSizingGrip event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderStatusStripSizingGrip(ToolStripRenderEventArgs e)
@@ -799,7 +799,7 @@ public class KryptonVisualStudio2010WithMicrosoft365Renderer : KryptonProfession
 
     #region OnRenderToolStripContentPanelBackground
     /// <summary>
-    /// Raises the RenderToolStripContentPanelBackground event. 
+    /// Raises the RenderToolStripContentPanelBackground event.
     /// </summary>
     /// <param name="e">An ToolStripContentPanelRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripContentPanelBackground(ToolStripContentPanelRenderEventArgs e)
@@ -819,7 +819,7 @@ public class KryptonVisualStudio2010WithMicrosoft365Renderer : KryptonProfession
 
     #region OnRenderToolStripBackground
     /// <summary>
-    /// Raises the RenderToolStripBackground event. 
+    /// Raises the RenderToolStripBackground event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripBackground(ToolStripRenderEventArgs e)
@@ -846,6 +846,10 @@ public class KryptonVisualStudio2010WithMicrosoft365Renderer : KryptonProfession
             }
             case StatusStrip:
             {
+                if (TryRenderStatusStripOverride(e, e.Graphics))
+                {
+                    break;
+                }
                 // Make sure the font is current
                 if (e.ToolStrip.Font != KCT.StatusStripFont)
                 {
@@ -938,7 +942,7 @@ public class KryptonVisualStudio2010WithMicrosoft365Renderer : KryptonProfession
 
     #region OnRenderToolStripBorder
     /// <summary>
-    /// Raises the RenderToolStripBorder event. 
+    /// Raises the RenderToolStripBorder event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripBorder(ToolStripRenderEventArgs e)
@@ -996,7 +1000,7 @@ public class KryptonVisualStudio2010WithMicrosoft365Renderer : KryptonProfession
 
     #region OnRenderImageMargin
     /// <summary>
-    /// Raises the RenderImageMargin event. 
+    /// Raises the RenderImageMargin event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderImageMargin(ToolStripRenderEventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonVisualStudioRender.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Rendering/KryptonVisualStudioRender.cs
@@ -1,16 +1,16 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed, tobitege et al. 2023 - 2025. All rights reserved. *
+ *
  */
 #endregion
 
 namespace Krypton.Toolkit;
 
 /// <summary>
-/// 
+///
 /// </summary>
 /// <seealso cref="KryptonProfessionalRenderer" />
 public class KryptonVisualStudio365Renderer : KryptonProfessionalRenderer
@@ -358,7 +358,7 @@ public class KryptonVisualStudio365Renderer : KryptonProfessionalRenderer
 
     #region OnRenderArrow
     /// <summary>
-    /// Raises the RenderArrow event. 
+    /// Raises the RenderArrow event.
     /// </summary>
     /// <param name="e">An ToolStripArrowRenderEventArgs containing the event data.</param>
     protected override void OnRenderArrow(ToolStripArrowRenderEventArgs e)
@@ -414,7 +414,7 @@ public class KryptonVisualStudio365Renderer : KryptonProfessionalRenderer
 
     #region OnRenderButtonBackground
     /// <summary>
-    /// Raises the RenderButtonBackground event. 
+    /// Raises the RenderButtonBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderButtonBackground(ToolStripItemRenderEventArgs e)
@@ -431,7 +431,7 @@ public class KryptonVisualStudio365Renderer : KryptonProfessionalRenderer
 
     #region OnRenderDropDownButtonBackground
     /// <summary>
-    /// Raises the RenderDropDownButtonBackground event. 
+    /// Raises the RenderDropDownButtonBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderDropDownButtonBackground(ToolStripItemRenderEventArgs e)
@@ -447,7 +447,7 @@ public class KryptonVisualStudio365Renderer : KryptonProfessionalRenderer
 
     #region OnRenderItemCheck
     /// <summary>
-    /// Raises the RenderItemCheck event. 
+    /// Raises the RenderItemCheck event.
     /// </summary>
     /// <param name="e">An ToolStripItemImageRenderEventArgs containing the event data.</param>
     protected override void OnRenderItemCheck(ToolStripItemImageRenderEventArgs e)
@@ -533,7 +533,7 @@ public class KryptonVisualStudio365Renderer : KryptonProfessionalRenderer
 
     #region OnRenderItemText
     /// <summary>
-    /// Raises the RenderItemText event. 
+    /// Raises the RenderItemText event.
     /// </summary>
     /// <param name="e">A ToolStripItemTextRenderEventArgs that contains the event data.</param>
     protected override void OnRenderItemText(ToolStripItemTextRenderEventArgs e)
@@ -608,7 +608,7 @@ public class KryptonVisualStudio365Renderer : KryptonProfessionalRenderer
 
     #region OnRenderItemImage
     /// <summary>
-    /// Raises the RenderItemImage event. 
+    /// Raises the RenderItemImage event.
     /// </summary>
     /// <param name="e">An ToolStripItemImageRenderEventArgs containing the event data.</param>
     protected override void OnRenderItemImage(ToolStripItemImageRenderEventArgs e)
@@ -643,7 +643,7 @@ public class KryptonVisualStudio365Renderer : KryptonProfessionalRenderer
 
     #region OnRenderMenuItemBackground
     /// <summary>
-    /// Raises the RenderMenuItemBackground event. 
+    /// Raises the RenderMenuItemBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderMenuItemBackground(ToolStripItemRenderEventArgs e)
@@ -706,7 +706,7 @@ public class KryptonVisualStudio365Renderer : KryptonProfessionalRenderer
 
     #region OnRenderSeparator
     /// <summary>
-    /// Raises the RenderSeparator event. 
+    /// Raises the RenderSeparator event.
     /// </summary>
     /// <param name="e">An ToolStripSeparatorRenderEventArgs containing the event data.</param>
     protected override void OnRenderSeparator(ToolStripSeparatorRenderEventArgs e)
@@ -726,13 +726,13 @@ public class KryptonVisualStudio365Renderer : KryptonProfessionalRenderer
 
     #region OnRenderSplitButtonBackground
     /// <summary>
-    /// Raises the RenderSplitButtonBackground event. 
+    /// Raises the RenderSplitButtonBackground event.
     /// </summary>
     /// <param name="e">An ToolStripItemRenderEventArgs containing the event data.</param>
     protected override void OnRenderSplitButtonBackground(ToolStripItemRenderEventArgs e)
     {
-        if (e is not null 
-            && e.ToolStrip is not null 
+        if (e is not null
+            && e.ToolStrip is not null
             && (e.Item.Selected || e.Item.Pressed))
         {
             // Cast to correct type
@@ -760,7 +760,7 @@ public class KryptonVisualStudio365Renderer : KryptonProfessionalRenderer
 
     #region OnRenderStatusStripSizingGrip
     /// <summary>
-    /// Raises the RenderStatusStripSizingGrip event. 
+    /// Raises the RenderStatusStripSizingGrip event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderStatusStripSizingGrip(ToolStripRenderEventArgs e)
@@ -798,7 +798,7 @@ public class KryptonVisualStudio365Renderer : KryptonProfessionalRenderer
 
     #region OnRenderToolStripContentPanelBackground
     /// <summary>
-    /// Raises the RenderToolStripContentPanelBackground event. 
+    /// Raises the RenderToolStripContentPanelBackground event.
     /// </summary>
     /// <param name="e">An ToolStripContentPanelRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripContentPanelBackground(ToolStripContentPanelRenderEventArgs e)
@@ -818,7 +818,7 @@ public class KryptonVisualStudio365Renderer : KryptonProfessionalRenderer
 
     #region OnRenderToolStripBackground
     /// <summary>
-    /// Raises the RenderToolStripBackground event. 
+    /// Raises the RenderToolStripBackground event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripBackground(ToolStripRenderEventArgs e)
@@ -845,6 +845,10 @@ public class KryptonVisualStudio365Renderer : KryptonProfessionalRenderer
             }
             case StatusStrip:
             {
+                if (TryRenderStatusStripOverride(e, e.Graphics))
+                {
+                    break;
+                }
                 // Make sure the font is current
                 if (e.ToolStrip.Font != KCT.StatusStripFont)
                 {
@@ -937,7 +941,7 @@ public class KryptonVisualStudio365Renderer : KryptonProfessionalRenderer
 
     #region OnRenderToolStripBorder
     /// <summary>
-    /// Raises the RenderToolStripBorder event. 
+    /// Raises the RenderToolStripBorder event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderToolStripBorder(ToolStripRenderEventArgs e)
@@ -995,7 +999,7 @@ public class KryptonVisualStudio365Renderer : KryptonProfessionalRenderer
 
     #region OnRenderImageMargin
     /// <summary>
-    /// Raises the RenderImageMargin event. 
+    /// Raises the RenderImageMargin event.
     /// </summary>
     /// <param name="e">An ToolStripRenderEventArgs containing the event data.</param>
     protected override void OnRenderImageMargin(ToolStripRenderEventArgs e)

--- a/Source/Krypton Components/TestForm/AdvancedEmojiViewerForm.cs
+++ b/Source/Krypton Components/TestForm/AdvancedEmojiViewerForm.cs
@@ -65,15 +65,15 @@ public partial class AdvancedEmojiViewerForm : KryptonForm
         {
             var selectedRow = kdvEmojis.SelectedRows[0];
 
-            var glyph = selectedRow.Cells["Glyph"].Value.ToString();
+            var glyph = selectedRow.Cells["Glyph"].Value!.ToString();
 
-            var name = selectedRow.Cells["Name"].Value.ToString();
+            var name = selectedRow.Cells["Name"].Value!.ToString();
 
-            var codepoints = selectedRow.Cells["CodePointsText"].Value.ToString();
+            var codepoints = selectedRow.Cells["CodepointsText"].Value!.ToString();
 
             string copiedText = $"{glyph} - {name} ({codepoints})";
 
-            Clipboard.SetText(copiedText);
+            Clipboard.SetText(copiedText!);
         }
         else
         {
@@ -87,9 +87,9 @@ public partial class AdvancedEmojiViewerForm : KryptonForm
         {
             var selectedRow = kdvEmojis.SelectedRows[0];
 
-            var glyph = selectedRow.Cells["Glyph"].Value.ToString();
+            var glyph = selectedRow.Cells["Glyph"].Value!.ToString();
 
-            Clipboard.SetText(glyph);
+            Clipboard.SetText(glyph!);
         }
         else
         {

--- a/Source/Krypton Components/TestForm/MenuToolBarStatusStripTest.Designer.cs
+++ b/Source/Krypton Components/TestForm/MenuToolBarStatusStripTest.Designer.cs
@@ -1,9 +1,9 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -62,13 +62,14 @@ namespace TestForm
             this.toolsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.customizeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.optionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.animateStatusStripToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.contentsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.indexToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.searchToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
             this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.statusStrip1 = new System.Windows.Forms.StatusStrip();
+            this.statusStrip1 = new Krypton.Toolkit.KryptonStatusStrip();
             this.toolStripStatusLabel1 = new System.Windows.Forms.ToolStripStatusLabel();
             this.kryptonProgressBarToolStripItem1 = new Krypton.Toolkit.KryptonProgressBarToolStripItem();
             this.toolStripContainer1 = new System.Windows.Forms.ToolStripContainer();
@@ -97,9 +98,9 @@ namespace TestForm
             this.toolStrip1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonToolStripComboBox1.KryptonComboBoxControl)).BeginInit();
             this.SuspendLayout();
-            // 
+            //
             // menuStrip1
-            // 
+            //
             this.menuStrip1.Font = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.World);
             this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.fileToolStripMenuItem,
@@ -108,12 +109,12 @@ namespace TestForm
             this.helpToolStripMenuItem});
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
-            this.menuStrip1.Size = new System.Drawing.Size(804, 24);
+            this.menuStrip1.Size = new System.Drawing.Size(808, 24);
             this.menuStrip1.TabIndex = 0;
             this.menuStrip1.Text = "menuStrip1";
-            // 
+            //
             // fileToolStripMenuItem
-            // 
+            //
             this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.newToolStripMenuItem,
             this.openToolStripMenuItem,
@@ -128,80 +129,80 @@ namespace TestForm
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
             this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
             this.fileToolStripMenuItem.Text = "&File";
-            // 
+            //
             // newToolStripMenuItem
-            // 
+            //
             this.newToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("newToolStripMenuItem.Image")));
             this.newToolStripMenuItem.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.newToolStripMenuItem.Name = "newToolStripMenuItem";
             this.newToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.N)));
             this.newToolStripMenuItem.Size = new System.Drawing.Size(146, 22);
             this.newToolStripMenuItem.Text = "&New";
-            // 
+            //
             // openToolStripMenuItem
-            // 
+            //
             this.openToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("openToolStripMenuItem.Image")));
             this.openToolStripMenuItem.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.openToolStripMenuItem.Name = "openToolStripMenuItem";
             this.openToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
             this.openToolStripMenuItem.Size = new System.Drawing.Size(146, 22);
             this.openToolStripMenuItem.Text = "&Open";
-            // 
+            //
             // toolStripSeparator
-            // 
+            //
             this.toolStripSeparator.Name = "toolStripSeparator";
             this.toolStripSeparator.Size = new System.Drawing.Size(143, 6);
-            // 
+            //
             // saveToolStripMenuItem
-            // 
+            //
             this.saveToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("saveToolStripMenuItem.Image")));
             this.saveToolStripMenuItem.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
             this.saveToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
             this.saveToolStripMenuItem.Size = new System.Drawing.Size(146, 22);
             this.saveToolStripMenuItem.Text = "&Save";
-            // 
+            //
             // saveAsToolStripMenuItem
-            // 
+            //
             this.saveAsToolStripMenuItem.Name = "saveAsToolStripMenuItem";
             this.saveAsToolStripMenuItem.Size = new System.Drawing.Size(146, 22);
             this.saveAsToolStripMenuItem.Text = "Save &As";
-            // 
+            //
             // toolStripSeparator1
-            // 
+            //
             this.toolStripSeparator1.Name = "toolStripSeparator1";
             this.toolStripSeparator1.Size = new System.Drawing.Size(143, 6);
-            // 
+            //
             // printToolStripMenuItem
-            // 
+            //
             this.printToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("printToolStripMenuItem.Image")));
             this.printToolStripMenuItem.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.printToolStripMenuItem.Name = "printToolStripMenuItem";
             this.printToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.P)));
             this.printToolStripMenuItem.Size = new System.Drawing.Size(146, 22);
             this.printToolStripMenuItem.Text = "&Print";
-            // 
+            //
             // printPreviewToolStripMenuItem
-            // 
+            //
             this.printPreviewToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("printPreviewToolStripMenuItem.Image")));
             this.printPreviewToolStripMenuItem.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.printPreviewToolStripMenuItem.Name = "printPreviewToolStripMenuItem";
             this.printPreviewToolStripMenuItem.Size = new System.Drawing.Size(146, 22);
             this.printPreviewToolStripMenuItem.Text = "Print Pre&view";
-            // 
+            //
             // toolStripSeparator2
-            // 
+            //
             this.toolStripSeparator2.Name = "toolStripSeparator2";
             this.toolStripSeparator2.Size = new System.Drawing.Size(143, 6);
-            // 
+            //
             // exitToolStripMenuItem
-            // 
+            //
             this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
             this.exitToolStripMenuItem.Size = new System.Drawing.Size(146, 22);
             this.exitToolStripMenuItem.Text = "E&xit";
-            // 
+            //
             // editToolStripMenuItem
-            // 
+            //
             this.editToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.undoToolStripMenuItem,
             this.redoToolStripMenuItem,
@@ -214,87 +215,96 @@ namespace TestForm
             this.editToolStripMenuItem.Name = "editToolStripMenuItem";
             this.editToolStripMenuItem.Size = new System.Drawing.Size(39, 20);
             this.editToolStripMenuItem.Text = "&Edit";
-            // 
+            //
             // undoToolStripMenuItem
-            // 
+            //
             this.undoToolStripMenuItem.Name = "undoToolStripMenuItem";
             this.undoToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Z)));
             this.undoToolStripMenuItem.Size = new System.Drawing.Size(144, 22);
             this.undoToolStripMenuItem.Text = "&Undo";
-            // 
+            //
             // redoToolStripMenuItem
-            // 
+            //
             this.redoToolStripMenuItem.Name = "redoToolStripMenuItem";
             this.redoToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Y)));
             this.redoToolStripMenuItem.Size = new System.Drawing.Size(144, 22);
             this.redoToolStripMenuItem.Text = "&Redo";
-            // 
+            //
             // toolStripSeparator3
-            // 
+            //
             this.toolStripSeparator3.Name = "toolStripSeparator3";
             this.toolStripSeparator3.Size = new System.Drawing.Size(141, 6);
-            // 
+            //
             // cutToolStripMenuItem
-            // 
+            //
             this.cutToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("cutToolStripMenuItem.Image")));
             this.cutToolStripMenuItem.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.cutToolStripMenuItem.Name = "cutToolStripMenuItem";
             this.cutToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.X)));
             this.cutToolStripMenuItem.Size = new System.Drawing.Size(144, 22);
             this.cutToolStripMenuItem.Text = "Cu&t";
-            // 
+            //
             // copyToolStripMenuItem
-            // 
+            //
             this.copyToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("copyToolStripMenuItem.Image")));
             this.copyToolStripMenuItem.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.copyToolStripMenuItem.Name = "copyToolStripMenuItem";
             this.copyToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
             this.copyToolStripMenuItem.Size = new System.Drawing.Size(144, 22);
             this.copyToolStripMenuItem.Text = "&Copy";
-            // 
+            //
             // pasteToolStripMenuItem
-            // 
+            //
             this.pasteToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("pasteToolStripMenuItem.Image")));
             this.pasteToolStripMenuItem.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.pasteToolStripMenuItem.Name = "pasteToolStripMenuItem";
             this.pasteToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.V)));
             this.pasteToolStripMenuItem.Size = new System.Drawing.Size(144, 22);
             this.pasteToolStripMenuItem.Text = "&Paste";
-            // 
+            //
             // toolStripSeparator4
-            // 
+            //
             this.toolStripSeparator4.Name = "toolStripSeparator4";
             this.toolStripSeparator4.Size = new System.Drawing.Size(141, 6);
-            // 
+            //
             // selectAllToolStripMenuItem
-            // 
+            //
             this.selectAllToolStripMenuItem.Name = "selectAllToolStripMenuItem";
             this.selectAllToolStripMenuItem.Size = new System.Drawing.Size(144, 22);
             this.selectAllToolStripMenuItem.Text = "Select &All";
-            // 
+            //
             // toolsToolStripMenuItem
-            // 
+            //
             this.toolsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.customizeToolStripMenuItem,
-            this.optionsToolStripMenuItem});
+            this.optionsToolStripMenuItem,
+            this.animateStatusStripToolStripMenuItem});
             this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
             this.toolsToolStripMenuItem.Size = new System.Drawing.Size(46, 20);
             this.toolsToolStripMenuItem.Text = "&Tools";
-            // 
+            //
             // customizeToolStripMenuItem
-            // 
+            //
             this.customizeToolStripMenuItem.Name = "customizeToolStripMenuItem";
-            this.customizeToolStripMenuItem.Size = new System.Drawing.Size(130, 22);
+            this.customizeToolStripMenuItem.Size = new System.Drawing.Size(178, 22);
             this.customizeToolStripMenuItem.Text = "&Customize";
-            // 
+            //
             // optionsToolStripMenuItem
-            // 
+            //
             this.optionsToolStripMenuItem.Name = "optionsToolStripMenuItem";
-            this.optionsToolStripMenuItem.Size = new System.Drawing.Size(130, 22);
+            this.optionsToolStripMenuItem.Size = new System.Drawing.Size(178, 22);
             this.optionsToolStripMenuItem.Text = "&Options";
-            // 
+            //
+            // animateStatusStripToolStripMenuItem
+            //
+            this.animateStatusStripToolStripMenuItem.CheckOnClick = true;
+            this.animateStatusStripToolStripMenuItem.Name = "animateStatusStripToolStripMenuItem";
+            this.animateStatusStripToolStripMenuItem.Size = new System.Drawing.Size(178, 22);
+            this.animateStatusStripToolStripMenuItem.Text = "&Animate StatusStrip";
+            this.animateStatusStripToolStripMenuItem.Click += new System.EventHandler(this.animateStatusStripToolStripMenuItem_Click);
+            //
             // helpToolStripMenuItem
-            // 
+            //
             this.helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.contentsToolStripMenuItem,
             this.indexToolStripMenuItem,
@@ -304,103 +314,103 @@ namespace TestForm
             this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
             this.helpToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
             this.helpToolStripMenuItem.Text = "&Help";
-            // 
+            //
             // contentsToolStripMenuItem
-            // 
+            //
             this.contentsToolStripMenuItem.Name = "contentsToolStripMenuItem";
             this.contentsToolStripMenuItem.Size = new System.Drawing.Size(122, 22);
             this.contentsToolStripMenuItem.Text = "&Contents";
-            // 
+            //
             // indexToolStripMenuItem
-            // 
+            //
             this.indexToolStripMenuItem.Name = "indexToolStripMenuItem";
             this.indexToolStripMenuItem.Size = new System.Drawing.Size(122, 22);
             this.indexToolStripMenuItem.Text = "&Index";
-            // 
+            //
             // searchToolStripMenuItem
-            // 
+            //
             this.searchToolStripMenuItem.Name = "searchToolStripMenuItem";
             this.searchToolStripMenuItem.Size = new System.Drawing.Size(122, 22);
             this.searchToolStripMenuItem.Text = "&Search";
-            // 
+            //
             // toolStripSeparator5
-            // 
+            //
             this.toolStripSeparator5.Name = "toolStripSeparator5";
             this.toolStripSeparator5.Size = new System.Drawing.Size(119, 6);
-            // 
+            //
             // aboutToolStripMenuItem
-            // 
+            //
             this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
             this.aboutToolStripMenuItem.Size = new System.Drawing.Size(122, 22);
             this.aboutToolStripMenuItem.Text = "&About...";
-            // 
+            //
             // statusStrip1
-            // 
+            //
             this.statusStrip1.Font = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.World);
             this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.toolStripStatusLabel1,
             this.kryptonProgressBarToolStripItem1});
-            this.statusStrip1.Location = new System.Drawing.Point(0, 430);
+            this.statusStrip1.Location = new System.Drawing.Point(0, 418);
             this.statusStrip1.Name = "statusStrip1";
             this.statusStrip1.RenderMode = System.Windows.Forms.ToolStripRenderMode.ManagerRenderMode;
-            this.statusStrip1.Size = new System.Drawing.Size(804, 24);
+            this.statusStrip1.Size = new System.Drawing.Size(808, 24);
             this.statusStrip1.TabIndex = 1;
             this.statusStrip1.Text = "statusStrip1";
-            // 
+            //
             // toolStripStatusLabel1
-            // 
+            //
             this.toolStripStatusLabel1.Name = "toolStripStatusLabel1";
             this.toolStripStatusLabel1.Size = new System.Drawing.Size(118, 19);
             this.toolStripStatusLabel1.Text = "toolStripStatusLabel1";
-            // 
+            //
             // kryptonProgressBarToolStripItem1
-            // 
+            //
             this.kryptonProgressBarToolStripItem1.Name = "kryptonProgressBarToolStripItem1";
             this.kryptonProgressBarToolStripItem1.StateCommon.Back.Color1 = System.Drawing.Color.Green;
             this.kryptonProgressBarToolStripItem1.StateDisabled.Back.ColorStyle = Krypton.Toolkit.PaletteColorStyle.OneNote;
             this.kryptonProgressBarToolStripItem1.StateNormal.Back.ColorStyle = Krypton.Toolkit.PaletteColorStyle.OneNote;
             this.kryptonProgressBarToolStripItem1.Value = 50;
             this.kryptonProgressBarToolStripItem1.Values.Text = "";
-            // 
+            //
             // toolStripContainer1
-            // 
-            // 
+            //
+            //
             // toolStripContainer1.ContentPanel
-            // 
+            //
             this.toolStripContainer1.ContentPanel.Controls.Add(this.kryptonPanel1);
-            this.toolStripContainer1.ContentPanel.Size = new System.Drawing.Size(804, 381);
+            this.toolStripContainer1.ContentPanel.Size = new System.Drawing.Size(808, 369);
             this.toolStripContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.toolStripContainer1.Location = new System.Drawing.Point(0, 24);
             this.toolStripContainer1.Name = "toolStripContainer1";
-            this.toolStripContainer1.Size = new System.Drawing.Size(804, 406);
+            this.toolStripContainer1.Size = new System.Drawing.Size(808, 394);
             this.toolStripContainer1.TabIndex = 2;
             this.toolStripContainer1.Text = "toolStripContainer1";
-            // 
+            //
             // toolStripContainer1.TopToolStripPanel
-            // 
+            //
             this.toolStripContainer1.TopToolStripPanel.Controls.Add(this.toolStrip1);
-            // 
+            //
             // kryptonPanel1
-            // 
+            //
             this.kryptonPanel1.Controls.Add(this.kryptonThemeListBox1);
             this.kryptonPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonPanel1.Location = new System.Drawing.Point(0, 0);
             this.kryptonPanel1.Name = "kryptonPanel1";
-            this.kryptonPanel1.Size = new System.Drawing.Size(804, 381);
+            this.kryptonPanel1.Size = new System.Drawing.Size(808, 369);
             this.kryptonPanel1.TabIndex = 0;
-            // 
+            //
             // kryptonThemeListBox1
-            // 
+            //
             this.kryptonThemeListBox1.DefaultPalette = Krypton.Toolkit.PaletteMode.ProfessionalSystem;
             this.kryptonThemeListBox1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonThemeListBox1.Location = new System.Drawing.Point(0, 0);
             this.kryptonThemeListBox1.Margin = new System.Windows.Forms.Padding(5);
             this.kryptonThemeListBox1.Name = "kryptonThemeListBox1";
-            this.kryptonThemeListBox1.Size = new System.Drawing.Size(804, 381);
+            this.kryptonThemeListBox1.Size = new System.Drawing.Size(808, 369);
             this.kryptonThemeListBox1.TabIndex = 0;
-            // 
+            //
             // toolStrip1
-            // 
+            //
             this.toolStrip1.Dock = System.Windows.Forms.DockStyle.None;
             this.toolStrip1.Font = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.World);
             this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -420,92 +430,91 @@ namespace TestForm
             this.toolStrip1.Name = "toolStrip1";
             this.toolStrip1.Size = new System.Drawing.Size(483, 25);
             this.toolStrip1.TabIndex = 0;
-            // 
+            //
             // newToolStripButton
-            // 
+            //
             this.newToolStripButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
             this.newToolStripButton.Image = ((System.Drawing.Image)(resources.GetObject("newToolStripButton.Image")));
             this.newToolStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.newToolStripButton.Name = "newToolStripButton";
             this.newToolStripButton.Size = new System.Drawing.Size(23, 22);
             this.newToolStripButton.Text = "&New";
-            // 
+            //
             // openToolStripButton
-            // 
+            //
             this.openToolStripButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
             this.openToolStripButton.Image = ((System.Drawing.Image)(resources.GetObject("openToolStripButton.Image")));
             this.openToolStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.openToolStripButton.Name = "openToolStripButton";
             this.openToolStripButton.Size = new System.Drawing.Size(23, 22);
             this.openToolStripButton.Text = "&Open";
-            // 
+            //
             // saveToolStripButton
-            // 
+            //
             this.saveToolStripButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
             this.saveToolStripButton.Image = ((System.Drawing.Image)(resources.GetObject("saveToolStripButton.Image")));
             this.saveToolStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.saveToolStripButton.Name = "saveToolStripButton";
             this.saveToolStripButton.Size = new System.Drawing.Size(23, 22);
             this.saveToolStripButton.Text = "&Save";
-            // 
+            //
             // printToolStripButton
-            // 
+            //
             this.printToolStripButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
             this.printToolStripButton.Image = ((System.Drawing.Image)(resources.GetObject("printToolStripButton.Image")));
             this.printToolStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.printToolStripButton.Name = "printToolStripButton";
             this.printToolStripButton.Size = new System.Drawing.Size(23, 22);
             this.printToolStripButton.Text = "&Print";
-            // 
+            //
             // toolStripSeparator6
-            // 
+            //
             this.toolStripSeparator6.Name = "toolStripSeparator6";
             this.toolStripSeparator6.Size = new System.Drawing.Size(6, 25);
-            // 
+            //
             // cutToolStripButton
-            // 
+            //
             this.cutToolStripButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
             this.cutToolStripButton.Image = ((System.Drawing.Image)(resources.GetObject("cutToolStripButton.Image")));
             this.cutToolStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.cutToolStripButton.Name = "cutToolStripButton";
             this.cutToolStripButton.Size = new System.Drawing.Size(23, 22);
             this.cutToolStripButton.Text = "C&ut";
-            // 
+            //
             // copyToolStripButton
-            // 
+            //
             this.copyToolStripButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
             this.copyToolStripButton.Image = ((System.Drawing.Image)(resources.GetObject("copyToolStripButton.Image")));
             this.copyToolStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.copyToolStripButton.Name = "copyToolStripButton";
             this.copyToolStripButton.Size = new System.Drawing.Size(23, 22);
             this.copyToolStripButton.Text = "&Copy";
-            // 
+            //
             // pasteToolStripButton
-            // 
+            //
             this.pasteToolStripButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
             this.pasteToolStripButton.Image = ((System.Drawing.Image)(resources.GetObject("pasteToolStripButton.Image")));
             this.pasteToolStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.pasteToolStripButton.Name = "pasteToolStripButton";
             this.pasteToolStripButton.Size = new System.Drawing.Size(23, 22);
             this.pasteToolStripButton.Text = "&Paste";
-            // 
+            //
             // toolStripSeparator7
-            // 
+            //
             this.toolStripSeparator7.Name = "toolStripSeparator7";
             this.toolStripSeparator7.Size = new System.Drawing.Size(6, 25);
-            // 
+            //
             // helpToolStripButton
-            // 
+            //
             this.helpToolStripButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
             this.helpToolStripButton.Image = ((System.Drawing.Image)(resources.GetObject("helpToolStripButton.Image")));
             this.helpToolStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.helpToolStripButton.Name = "helpToolStripButton";
             this.helpToolStripButton.Size = new System.Drawing.Size(23, 22);
             this.helpToolStripButton.Text = "He&lp";
-            // 
+            //
             // toolStripComboBox1
-            // 
-            this.toolStripComboBox1.BackColor = System.Drawing.Color.Fuchsia;
+            //
             this.toolStripComboBox1.Items.AddRange(new object[] {
             "1",
             "2",
@@ -519,13 +528,13 @@ namespace TestForm
             "10"});
             this.toolStripComboBox1.Name = "toolStripComboBox1";
             this.toolStripComboBox1.Size = new System.Drawing.Size(121, 25);
-            // 
+            //
             // kryptonToolStripComboBox1
-            // 
+            //
             this.kryptonToolStripComboBox1.AutoSize = false;
-            // 
+            //
             // kryptonToolStripComboBox1
-            // 
+            //
             this.kryptonToolStripComboBox1.KryptonComboBoxControl.AccessibleName = "kryptonToolStripComboBox1";
             this.kryptonToolStripComboBox1.KryptonComboBoxControl.DropDownWidth = 121;
             this.kryptonToolStripComboBox1.KryptonComboBoxControl.IntegralHeight = false;
@@ -540,20 +549,20 @@ namespace TestForm
             "8",
             "9",
             "10"});
-            this.kryptonToolStripComboBox1.KryptonComboBoxControl.Location = new System.Drawing.Point(328, 2);
+            this.kryptonToolStripComboBox1.KryptonComboBoxControl.Location = new System.Drawing.Point(328, 1);
             this.kryptonToolStripComboBox1.KryptonComboBoxControl.Name = "kryptonToolStripComboBox1";
             this.kryptonToolStripComboBox1.KryptonComboBoxControl.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
             this.kryptonToolStripComboBox1.KryptonComboBoxControl.TabIndex = 0;
             this.kryptonToolStripComboBox1.KryptonComboBoxControl.Text = "kryptonToolStripComboBox1";
             this.kryptonToolStripComboBox1.Name = "kryptonToolStripComboBox1";
-            this.kryptonToolStripComboBox1.Size = new System.Drawing.Size(121, 21);
+            this.kryptonToolStripComboBox1.Size = new System.Drawing.Size(121, 22);
             this.kryptonToolStripComboBox1.Text = "kryptonToolStripComboBox1";
-            // 
+            //
             // MenuToolBarStatusStripTest
-            // 
+            //
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(804, 454);
+            this.ClientSize = new System.Drawing.Size(808, 442);
             this.Controls.Add(this.toolStripContainer1);
             this.Controls.Add(this.statusStrip1);
             this.Controls.Add(this.menuStrip1);
@@ -613,7 +622,7 @@ namespace TestForm
         private System.Windows.Forms.ToolStripMenuItem searchToolStripMenuItem;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator5;
         private System.Windows.Forms.ToolStripMenuItem aboutToolStripMenuItem;
-        private System.Windows.Forms.StatusStrip statusStrip1;
+        private Krypton.Toolkit.KryptonStatusStrip statusStrip1;
         private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel1;
         private Krypton.Toolkit.KryptonProgressBarToolStripItem kryptonProgressBarToolStripItem1;
         private System.Windows.Forms.ToolStripContainer toolStripContainer1;
@@ -632,5 +641,6 @@ namespace TestForm
         private KryptonPanel kryptonPanel1;
         private KryptonThemeListBox kryptonThemeListBox1;
         private KryptonToolStripComboBox kryptonToolStripComboBox1;
+        private System.Windows.Forms.ToolStripMenuItem animateStatusStripToolStripMenuItem;
     }
 }

--- a/Source/Krypton Components/TestForm/MenuToolBarStatusStripTest.cs
+++ b/Source/Krypton Components/TestForm/MenuToolBarStatusStripTest.cs
@@ -1,9 +1,9 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -11,8 +11,147 @@ namespace TestForm;
 
 public partial class MenuToolBarStatusStripTest : KryptonForm
 {
+    private readonly System.Windows.Forms.Timer _statusStripTimer = new System.Windows.Forms.Timer();
+    private Color _baseStatusStripColor;
+    private readonly Color _targetStatusStripColor = Color.DarkOrange;
+    private int _animStep;
+    private int _animDir = 1;
+
     public MenuToolBarStatusStripTest()
     {
         InitializeComponent();
+        _statusStripTimer.Interval = 50;
+        _statusStripTimer.Tick += StatusStripTimer_Tick;
+        KryptonManager.GlobalPaletteChanged += KryptonManager_GlobalPaletteChanged;
+    }
+
+    private void animateStatusStripToolStripMenuItem_Click(object? sender, EventArgs e)
+    {
+        if (animateStatusStripToolStripMenuItem.Checked)
+        {
+            _animStep = 0;
+            _animDir = 1;
+            _baseStatusStripColor = GetCurrentStatusStripBaseColor();
+            _statusStripTimer.Start();
+        }
+        else
+        {
+            _statusStripTimer.Stop();
+            // Reset to palette defaults when manually stopped
+            if (statusStrip1 is Krypton.Toolkit.KryptonStatusStrip kss)
+            {
+                kss.StateCommon.Color1 = GlobalStaticValues.EMPTY_COLOR;
+                kss.StateCommon.Color2 = GlobalStaticValues.EMPTY_COLOR;
+                kss.StateCommon.ColorStyle = PaletteColorStyle.Inherit;
+                kss.StateCommon.ColorAngle = -1f;
+                kss.Invalidate();
+            }
+            else
+            {
+                statusStrip1.BackColor = SystemColors.Control;
+            }
+        }
+    }
+
+    private void StatusStripTimer_Tick(object? sender, EventArgs e)
+    {
+        // Fast ping-pong between base color and dark orange
+        const int maxSteps = 14; // smaller is faster
+        _animStep += _animDir;
+        if (_animStep >= maxSteps || _animStep <= 0)
+        {
+            _animDir *= -1;
+            if (_animStep < 0)
+            {
+                _animStep = 0;
+            }
+            else if (_animStep > maxSteps)
+            {
+                _animStep = maxSteps;
+            }
+        }
+        float t = _animStep / (float)maxSteps;
+        var color = LerpColor(_baseStatusStripColor, _targetStatusStripColor, t);
+
+        if (statusStrip1 is Krypton.Toolkit.KryptonStatusStrip kss)
+        {
+            // Use per-control override path
+            kss.StateCommon.ColorStyle = Krypton.Toolkit.PaletteColorStyle.Solid;
+            kss.StateCommon.Color1 = color;
+            kss.StateCommon.Color2 = GlobalStaticValues.EMPTY_COLOR;
+            kss.StateCommon.ColorAngle = -1f;
+        }
+        else
+        {
+            statusStrip1.BackColor = color;
+        }
+    }
+
+    private void KryptonManager_GlobalPaletteChanged(object? sender, EventArgs e)
+    {
+        // Stop animation and reset to palette defaults
+        _statusStripTimer.Stop();
+        if (animateStatusStripToolStripMenuItem.Checked)
+        {
+            animateStatusStripToolStripMenuItem.Checked = false;
+        }
+
+        if (statusStrip1 is Krypton.Toolkit.KryptonStatusStrip kss)
+        {
+            // Clear per-control overrides to fall back to palette
+            kss.StateCommon.Color1 = GlobalStaticValues.EMPTY_COLOR;
+            kss.StateCommon.Color2 = GlobalStaticValues.EMPTY_COLOR;
+            kss.StateCommon.ColorStyle = PaletteColorStyle.Inherit;
+            kss.StateCommon.ColorAngle = -1f;
+            kss.Invalidate();
+        }
+    }
+
+    /*
+    “Lerp” = linear interpolation. LerpColor blends between two colors by a fraction t in [0,1], per channel:
+    - t=0 returns the start color
+    - t=1 returns the end color
+    - 0<t<1 returns a mix
+
+    Example (conceptually): result.R = a.R + (b.R - a.R) * t, same for G and B.
+    */
+    private static Color LerpColor(Color a, Color b, float t)
+    {
+        t = Math.Max(0f, Math.Min(1f, t));
+        int r = (int)Math.Round(a.R + (b.R - a.R) * t);
+        int g = (int)Math.Round(a.G + (b.G - a.G) * t);
+        int bch = (int)Math.Round(a.B + (b.B - a.B) * t);
+        return Color.FromArgb(255, r, g, bch);
+    }
+
+    private Color GetCurrentStatusStripBaseColor()
+    {
+        // Prefer palette ColorTable values for the current theme
+        var ct = KryptonManager.CurrentGlobalPalette?.ColorTable;
+        if (ct is not null)
+        {
+            if (ct.StatusStripGradientEnd != GlobalStaticValues.EMPTY_COLOR)
+            {
+                return ct.StatusStripGradientEnd;
+            }
+            if (ct.StatusStripGradientBegin != GlobalStaticValues.EMPTY_COLOR)
+            {
+                return ct.StatusStripGradientBegin;
+            }
+        }
+
+        // Fallbacks
+        if (statusStrip1 is Krypton.Toolkit.KryptonStatusStrip kss)
+        {
+            // Use inherited default if available
+            var c1 = kss.StateCommon.GetBackColor1(Krypton.Toolkit.PaletteState.Normal);
+            if (c1 != GlobalStaticValues.EMPTY_COLOR && !c1.IsEmpty)
+            {
+                return c1;
+            }
+        }
+        return statusStrip1.BackColor.IsEmpty
+            ? SystemColors.Control
+            : statusStrip1.BackColor;
     }
 }

--- a/Source/Krypton Components/TestForm/PanelForm.cs
+++ b/Source/Krypton Components/TestForm/PanelForm.cs
@@ -44,11 +44,11 @@ public partial class PanelForm : KryptonForm
         kryptonDataGridView1.InvalidateColumn(0);
         return;
 
-        MessageBox.Show(
+        //MessageBox.Show(
 
-            $"IsWindowsEleven: {OSUtilities.IsWindowsEleven}" +
-            $"PlatformID: {OSUtilities.OsVersionInfo.PlatformId}"
-            );
+        //    $"IsWindowsEleven: {OSUtilities.IsWindowsEleven}" +
+        //    $"PlatformID: {OSUtilities.OsVersionInfo.PlatformId}"
+        //    );
     }
 
     private void kryptonButton2_Click(object sender, EventArgs e)


### PR DESCRIPTION
Implements #2048 

- With palette-backed overrides and full renderer integration
- `KryptonStatusStrip`: add `StateCommon`/`StateDisabled`/`StateNormal` (`PaletteBack`) with designer-serializable overrides
- Defaults inherit from active palette via new `PaletteBackInheritStatusStrip` (reads `StatusStripGradientBegin`/End from `CurrentGlobalPalette.ColorTable`)
- Rendering: add `TryRenderStatusStripOverride` in `KryptonProfessionalRenderer` and invoke from all `ToolStrip` renderers before palette painting
  - honors Draw == InheritBool.False (suppresses painting)
  - uses solid when only `Color1` provided; otherwise linear gradient (angle default 90°)
  - preserves top border area (y=1.5 offset) consistent with existing renderers
- Keep palette visuals unchanged when no per-control overrides are set

Extras:
- TestForm: added "Animate StatusStrip" toggle to MenuToolBarStatusStripTest form. Fun! 😄 
- Fixed warnings in TestForm.

100% coded by gpt5.