### PR TITLE
2125 V100 Refactor UpdateIcon method in multiple forms

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,7 +3,7 @@
 ====
 
 ## 2025-11-xx - Build 2511 (V10 - alpha) - November 2025
-* Resolved [#2397](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2397), `KryptonForm` throws and exception on CTRL+F1.
+* Resolved [#2125](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2125), Refactored `GetToastNotificationIconType`.
 * Implemented [#2392](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2392), Fix `KryptonPropertyGrid` theme switching
 * Implemented [#2389](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2389), Transform private color arrays in base palettes.
 * Implemented [#2377](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2377), Adds the `KryptonDataGridViewRatingColumn`.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/Basic/LTR/VisualToastNotificationBasicForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/Basic/LTR/VisualToastNotificationBasicForm.cs
@@ -111,82 +111,13 @@ internal partial class VisualToastNotificationBasicForm : VisualToastNotificatio
 
     private void UpdateIcon()
     {
-        switch (_basicToastNotificationData.NotificationIcon)
-        {
-            case KryptonToastNotificationIcon.None:
-                SetIcon(null);
-                break;
-            case KryptonToastNotificationIcon.Hand:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Hand_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemHand:
-#if NET8_0_OR_GREATER
-                    //SetIcon(GraphicsExtensions.ScaleImage());
-#else
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Hand.ToBitmap(), 128, 128));
-#endif
-                break;
-            case KryptonToastNotificationIcon.Question:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Question_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemQuestion:
-                break;
-            case KryptonToastNotificationIcon.Exclamation:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.SystemExclamation:
-                break;
-            case KryptonToastNotificationIcon.Asterisk:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Asterisk_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemAsterisk:
-                break;
-            case KryptonToastNotificationIcon.Stop:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Stop_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Error:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Critical_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Warning:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.Information:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Information_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Shield:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_11_128_x_128);
-                }
-                else if (OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_10_128_x_128);
-                }
-                else
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_7_and_8_128_x_128);
-                }
-                break;
-            case KryptonToastNotificationIcon.WindowsLogo:
-                break;
-            case KryptonToastNotificationIcon.Application:
-                break;
-            case KryptonToastNotificationIcon.SystemApplication:
-                break;
-            case KryptonToastNotificationIcon.Ok:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Ok_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Custom:
-                SetIcon(_basicToastNotificationData.CustomImage != null
-                    ? new Bitmap(_basicToastNotificationData.CustomImage)
-                    : null);
-                break;
-            case null:
-                SetIcon(null);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
+        var bitmap = GraphicsExtensions.GetToastNotificationBitmap(
+            _basicToastNotificationData.NotificationIcon,
+            null,
+            _basicToastNotificationData.CustomImage,
+            new Size(128, 128));
+
+        SetIcon(bitmap);
     }
 
     private void UpdateDoNotShowAgainOptionChecked() =>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/Basic/LTR/VisualToastNotificationBasicForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/Basic/LTR/VisualToastNotificationBasicForm.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/Basic/LTR/VisualToastNotificationBasicWithProgressBarForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/Basic/LTR/VisualToastNotificationBasicWithProgressBarForm.cs
@@ -61,7 +61,7 @@ internal partial class VisualToastNotificationBasicWithProgressBarForm : VisualT
 
     internal CheckState ReturnCheckBoxStateValue => kchkDoNotShowAgain.CheckState;
 
-    #endregion 
+    #endregion
 
     #region Implementation
 
@@ -107,82 +107,13 @@ internal partial class VisualToastNotificationBasicWithProgressBarForm : VisualT
 
     private void UpdateIcon()
     {
-        switch (_basicToastNotificationData.NotificationIcon)
-        {
-            case KryptonToastNotificationIcon.None:
-                SetIcon(null);
-                break;
-            case KryptonToastNotificationIcon.Hand:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Hand_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemHand:
-#if NET8_0_OR_GREATER
-                    //SetIcon(GraphicsExtensions.ScaleImage());
-#else
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Hand.ToBitmap(), 128, 128));
-#endif
-                break;
-            case KryptonToastNotificationIcon.Question:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Question_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemQuestion:
-                break;
-            case KryptonToastNotificationIcon.Exclamation:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.SystemExclamation:
-                break;
-            case KryptonToastNotificationIcon.Asterisk:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Asterisk_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemAsterisk:
-                break;
-            case KryptonToastNotificationIcon.Stop:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Stop_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Error:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Critical_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Warning:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.Information:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Information_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Shield:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_11_128_x_128);
-                }
-                else if (OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_10_128_x_128);
-                }
-                else
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_7_and_8_128_x_128);
-                }
-                break;
-            case KryptonToastNotificationIcon.WindowsLogo:
-                break;
-            case KryptonToastNotificationIcon.Application:
-                break;
-            case KryptonToastNotificationIcon.SystemApplication:
-                break;
-            case KryptonToastNotificationIcon.Ok:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Ok_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Custom:
-                SetIcon(_basicToastNotificationData.CustomImage != null
-                    ? new Bitmap(_basicToastNotificationData.CustomImage)
-                    : null);
-                break;
-            case null:
-                SetIcon(null);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
+        var bitmap = GraphicsExtensions.GetToastNotificationBitmap(
+            _basicToastNotificationData.NotificationIcon,
+            null,
+            _basicToastNotificationData.CustomImage,
+            new Size(128, 128));
+
+        SetIcon(bitmap);
     }
 
     private void UpdateDoNotShowAgainOptionChecked() =>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/Basic/LTR/VisualToastNotificationBasicWithProgressBarForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/Basic/LTR/VisualToastNotificationBasicWithProgressBarForm.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/Basic/RTL/VisualToastNotificationBasicRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/Basic/RTL/VisualToastNotificationBasicRtlAwareForm.cs
@@ -34,7 +34,7 @@ internal partial class VisualToastNotificationBasicRtlAwareForm : VisualToastNot
 
     internal CheckState ReturnCheckBoxStateValue => kchkDoNotShowAgain.CheckState;
 
-    #endregion 
+    #endregion
 
     #region Identity
 
@@ -106,82 +106,13 @@ internal partial class VisualToastNotificationBasicRtlAwareForm : VisualToastNot
 
     private void UpdateIcon()
     {
-        switch (_basicToastNotificationData.NotificationIcon)
-        {
-            case KryptonToastNotificationIcon.None:
-                SetIcon(null);
-                break;
-            case KryptonToastNotificationIcon.Hand:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Hand_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemHand:
-#if NET8_0_OR_GREATER
-                    //SetIcon(GraphicsExtensions.ScaleImage());
-#else
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Hand.ToBitmap(), 128, 128));
-#endif
-                break;
-            case KryptonToastNotificationIcon.Question:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Question_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemQuestion:
-                break;
-            case KryptonToastNotificationIcon.Exclamation:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.SystemExclamation:
-                break;
-            case KryptonToastNotificationIcon.Asterisk:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Asterisk_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemAsterisk:
-                break;
-            case KryptonToastNotificationIcon.Stop:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Stop_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Error:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Critical_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Warning:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.Information:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Information_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Shield:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_11_128_x_128);
-                }
-                else if (OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_10_128_x_128);
-                }
-                else
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_7_and_8_128_x_128);
-                }
-                break;
-            case KryptonToastNotificationIcon.WindowsLogo:
-                break;
-            case KryptonToastNotificationIcon.Application:
-                break;
-            case KryptonToastNotificationIcon.SystemApplication:
-                break;
-            case KryptonToastNotificationIcon.Ok:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Ok_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Custom:
-                SetIcon(_basicToastNotificationData.CustomImage != null
-                    ? new Bitmap(_basicToastNotificationData.CustomImage)
-                    : null);
-                break;
-            case null:
-                SetIcon(null);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
+        var bitmap = GraphicsExtensions.GetToastNotificationBitmap(
+            _basicToastNotificationData.NotificationIcon,
+            null,
+            _basicToastNotificationData.CustomImage,
+            new Size(128, 128));
+
+        SetIcon(bitmap);
     }
 
     private void SetIcon(Bitmap? image) => pbxImage.Image = image;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/Basic/RTL/VisualToastNotificationBasicRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/Basic/RTL/VisualToastNotificationBasicRtlAwareForm.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/Basic/RTL/VisualToastNotificationBasicWithProgressBarRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/Basic/RTL/VisualToastNotificationBasicWithProgressBarRtlAwareForm.cs
