### PR TITLE
2406 V100 KryptonProgressBar enhancements

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,7 +3,7 @@
 ====
 
 ## 2025-11-xx - Build 2511 (V10 - alpha) - November 2025
-* Resolved [#2125](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2125), Refactored `GetToastNotificationIconType`.
+* Resolved [#2406](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2406), Enhance `KryptonProgressBar` options and painting.
 * Implemented [#2048](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2048), `KryptonStatusStrip` control theming.
 * Implemented [#2291](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2291), Add tooltips to `KryptonPictureBox`.
 * Resolved [#2401](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2401), Fix `KryptonComboBox` event `OnEnabledChanged`.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonProgressBar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonProgressBar.cs
@@ -1,7 +1,7 @@
 ﻿#region BSD License
 /*
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2022 - 2025. All rights reserved. 
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2022 - 2025. All rights reserved.
  */
 #endregion
 
@@ -46,6 +46,11 @@ public class KryptonProgressBar : Control, IContentValues
     private readonly PaletteBack _stateBackValue;
     private readonly Timer _marqueeTimer;
     private int _marqueeLocation;
+    private int _blockCount;
+    private bool _showTextShadow;
+    private Color _textShadowColor;
+    private bool _showTextBackdrop;
+    private Color _textBackdropColor;
 
     #endregion
 
@@ -120,7 +125,12 @@ public class KryptonProgressBar : Control, IContentValues
         StateNormal = new PaletteTriple(StateCommon, OnNeedPaintHandler);
         ((PaletteBack)StateNormal.PaletteBack).ColorStyle = PaletteColorStyle.OneNote;
         _stateBackValue = new PaletteTriple(StateCommon, OnNeedPaintHandler).Back;
-        _stateBackValue.ColorStyle = PaletteColorStyle.SolidAllLine;
+        _stateBackValue.ColorStyle = PaletteColorStyle.GlassNormalFull;
+        _blockCount = 0; // 0 = automatic sizing
+        _showTextShadow = true;
+        _textShadowColor = Color.Empty;
+        _showTextBackdrop = true;
+        _textBackdropColor = Color.Empty;
     }
 
     /// <inheritdoc />
@@ -243,8 +253,121 @@ public class KryptonProgressBar : Control, IContentValues
             {
                 Invalidate();
                 _marqueeTimer.Stop();
-                _stateBackValue.ColorStyle = PaletteColorStyle.SolidAllLine;
             }
+        }
+    }
+
+    /// <summary>Gets or sets the number of blocks to render for Blocks style; 0 means automatic sizing based on height.</summary>
+    [Category("Behavior")]
+    [Description("Number of blocks when using Blocks style; 0 for automatic.")]
+    [DefaultValue(0)]
+    public int BlockCount
+    {
+        get => _blockCount;
+        set
+        {
+            if (value < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(BlockCount));
+            }
+            if (_blockCount == value)
+            {
+                return;
+            }
+            _blockCount = value;
+            if (Style == ProgressBarStyle.Blocks)
+            {
+                Invalidate();
+            }
+        }
+    }
+
+    /// <summary>Gets or sets the color drawing style of the filled value area.</summary>
+    [Category(@"Visuals")]
+    [Description(@"Color drawing style of the progress value segment.")]
+    [DefaultValue(PaletteColorStyle.GlassNormalFull)]
+    public PaletteColorStyle ValueBackColorStyle
+    {
+        get => _stateBackValue.ColorStyle;
+        set
+        {
+            if (_stateBackValue.ColorStyle == value)
+            {
+                return;
+            }
+
+            _stateBackValue.ColorStyle = value;
+            Invalidate();
+        }
+    }
+
+    [Category(@"Visuals")]
+    [Description(@"Draw a subtle shadow behind the text to improve readability.")]
+    [DefaultValue(true)]
+    public bool ShowTextShadow
+    {
+        get => _showTextShadow;
+        set
+        {
+            if (_showTextShadow == value)
+            {
+                return;
+            }
+
+            _showTextShadow = value;
+            Invalidate();
+        }
+    }
+
+    [Category(@"Visuals")]
+    [Description(@"Shadow color for the text; Empty for automatic.")]
+    public Color TextShadowColor
+    {
+        get => _textShadowColor;
+        set
+        {
+            if (_textShadowColor == value)
+            {
+                return;
+            }
+
+            _textShadowColor = value;
+            Invalidate();
+        }
+    }
+
+    [Category(@"Visuals")]
+    [Description(@"Draw a rounded backdrop behind the text for readability.")]
+    [DefaultValue(true)]
+    public bool ShowTextBackdrop
+    {
+        get => _showTextBackdrop;
+        set
+        {
+            if (_showTextBackdrop == value)
+            {
+                return;
+            }
+
+            _showTextBackdrop = value;
+            Invalidate();
+        }
+    }
+
+    [Category(@"Visuals")]
+    [Description(@"Backdrop color for the text; Empty for automatic semi-transparent.")]
+    public Color TextBackdropColor
+    {
+        get => _textBackdropColor;
+        set
+        {
+            if (_textBackdropColor == value)
+            {
+                return;
+            }
+
+            _textBackdropColor = value;
+            Invalidate();
         }
     }
 
@@ -389,7 +512,7 @@ public class KryptonProgressBar : Control, IContentValues
     }
 
     /// <summary>
