### PR TITLE
2048 V100 Fix KryptonComboBox event handling

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 ====
 
 ## 2025-11-xx - Build 2511 (V10 - alpha) - November 2025
+* Resolved [#2401](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2401), Fix `KryptonComboBox` event `OnEnabledChanged`.
 * Resolved [#2397](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2397), `KryptonForm` throws and exception on CTRL+F1.
 * Implemented [#2392](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2392), Fix `KryptonPropertyGrid` theme switching
 * Implemented [#2389](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2389), Transform private color arrays in base palettes.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonComboBox.cs
@@ -216,8 +216,10 @@ public class KryptonComboBox : VisualControlBase,
         #region Protected
         protected override void OnEnabledChanged(EventArgs e)
         {
-            // Do not forward, to allow the correct Background for disabled state
-            // See https://github.com/Krypton-Suite/Standard-Toolkit/issues/662
+            if (Enabled)
+            {
+                base.OnEnabledChanged(e);
+            }
         }
 
         /// <summary>

--- a/Source/Krypton Components/TestForm/GroupBoxTest.Designer.cs
+++ b/Source/Krypton Components/TestForm/GroupBoxTest.Designer.cs
@@ -1,9 +1,9 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -52,6 +52,9 @@ namespace TestForm
             this.kryptonGroupBox2 = new Krypton.Toolkit.KryptonGroupBox();
             this.kryptonThemeComboBox2 = new Krypton.Toolkit.KryptonThemeComboBox();
             this.kryptonGroup1 = new Krypton.Toolkit.KryptonGroup();
+            this.kryptonButtonToggleComboEnabled = new Krypton.Toolkit.KryptonButton();
+            this.kryptonComboBoxCtorDisabled = new Krypton.Toolkit.KryptonComboBox();
+            this.kryptonComboBoxDesignDisabled = new Krypton.Toolkit.KryptonComboBox();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonNavigator1)).BeginInit();
             this.kryptonNavigator1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPage3)).BeginInit();
@@ -74,14 +77,16 @@ namespace TestForm
             ((System.ComponentModel.ISupportInitialize)(this.kryptonThemeComboBox2)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonGroup1)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonGroup1.Panel)).BeginInit();
+            this.kryptonGroup1.Panel.SuspendLayout();
             this.kryptonGroup1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonComboBoxCtorDisabled)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonComboBoxDesignDisabled)).BeginInit();
             this.SuspendLayout();
-            // 
+            //
             // kryptonNavigator1
-            // 
+            //
             this.kryptonNavigator1.ControlKryptonFormFeatures = false;
-            this.kryptonNavigator1.Location = new System.Drawing.Point(502, 41);
-            this.kryptonNavigator1.Margin = new System.Windows.Forms.Padding(4);
+            this.kryptonNavigator1.Location = new System.Drawing.Point(402, 33);
             this.kryptonNavigator1.NavigatorMode = Krypton.Navigator.NavigatorMode.BarTabGroup;
             this.kryptonNavigator1.Owner = null;
             this.kryptonNavigator1.PageBackStyle = Krypton.Toolkit.PaletteBackStyle.PanelClient;
@@ -93,98 +98,95 @@ namespace TestForm
             this.kryptonNavigator1.Size = new System.Drawing.Size(383, 150);
             this.kryptonNavigator1.TabIndex = 0;
             this.kryptonNavigator1.Text = "kryptonNavigator1";
-            // 
+            //
             // kryptonPage3
-            // 
+            //
             this.kryptonPage3.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
             this.kryptonPage3.Flags = 65534;
             this.kryptonPage3.LastVisibleSet = true;
-            this.kryptonPage3.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonPage3.MinimumSize = new System.Drawing.Size(200, 62);
+            this.kryptonPage3.MinimumSize = new System.Drawing.Size(160, 50);
             this.kryptonPage3.Name = "kryptonPage3";
-            this.kryptonPage3.Size = new System.Drawing.Size(381, 119);
+            this.kryptonPage3.Size = new System.Drawing.Size(381, 123);
             this.kryptonPage3.Text = "kryptonPage3";
             this.kryptonPage3.ToolTipTitle = "Page ToolTip";
             this.kryptonPage3.UniqueName = "a9189fdf28634a62853973875dd71869";
-            // 
+            //
             // kryptonPage4