@@ -107,82 +107,13 @@ internal partial class VisualToastNotificationBasicWithProgressBarRtlAwareForm :
 
     private void UpdateIcon()
     {
-        switch (_basicToastNotificationData.NotificationIcon)
-        {
-            case KryptonToastNotificationIcon.None:
-                SetIcon(null);
-                break;
-            case KryptonToastNotificationIcon.Hand:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Hand_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemHand:
-#if NET8_0_OR_GREATER
-                    //SetIcon(GraphicsExtensions.ScaleImage());
-#else
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Hand.ToBitmap(), 128, 128));
-#endif
-                break;
-            case KryptonToastNotificationIcon.Question:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Question_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemQuestion:
-                break;
-            case KryptonToastNotificationIcon.Exclamation:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.SystemExclamation:
-                break;
-            case KryptonToastNotificationIcon.Asterisk:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Asterisk_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemAsterisk:
-                break;
-            case KryptonToastNotificationIcon.Stop:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Stop_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Error:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Critical_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Warning:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.Information:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Information_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Shield:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_11_128_x_128);
-                }
-                else if (OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_10_128_x_128);
-                }
-                else
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_7_and_8_128_x_128);
-                }
-                break;
-            case KryptonToastNotificationIcon.WindowsLogo:
-                break;
-            case KryptonToastNotificationIcon.Application:
-                break;
-            case KryptonToastNotificationIcon.SystemApplication:
-                break;
-            case KryptonToastNotificationIcon.Ok:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Ok_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Custom:
-                SetIcon(_basicToastNotificationData.CustomImage != null
-                    ? new Bitmap(_basicToastNotificationData.CustomImage)
-                    : null);
-                break;
-            case null:
-                SetIcon(null);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
+        var bitmap = GraphicsExtensions.GetToastNotificationBitmap(
+            _basicToastNotificationData.NotificationIcon,
+            null,
+            _basicToastNotificationData.CustomImage,
+            new Size(128, 128));
+
+        SetIcon(bitmap);
     }
 
     private void UpdateDoNotShowAgainOptionChecked() =>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/Basic/RTL/VisualToastNotificationBasicWithProgressBarRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/Basic/RTL/VisualToastNotificationBasicWithProgressBarRtlAwareForm.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/Normal/VisualToastNotificationComboBoxUserInputForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/Normal/VisualToastNotificationComboBoxUserInputForm.cs