-    /// Gets or sets the text associated with this control. 
+    /// Gets or sets the text associated with this control.
     /// </summary>
     [Editor(typeof(MultilineStringEditor), typeof(UITypeEditor))]
     [RefreshProperties(RefreshProperties.Repaint)]
@@ -584,7 +707,7 @@ public class KryptonProgressBar : Control, IContentValues
         // Set the style we want picked up from the base palette
         var (barPaletteState, barState) = GetBarPaletteState();
 
-        // Draw the background of the entire control over the entire client area. 
+        // Draw the background of the entire control over the entire client area.
         using (GraphicsPath path = CreateRectGraphicsPath(ClientRectangle))
         {
             var panelState = !Parent!.Enabled
@@ -619,101 +742,285 @@ public class KryptonProgressBar : Control, IContentValues
         // Create a rectangle inset
         Rectangle innerRect = ClientRectangle;
         var maximumRange = (Maximum - Minimum);
-        if (_style == ProgressBarStyle.Marquee)
+
+        switch (Style)
         {
-            float ratio = 1.0f / maximumRange;
-            int half = (int)(3 * ratio);
-            int lower = Math.Max(_marqueeLocation - Minimum - half, Minimum);
-            int higher = Math.Min(lower + half, maximumRange);
-            switch (Orientation)
+            case ProgressBarStyle.Marquee:
             {
-                case VisualOrientation.Top:
-                case VisualOrientation.Bottom:
+                int bandUnits = Math.Max(1, maximumRange / 10);
+                int lowerUnits = Math.Max(_marqueeLocation - Minimum, Minimum);
+                int upperUnits = Math.Min(lowerUnits + bandUnits, maximumRange);
+
+                switch (Orientation)
                 {
-                    int width = innerRect.Width;
+                    case VisualOrientation.Top:
+                    case VisualOrientation.Bottom:
+                    {
+                        int width = innerRect.Width;
+                        float pixelsPerUnit = width / (float)maximumRange;
 
-                    innerRect.X += (int)(ratio * width * lower);
-                    innerRect.Width = (int)(ratio * width * higher);
-                    // Now do special clipping handling for curved borders
-                    if (innerRect.Right > ClientRectangle.Right)
-                    {
-                        innerRect.Width -= (innerRect.Right - ClientRectangle.Right);
+                        innerRect.X += (int)(pixelsPerUnit * lowerUnits);
+                        innerRect.Width = (int)(pixelsPerUnit * (upperUnits - lowerUnits));
+                        if (innerRect.Right > ClientRectangle.Right)
+                        {
+                            innerRect.Width -= (innerRect.Right - ClientRectangle.Right);
+                        }
+                        if (innerRect.X > ClientRectangle.Right)
+                        {
+                            innerRect.X = ClientRectangle.Right;
+                        }
                     }
-                    if (innerRect.X > ClientRectangle.Right)
+                        break;
+
+                    case VisualOrientation.Left:
+                    case VisualOrientation.Right:
                     {
-                        innerRect.X = ClientRectangle.Right;
+                        int height = innerRect.Height;
+                        float pixelsPerUnit = height / (float)maximumRange;
+
+                        innerRect.Y += (int)(pixelsPerUnit * lowerUnits);
+                        innerRect.Height = (int)(pixelsPerUnit * (upperUnits - lowerUnits));
+                        if (innerRect.Bottom > ClientRectangle.Bottom)
+                        {
+                            innerRect.Height -= (innerRect.Bottom - ClientRectangle.Bottom);
+                        }
+                        if (innerRect.Y > ClientRectangle.Bottom)
+                        {
+                            innerRect.Y = ClientRectangle.Bottom;
+                        }
                     }
+                        break;
                 }
-                    break;
 
-                case VisualOrientation.Left:
-                case VisualOrientation.Right:
+                using (GraphicsPath valueLozengePath = renderer.RenderStandardBorder.GetBackPath(renderContext,
+                           innerRect,
+                           barPaletteState.PaletteBorder!,
+                           Orientation,
+                           barState))
                 {
-                    int height = innerRect.Height;
-
-                    innerRect.Y += (int)(ratio * height * lower);
-                    innerRect.Height = (int)(ratio * height * higher);
-                    // Now do special clipping handling for curved borders
-                    if (innerRect.Bottom > ClientRectangle.Bottom)
-                    {
-                        innerRect.Height -= (innerRect.Bottom - ClientRectangle.Bottom);
-                    }
-
-                    if (innerRect.Y > ClientRectangle.Bottom)
-                    {
-                        innerRect.Y = ClientRectangle.Bottom;
-                    }
+                    using var gh = new GraphicsHint(renderContext.Graphics,
+                        barPaletteState.PaletteBorder.GetBorderGraphicsHint(PaletteState.Normal));
+                    _mementoBackProgressValue = renderer.RenderStandardBack.DrawBack(renderContext, innerRect, valueLozengePath, _stateBackValue,
+                        Orientation, barState, _mementoBackProgressValue);
                 }
-                    break;
+                break;
             }
-        }
-        else
-        {
-            // Draw the value offset
-            float v = (Value - Minimum);
-            float ratio = v / maximumRange;
-            switch (Orientation)
+
+            case ProgressBarStyle.Blocks:
             {
-                case VisualOrientation.Top:
-                case VisualOrientation.Bottom:
-                    innerRect.Width = (int)(ratio * innerRect.Width);
-                    if (RightToLeft == RightToLeft.Yes)
+                float v = (Value - Minimum);
+                float ratio = maximumRange == 0 ? 0f : v / maximumRange;
+                int totalBlocks = _blockCount > 0 ? _blockCount : Math.Max(1, maximumRange / 10);
+                float filledBlocksFloat = ratio * totalBlocks;
+                int fullBlocks = Math.Max(0, Math.Min(totalBlocks, (int)Math.Floor(filledBlocksFloat)));
+                float fractional = Math.Max(0f, Math.Min(1f, filledBlocksFloat - fullBlocks));
+                bool rtl = RightToLeft == RightToLeft.Yes;
+
+                switch (Orientation)
+                {
+                    case VisualOrientation.Top:
+                    case VisualOrientation.Bottom:
                     {
-                        innerRect.X = ClientRectangle.Right - innerRect.Width;
+                        Rectangle barRect = ClientRectangle;
+                        int gap = Math.Max(1, Math.Min(3, barRect.Height / 6));
+                        int blockWidth = Math.Max(1, (barRect.Width - ((totalBlocks - 1) * gap)) / totalBlocks);
+                        // Draw full blocks
+                        for (int i = 0; i < fullBlocks; i++)
+                        {
+                            int x = rtl
+                                ? barRect.Right - ((i + 1) * blockWidth) - (i * gap)
+                                : barRect.Left + (i * (blockWidth + gap));
+                            Rectangle block = new Rectangle(x, barRect.Y, blockWidth, barRect.Height);
+                            using (GraphicsPath path = renderer.RenderStandardBorder.GetBackPath(renderContext, block,
+                                       barPaletteState.PaletteBorder!, Orientation, barState))
+                            {
+                                using var gh = new GraphicsHint(renderContext.Graphics,
+                                    barPaletteState.PaletteBorder.GetBorderGraphicsHint(PaletteState.Normal));
+                                _mementoBackProgressValue = renderer.RenderStandardBack.DrawBack(renderContext, block, path, _stateBackValue,
+                                    Orientation, barState, _mementoBackProgressValue);
+                            }
+                        }
+                        // Draw partial last block if needed
+                        if (fractional > 0f && fullBlocks < totalBlocks)
+                        {
+                            int i = fullBlocks;
+                            int fractionWidth = Math.Max(1, (int)Math.Round(blockWidth * fractional, MidpointRounding.AwayFromZero));
+                            int xBase = rtl
+                                ? barRect.Right - ((i + 1) * blockWidth) - (i * gap)
+                                : barRect.Left + (i * (blockWidth + gap));
+                            int x = rtl ? xBase + (blockWidth - fractionWidth) : xBase;
+                            Rectangle block = new Rectangle(x, barRect.Y, fractionWidth, barRect.Height);
+                            using (GraphicsPath path = renderer.RenderStandardBorder.GetBackPath(renderContext, block,
+                                       barPaletteState.PaletteBorder!, Orientation, barState))
+                            {
+                                using var gh = new GraphicsHint(renderContext.Graphics,
+                                    barPaletteState.PaletteBorder.GetBorderGraphicsHint(PaletteState.Normal));
+                                _mementoBackProgressValue = renderer.RenderStandardBack.DrawBack(renderContext, block, path, _stateBackValue,
+                                    Orientation, barState, _mementoBackProgressValue);
+                            }
+                        }
                     }
+                        break;
 
-                    break;
-
-                case VisualOrientation.Left:
-                case VisualOrientation.Right:
-                    innerRect.Height = (int)(ratio * innerRect.Height);
-                    if (RightToLeft == RightToLeft.Yes)
+                    case VisualOrientation.Left:
+                    case VisualOrientation.Right:
                     {
-                        innerRect.Y = ClientRectangle.Bottom - innerRect.Height;
+                        Rectangle barRect = ClientRectangle;
+                        int gap = Math.Max(1, Math.Min(3, barRect.Width / 6));
+                        int blockHeight = Math.Max(1, (barRect.Height - ((totalBlocks - 1) * gap)) / totalBlocks);
+                        // Draw full blocks
+                        for (int i = 0; i < fullBlocks; i++)
+                        {
+                            int y = rtl
+                                ? barRect.Bottom - ((i + 1) * blockHeight) - (i * gap)
+                                : barRect.Top + (i * (blockHeight + gap));
+                            Rectangle block = new Rectangle(barRect.X, y, barRect.Width, blockHeight);
+                            using (GraphicsPath path = renderer.RenderStandardBorder.GetBackPath(renderContext, block,
+                                       barPaletteState.PaletteBorder!, Orientation, barState))
+                            {
+                                using var gh = new GraphicsHint(renderContext.Graphics,
+                                    barPaletteState.PaletteBorder.GetBorderGraphicsHint(PaletteState.Normal));
+                                _mementoBackProgressValue = renderer.RenderStandardBack.DrawBack(renderContext, block, path, _stateBackValue,
+                                    Orientation, barState, _mementoBackProgressValue);
+                            }
+                        }
+                        // Draw partial last block if needed
+                        if (fractional > 0f && fullBlocks < totalBlocks)
+                        {
+                            int i = fullBlocks;
+                            int fractionHeight = Math.Max(1, (int)Math.Round(blockHeight * fractional, MidpointRounding.AwayFromZero));
+                            int yBase = rtl
+                                ? barRect.Bottom - ((i + 1) * blockHeight) - (i * gap)
+                                : barRect.Top + (i * (blockHeight + gap));
+                            int y = rtl ? yBase + (blockHeight - fractionHeight) : yBase;
+                            Rectangle block = new Rectangle(barRect.X, y, barRect.Width, fractionHeight);
+                            using (GraphicsPath path = renderer.RenderStandardBorder.GetBackPath(renderContext, block,
+                                       barPaletteState.PaletteBorder!, Orientation, barState))
+                            {
+                                using var gh = new GraphicsHint(renderContext.Graphics,
+                                    barPaletteState.PaletteBorder.GetBorderGraphicsHint(PaletteState.Normal));
+                                _mementoBackProgressValue = renderer.RenderStandardBack.DrawBack(renderContext, block, path, _stateBackValue,
+                                    Orientation, barState, _mementoBackProgressValue);
+                            }
+                        }
                     }
-
-                    break;
+                        break;
+                }
+                break;
             }
-        }
 
-        using (GraphicsPath valueLozengePath = renderer.RenderStandardBorder.GetBackPath(renderContext,
-                   innerRect,
-                   barPaletteState.PaletteBorder!,
-                   Orientation,
-                   barState))
-        {
-            using var gh = new GraphicsHint(renderContext.Graphics,
-                barPaletteState.PaletteBorder.GetBorderGraphicsHint(PaletteState.Normal));
-            // Ask renderer to Fill the Progress lozenge
-            _mementoBackProgressValue = renderer.RenderStandardBack.DrawBack(renderContext, innerRect, valueLozengePath, _stateBackValue,
-                Orientation, barState, _mementoBackProgressValue);
+            default: // Continuous
+            {
+                float v = (Value - Minimum);
+                float ratio = maximumRange == 0 ? 0f : v / maximumRange;
+                switch (Orientation)
+                {
+                    case VisualOrientation.Top:
+                    case VisualOrientation.Bottom:
+                        innerRect.Width = (int)(ratio * innerRect.Width);
+                        if (RightToLeft == RightToLeft.Yes)
+                        {
+                            innerRect.X = ClientRectangle.Right - innerRect.Width;
+                        }
+                        break;
+
+                    case VisualOrientation.Left:
+                    case VisualOrientation.Right:
+                        innerRect.Height = (int)(ratio * innerRect.Height);
+                        if (RightToLeft == RightToLeft.Yes)
+                        {
+                            innerRect.Y = ClientRectangle.Bottom - innerRect.Height;
+                        }
+                        break;
+                }
+
+                using (GraphicsPath valueLozengePath = renderer.RenderStandardBorder.GetBackPath(renderContext,
+                           innerRect,
+                           barPaletteState.PaletteBorder!,
+                           Orientation,
+                           barState))
+                {
+                    using var gh = new GraphicsHint(renderContext.Graphics,
+                        barPaletteState.PaletteBorder.GetBorderGraphicsHint(PaletteState.Normal));
+                    _mementoBackProgressValue = renderer.RenderStandardBack.DrawBack(renderContext, innerRect, valueLozengePath, _stateBackValue,
+                        Orientation, barState, _mementoBackProgressValue);
+                }
+                break;
+            }
         }
 
         // Now we draw the border of the inner area
         renderer.RenderStandardBorder.DrawBorder(renderContext, ClientRectangle, barPaletteState.PaletteBorder,
             Orientation, barState);
 
+        // Optional text backdrop for readability
+        if (_showTextBackdrop && !string.IsNullOrEmpty(Text))
+        {
+            Size textSize;
+            using (var viewContext = new ViewLayoutContext(this, renderer))
+            {
+                textSize = renderer.RenderStandardContent.GetContentPreferredSize(viewContext,
+                    barPaletteState.PaletteContent!, this, Orientation, barState);
+            }
+            var textRect = new Rectangle(Point.Empty, textSize);
+            textRect.X = ClientRectangle.X + (ClientRectangle.Width - textRect.Width) / 2;
+            textRect.Y = ClientRectangle.Y + (ClientRectangle.Height - textRect.Height) / 2;
+            var backRect = Rectangle.Inflate(textRect, 6, 2);
+
+            using (GraphicsPath gp = new GraphicsPath())
+            {
+                int r = Math.Min(backRect.Height, 10);
+                var arc = new Rectangle(backRect.X, backRect.Y, r, r);
+                gp.AddArc(arc, 180, 90);
+                arc.X = backRect.Right - r; gp.AddArc(arc, 270, 90);
+                arc.Y = backRect.Bottom - r; gp.AddArc(arc, 0, 90);
+                arc.X = backRect.X; gp.AddArc(arc, 90, 90);
+                gp.CloseFigure();
+
+                Color fill = _textBackdropColor != Color.Empty ? _textBackdropColor : Color.FromArgb(150, Color.White);
+                using (var b = new SolidBrush(fill))
+                {
+                    renderContext.Graphics.FillPath(b, gp);
+                }
+                using (var p = new Pen(Color.FromArgb(100, ControlPaint.Dark(fill)), 1f))
+                {
+                    renderContext.Graphics.DrawPath(p, gp);
+                }
+            }
+        }
+
         // Last of all we draw the content over the top of the border and background
+        if (_showTextShadow && !string.IsNullOrEmpty(Text))
+        {
+            Rectangle shadowRect = new Rectangle(ClientRectangle.X,
+                ClientRectangle.Y,
+                ClientRectangle.Width,
+                ClientRectangle.Height);
+
+            var hAlign = barPaletteState.PaletteContent!.GetContentShortTextH(barState);
+            var vAlign = barPaletteState.PaletteContent!.GetContentShortTextV(barState);
+
+            TextFormatFlags flags = TextFormatFlags.NoPadding | TextFormatFlags.NoClipping;
+            flags |= hAlign switch
+            {
+                PaletteRelativeAlign.Center => TextFormatFlags.HorizontalCenter,
+                PaletteRelativeAlign.Far => TextFormatFlags.Right,
+                _ => TextFormatFlags.Left
+            };
+            flags |= vAlign switch
+            {
+                PaletteRelativeAlign.Center => TextFormatFlags.VerticalCenter,
+                PaletteRelativeAlign.Far => TextFormatFlags.Bottom,
+                _ => TextFormatFlags.Top
+            };
+
+            Color baseText = barPaletteState.PaletteContent!.GetContentShortTextColor1(barState);
+            Color shadow = _textShadowColor != Color.Empty ? _textShadowColor : ControlPaint.Dark(baseText);
+            shadow = Color.FromArgb(160, shadow);
+            var textFont = barPaletteState.PaletteContent!.GetContentShortTextFont(barState) ?? Font;
+            TextRenderer.DrawText(renderContext.Graphics, Text, textFont, shadowRect, shadow, flags);
+        }
+
         renderer.RenderStandardContent.DrawContent(renderContext, ClientRectangle,
             barPaletteState.PaletteContent!, _mementoContent!,
             Orientation, barState, false);

--- a/Source/Krypton Components/TestForm/ProgressBarTest.Designer.cs
+++ b/Source/Krypton Components/TestForm/ProgressBarTest.Designer.cs
@@ -1,9 +1,9 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -39,8 +39,13 @@ namespace TestForm
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ProgressBarTest));
             this.kryptonPanel1 = new Krypton.Toolkit.KryptonPanel();