-            // 
+            //
             this.kryptonPage4.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
             this.kryptonPage4.Flags = 65534;
             this.kryptonPage4.LastVisibleSet = true;
-            this.kryptonPage4.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonPage4.MinimumSize = new System.Drawing.Size(200, 62);
+            this.kryptonPage4.MinimumSize = new System.Drawing.Size(160, 50);
             this.kryptonPage4.Name = "kryptonPage4";
-            this.kryptonPage4.Size = new System.Drawing.Size(200, 122);
+            this.kryptonPage4.Size = new System.Drawing.Size(160, 98);
             this.kryptonPage4.Text = "kryptonPage4";
             this.kryptonPage4.ToolTipTitle = "Page ToolTip";
             this.kryptonPage4.UniqueName = "801c2ddef54f4384b79d26af7bf1e74a";
-            // 
+            //
             // kryptonPage5
-            // 
+            //
             this.kryptonPage5.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
             this.kryptonPage5.Flags = 65534;
             this.kryptonPage5.LastVisibleSet = true;
-            this.kryptonPage5.Margin = new System.Windows.Forms.Padding(4);
-            this.kryptonPage5.MinimumSize = new System.Drawing.Size(200, 62);
+            this.kryptonPage5.MinimumSize = new System.Drawing.Size(160, 50);
             this.kryptonPage5.Name = "kryptonPage5";
-            this.kryptonPage5.Size = new System.Drawing.Size(200, 122);
+            this.kryptonPage5.Size = new System.Drawing.Size(160, 98);
             this.kryptonPage5.Text = "kryptonPage5";
             this.kryptonPage5.ToolTipTitle = "Page ToolTip";
             this.kryptonPage5.UniqueName = "cb41c8b434b24d5cb168a330b0a8b375";
-            // 
+            //
             // kryptonCommand1
-            // 
+            //
             this.kryptonCommand1.Text = "kryptonCommand1";
-            // 
+            //
             // kryptonGroupBox1
-            // 
-            this.kryptonGroupBox1.Location = new System.Drawing.Point(65, 66);
+            //
+            this.kryptonGroupBox1.Location = new System.Drawing.Point(52, 53);
             this.kryptonGroupBox1.Margin = new System.Windows.Forms.Padding(2);
-            // 
+            //
             // kryptonGroupBox1.Panel
-            // 
+            //
             this.kryptonGroupBox1.Panel.Controls.Add(this.kryptonThemeComboBox3);
             this.kryptonGroupBox1.Panel.Controls.Add(this.kryptonComboBox1);
             this.kryptonGroupBox1.Panel.Controls.Add(this.kryptonCheckBox1);
-            this.kryptonGroupBox1.Size = new System.Drawing.Size(278, 255);
+            this.kryptonGroupBox1.Size = new System.Drawing.Size(222, 204);
             this.kryptonGroupBox1.TabIndex = 1;
-            // 
+            //
             // kryptonThemeComboBox3
-            // 
+            //
             this.kryptonThemeComboBox3.DefaultPalette = Krypton.Toolkit.PaletteMode.Microsoft365Blue;
             this.kryptonThemeComboBox3.DisplayMember = "Key";
             this.kryptonThemeComboBox3.DropDownWidth = 121;
             this.kryptonThemeComboBox3.IntegralHeight = false;
-            this.kryptonThemeComboBox3.Location = new System.Drawing.Point(28, 174);
+            this.kryptonThemeComboBox3.Location = new System.Drawing.Point(22, 139);
             this.kryptonThemeComboBox3.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonThemeComboBox3.Name = "kryptonThemeComboBox3";
-            this.kryptonThemeComboBox3.Size = new System.Drawing.Size(121, 26);
+            this.kryptonThemeComboBox3.Size = new System.Drawing.Size(97, 22);
             this.kryptonThemeComboBox3.TabIndex = 2;
             this.kryptonThemeComboBox3.ValueMember = "Value";
-            // 
+            //
             // kryptonComboBox1
-            // 
+            //
             this.kryptonComboBox1.DropDownWidth = 216;
             this.kryptonComboBox1.IntegralHeight = false;
-            this.kryptonComboBox1.Location = new System.Drawing.Point(28, 98);
+            this.kryptonComboBox1.Location = new System.Drawing.Point(22, 78);
             this.kryptonComboBox1.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonComboBox1.Name = "kryptonComboBox1";