@@ -86,95 +86,13 @@ internal partial class VisualToastNotificationComboBoxUserInputForm : VisualToas
 
     private void UpdateIcon()
     {
-        switch (_data.NotificationIcon)
-        {
-            case KryptonToastNotificationIcon.None:
-                SetIcon(null);
-                break;
-            case KryptonToastNotificationIcon.Hand:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Hand_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemHand:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Hand.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Question:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Question_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemQuestion:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Question.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Exclamation:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.SystemExclamation:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Exclamation.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Asterisk:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Asterisk_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemAsterisk:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Stop:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Stop_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Error:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Critical_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Warning:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.Information:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Information_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Shield:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_11_128_x_128);
-                }
-                else if (OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_10_128_x_128);
-                }
-                else
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_7_and_8_128_x_128);
-                }
-                break;
-            case KryptonToastNotificationIcon.WindowsLogo:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_11_128_128);
-                }
-                else if (OSUtilities.IsWindowsEight || OSUtilities.IsWindowsEightPointOne || OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_8_81_10_128_128);
-                }
-                else
-                {
-                    SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.WinLogo.ToBitmap(), new Size(128, 128)));
-                }
-                break;
-            case KryptonToastNotificationIcon.Application:
-                SetIcon(GraphicsExtensions.ScaleImage(_data.ApplicationIcon.ToBitmap(), new Size(128, 128)));
-                break;
-            case KryptonToastNotificationIcon.SystemApplication:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Ok:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Ok_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Custom:
-                SetIcon(_data.CustomImage != null
-                    ? new Bitmap(_data.CustomImage)
-                    : null);
-                break;
-            case null:
-                SetIcon(null);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
+        var bitmap = GraphicsExtensions.GetToastNotificationBitmap(
+            _data.NotificationIcon,
+            _data.ApplicationIcon,
+            _data.CustomImage,
+            new Size(128, 128));
+
+        SetIcon(bitmap);
     }
 
     private void ShowCloseButton()

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/Normal/VisualToastNotificationComboBoxUserInputForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/Normal/VisualToastNotificationComboBoxUserInputForm.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/Normal/VisualToastNotificationDateTimeUserInputForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/Normal/VisualToastNotificationDateTimeUserInputForm.cs
@@ -85,95 +85,13 @@ internal partial class VisualToastNotificationDateTimeUserInputForm : VisualToas
 
     private void UpdateIcon()
     {
-        switch (_data.NotificationIcon)
-        {
-            case KryptonToastNotificationIcon.None:
-                SetIcon(null);
-                break;
-            case KryptonToastNotificationIcon.Hand:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Hand_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemHand:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Hand.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Question:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Question_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemQuestion:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Question.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Exclamation:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.SystemExclamation:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Exclamation.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Asterisk:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Asterisk_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemAsterisk:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Stop:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Stop_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Error:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Critical_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Warning:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.Information:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Information_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Shield:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_11_128_x_128);
-                }
-                else if (OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_10_128_x_128);
-                }
-                else
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_7_and_8_128_x_128);
-                }
-                break;
-            case KryptonToastNotificationIcon.WindowsLogo:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_11_128_128);
-                }
-                else if (OSUtilities.IsWindowsEight || OSUtilities.IsWindowsEightPointOne || OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_8_81_10_128_128);
-                }
-                else
-                {
-                    SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.WinLogo.ToBitmap(), new Size(128, 128)));
-                }
-                break;
-            case KryptonToastNotificationIcon.Application:
-                SetIcon(GraphicsExtensions.ScaleImage(_data.ApplicationIcon.ToBitmap(), new Size(128, 128)));
-                break;
-            case KryptonToastNotificationIcon.SystemApplication:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Ok:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Ok_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Custom:
-                SetIcon(_data.CustomImage != null
-                    ? new Bitmap(_data.CustomImage)
-                    : null);
-                break;
-            case null:
-                SetIcon(null);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
+        var bitmap = GraphicsExtensions.GetToastNotificationBitmap(
+            _data.NotificationIcon,
+            _data.ApplicationIcon,
+            _data.CustomImage,
+            new Size(128, 128));
+
+        SetIcon(bitmap);
     }
 
     private void VisualToastNotificationDateTimeUserInputForm_Load(object sender, EventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/Normal/VisualToastNotificationDateTimeUserInputForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/Normal/VisualToastNotificationDateTimeUserInputForm.cs
@@ -2,8 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
- *
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
  */
 #endregion
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/Normal/VisualToastNotificationDomainUpDownUserInputForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/Normal/VisualToastNotificationDomainUpDownUserInputForm.cs
@@ -105,95 +105,13 @@ internal partial class VisualToastNotificationDomainUpDownUserInputForm : Visual
 
     private void UpdateIcon()
     {
-        switch (_data.NotificationIcon)
-        {
-            case KryptonToastNotificationIcon.None:
-                SetIcon(null);
-                break;
-            case KryptonToastNotificationIcon.Hand:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Hand_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemHand:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Hand.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Question:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Question_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemQuestion:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Question.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Exclamation:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.SystemExclamation:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Exclamation.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Asterisk:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Asterisk_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemAsterisk:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Stop:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Stop_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Error:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Critical_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Warning:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.Information:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Information_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Shield:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_11_128_x_128);
-                }
-                else if (OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_10_128_x_128);
-                }
-                else
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_7_and_8_128_x_128);
-                }
-                break;
-            case KryptonToastNotificationIcon.WindowsLogo:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_11_128_128);
-                }
-                else if (OSUtilities.IsWindowsEight || OSUtilities.IsWindowsEightPointOne || OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_8_81_10_128_128);
-                }
-                else
-                {
-                    SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.WinLogo.ToBitmap(), new Size(128, 128)));
-                }
-                break;
-            case KryptonToastNotificationIcon.Application:
-                SetIcon(GraphicsExtensions.ScaleImage(_data.ApplicationIcon.ToBitmap(), new Size(128, 128)));
-                break;
-            case KryptonToastNotificationIcon.SystemApplication:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Ok:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Ok_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Custom:
-                SetIcon(_data.CustomImage != null
-                    ? new Bitmap(_data.CustomImage)
-                    : null);
-                break;
-            case null:
-                SetIcon(null);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
+        var bitmap = GraphicsExtensions.GetToastNotificationBitmap(
+            _data.NotificationIcon,
+            _data.ApplicationIcon,
+            _data.CustomImage,
+            new Size(128, 128));
+
+        SetIcon(bitmap);
     }
 
     private void itbDismiss_Click(object sender, EventArgs e) => Close();

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/Normal/VisualToastNotificationDomainUpDownUserInputForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/Normal/VisualToastNotificationDomainUpDownUserInputForm.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/Normal/VisualToastNotificationMaskedTextBoxUserInputForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/Normal/VisualToastNotificationMaskedTextBoxUserInputForm.cs
@@ -77,95 +77,13 @@ internal partial class VisualToastNotificationMaskedTextBoxUserInputForm : Visua
 
     private void UpdateIcon()
     {
-        switch (_data.NotificationIcon)
-        {
-            case KryptonToastNotificationIcon.None:
-                SetIcon(null);
-                break;
-            case KryptonToastNotificationIcon.Hand:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Hand_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemHand:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Hand.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Question:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Question_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemQuestion:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Question.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Exclamation:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.SystemExclamation:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Exclamation.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Asterisk:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Asterisk_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemAsterisk:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Stop:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Stop_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Error:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Critical_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Warning:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.Information:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Information_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Shield:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_11_128_x_128);
-                }
-                else if (OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_10_128_x_128);
-                }
-                else
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_7_and_8_128_x_128);
-                }
-                break;
-            case KryptonToastNotificationIcon.WindowsLogo:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_11_128_128);
-                }
-                else if (OSUtilities.IsWindowsEight || OSUtilities.IsWindowsEightPointOne || OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_8_81_10_128_128);
-                }
-                else
-                {
-                    SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.WinLogo.ToBitmap(), new Size(128, 128)));
-                }
-                break;
-            case KryptonToastNotificationIcon.Application:
-                SetIcon(GraphicsExtensions.ScaleImage(_data.ApplicationIcon.ToBitmap(), new Size(128, 128)));
-                break;
-            case KryptonToastNotificationIcon.SystemApplication:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Ok:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Ok_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Custom:
-                SetIcon(_data.CustomImage != null
-                    ? new Bitmap(_data.CustomImage)
-                    : null);
-                break;
-            case null:
-                SetIcon(null);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
+        var bitmap = GraphicsExtensions.GetToastNotificationBitmap(
+            _data.NotificationIcon,
+            _data.ApplicationIcon,
+            _data.CustomImage,
+            new Size(128, 128));
+
+        SetIcon(bitmap);
     }
 
     private void VisualToastNotificationMaskedTextBoxUserInputForm_Load(object sender, EventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/Normal/VisualToastNotificationMaskedTextBoxUserInputForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/Normal/VisualToastNotificationMaskedTextBoxUserInputForm.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/Normal/VisualToastNotificationNUDUserInputForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/Normal/VisualToastNotificationNUDUserInputForm.cs
@@ -81,95 +81,13 @@ internal partial class VisualToastNotificationNUDUserInputForm : VisualToastNoti
 
     private void UpdateIcon()
     {
-        switch (_data.NotificationIcon)
-        {
-            case KryptonToastNotificationIcon.None:
-                SetIcon(null);
-                break;
-            case KryptonToastNotificationIcon.Hand:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Hand_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemHand:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Hand.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Question:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Question_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemQuestion:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Question.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Exclamation:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.SystemExclamation:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Exclamation.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Asterisk:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Asterisk_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemAsterisk:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Stop:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Stop_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Error:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Critical_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Warning:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.Information:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Information_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Shield:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_11_128_x_128);
-                }
-                else if (OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_10_128_x_128);
-                }
-                else
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_7_and_8_128_x_128);
-                }
-                break;
-            case KryptonToastNotificationIcon.WindowsLogo:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_11_128_128);
-                }
-                else if (OSUtilities.IsWindowsEight || OSUtilities.IsWindowsEightPointOne || OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_8_81_10_128_128);
-                }
-                else
-                {
-                    SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.WinLogo.ToBitmap(), new Size(128, 128)));
-                }
-                break;
-            case KryptonToastNotificationIcon.Application:
-                SetIcon(GraphicsExtensions.ScaleImage(_data.ApplicationIcon.ToBitmap(), new Size(128, 128)));
-                break;
-            case KryptonToastNotificationIcon.SystemApplication:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Ok:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Ok_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Custom:
-                SetIcon(_data.CustomImage != null
-                    ? new Bitmap(_data.CustomImage)
-                    : null);
-                break;
-            case null:
-                SetIcon(null);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
+        var bitmap = GraphicsExtensions.GetToastNotificationBitmap(
+            _data.NotificationIcon,
+            _data.ApplicationIcon,
+            _data.CustomImage,
+            new Size(128, 128));
+
+        SetIcon(bitmap);
     }
 
     private void VisualToastNotificationNumericUpDownUserInputForm_Load(object sender, EventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/Normal/VisualToastNotificationNUDUserInputForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/Normal/VisualToastNotificationNUDUserInputForm.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/Normal/VisualToastNotificationTextBoxUserInputForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/Normal/VisualToastNotificationTextBoxUserInputForm.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/Normal/VisualToastNotificationTextBoxUserInputForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/Normal/VisualToastNotificationTextBoxUserInputForm.cs
@@ -103,92 +103,13 @@ internal partial class VisualToastNotificationTextBoxUserInputForm : VisualToast
 
     private void UpdateIcon()
     {
-        switch (_toastNotificationIcon)
-        {
-            case KryptonToastNotificationIcon.None:
-                SetIcon(null);
-                break;
-            case KryptonToastNotificationIcon.Hand:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Hand_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemHand:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Hand.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Question:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Question_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemQuestion:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Question.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Exclamation:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.SystemExclamation:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Exclamation.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Asterisk:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Asterisk_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemAsterisk:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Stop:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Stop_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Error:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Critical_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Warning:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.Information:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Information_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Shield:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_11_128_x_128);
-                }
-                else if (OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_10_128_x_128);
-                }
-                else
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_7_and_8_128_x_128);
-                }
-                break;
-            case KryptonToastNotificationIcon.WindowsLogo:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_11_128_128);
-                }
-                else if (OSUtilities.IsWindowsEight || OSUtilities.IsWindowsEightPointOne || OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_8_81_10_128_128);
-                }
-                else
-                {
-                    SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.WinLogo.ToBitmap(), new Size(128, 128)));
-                }
-                break;
-            case KryptonToastNotificationIcon.Application:
-                SetIcon(GraphicsExtensions.ScaleImage(_data.ApplicationIcon.ToBitmap(), new Size(128, 128)));
-                break;
-            case KryptonToastNotificationIcon.SystemApplication:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Ok:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Ok_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Custom:
-                SetIcon(_data.CustomImage != null
-                    ? new Bitmap(_data.CustomImage)
-                    : null);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
+        var bitmap = GraphicsExtensions.GetToastNotificationBitmap(
+            _toastNotificationIcon,
+            _data.ApplicationIcon,
+            _data.CustomImage,
+            new Size(128, 128));
+
+        SetIcon(bitmap);
     }
 
     private void VisualToastNotificationTextBoxUserInputForm_GotFocus(object? sender, EventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationComboBoxUserInputWithProgressBarForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationComboBoxUserInputWithProgressBarForm.cs
@@ -88,95 +88,13 @@ internal partial class VisualToastNotificationComboBoxUserInputWithProgressBarFo
 
     private void UpdateIcon()
     {
-        switch (_data.NotificationIcon)
-        {
-            case KryptonToastNotificationIcon.None:
-                SetIcon(null);
-                break;
-            case KryptonToastNotificationIcon.Hand:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Hand_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemHand:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Hand.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Question:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Question_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemQuestion:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Question.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Exclamation:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.SystemExclamation:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Exclamation.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Asterisk:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Asterisk_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemAsterisk:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Stop:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Stop_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Error:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Critical_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Warning:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.Information:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Information_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Shield:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_11_128_x_128);
-                }
-                else if (OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_10_128_x_128);
-                }
-                else
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_7_and_8_128_x_128);
-                }
-                break;
-            case KryptonToastNotificationIcon.WindowsLogo:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_11_128_128);
-                }
-                else if (OSUtilities.IsWindowsEight || OSUtilities.IsWindowsEightPointOne || OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_8_81_10_128_128);
-                }
-                else
-                {
-                    SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.WinLogo.ToBitmap(), new Size(128, 128)));
-                }
-                break;
-            case KryptonToastNotificationIcon.Application:
-                SetIcon(GraphicsExtensions.ScaleImage(_data.ApplicationIcon.ToBitmap(), new Size(128, 128)));
-                break;
-            case KryptonToastNotificationIcon.SystemApplication:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Ok:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Ok_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Custom:
-                SetIcon(_data.CustomImage != null
-                    ? new Bitmap(_data.CustomImage)
-                    : null);
-                break;
-            case null:
-                SetIcon(null);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
+        var bitmap = GraphicsExtensions.GetToastNotificationBitmap(
+            _data.NotificationIcon,
+            _data.ApplicationIcon,
+            _data.CustomImage,
+            new Size(128, 128));
+
+        SetIcon(bitmap);
     }
 
     private void ShowCloseButton()

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationComboBoxUserInputWithProgressBarForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationComboBoxUserInputWithProgressBarForm.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationDateTimeUserInputWithProgressBarForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationDateTimeUserInputWithProgressBarForm.cs
@@ -87,95 +87,13 @@ internal partial class VisualToastNotificationDateTimeUserInputWithProgressBarFo
 
     private void UpdateIcon()
     {
-        switch (_data.NotificationIcon)
-        {
-            case KryptonToastNotificationIcon.None:
-                SetIcon(null);
-                break;
-            case KryptonToastNotificationIcon.Hand:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Hand_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemHand:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Hand.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Question:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Question_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemQuestion:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Question.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Exclamation:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.SystemExclamation:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Exclamation.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Asterisk:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Asterisk_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemAsterisk:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Stop:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Stop_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Error:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Critical_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Warning:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.Information:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Information_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Shield:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_11_128_x_128);
-                }
-                else if (OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_10_128_x_128);
-                }
-                else
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_7_and_8_128_x_128);
-                }
-                break;
-            case KryptonToastNotificationIcon.WindowsLogo:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_11_128_128);
-                }
-                else if (OSUtilities.IsWindowsEight || OSUtilities.IsWindowsEightPointOne || OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_8_81_10_128_128);
-                }
-                else
-                {
-                    SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.WinLogo.ToBitmap(), new Size(128, 128)));
-                }
-                break;
-            case KryptonToastNotificationIcon.Application:
-                SetIcon(GraphicsExtensions.ScaleImage(_data.ApplicationIcon.ToBitmap(), new Size(128, 128)));
-                break;
-            case KryptonToastNotificationIcon.SystemApplication:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Ok:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Ok_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Custom:
-                SetIcon(_data.CustomImage != null
-                    ? new Bitmap(_data.CustomImage)
-                    : null);
-                break;
-            case null:
-                SetIcon(null);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
+        var bitmap = GraphicsExtensions.GetToastNotificationBitmap(
+            _data.NotificationIcon,
+            _data.ApplicationIcon,
+            _data.CustomImage,
+            new Size(128, 128));
+
+        SetIcon(bitmap);
     }
 
     private void VisualToastNotificationDateTimeUserInputWithProgressBarForm_Resize(object? sender, EventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationDateTimeUserInputWithProgressBarForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationDateTimeUserInputWithProgressBarForm.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationDomianUpDownInputWithProgressBarForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationDomianUpDownInputWithProgressBarForm.cs
@@ -87,95 +87,13 @@ internal partial class VisualToastNotificationDomianUpDownInputWithProgressBarFo
 
     private void UpdateIcon()
     {
-        switch (_data.NotificationIcon)
-        {
-            case KryptonToastNotificationIcon.None:
-                SetIcon(null);
-                break;
-            case KryptonToastNotificationIcon.Hand:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Hand_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemHand:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Hand.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Question:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Question_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemQuestion:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Question.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Exclamation:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.SystemExclamation:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Exclamation.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Asterisk:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Asterisk_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemAsterisk:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Stop:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Stop_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Error:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Critical_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Warning:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.Information:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Information_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Shield:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_11_128_x_128);
-                }
-                else if (OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_10_128_x_128);
-                }
-                else
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_7_and_8_128_x_128);
-                }
-                break;
-            case KryptonToastNotificationIcon.WindowsLogo:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_11_128_128);
-                }
-                else if (OSUtilities.IsWindowsEight || OSUtilities.IsWindowsEightPointOne || OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_8_81_10_128_128);
-                }
-                else
-                {
-                    SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.WinLogo.ToBitmap(), new Size(128, 128)));
-                }
-                break;
-            case KryptonToastNotificationIcon.Application:
-                SetIcon(GraphicsExtensions.ScaleImage(_data.ApplicationIcon.ToBitmap(), new Size(128, 128)));
-                break;
-            case KryptonToastNotificationIcon.SystemApplication:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Ok:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Ok_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Custom:
-                SetIcon(_data.CustomImage != null
-                    ? new Bitmap(_data.CustomImage)
-                    : null);
-                break;
-            case null:
-                SetIcon(null);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
+        var bitmap = GraphicsExtensions.GetToastNotificationBitmap(
+            _data.NotificationIcon,
+            _data.ApplicationIcon,
+            _data.CustomImage,
+            new Size(128, 128));
+
+        SetIcon(bitmap);
     }
 
     private void VisualToastNotificationDomianUpDownInputWithProgressBarForm_Resize(object? sender, EventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationDomianUpDownInputWithProgressBarForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationDomianUpDownInputWithProgressBarForm.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationMaskedTextBoxInputWithProgressBarForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationMaskedTextBoxInputWithProgressBarForm.cs
@@ -79,95 +79,13 @@ internal partial class VisualToastNotificationMaskedTextBoxInputWithProgressBarF
 
     private void UpdateIcon()
     {
-        switch (_data.NotificationIcon)
-        {
-            case KryptonToastNotificationIcon.None:
-                SetIcon(null);
-                break;
-            case KryptonToastNotificationIcon.Hand:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Hand_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemHand:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Hand.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Question:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Question_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemQuestion:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Question.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Exclamation:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.SystemExclamation:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Exclamation.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Asterisk:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Asterisk_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemAsterisk:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Stop:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Stop_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Error:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Critical_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Warning:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.Information:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Information_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Shield:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_11_128_x_128);
-                }
-                else if (OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_10_128_x_128);
-                }
-                else
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_7_and_8_128_x_128);
-                }
-                break;
-            case KryptonToastNotificationIcon.WindowsLogo:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_11_128_128);
-                }
-                else if (OSUtilities.IsWindowsEight || OSUtilities.IsWindowsEightPointOne || OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_8_81_10_128_128);
-                }
-                else
-                {
-                    SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.WinLogo.ToBitmap(), new Size(128, 128)));
-                }
-                break;
-            case KryptonToastNotificationIcon.Application:
-                SetIcon(GraphicsExtensions.ScaleImage(_data.ApplicationIcon.ToBitmap(), new Size(128, 128)));
-                break;
-            case KryptonToastNotificationIcon.SystemApplication:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Ok:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Ok_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Custom:
-                SetIcon(_data.CustomImage != null
-                    ? new Bitmap(_data.CustomImage)
-                    : null);
-                break;
-            case null:
-                SetIcon(null);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
+        var bitmap = GraphicsExtensions.GetToastNotificationBitmap(
+            _data.NotificationIcon,
+            _data.ApplicationIcon,
+            _data.CustomImage,
+            new Size(128, 128));
+
+        SetIcon(bitmap);
     }
 
     private void VisualToastNotificationMaskedTextBoxInputWithProgressBarForm_Resize(object? sender, EventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationMaskedTextBoxInputWithProgressBarForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationMaskedTextBoxInputWithProgressBarForm.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationNUDUserInputWithProgressBarForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationNUDUserInputWithProgressBarForm.cs
@@ -83,95 +83,13 @@ internal partial class VisualToastNotificationNUDUserInputWithProgressBarForm : 
 
     private void UpdateIcon()
     {
-        switch (_data.NotificationIcon)
-        {
-            case KryptonToastNotificationIcon.None:
-                SetIcon(null);
-                break;
-            case KryptonToastNotificationIcon.Hand:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Hand_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemHand:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Hand.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Question:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Question_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemQuestion:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Question.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Exclamation:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.SystemExclamation:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Exclamation.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Asterisk:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Asterisk_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemAsterisk:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Stop:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Stop_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Error:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Critical_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Warning:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.Information:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Information_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Shield:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_11_128_x_128);
-                }
-                else if (OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_10_128_x_128);
-                }
-                else
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_7_and_8_128_x_128);
-                }
-                break;
-            case KryptonToastNotificationIcon.WindowsLogo:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_11_128_128);
-                }
-                else if (OSUtilities.IsWindowsEight || OSUtilities.IsWindowsEightPointOne || OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_8_81_10_128_128);
-                }
-                else
-                {
-                    SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.WinLogo.ToBitmap(), new Size(128, 128)));
-                }
-                break;
-            case KryptonToastNotificationIcon.Application:
-                SetIcon(GraphicsExtensions.ScaleImage(_data.ApplicationIcon.ToBitmap(), new Size(128, 128)));
-                break;
-            case KryptonToastNotificationIcon.SystemApplication:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Ok:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Ok_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Custom:
-                SetIcon(_data.CustomImage != null
-                    ? new Bitmap(_data.CustomImage)
-                    : null);
-                break;
-            case null:
-                SetIcon(null);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
+        var bitmap = GraphicsExtensions.GetToastNotificationBitmap(
+            _data.NotificationIcon,
+            _data.ApplicationIcon,
+            _data.CustomImage,
+            new Size(128, 128));
+
+        SetIcon(bitmap);
     }
 
     private void VisualToastNotificationNumericUpDownUserInputWithProgressBarForm_Resize(object? sender, EventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationNUDUserInputWithProgressBarForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationNUDUserInputWithProgressBarForm.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationTextBoxUserInputWithProgressBarForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationTextBoxUserInputWithProgressBarForm.cs
@@ -84,95 +84,13 @@ internal partial class VisualToastNotificationTextBoxUserInputWithProgressBarFor
 
     private void UpdateIcon()
     {
-        switch (_data.NotificationIcon)
-        {
-            case KryptonToastNotificationIcon.None:
-                SetIcon(null);
-                break;
-            case KryptonToastNotificationIcon.Hand:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Hand_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemHand:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Hand.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Question:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Question_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemQuestion:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Question.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Exclamation:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.SystemExclamation:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Exclamation.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Asterisk:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Asterisk_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemAsterisk:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Stop:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Stop_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Error:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Critical_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Warning:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.Information:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Information_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Shield:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_11_128_x_128);
-                }
-                else if (OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_10_128_x_128);
-                }
-                else
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_7_and_8_128_x_128);
-                }
-                break;
-            case KryptonToastNotificationIcon.WindowsLogo:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_11_128_128);
-                }
-                else if (OSUtilities.IsWindowsEight || OSUtilities.IsWindowsEightPointOne || OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_8_81_10_128_128);
-                }
-                else
-                {
-                    SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.WinLogo.ToBitmap(), new Size(128, 128)));
-                }
-                break;
-            case KryptonToastNotificationIcon.Application:
-                SetIcon(GraphicsExtensions.ScaleImage(_data.ApplicationIcon.ToBitmap(), new Size(128, 128)));
-                break;
-            case KryptonToastNotificationIcon.SystemApplication:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Ok:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Ok_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Custom:
-                SetIcon(_data.CustomImage != null
-                    ? new Bitmap(_data.CustomImage)
-                    : null);
-                break;
-            case null:
-                SetIcon(null);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
+        var bitmap = GraphicsExtensions.GetToastNotificationBitmap(
+            _data.NotificationIcon,
+            _data.ApplicationIcon,
+            _data.CustomImage,
+            new Size(128, 128));
+
+        SetIcon(bitmap);
     }
 
     private void VisualToastNotificationTextBoxUserInputWithProgressBarForm_Resize(object? sender, EventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationTextBoxUserInputWithProgressBarForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationTextBoxUserInputWithProgressBarForm.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationComboBoxUserInputRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationComboBoxUserInputRtlAwareForm.cs
@@ -86,95 +86,13 @@ internal partial class VisualToastNotificationComboBoxUserInputRtlAwareForm : Vi
 
     private void UpdateIcon()
     {
-        switch (_data.NotificationIcon)
-        {
-            case KryptonToastNotificationIcon.None:
-                SetIcon(null);
-                break;
-            case KryptonToastNotificationIcon.Hand:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Hand_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemHand:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Hand.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Question:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Question_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemQuestion:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Question.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Exclamation:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.SystemExclamation:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Exclamation.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Asterisk:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Asterisk_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemAsterisk:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Stop:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Stop_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Error:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Critical_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Warning:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.Information:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Information_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Shield:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_11_128_x_128);
-                }
-                else if (OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_10_128_x_128);
-                }
-                else
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_7_and_8_128_x_128);
-                }
-                break;
-            case KryptonToastNotificationIcon.WindowsLogo:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_11_128_128);
-                }
-                else if (OSUtilities.IsWindowsEight || OSUtilities.IsWindowsEightPointOne || OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_8_81_10_128_128);
-                }
-                else
-                {
-                    SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.WinLogo.ToBitmap(), new Size(128, 128)));
-                }
-                break;
-            case KryptonToastNotificationIcon.Application:
-                SetIcon(GraphicsExtensions.ScaleImage(_data.ApplicationIcon.ToBitmap(), new Size(128, 128)));
-                break;
-            case KryptonToastNotificationIcon.SystemApplication:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Ok:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Ok_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Custom:
-                SetIcon(_data.CustomImage != null
-                    ? new Bitmap(_data.CustomImage)
-                    : null);
-                break;
-            case null:
-                SetIcon(null);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
+        var bitmap = GraphicsExtensions.GetToastNotificationBitmap(
+            _data.NotificationIcon,
+            _data.ApplicationIcon,
+            _data.CustomImage,
+            new Size(128, 128));
+
+        SetIcon(bitmap);
     }
 
     private void ShowCloseButton()

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationComboBoxUserInputRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationComboBoxUserInputRtlAwareForm.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationDateTimeUserInputRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationDateTimeUserInputRtlAwareForm.cs
@@ -89,95 +89,13 @@ internal partial class VisualToastNotificationDateTimeUserInputRtlAwareForm : Vi
 
     private void UpdateIcon()
     {
-        switch (_data.NotificationIcon)
-        {
-            case KryptonToastNotificationIcon.None:
-                SetIcon(null);
-                break;
-            case KryptonToastNotificationIcon.Hand:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Hand_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemHand:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Hand.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Question:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Question_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemQuestion:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Question.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Exclamation:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.SystemExclamation:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Exclamation.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Asterisk:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Asterisk_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemAsterisk:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Stop:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Stop_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Error:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Critical_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Warning:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.Information:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Information_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Shield:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_11_128_x_128);
-                }
-                else if (OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_10_128_x_128);
-                }
-                else
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_7_and_8_128_x_128);
-                }
-                break;
-            case KryptonToastNotificationIcon.WindowsLogo:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_11_128_128);
-                }
-                else if (OSUtilities.IsWindowsEight || OSUtilities.IsWindowsEightPointOne || OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_8_81_10_128_128);
-                }
-                else
-                {
-                    SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.WinLogo.ToBitmap(), new Size(128, 128)));
-                }
-                break;
-            case KryptonToastNotificationIcon.Application:
-                SetIcon(GraphicsExtensions.ScaleImage(_data.ApplicationIcon.ToBitmap(), new Size(128, 128)));
-                break;
-            case KryptonToastNotificationIcon.SystemApplication:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Ok:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Ok_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Custom:
-                SetIcon(_data.CustomImage != null
-                    ? new Bitmap(_data.CustomImage)
-                    : null);
-                break;
-            case null:
-                SetIcon(null);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
+        var bitmap = GraphicsExtensions.GetToastNotificationBitmap(
+            _data.NotificationIcon,
+            _data.ApplicationIcon,
+            _data.CustomImage,
+            new Size(128, 128));
+
+        SetIcon(bitmap);
     }
 
     private void itbDismiss_Click(object sender, EventArgs e) => Close();

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationDateTimeUserInputRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationDateTimeUserInputRtlAwareForm.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationDomainUpDownUserInputRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationDomainUpDownUserInputRtlAwareForm.cs
@@ -96,95 +96,13 @@ internal partial class VisualToastNotificationDomainUpDownUserInputRtlAwareForm 
 
     private void UpdateIcon()
     {
-        switch (_data.NotificationIcon)
-        {
-            case KryptonToastNotificationIcon.None:
-                SetIcon(null);
-                break;
-            case KryptonToastNotificationIcon.Hand:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Hand_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemHand:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Hand.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Question:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Question_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemQuestion:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Question.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Exclamation:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.SystemExclamation:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Exclamation.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Asterisk:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Asterisk_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemAsterisk:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Stop:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Stop_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Error:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Critical_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Warning:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.Information:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Information_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Shield:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_11_128_x_128);
-                }
-                else if (OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_10_128_x_128);
-                }
-                else
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_7_and_8_128_x_128);
-                }
-                break;
-            case KryptonToastNotificationIcon.WindowsLogo:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_11_128_128);
-                }
-                else if (OSUtilities.IsWindowsEight || OSUtilities.IsWindowsEightPointOne || OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_8_81_10_128_128);
-                }
-                else
-                {
-                    SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.WinLogo.ToBitmap(), new Size(128, 128)));
-                }
-                break;
-            case KryptonToastNotificationIcon.Application:
-                SetIcon(GraphicsExtensions.ScaleImage(_data.ApplicationIcon.ToBitmap(), new Size(128, 128)));
-                break;
-            case KryptonToastNotificationIcon.SystemApplication:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Ok:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Ok_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Custom:
-                SetIcon(_data.CustomImage != null
-                    ? new Bitmap(_data.CustomImage)
-                    : null);
-                break;
-            case null:
-                SetIcon(null);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
+        var bitmap = GraphicsExtensions.GetToastNotificationBitmap(
+            _data.NotificationIcon,
+            _data.ApplicationIcon,
+            _data.CustomImage,
+            new Size(128, 128));
+
+        SetIcon(bitmap);
     }
 
     private void itbDismiss_Click(object sender, EventArgs e) => Close();

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationDomainUpDownUserInputRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationDomainUpDownUserInputRtlAwareForm.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationMaskedTextBoxUserInputRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationMaskedTextBoxUserInputRtlAwareForm.cs
@@ -79,95 +79,13 @@ internal partial class VisualToastNotificationMaskedTextBoxUserInputRtlAwareForm
 
     private void UpdateIcon()
     {
-        switch (_data.NotificationIcon)
-        {
-            case KryptonToastNotificationIcon.None:
-                SetIcon(null);
-                break;
-            case KryptonToastNotificationIcon.Hand:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Hand_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemHand:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Hand.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Question:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Question_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemQuestion:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Question.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Exclamation:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.SystemExclamation:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Exclamation.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Asterisk:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Asterisk_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemAsterisk:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Stop:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Stop_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Error:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Critical_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Warning:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.Information:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Information_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Shield:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_11_128_x_128);
-                }
-                else if (OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_10_128_x_128);
-                }
-                else
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_7_and_8_128_x_128);
-                }
-                break;
-            case KryptonToastNotificationIcon.WindowsLogo:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_11_128_128);
-                }
-                else if (OSUtilities.IsWindowsEight || OSUtilities.IsWindowsEightPointOne || OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_8_81_10_128_128);
-                }
-                else
-                {
-                    SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.WinLogo.ToBitmap(), new Size(128, 128)));
-                }
-                break;
-            case KryptonToastNotificationIcon.Application:
-                SetIcon(GraphicsExtensions.ScaleImage(_data.ApplicationIcon.ToBitmap(), new Size(128, 128)));
-                break;
-            case KryptonToastNotificationIcon.SystemApplication:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Ok:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Ok_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Custom:
-                SetIcon(_data.CustomImage != null
-                    ? new Bitmap(_data.CustomImage)
-                    : null);
-                break;
-            case null:
-                SetIcon(null);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
+        var bitmap = GraphicsExtensions.GetToastNotificationBitmap(
+            _data.NotificationIcon,
+            _data.ApplicationIcon,
+            _data.CustomImage,
+            new Size(128, 128));
+
+        SetIcon(bitmap);
     }
 
     private void ShowCloseButton()

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationMaskedTextBoxUserInputRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationMaskedTextBoxUserInputRtlAwareForm.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationNUDUserInputRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationNUDUserInputRtlAwareForm.cs
@@ -83,95 +83,13 @@ internal partial class VisualToastNotificationNUDUserInputRtlAwareForm : VisualT
 
     private void UpdateIcon()
     {
-        switch (_data.NotificationIcon)
-        {
-            case KryptonToastNotificationIcon.None:
-                SetIcon(null);
-                break;
-            case KryptonToastNotificationIcon.Hand:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Hand_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemHand:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Hand.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Question:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Question_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemQuestion:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Question.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Exclamation:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.SystemExclamation:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Exclamation.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Asterisk:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Asterisk_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemAsterisk:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Stop:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Stop_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Error:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Critical_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Warning:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.Information:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Information_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Shield:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_11_128_x_128);
-                }
-                else if (OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_10_128_x_128);
-                }
-                else
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_7_and_8_128_x_128);
-                }
-                break;
-            case KryptonToastNotificationIcon.WindowsLogo:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_11_128_128);
-                }
-                else if (OSUtilities.IsWindowsEight || OSUtilities.IsWindowsEightPointOne || OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_8_81_10_128_128);
-                }
-                else
-                {
-                    SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.WinLogo.ToBitmap(), new Size(128, 128)));
-                }
-                break;
-            case KryptonToastNotificationIcon.Application:
-                SetIcon(GraphicsExtensions.ScaleImage(_data.ApplicationIcon.ToBitmap(), new Size(128, 128)));
-                break;
-            case KryptonToastNotificationIcon.SystemApplication:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Ok:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Ok_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Custom:
-                SetIcon(_data.CustomImage != null
-                    ? new Bitmap(_data.CustomImage)
-                    : null);
-                break;
-            case null:
-                SetIcon(null);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
+        var bitmap = GraphicsExtensions.GetToastNotificationBitmap(
+            _data.NotificationIcon,
+            _data.ApplicationIcon,
+            _data.CustomImage,
+            new Size(128, 128));
+
+        SetIcon(bitmap);
     }
 
     private void ShowCloseButton()

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationNUDUserInputRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationNUDUserInputRtlAwareForm.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationTextBoxUserInputRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationTextBoxUserInputRtlAwareForm.cs
@@ -101,92 +101,13 @@ internal partial class VisualToastNotificationTextBoxUserInputRtlAwareForm : Vis
 
     private void UpdateIcon()
     {
-        switch (_toastNotificationIcon)
-        {
-            case KryptonToastNotificationIcon.None:
-                SetIcon(null);
-                break;
-            case KryptonToastNotificationIcon.Hand:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Hand_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemHand:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Hand.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Question:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Question_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemQuestion:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Question.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Exclamation:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.SystemExclamation:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Exclamation.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Asterisk:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Asterisk_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemAsterisk:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Stop:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Stop_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Error:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Critical_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Warning:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.Information:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Information_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Shield:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_11_128_x_128);
-                }
-                else if (OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_10_128_x_128);
-                }
-                else
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_7_and_8_128_x_128);
-                }
-                break;
-            case KryptonToastNotificationIcon.WindowsLogo:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_11_128_128);
-                }
-                else if (OSUtilities.IsWindowsEight || OSUtilities.IsWindowsEightPointOne || OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_8_81_10_128_128);
-                }
-                else
-                {
-                    SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.WinLogo.ToBitmap(), new Size(128, 128)));
-                }
-                break;
-            case KryptonToastNotificationIcon.Application:
-                SetIcon(GraphicsExtensions.ScaleImage(_data.ApplicationIcon.ToBitmap(), new Size(128, 128)));
-                break;
-            case KryptonToastNotificationIcon.SystemApplication:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Ok:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Ok_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Custom:
-                SetIcon(_data.CustomImage != null
-                    ? new Bitmap(_data.CustomImage)
-                    : null);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
+        var bitmap = GraphicsExtensions.GetToastNotificationBitmap(
+            _toastNotificationIcon,
+            _data.ApplicationIcon,
+            _data.CustomImage,
+            new Size(128, 128));
+
+        SetIcon(bitmap);
     }
 
     private void ShowCloseButton()

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationTextBoxUserInputRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/Normal/VisualToastNotificationTextBoxUserInputRtlAwareForm.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationComboBoxUserInputWithProgressBarRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationComboBoxUserInputWithProgressBarRtlAwareForm.cs
@@ -88,95 +88,13 @@ internal partial class VisualToastNotificationComboBoxUserInputWithProgressBarRt
 
     private void UpdateIcon()
     {
-        switch (_data.NotificationIcon)
-        {
-            case KryptonToastNotificationIcon.None:
-                SetIcon(null);
-                break;
-            case KryptonToastNotificationIcon.Hand:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Hand_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemHand:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Hand.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Question:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Question_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemQuestion:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Question.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Exclamation:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.SystemExclamation:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Exclamation.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Asterisk:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Asterisk_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemAsterisk:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Stop:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Stop_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Error:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Critical_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Warning:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.Information:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Information_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Shield:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_11_128_x_128);
-                }
-                else if (OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_10_128_x_128);
-                }
-                else
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_7_and_8_128_x_128);
-                }
-                break;
-            case KryptonToastNotificationIcon.WindowsLogo:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_11_128_128);
-                }
-                else if (OSUtilities.IsWindowsEight || OSUtilities.IsWindowsEightPointOne || OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_8_81_10_128_128);
-                }
-                else
-                {
-                    SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.WinLogo.ToBitmap(), new Size(128, 128)));
-                }
-                break;
-            case KryptonToastNotificationIcon.Application:
-                SetIcon(GraphicsExtensions.ScaleImage(_data.ApplicationIcon.ToBitmap(), new Size(128, 128)));
-                break;
-            case KryptonToastNotificationIcon.SystemApplication:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Ok:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Ok_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Custom:
-                SetIcon(_data.CustomImage != null
-                    ? new Bitmap(_data.CustomImage)
-                    : null);
-                break;
-            case null:
-                SetIcon(null);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
+        var bitmap = GraphicsExtensions.GetToastNotificationBitmap(
+            _data.NotificationIcon,
+            _data.ApplicationIcon,
+            _data.CustomImage,
+            new Size(128, 128));
+
+        SetIcon(bitmap);
     }
 
     private void ShowCloseButton()

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationComboBoxUserInputWithProgressBarRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationComboBoxUserInputWithProgressBarRtlAwareForm.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationDateTimeUserInputWithProgressBarRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationDateTimeUserInputWithProgressBarRtlAwareForm.cs
@@ -87,95 +87,13 @@ internal partial class VisualToastNotificationDateTimeUserInputWithProgressBarRt
 
     private void UpdateIcon()
     {
-        switch (_data.NotificationIcon)
-        {
-            case KryptonToastNotificationIcon.None:
-                SetIcon(null);
-                break;
-            case KryptonToastNotificationIcon.Hand:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Hand_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemHand:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Hand.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Question:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Question_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemQuestion:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Question.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Exclamation:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.SystemExclamation:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Exclamation.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Asterisk:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Asterisk_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemAsterisk:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Stop:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Stop_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Error:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Critical_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Warning:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.Information:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Information_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Shield:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_11_128_x_128);
-                }
-                else if (OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_10_128_x_128);
-                }
-                else
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_7_and_8_128_x_128);
-                }
-                break;
-            case KryptonToastNotificationIcon.WindowsLogo:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_11_128_128);
-                }
-                else if (OSUtilities.IsWindowsEight || OSUtilities.IsWindowsEightPointOne || OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_8_81_10_128_128);
-                }
-                else
-                {
-                    SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.WinLogo.ToBitmap(), new Size(128, 128)));
-                }
-                break;
-            case KryptonToastNotificationIcon.Application:
-                SetIcon(GraphicsExtensions.ScaleImage(_data.ApplicationIcon.ToBitmap(), new Size(128, 128)));
-                break;
-            case KryptonToastNotificationIcon.SystemApplication:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Ok:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Ok_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Custom:
-                SetIcon(_data.CustomImage != null
-                    ? new Bitmap(_data.CustomImage)
-                    : null);
-                break;
-            case null:
-                SetIcon(null);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
+        var bitmap = GraphicsExtensions.GetToastNotificationBitmap(
+            _data.NotificationIcon,
+            _data.ApplicationIcon,
+            _data.CustomImage,
+            new Size(128, 128));
+
+        SetIcon(bitmap);
     }
 
     private void ShowCloseButton()

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationDateTimeUserInputWithProgressBarRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationDateTimeUserInputWithProgressBarRtlAwareForm.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationDomainUpDownInputWithProgressBarRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationDomainUpDownInputWithProgressBarRtlAwareForm.cs
@@ -87,95 +87,13 @@ internal partial class VisualToastNotificationDomainUpDownInputWithProgressBarRt
 
     private void UpdateIcon()
     {
-        switch (_data.NotificationIcon)
-        {
-            case KryptonToastNotificationIcon.None:
-                SetIcon(null);
-                break;
-            case KryptonToastNotificationIcon.Hand:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Hand_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemHand:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Hand.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Question:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Question_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemQuestion:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Question.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Exclamation:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.SystemExclamation:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Exclamation.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Asterisk:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Asterisk_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemAsterisk:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Stop:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Stop_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Error:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Critical_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Warning:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.Information:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Information_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Shield:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_11_128_x_128);
-                }
-                else if (OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_10_128_x_128);
-                }
-                else
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_7_and_8_128_x_128);
-                }
-                break;
-            case KryptonToastNotificationIcon.WindowsLogo:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_11_128_128);
-                }
-                else if (OSUtilities.IsWindowsEight || OSUtilities.IsWindowsEightPointOne || OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_8_81_10_128_128);
-                }
-                else
-                {
-                    SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.WinLogo.ToBitmap(), new Size(128, 128)));
-                }
-                break;
-            case KryptonToastNotificationIcon.Application:
-                SetIcon(GraphicsExtensions.ScaleImage(_data.ApplicationIcon.ToBitmap(), new Size(128, 128)));
-                break;
-            case KryptonToastNotificationIcon.SystemApplication:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Ok:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Ok_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Custom:
-                SetIcon(_data.CustomImage != null
-                    ? new Bitmap(_data.CustomImage)
-                    : null);
-                break;
-            case null:
-                SetIcon(null);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
+        var bitmap = GraphicsExtensions.GetToastNotificationBitmap(
+            _data.NotificationIcon,
+            _data.ApplicationIcon,
+            _data.CustomImage,
+            new Size(128, 128));
+
+        SetIcon(bitmap);
     }
 
     private void ShowCloseButton()

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationDomainUpDownInputWithProgressBarRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationDomainUpDownInputWithProgressBarRtlAwareForm.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationMaskedTextBoxInputWithProgressBarRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationMaskedTextBoxInputWithProgressBarRtlAwareForm.cs
@@ -79,95 +79,13 @@ internal partial class VisualToastNotificationMaskedTextBoxInputWithProgressBarR
 
     private void UpdateIcon()
     {
-        switch (_data.NotificationIcon)
-        {
-            case KryptonToastNotificationIcon.None:
-                SetIcon(null);
-                break;
-            case KryptonToastNotificationIcon.Hand:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Hand_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemHand:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Hand.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Question:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Question_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemQuestion:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Question.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Exclamation:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.SystemExclamation:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Exclamation.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Asterisk:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Asterisk_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemAsterisk:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Stop:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Stop_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Error:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Critical_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Warning:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.Information:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Information_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Shield:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_11_128_x_128);
-                }
-                else if (OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_10_128_x_128);
-                }
-                else
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_7_and_8_128_x_128);
-                }
-                break;
-            case KryptonToastNotificationIcon.WindowsLogo:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_11_128_128);
-                }
-                else if (OSUtilities.IsWindowsEight || OSUtilities.IsWindowsEightPointOne || OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_8_81_10_128_128);
-                }
-                else
-                {
-                    SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.WinLogo.ToBitmap(), new Size(128, 128)));
-                }
-                break;
-            case KryptonToastNotificationIcon.Application:
-                SetIcon(GraphicsExtensions.ScaleImage(_data.ApplicationIcon.ToBitmap(), new Size(128, 128)));
-                break;
-            case KryptonToastNotificationIcon.SystemApplication:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Ok:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Ok_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Custom:
-                SetIcon(_data.CustomImage != null
-                    ? new Bitmap(_data.CustomImage)
-                    : null);
-                break;
-            case null:
-                SetIcon(null);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
+        var bitmap = GraphicsExtensions.GetToastNotificationBitmap(
+            _data.NotificationIcon,
+            _data.ApplicationIcon,
+            _data.CustomImage,
+            new Size(128, 128));
+
+        SetIcon(bitmap);
     }
 
     private void ShowCloseButton()

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationMaskedTextBoxInputWithProgressBarRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationMaskedTextBoxInputWithProgressBarRtlAwareForm.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationNUDUserInputWithProgressBarRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationNUDUserInputWithProgressBarRtlAwareForm.cs
@@ -83,95 +83,13 @@ internal partial class VisualToastNotificationNUDUserInputWithProgressBarRtlAwar
 
     private void UpdateIcon()
     {
-        switch (_data.NotificationIcon)
-        {
-            case KryptonToastNotificationIcon.None:
-                SetIcon(null);
-                break;
-            case KryptonToastNotificationIcon.Hand:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Hand_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemHand:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Hand.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Question:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Question_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemQuestion:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Question.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Exclamation:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.SystemExclamation:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Exclamation.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Asterisk:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Asterisk_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemAsterisk:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Stop:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Stop_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Error:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Critical_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Warning:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.Information:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Information_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Shield:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_11_128_x_128);
-                }
-                else if (OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_10_128_x_128);
-                }
-                else
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_7_and_8_128_x_128);
-                }
-                break;
-            case KryptonToastNotificationIcon.WindowsLogo:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_11_128_128);
-                }
-                else if (OSUtilities.IsWindowsEight || OSUtilities.IsWindowsEightPointOne || OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_8_81_10_128_128);
-                }
-                else
-                {
-                    SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.WinLogo.ToBitmap(), new Size(128, 128)));
-                }
-                break;
-            case KryptonToastNotificationIcon.Application:
-                SetIcon(GraphicsExtensions.ScaleImage(_data.ApplicationIcon.ToBitmap(), new Size(128, 128)));
-                break;
-            case KryptonToastNotificationIcon.SystemApplication:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Ok:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Ok_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Custom:
-                SetIcon(_data.CustomImage != null
-                    ? new Bitmap(_data.CustomImage)
-                    : null);
-                break;
-            case null:
-                SetIcon(null);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
+        var bitmap = GraphicsExtensions.GetToastNotificationBitmap(
+            _data.NotificationIcon,
+            _data.ApplicationIcon,
+            _data.CustomImage,
+            new Size(128, 128));
+
+        SetIcon(bitmap);
     }
 
     private void ShowCloseButton()

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationNUDUserInputWithProgressBarRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationNUDUserInputWithProgressBarRtlAwareForm.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationTextBoxUserInputWithProgressBarRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationTextBoxUserInputWithProgressBarRtlAwareForm.cs
@@ -84,95 +84,13 @@ internal partial class VisualToastNotificationTextBoxUserInputWithProgressBarRtl
 
     private void UpdateIcon()
     {
-        switch (_data.NotificationIcon)
-        {
-            case KryptonToastNotificationIcon.None:
-                SetIcon(null);
-                break;
-            case KryptonToastNotificationIcon.Hand:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Hand_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemHand:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Hand.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Question:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Question_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemQuestion:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Question.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Exclamation:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.SystemExclamation:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Exclamation.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Asterisk:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Asterisk_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.SystemAsterisk:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Stop:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Stop_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Error:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Critical_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Warning:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Warning_128_x_115);
-                break;
-            case KryptonToastNotificationIcon.Information:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Information_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Shield:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_11_128_x_128);
-                }
-                else if (OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_10_128_x_128);
-                }
-                else
-                {
-                    SetIcon(ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_7_and_8_128_x_128);
-                }
-                break;
-            case KryptonToastNotificationIcon.WindowsLogo:
-                if (OSUtilities.IsAtLeastWindowsEleven)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_11_128_128);
-                }
-                else if (OSUtilities.IsWindowsEight || OSUtilities.IsWindowsEightPointOne || OSUtilities.IsWindowsTen)
-                {
-                    SetIcon(WindowsLogoImageResources.Windows_8_81_10_128_128);
-                }
-                else
-                {
-                    SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.WinLogo.ToBitmap(), new Size(128, 128)));
-                }
-                break;
-            case KryptonToastNotificationIcon.Application:
-                SetIcon(GraphicsExtensions.ScaleImage(_data.ApplicationIcon.ToBitmap(), new Size(128, 128)));
-                break;
-            case KryptonToastNotificationIcon.SystemApplication:
-                SetIcon(GraphicsExtensions.ScaleImage(SystemIcons.Asterisk.ToBitmap(), 128, 128));
-                break;
-            case KryptonToastNotificationIcon.Ok:
-                SetIcon(ToastNotificationImageResources.Toast_Notification_Ok_128_x_128);
-                break;
-            case KryptonToastNotificationIcon.Custom:
-                SetIcon(_data.CustomImage != null
-                    ? new Bitmap(_data.CustomImage)
-                    : null);
-                break;
-            case null:
-                SetIcon(null);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException();
-        }
+        var bitmap = GraphicsExtensions.GetToastNotificationBitmap(
+            _data.NotificationIcon,
+            _data.ApplicationIcon,
+            _data.CustomImage,
+            new Size(128, 128));
+
+        SetIcon(bitmap);
     }
 
     private void ShowCloseButton()

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationTextBoxUserInputWithProgressBarRtlAwareForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/RTL/ProgressBar/VisualToastNotificationTextBoxUserInputWithProgressBarRtlAwareForm.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Utilities/GraphicsExtensions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Utilities/GraphicsExtensions.cs
@@ -1,9 +1,9 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
  *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *
  */
 #endregion
 