+            this.kryptonLabel1 = new Krypton.Toolkit.KryptonLabel();
             this.kcbtnProgressBarColour = new Krypton.Toolkit.KryptonColorButton();
             this.kcmbProgressBarStyle = new Krypton.Toolkit.KryptonComboBox();
+            this.klblColorStyle = new Krypton.Toolkit.KryptonLabel();
+            this.kcmbColorStyle = new Krypton.Toolkit.KryptonComboBox();
+            this.kchkShowTextBackdrop = new Krypton.Toolkit.KryptonCheckBox();
+            this.kcbtnBackdropColor = new Krypton.Toolkit.KryptonColorButton();
             this.kchkUseProgressValueAsText = new Krypton.Toolkit.KryptonCheckBox();
             this.ktrkProgressValues = new Krypton.Toolkit.KryptonTrackBar();
             this.kryptonProgressBar2 = new Krypton.Toolkit.KryptonProgressBar();
@@ -48,12 +53,18 @@ namespace TestForm
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).BeginInit();
             this.kryptonPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.kcmbProgressBarStyle)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kcmbColorStyle)).BeginInit();
             this.SuspendLayout();
-            // 
+            //
             // kryptonPanel1
-            // 
+            //
+            this.kryptonPanel1.Controls.Add(this.kryptonLabel1);
             this.kryptonPanel1.Controls.Add(this.kcbtnProgressBarColour);
             this.kryptonPanel1.Controls.Add(this.kcmbProgressBarStyle);