-            this.kryptonComboBox1.Size = new System.Drawing.Size(216, 26);
+            this.kryptonComboBox1.Size = new System.Drawing.Size(173, 22);
             this.kryptonComboBox1.TabIndex = 1;
             this.kryptonComboBox1.Text = "kryptonComboBox1";
-            // 
+            //
             // kryptonCheckBox1
-            // 
-            this.kryptonCheckBox1.Location = new System.Drawing.Point(45, 22);
+            //
+            this.kryptonCheckBox1.Location = new System.Drawing.Point(36, 18);
             this.kryptonCheckBox1.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonCheckBox1.Name = "kryptonCheckBox1";
-            this.kryptonCheckBox1.Size = new System.Drawing.Size(152, 24);
+            this.kryptonCheckBox1.Size = new System.Drawing.Size(125, 20);
             this.kryptonCheckBox1.TabIndex = 0;
             this.kryptonCheckBox1.Values.Text = "kryptonCheckBox1";
-            // 
+            //
             // kryptonPage6
-            // 
+            //
             this.kryptonPage6.AutoHiddenSlideSize = new System.Drawing.Size(200, 200);
             this.kryptonPage6.Flags = 65534;
             this.kryptonPage6.LastVisibleSet = true;
@@ -194,78 +196,122 @@ namespace TestForm
             this.kryptonPage6.Text = "kryptonPage6";
             this.kryptonPage6.ToolTipTitle = "Page ToolTip";
             this.kryptonPage6.UniqueName = "4efe7db16ebe4584a708f5d09fc41c1e";
-            // 
+            //
             // kryptonPanel1
-            // 
+            //
             this.kryptonPanel1.Controls.Add(this.kryptonThemeComboBox1);
-            this.kryptonPanel1.Location = new System.Drawing.Point(502, 254);
+            this.kryptonPanel1.Location = new System.Drawing.Point(402, 203);
             this.kryptonPanel1.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonPanel1.Name = "kryptonPanel1";
-            this.kryptonPanel1.Size = new System.Drawing.Size(371, 208);
+            this.kryptonPanel1.Size = new System.Drawing.Size(297, 166);
             this.kryptonPanel1.TabIndex = 2;
-            // 
+            //
             // kryptonThemeComboBox1
-            // 
+            //
             this.kryptonThemeComboBox1.DefaultPalette = Krypton.Toolkit.PaletteMode.Microsoft365Blue;
             this.kryptonThemeComboBox1.DisplayMember = "Key";
             this.kryptonThemeComboBox1.DropDownWidth = 250;
             this.kryptonThemeComboBox1.IntegralHeight = false;
-            this.kryptonThemeComboBox1.Location = new System.Drawing.Point(65, 92);
+            this.kryptonThemeComboBox1.Location = new System.Drawing.Point(52, 74);
             this.kryptonThemeComboBox1.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonThemeComboBox1.Name = "kryptonThemeComboBox1";
-            this.kryptonThemeComboBox1.Size = new System.Drawing.Size(250, 26);
+            this.kryptonThemeComboBox1.Size = new System.Drawing.Size(200, 22);
             this.kryptonThemeComboBox1.StateCommon.Item.Content.ShortText.Font = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.kryptonThemeComboBox1.TabIndex = 0;
             this.kryptonThemeComboBox1.ValueMember = "Value";
-            // 
+            //
             // kryptonGroupBox2
-            // 
-            this.kryptonGroupBox2.Location = new System.Drawing.Point(82, 362);
+            //
+            this.kryptonGroupBox2.Location = new System.Drawing.Point(66, 290);
             this.kryptonGroupBox2.Margin = new System.Windows.Forms.Padding(2);
-            // 
+            //
             // kryptonGroupBox2.Panel
-            // 
+            //
             this.kryptonGroupBox2.Panel.Controls.Add(this.kryptonThemeComboBox2);
-            this.kryptonGroupBox2.Size = new System.Drawing.Size(182, 150);
+            this.kryptonGroupBox2.Size = new System.Drawing.Size(146, 120);
             this.kryptonGroupBox2.StateCommon.Border.Draw = Krypton.Toolkit.InheritBool.True;
             this.kryptonGroupBox2.StateCommon.Border.Width = 4;
             this.kryptonGroupBox2.TabIndex = 3;
-            // 
+            //
             // kryptonThemeComboBox2