@@ -287,8 +287,9 @@ public static class GraphicsExtensions
             case KryptonToastNotificationIcon.Warning:
                 return ToastNotificationImageResources.Toast_Notification_Warning_128_x_115;
             case KryptonToastNotificationIcon.Asterisk:
-            case KryptonToastNotificationIcon.Error:
                 return ToastNotificationImageResources.Toast_Notification_Asterisk_128_x_128;
+            case KryptonToastNotificationIcon.Error:
+                return ToastNotificationImageResources.Toast_Notification_Critical_128_x_128;
             case KryptonToastNotificationIcon.SystemAsterisk:
                 return ScaleImage(SystemIcons.Asterisk.ToBitmap(), newSize);
             case KryptonToastNotificationIcon.Stop:
@@ -338,6 +339,40 @@ public static class GraphicsExtensions
                 DebugTools.NotImplemented(notificationIconType.ToString());
                 throw new ArgumentOutOfRangeException(nameof(notificationIconType), notificationIconType, null);
         }
+    }
+
+    /// <summary>
+    /// Returns a Bitmap for a toast notification icon, using existing mapping and optional scaling.
+    /// Centralizes conversion to Bitmap to reduce duplication in forms that require Bitmap images.
+    /// </summary>
+    /// <param name="notificationIconType">Type of icon to resolve. If null, returns null.</param>
+    /// <param name="applicationIcon">Optional application Icon used when the icon type is Application.</param>
+    /// <param name="customImage">Optional custom image used when the icon type is Custom or Application.</param>
+    /// <param name="customSize">Optional target size for system-derived images.</param>
+    /// <returns>Bitmap or null.</returns>
+    public static Bitmap? GetToastNotificationBitmap(
+        KryptonToastNotificationIcon? notificationIconType,
+        Icon? applicationIcon = null,
+        Image? customImage = null,
+        Size? customSize = null)
+    {
+        if (notificationIconType is null)
+        {
+            return null;
+        }
+
+        // If asking for Application, prefer the provided applicationIcon converted to Bitmap.
+        Image? customForMapping = notificationIconType == KryptonToastNotificationIcon.Application
+            ? (applicationIcon?.ToBitmap() ?? customImage)
+            : customImage;
+
+        Image? resolved = GetToastNotificationIconType(notificationIconType.Value, customForMapping, customSize);
+        if (resolved == null)
+        {
+            return null;
+        }
+
+        return resolved as Bitmap ?? new Bitmap(resolved);
     }
 }
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Utilities/GraphicsExtensions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Utilities/GraphicsExtensions.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
  *
  */
 #endregion