+            this.kryptonPanel1.Controls.Add(this.klblColorStyle);
+            this.kryptonPanel1.Controls.Add(this.kcmbColorStyle);
+            this.kryptonPanel1.Controls.Add(this.kchkShowTextBackdrop);
+            this.kryptonPanel1.Controls.Add(this.kcbtnBackdropColor);
             this.kryptonPanel1.Controls.Add(this.kchkUseProgressValueAsText);
             this.kryptonPanel1.Controls.Add(this.ktrkProgressValues);
             this.kryptonPanel1.Controls.Add(this.kryptonProgressBar2);
@@ -61,11 +72,19 @@ namespace TestForm
             this.kryptonPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonPanel1.Location = new System.Drawing.Point(0, 0);
             this.kryptonPanel1.Name = "kryptonPanel1";
-            this.kryptonPanel1.Size = new System.Drawing.Size(485, 177);
+            this.kryptonPanel1.Size = new System.Drawing.Size(489, 245);
             this.kryptonPanel1.TabIndex = 0;
-            // 
+            //
+            // kryptonLabel1
+            //
+            this.kryptonLabel1.Location = new System.Drawing.Point(197, 120);
+            this.kryptonLabel1.Name = "kryptonLabel1";
+            this.kryptonLabel1.Size = new System.Drawing.Size(87, 20);
+            this.kryptonLabel1.TabIndex = 21;
+            this.kryptonLabel1.Values.Text = "Progress Style";
+            //
             // kcbtnProgressBarColour