-            // 
+            //
             this.kryptonThemeComboBox2.DefaultPalette = Krypton.Toolkit.PaletteMode.Microsoft365Blue;
             this.kryptonThemeComboBox2.DisplayMember = "Key";
             this.kryptonThemeComboBox2.DropDownWidth = 121;
             this.kryptonThemeComboBox2.IntegralHeight = false;
-            this.kryptonThemeComboBox2.Location = new System.Drawing.Point(28, 28);
+            this.kryptonThemeComboBox2.Location = new System.Drawing.Point(22, 22);
             this.kryptonThemeComboBox2.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonThemeComboBox2.Name = "kryptonThemeComboBox2";
-            this.kryptonThemeComboBox2.Size = new System.Drawing.Size(121, 26);
+            this.kryptonThemeComboBox2.Size = new System.Drawing.Size(97, 22);
             this.kryptonThemeComboBox2.TabIndex = 0;
             this.kryptonThemeComboBox2.ValueMember = "Value";
-            // 
+            //
             // kryptonGroup1
-            // 
-            this.kryptonGroup1.Location = new System.Drawing.Point(295, 367);
+            //
+            this.kryptonGroup1.Location = new System.Drawing.Point(236, 294);
             this.kryptonGroup1.Margin = new System.Windows.Forms.Padding(2);
-            this.kryptonGroup1.Size = new System.Drawing.Size(150, 150);
+            //
+            // kryptonGroup1.Panel
+            //
+            this.kryptonGroup1.Panel.Controls.Add(this.kryptonButtonToggleComboEnabled);
+            this.kryptonGroup1.Panel.Controls.Add(this.kryptonComboBoxCtorDisabled);
+            this.kryptonGroup1.Panel.Controls.Add(this.kryptonComboBoxDesignDisabled);
+            this.kryptonGroup1.Size = new System.Drawing.Size(120, 120);
             this.kryptonGroup1.TabIndex = 4;
-            // 
+            //
+            // kryptonButtonToggleComboEnabled
+            //
+            this.kryptonButtonToggleComboEnabled.Location = new System.Drawing.Point(10, 74);
+            this.kryptonButtonToggleComboEnabled.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.kryptonButtonToggleComboEnabled.Name = "kryptonButtonToggleComboEnabled";
+            this.kryptonButtonToggleComboEnabled.Size = new System.Drawing.Size(96, 20);
+            this.kryptonButtonToggleComboEnabled.TabIndex = 2;
+            this.kryptonButtonToggleComboEnabled.Values.DropDownArrowColor = System.Drawing.Color.Empty;
+            this.kryptonButtonToggleComboEnabled.Values.Text = "Toggle Enabled";
+            this.kryptonButtonToggleComboEnabled.Click += new System.EventHandler(this.kryptonButtonToggleComboEnabled_Click);
+            //
+            // kryptonComboBoxCtorDisabled
+            //
+            this.kryptonComboBoxCtorDisabled.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.kryptonComboBoxCtorDisabled.DropDownWidth = 120;
+            this.kryptonComboBoxCtorDisabled.Items.AddRange(new object[] {
+            "Item 1",
+            "Item 2",
+            "Item 3"});
+            this.kryptonComboBoxCtorDisabled.Location = new System.Drawing.Point(10, 43);
+            this.kryptonComboBoxCtorDisabled.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.kryptonComboBoxCtorDisabled.Name = "kryptonComboBoxCtorDisabled";
+            this.kryptonComboBoxCtorDisabled.Size = new System.Drawing.Size(96, 22);
+            this.kryptonComboBoxCtorDisabled.TabIndex = 1;
+            //
+            // kryptonComboBoxDesignDisabled
+            //
+            this.kryptonComboBoxDesignDisabled.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.kryptonComboBoxDesignDisabled.DropDownWidth = 120;
+            this.kryptonComboBoxDesignDisabled.Enabled = false;
+            this.kryptonComboBoxDesignDisabled.Items.AddRange(new object[] {
+            "Item 1",
+            "Item 2",
+            "Item 3"});
+            this.kryptonComboBoxDesignDisabled.Location = new System.Drawing.Point(10, 13);
+            this.kryptonComboBoxDesignDisabled.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.kryptonComboBoxDesignDisabled.Name = "kryptonComboBoxDesignDisabled";
+            this.kryptonComboBoxDesignDisabled.Size = new System.Drawing.Size(96, 22);
+            this.kryptonComboBoxDesignDisabled.TabIndex = 0;
+            //
             // GroupBoxTest