### PR DESCRIPTION
Fixes #2125 for alpha branch

Utilize GetToastNotificationBitmap for icon setting, improving code maintainability and reducing redundancy by over 2K lines.

### Refactor plan implemented
- Centralized icon mapping and scaling in a single helper:
  - Added `GraphicsExtensions.GetToastNotificationBitmap(KryptonToastNotificationIcon? icon, Icon? applicationIcon, Image? customImage, Size? size)` that:
    - Uses the existing OS-detection and resources via `GetToastNotificationIconType(...)`
    - Returns a Bitmap sized for the target `PictureBox` consumers
    - Accepts the per-form `ApplicationIcon` and `CustomImage`
- Replaced duplicated switch/OS-specific branches in all `VisualToastNotification*Form.UpdateIcon()` methods with a one-liner call to the new helper.
- Corrected a mapping bug so `KryptonToastNotificationIcon.Error` returns the “Critical” bitmap (previously the mapping returned the asterisk image in one central path).

### Key helper (centralized) 
```262:341:Source/Krypton Components/Krypton.Toolkit/Utilities/GraphicsExtensions.cs
public static Image? GetToastNotificationIconType(KryptonToastNotificationIcon notificationIconType,
    Image? customImage = null, Size? customSize = null)
{
    Size newSize = customSize ?? new Size(128, 128);
    switch (notificationIconType)
    {
        case KryptonToastNotificationIcon.None:
            return null;
        case KryptonToastNotificationIcon.Hand:
            return ToastNotificationImageResources.Toast_Notification_Hand_128_x_128;
        case KryptonToastNotificationIcon.SystemHand:
            return ScaleImage(SystemIcons.Hand.ToBitmap(), newSize);
        case KryptonToastNotificationIcon.Question:
            return ToastNotificationImageResources.Toast_Notification_Question_128_x_128;
        case KryptonToastNotificationIcon.SystemQuestion:
            return ScaleImage(SystemIcons.Question.ToBitmap(), newSize);
        case KryptonToastNotificationIcon.Exclamation:
        case KryptonToastNotificationIcon.SystemExclamation:
        case KryptonToastNotificationIcon.Warning:
            return ToastNotificationImageResources.Toast_Notification_Warning_128_x_115;
        case KryptonToastNotificationIcon.Asterisk:
            return ToastNotificationImageResources.Toast_Notification_Asterisk_128_x_128;
        case KryptonToastNotificationIcon.Error:
            return ToastNotificationImageResources.Toast_Notification_Critical_128_x_128; // fixed
        case KryptonToastNotificationIcon.SystemAsterisk:
            return ScaleImage(SystemIcons.Asterisk.ToBitmap(), newSize);
        case KryptonToastNotificationIcon.Stop:
            return ToastNotificationImageResources.Toast_Notification_Stop_128_x_128;
        case KryptonToastNotificationIcon.Information:
            return ToastNotificationImageResources.Toast_Notification_Information_128_x_128;
        case KryptonToastNotificationIcon.Shield:
            if (OSUtilities.IsAtLeastWindowsEleven)
                return ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_11_128_x_128;
            else if (OSUtilities.IsWindowsTen)
                return ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_10_128_x_128;
            else if (OSUtilities.IsWindowsEightPointOne || OSUtilities.IsWindowsEight || OSUtilities.IsWindowsSeven)
                return ToastNotificationImageResources.Toast_Notification_UAC_Shield_Windows_7_and_8_128_x_128;
            else
                return ScaleImage(SystemIcons.Shield.ToBitmap(), newSize);
        case KryptonToastNotificationIcon.WindowsLogo:
            if (OSUtilities.IsAtLeastWindowsEleven)
                return ToastNotificationImageResources.Toast_Notification_Windows_11_128_x_128;
            else if (OSUtilities.IsWindowsTen || OSUtilities.IsWindowsEightPointOne || OSUtilities.IsWindowsEight)
                return ToastNotificationImageResources.Toast_Notification_Windows_10_128_x_121;
            else
                return ScaleImage(SystemIcons.WinLogo.ToBitmap(), newSize);
        case KryptonToastNotificationIcon.Application:
            return customImage != null ? ScaleImage(customImage, newSize) : ScaleImage(SystemIcons.Application.ToBitmap(), newSize);
        case KryptonToastNotificationIcon.SystemApplication:
            return ScaleImage(SystemIcons.Application.ToBitmap(), newSize);
        case KryptonToastNotificationIcon.Ok:
            return ToastNotificationImageResources.Toast_Notification_Ok_128_x_128;
        case KryptonToastNotificationIcon.Custom:
            return customImage != null ? ScaleImage(customImage, newSize) : null;
        default:
            DebugTools.NotImplemented(notificationIconType.ToString());
            throw new ArgumentOutOfRangeException(nameof(notificationIconType), notificationIconType, null);
    }
}

public static Bitmap? GetToastNotificationBitmap(
    KryptonToastNotificationIcon? notificationIconType,
    Icon? applicationIcon = null,
    Image? customImage = null,
    Size? customSize = null)
{
    if (notificationIconType is null)
        return null;

    Image? customForMapping = notificationIconType == KryptonToastNotificationIcon.Application
        ? (applicationIcon?.ToBitmap() ?? customImage)
        : customImage;

    Image? resolved = GetToastNotificationIconType(notificationIconType.Value, customForMapping, customSize);
    if (resolved == null)
        return null;

    return resolved as Bitmap ?? new Bitmap(resolved);
}
```