-            // 
+            //
             this.kcbtnProgressBarColour.CustomColorPreviewShape = Krypton.Toolkit.KryptonColorButtonCustomColorPreviewShape.Circle;
             this.kcbtnProgressBarColour.Location = new System.Drawing.Point(13, 143);
             this.kcbtnProgressBarColour.Name = "kcbtnProgressBarColour";
@@ -76,69 +95,130 @@ namespace TestForm
             this.kcbtnProgressBarColour.Values.RoundedCorners = 8;
             this.kcbtnProgressBarColour.Values.Text = "ProgressBar Colour";
             this.kcbtnProgressBarColour.SelectedColorChanged += new System.EventHandler<Krypton.Toolkit.ColorEventArgs>(this.kcbtnProgressBarColour_SelectedColorChanged);
-            // 
+            //
             // kcmbProgressBarStyle
-            // 
+            //
             this.kcmbProgressBarStyle.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.kcmbProgressBarStyle.DropDownWidth = 261;
             this.kcmbProgressBarStyle.IntegralHeight = false;
-            this.kcmbProgressBarStyle.Location = new System.Drawing.Point(208, 117);
+            this.kcmbProgressBarStyle.Location = new System.Drawing.Point(290, 117);
             this.kcmbProgressBarStyle.Name = "kcmbProgressBarStyle";