-            // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(120F, 120F);
+            //
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.ClientSize = new System.Drawing.Size(1078, 528);
+            this.ClientSize = new System.Drawing.Size(866, 476);
             this.Controls.Add(this.kryptonGroup1);
             this.Controls.Add(this.kryptonGroupBox2);
             this.Controls.Add(this.kryptonPanel1);
             this.Controls.Add(this.kryptonGroupBox1);
             this.Controls.Add(this.kryptonNavigator1);
-            this.Margin = new System.Windows.Forms.Padding(4);
             this.Name = "GroupBoxTest";
             this.Text = "Group Box";
             this.TopMost = true;
-            this.WindowState = System.Windows.Forms.FormWindowState.Maximized;
             ((System.ComponentModel.ISupportInitialize)(this.kryptonNavigator1)).EndInit();
             this.kryptonNavigator1.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPage3)).EndInit();
@@ -288,8 +334,11 @@ namespace TestForm
             this.kryptonGroupBox2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.kryptonThemeComboBox2)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonGroup1.Panel)).EndInit();
+            this.kryptonGroup1.Panel.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.kryptonGroup1)).EndInit();
             this.kryptonGroup1.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonComboBoxCtorDisabled)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kryptonComboBoxDesignDisabled)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -311,5 +360,8 @@ namespace TestForm
         private Krypton.Toolkit.KryptonGroup kryptonGroup1;
         private Krypton.Toolkit.KryptonThemeComboBox kryptonThemeComboBox3;
         private Krypton.Toolkit.KryptonThemeComboBox kryptonThemeComboBox2;
+        private Krypton.Toolkit.KryptonComboBox kryptonComboBoxDesignDisabled;
+        private Krypton.Toolkit.KryptonComboBox kryptonComboBoxCtorDisabled;
+        private Krypton.Toolkit.KryptonButton kryptonButtonToggleComboEnabled;
     }
 }

--- a/Source/Krypton Components/TestForm/GroupBoxTest.cs
+++ b/Source/Krypton Components/TestForm/GroupBoxTest.cs
@@ -1,9 +1,9 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -14,5 +14,24 @@ public partial class GroupBoxTest : KryptonForm
     public GroupBoxTest()
     {
         InitializeComponent();
+
+        // Runtime disable second combo to mirror the issue scenario
+        kryptonComboBoxCtorDisabled.Enabled = false;
+
+        // Seed items already set by designer; select first item for both
+        if (kryptonComboBoxDesignDisabled.Items.Count > 0)
+        {
+            kryptonComboBoxDesignDisabled.SelectedIndex = 0;
+        }
+        if (kryptonComboBoxCtorDisabled.Items.Count > 0)
+        {
+            kryptonComboBoxCtorDisabled.SelectedIndex = 0;
+        }
+    }
+
+    private void kryptonButtonToggleComboEnabled_Click(object? sender, EventArgs e)
+    {
+        kryptonComboBoxDesignDisabled.Enabled = !kryptonComboBoxDesignDisabled.Enabled;
+        kryptonComboBoxCtorDisabled.Enabled = !kryptonComboBoxCtorDisabled.Enabled;
     }
 }


### PR DESCRIPTION
Fixes #2048 

- Fix for `KryptonComboBox` event `OnEnabledChanged`:  call the base method only when the control is enabled.
- `TestForm`: enhanced `GroupBoxTest` (button "GroupBox") to include new combo box controls and a button to toggle their enabled state.

### Root cause

- Suppressing `InternalComboBox.OnEnabledChanged` likely prevents the underlying WinForms `ComboBox` from refreshing its internal enabled state and input routing when transitioning from disabled (especially when disabled at design-time prior to handle creation) to enabled at runtime.  
- The outer control repaints correctly, but the hosted native combo’s internal logic never runs its enable/disable transition code because `base.OnEnabledChanged(e)` is not called in `InternalComboBox`.

### Solutions
  - Only forward when transitioning to enabled:
  
    ```csharp
    protected override void OnEnabledChanged(EventArgs e)
    {
        if (Enabled)
        {
            base.OnEnabledChanged(e);
        }
    }
    ```
  - This preserves the original intent of not forwarding on disable (for #662), while still letting the native `ComboBox` re-arm itself when re-enabled. In practice, the simple “always call base” above is sufficient.