### Example usage after refactor
```85:99:Source/Krypton Components/Krypton.Toolkit/Controls Visuals/Notification Toast/User Input/LTR/ProgressBar/VisualToastNotificationTextBoxUserInputWithProgressBarForm.cs
private void UpdateIcon()
{
    var bitmap = GraphicsExtensions.GetToastNotificationBitmap(
        _data.NotificationIcon,
        _data.ApplicationIcon,
        _data.CustomImage,
        new Size(128, 128));

    SetIcon(bitmap);
}
```

### Why this works well here
- Uses existing toolkit facilities:
  - Centralizes OS-aware icon selection identical to how message box images are already handled in `GraphicsExtensions`.
  - Reuses embedded resources (`ToastNotificationImageResources`) and `SystemIcons` consistently.
- Reduces risk and churn:
  - Each form now defers to one path; future visual tweaks (e.g., Windows 12 badges, new sizes) are a single change.
- Keeps UI code minimal:
  - Forms preserve their own `SetIcon(...)` and do not duplicate switch logic.

### Notes
- While replacing the duplicated logic, I corrected `Error` mapping to use the “Critical” image in the centralized method.
- If you want the “SystemApplication” option to remain the previous Asterisk behavior for backward-compatibility in specific UIs, we can add a toggle flag in data, or map that one enum differently per form. Right now it returns the expected `SystemIcons.Application` to align with enum semantics.

Reference: [PR “Implemented #2125 #2126” (files view)](https://github.com/Krypton-Suite/Standard-Toolkit/pull/2126/files)

- All affected `UpdateIcon()` methods in toast forms now call the helper; no linter issues detected in the touched files.

- If you prefer, we can also add a tiny wrapper in `VisualToastNotificationBaseForm` like `protected Bitmap? ResolveToastIcon(KryptonToastNotificationIcon?, Icon?, Image?, Size?)` that forwards to `GraphicsExtensions.GetToastNotificationBitmap(...)` for an even clearer pattern. Let me know and I’ll wire it up.

- I can also add a small doc blurb to developer docs to standardize this usage across future forms.

- Status: centralized helper added and used across toast forms; mapping bug fixed; build-lint clean.

- Changed `GraphicsExtensions.GetToastNotificationIconType(...)` to return Critical for `Error`.
- Added `GraphicsExtensions.GetToastNotificationBitmap(...)`.
- Replaced icon-switch blocks in all toast notification forms’ `UpdateIcon()` with the one-liner helper call.