-            this.kcmbProgressBarStyle.Size = new System.Drawing.Size(261, 22);
+            this.kcmbProgressBarStyle.Size = new System.Drawing.Size(179, 22);
             this.kcmbProgressBarStyle.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
             this.kcmbProgressBarStyle.TabIndex = 15;
             this.kcmbProgressBarStyle.SelectedIndexChanged += new System.EventHandler(this.kcmbProgressBarStyle_SelectedIndexChanged);
-            // 
+            //
+            // klblColorStyle
+            //
+            this.klblColorStyle.Location = new System.Drawing.Point(197, 146);
+            this.klblColorStyle.Name = "klblColorStyle";
+            this.klblColorStyle.Size = new System.Drawing.Size(70, 20);
+            this.klblColorStyle.TabIndex = 17;
+            this.klblColorStyle.Values.Text = "Color Style";
+            //
+            // kcmbColorStyle
+            //
+            this.kcmbColorStyle.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.kcmbColorStyle.DropDownWidth = 179;
+            this.kcmbColorStyle.IntegralHeight = false;
+            this.kcmbColorStyle.Location = new System.Drawing.Point(290, 146);
+            this.kcmbColorStyle.Name = "kcmbColorStyle";
+            this.kcmbColorStyle.Size = new System.Drawing.Size(179, 22);
+            this.kcmbColorStyle.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
+            this.kcmbColorStyle.TabIndex = 18;
+            this.kcmbColorStyle.SelectedIndexChanged += new System.EventHandler(this.kcmbColorStyle_SelectedIndexChanged);
+            //
+            // kchkShowTextBackdrop
+            //
+            this.kchkShowTextBackdrop.Checked = true;
+            this.kchkShowTextBackdrop.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.kchkShowTextBackdrop.Location = new System.Drawing.Point(13, 175);
+            this.kchkShowTextBackdrop.Name = "kchkShowTextBackdrop";
+            this.kchkShowTextBackdrop.Size = new System.Drawing.Size(132, 20);
+            this.kchkShowTextBackdrop.TabIndex = 19;
+            this.kchkShowTextBackdrop.Values.Text = "Show text backdrop";
+            this.kchkShowTextBackdrop.CheckedChanged += new System.EventHandler(this.kchkShowTextBackdrop_CheckedChanged);
+            //
+            // kcbtnBackdropColor
+            //
+            this.kcbtnBackdropColor.CustomColorPreviewShape = Krypton.Toolkit.KryptonColorButtonCustomColorPreviewShape.Circle;
+            this.kcbtnBackdropColor.Location = new System.Drawing.Point(13, 201);
+            this.kcbtnBackdropColor.Name = "kcbtnBackdropColor";
+            this.kcbtnBackdropColor.SelectedColor = System.Drawing.Color.WhiteSmoke;
+            this.kcbtnBackdropColor.Size = new System.Drawing.Size(179, 25);
+            this.kcbtnBackdropColor.TabIndex = 20;
+            this.kcbtnBackdropColor.Values.Image = ((System.Drawing.Image)(resources.GetObject("kcbtnBackdropColor.Values.Image")));
+            this.kcbtnBackdropColor.Values.RoundedCorners = 8;
+            this.kcbtnBackdropColor.Values.Text = "Text Backdrop Colour";
+            this.kcbtnBackdropColor.SelectedColorChanged += new System.EventHandler<Krypton.Toolkit.ColorEventArgs>(this.kcbtnBackdropColor_SelectedColorChanged);
+            //
             // kchkUseProgressValueAsText
-            // 
-            this.kchkUseProgressValueAsText.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            //
+            this.kchkUseProgressValueAsText.Checked = true;
+            this.kchkUseProgressValueAsText.CheckState = System.Windows.Forms.CheckState.Checked;
             this.kchkUseProgressValueAsText.Location = new System.Drawing.Point(17, 116);
             this.kchkUseProgressValueAsText.Name = "kchkUseProgressValueAsText";
             this.kchkUseProgressValueAsText.Size = new System.Drawing.Size(165, 20);
             this.kchkUseProgressValueAsText.TabIndex = 14;
             this.kchkUseProgressValueAsText.Values.Text = "Use progress value as text";
             this.kchkUseProgressValueAsText.CheckedChanged += new System.EventHandler(this.kchkUseProgressValueAsText_CheckedChanged);
-            // 
+            //
             // ktrkProgressValues
-            // 
-            this.ktrkProgressValues.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.ktrkProgressValues.Location = new System.Drawing.Point(17, 77);
+            //
+            this.ktrkProgressValues.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.ktrkProgressValues.Location = new System.Drawing.Point(13, 77);
             this.ktrkProgressValues.Maximum = 100;
             this.ktrkProgressValues.Name = "ktrkProgressValues";
-            this.ktrkProgressValues.Size = new System.Drawing.Size(456, 33);
+            this.ktrkProgressValues.Size = new System.Drawing.Size(460, 33);
             this.ktrkProgressValues.TabIndex = 13;
             this.ktrkProgressValues.TickStyle = System.Windows.Forms.TickStyle.Both;
             this.ktrkProgressValues.ValueChanged += new System.EventHandler(this.ktrkProgressValues_ValueChanged);
-            // 
+            //
             // kryptonProgressBar2
-            // 
+            //
+            this.kryptonProgressBar2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.kryptonProgressBar2.Enabled = false;
             this.kryptonProgressBar2.Location = new System.Drawing.Point(13, 45);
             this.kryptonProgressBar2.Name = "kryptonProgressBar2";
-            this.kryptonProgressBar2.Size = new System.Drawing.Size(456, 26);
+            this.kryptonProgressBar2.Size = new System.Drawing.Size(460, 26);
             this.kryptonProgressBar2.StateCommon.Back.Color1 = System.Drawing.Color.Green;
             this.kryptonProgressBar2.StateDisabled.Back.ColorStyle = Krypton.Toolkit.PaletteColorStyle.OneNote;
             this.kryptonProgressBar2.StateNormal.Back.ColorStyle = Krypton.Toolkit.PaletteColorStyle.OneNote;
             this.kryptonProgressBar2.TabIndex = 1;
-            this.kryptonProgressBar2.Values.Text = "";
-            // 
+            this.kryptonProgressBar2.Text = "75%";
+            this.kryptonProgressBar2.TextBackdropColor = System.Drawing.Color.Empty;
+            this.kryptonProgressBar2.TextShadowColor = System.Drawing.Color.Empty;
+            this.kryptonProgressBar2.UseValueAsText = true;
+            this.kryptonProgressBar2.Value = 75;
+            this.kryptonProgressBar2.Values.Text = "75%";
+            //
             // kryptonProgressBar1
-            // 
+            //
+            this.kryptonProgressBar1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.kryptonProgressBar1.Location = new System.Drawing.Point(13, 13);
             this.kryptonProgressBar1.Name = "kryptonProgressBar1";
-            this.kryptonProgressBar1.Size = new System.Drawing.Size(456, 26);
+            this.kryptonProgressBar1.Size = new System.Drawing.Size(460, 26);
             this.kryptonProgressBar1.StateCommon.Back.Color1 = System.Drawing.Color.Green;
             this.kryptonProgressBar1.StateDisabled.Back.ColorStyle = Krypton.Toolkit.PaletteColorStyle.OneNote;
             this.kryptonProgressBar1.StateNormal.Back.ColorStyle = Krypton.Toolkit.PaletteColorStyle.OneNote;
             this.kryptonProgressBar1.TabIndex = 0;
-            this.kryptonProgressBar1.Values.Text = "";
-            // 
+            this.kryptonProgressBar1.Text = "75%";
+            this.kryptonProgressBar1.TextBackdropColor = System.Drawing.Color.Empty;
+            this.kryptonProgressBar1.TextShadowColor = System.Drawing.Color.Empty;
+            this.kryptonProgressBar1.UseValueAsText = true;
+            this.kryptonProgressBar1.Value = 75;
+            this.kryptonProgressBar1.Values.Text = "75%";
+            //
             // ProgressBarTest
-            // 
+            //
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(485, 177);
+            this.ClientSize = new System.Drawing.Size(489, 245);
             this.Controls.Add(this.kryptonPanel1);
+            this.MinimumSize = new System.Drawing.Size(500, 290);
             this.Name = "ProgressBarTest";
             this.Text = "ProgressBarTest";
             this.Load += new System.EventHandler(this.ProgressBarTest_Load);
@@ -146,6 +226,7 @@ namespace TestForm
             this.kryptonPanel1.ResumeLayout(false);
             this.kryptonPanel1.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.kcmbProgressBarStyle)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kcmbColorStyle)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -159,5 +240,10 @@ namespace TestForm
         private Krypton.Toolkit.KryptonTrackBar ktrkProgressValues;
         private Krypton.Toolkit.KryptonComboBox kcmbProgressBarStyle;
         private Krypton.Toolkit.KryptonColorButton kcbtnProgressBarColour;
+        private Krypton.Toolkit.KryptonLabel klblColorStyle;
+        private Krypton.Toolkit.KryptonComboBox kcmbColorStyle;
+        private Krypton.Toolkit.KryptonCheckBox kchkShowTextBackdrop;
+        private Krypton.Toolkit.KryptonColorButton kcbtnBackdropColor;
+        private KryptonLabel kryptonLabel1;
     }
 }

--- a/Source/Krypton Components/TestForm/ProgressBarTest.cs
+++ b/Source/Krypton Components/TestForm/ProgressBarTest.cs
@@ -1,9 +1,9 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -14,6 +14,7 @@ public partial class ProgressBarTest : KryptonForm
     public ProgressBarTest()
     {
         InitializeComponent();
+        ktrkProgressValues.Value = 75;
     }
 
     private void ProgressBarTest_Load(object sender, EventArgs e)
@@ -24,6 +25,13 @@ public partial class ProgressBarTest : KryptonForm
         }
 
         kcmbProgressBarStyle.SelectedIndex = 1;
+
+        foreach (var value in Enum.GetValues(typeof(PaletteColorStyle)))
+        {
+            kcmbColorStyle.Items.Add(value);
+        }
+
+        kcmbColorStyle.SelectedItem = PaletteColorStyle.GlassNormalFull;
     }
 
     private void ktrkProgressValues_ValueChanged(object sender, EventArgs e)
@@ -54,5 +62,24 @@ public partial class ProgressBarTest : KryptonForm
         kryptonProgressBar1.StateCommon.Back.Color1 = e.Color;
 
         kryptonProgressBar2.StateCommon.Back.Color1 = e.Color;
+    }
+
+    private void kcmbColorStyle_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        var style = (PaletteColorStyle)Enum.Parse(typeof(PaletteColorStyle), kcmbColorStyle.Text);
+        kryptonProgressBar1.ValueBackColorStyle = style;
+        kryptonProgressBar2.ValueBackColorStyle = style;
+    }
+
+    private void kchkShowTextBackdrop_CheckedChanged(object sender, EventArgs e)
+    {
+        kryptonProgressBar1.ShowTextBackdrop = kchkShowTextBackdrop.Checked;
+        kryptonProgressBar2.ShowTextBackdrop = kchkShowTextBackdrop.Checked;
+    }
+
+    private void kcbtnBackdropColor_SelectedColorChanged(object sender, ColorEventArgs e)
+    {
+        kryptonProgressBar1.TextBackdropColor = e.Color;
+        kryptonProgressBar2.TextBackdropColor = e.Color;
     }
 }

--- a/Source/Krypton Components/TestForm/ProgressBarTest.resx
+++ b/Source/Krypton Components/TestForm/ProgressBarTest.resx
@@ -121,8 +121,15 @@
   <data name="kcbtnProgressBarColour.Values.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
-        DgAACw4BQL7hQQAAAAd0SU1FB9gBEgI0L+a2mIYAAAASSURBVDhPY2AYBaNgFIwCCAAABBAAAUy7RlUA
-        AAAASUVORK5CYII=
+        DAAACwwBP0AiyAAAAAd0SU1FB9gBEgI0L+a2mIYAAAATSURBVDhPYxgFo2AUjAIwYGAAAAQQAAGnRHxj
+        AAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="kcbtnBackdropColor.Values.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        DAAACwwBP0AiyAAAAAd0SU1FB9gBEgI0L+a2mIYAAAATSURBVDhPYxgFo2AUjAIwYGAAAAQQAAGnRHxj
+        AAAAAElFTkSuQmCC
 </value>
   </data>
 </root>


### PR DESCRIPTION
### PR description
- Fix KryptonProgressBar value fill rendering to match palette 3D style
  - Progress value now uses `PaletteColorStyle.GlassNormalFull` by default (instead of flat fill), driven by renderer and theme.
  - Added `ValueBackColorStyle` property to allow choosing any `PaletteColorStyle` for the value area.

- Correct and unify style rendering
  - Reworked painting into a single `switch (Style)` with clear branches for `Marquee`, `Blocks`, and `Continuous`.
  - Fixed `Marquee` computation to use pixel-per-unit mapping, ensuring correct band size and position in all orientations and ranges.
  - Implemented proper `Blocks` style:
    - Draws discrete segments with theme 3D fill.
    - Supports RTL and vertical orientations.
    - Renders a partial block for fractional progress (no “jump” between blocks).

- New customization options
  - `BlockCount` property: exact number of blocks; when `0` (default), block count derives from the range as one block per 10 units (e.g., 10 blocks for 0–100) for intuitive percentage reading.
  - Text readability:
    - `ShowTextShadow` and `TextShadowColor` (default shadow uses palette text color darkened; subtle and tight to glyphs).
    - `ShowTextBackdrop` and `TextBackdropColor` (rounded semi-transparent backdrop behind text, centered and sized to measured content).

- Misc
  - Kept palette-driven colors; rendering paths leverage `RenderStandardBack`/`RenderStandardContent`.
  - Maintained clipping for rounded borders and respecced RTL/orientation behavior.
  - Removed nullability warning by asserting non-null `PaletteContent` in the paint path.

- `TestForm` -> `ProgressBar` demo shows all new options

<img width="670" height="349" alt="image" src="https://github.com/user-attachments/assets/48b5fc24-5f62-434e-a08c-30ed0b395506" />

