### PR TITLE
2406 V95 Enhance `KryptonProgressBar` with new properties

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2025-08-25 - Build 2508 (Patch 8) - August 2025
+* Implemented [#2406](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2406), `KryptonProgressBar` enhancements.
 * Resolved [#1971](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2416), `KryptonDataGridViewColumn` Drop-down arrow image incorrect for Sparkle themes.
 * Resolved [#2397](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2397), `KryptonForm` throws and exception on CTRL+F1.
 * Resolved [#2331](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2331), Correction of edges, 3D effect and color adjustment in `KryptonRibbon` in Office 2010 themes.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonProgressBar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonProgressBar.cs
@@ -1,10 +1,9 @@
 ﻿#region BSD License
 /*
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2022 - 2024. All rights reserved. 
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2022 - 2025. All rights reserved.
  */
 #endregion
-
 
 using Timer = System.Windows.Forms.Timer;
 // ReSharper disable UnusedMember.Global
@@ -46,6 +45,11 @@ namespace Krypton.Toolkit
         private readonly PaletteBack _stateBackValue;
         private readonly Timer _marqueeTimer;
         private int _marqueeLocation;
+        private int _blockCount;
+        private bool _showTextShadow;
+        private Color _textShadowColor;
+        private bool _showTextBackdrop;
+        private Color _textBackdropColor;
 
         #endregion
 
@@ -78,7 +82,7 @@ namespace Krypton.Toolkit
             {
                 Interval = _marqueeSpeed
             };
-            _marqueeTimer.Tick += OnMarqueeTick;
+            _marqueeTimer.Tick += OnMarqueeTick!;
 
             // Cache the current global palette setting
             _palette = KryptonManager.CurrentGlobalPalette;
@@ -86,7 +90,7 @@ namespace Krypton.Toolkit
             // Hook into palette events
             if (_palette != null)
             {
-                _palette.PalettePaint += OnPalettePaint;
+                _palette.PalettePaint += OnPalettePaint!;
             }
 
             // Create content storage
@@ -94,10 +98,10 @@ namespace Krypton.Toolkit
             {
                 Text = string.Empty
             };
-            Values.TextChanged += OnLabelTextChanged;
+            Values.TextChanged += OnLabelTextChanged!;
 
             // We want to be notified whenever the global palette changes
-            KryptonManager.GlobalPaletteChanged += OnGlobalPaletteChanged;
+            KryptonManager.GlobalPaletteChanged += OnGlobalPaletteChanged!;
 
             // Create redirection object to the base palette
             _paletteRedirect = new PaletteRedirect(_palette);
@@ -120,7 +124,12 @@ namespace Krypton.Toolkit
             StateNormal = new PaletteTriple(StateCommon, OnNeedPaintHandler);
             ((PaletteBack)StateNormal.PaletteBack).ColorStyle = PaletteColorStyle.OneNote;
             _stateBackValue = new PaletteTriple(StateCommon, OnNeedPaintHandler).Back;
-            _stateBackValue.ColorStyle = PaletteColorStyle.SolidAllLine;
+            _stateBackValue.ColorStyle = PaletteColorStyle.GlassNormalFull;
+            _blockCount = 0; // 0 = automatic sizing
+            _showTextShadow = false;
+            _textShadowColor = Color.Empty;
+            _showTextBackdrop = false;
+            _textBackdropColor = Color.Empty;
         }
 
         /// <inheritdoc />
@@ -155,12 +164,12 @@ namespace Krypton.Toolkit
                 // Unhook from the palette events
                 if (_palette != null)
                 {
-                    _palette.PalettePaint -= OnPalettePaint;
+                    _palette.PalettePaint -= OnPalettePaint!;
                     _palette = null;
                 }
 
                 // Unhook from the static events, otherwise we cannot be garbage collected
-                KryptonManager.GlobalPaletteChanged -= OnGlobalPaletteChanged;
+                KryptonManager.GlobalPaletteChanged -= OnGlobalPaletteChanged!;
             }
 
             base.Dispose(disposing);
@@ -247,6 +256,127 @@ namespace Krypton.Toolkit
                 }
             }
         }
+
+        /// <summary>Gets or sets the number of blocks to render for Blocks style; 0 means automatic sizing based on height.</summary>
+        [Category("Behavior")]
+        [Description("Number of blocks when using Blocks style; 0 for automatic.")]
+        [DefaultValue(0)]
+        public int BlockCount
+        {
+            get => _blockCount;
+            set
+            {
+                if (value < 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(BlockCount));
+                }
+                if (_blockCount == value)
+                {
+                    return;
+                }
+                _blockCount = value;
+                if (Style == ProgressBarStyle.Blocks)
+                {
+                    Invalidate();
+                }
+            }
+        }
+
+        /// <summary>Gets or sets the color drawing style of the filled value area.</summary>
+        [Category(@"Visuals")]
+        [Description(@"Color drawing style of the progress value segment.")]
+        [DefaultValue(PaletteColorStyle.GlassNormalFull)]
+        public PaletteColorStyle ValueBackColorStyle
+        {
+            get => _stateBackValue.ColorStyle;
+            set
+            {
+                if (_stateBackValue.ColorStyle == value)
+                {
+                    return;
+                }
+
+                _stateBackValue.ColorStyle = value;
+                Invalidate();
+            }
+        }
+
+        [Category(@"Visuals")]
+        [Description(@"Draw a subtle shadow behind the text to improve readability.")]
+        [DefaultValue(false)]
+        public bool ShowTextShadow
+        {
+            get => _showTextShadow;
+            set
+            {
+                if (_showTextShadow == value)
+                {
+                    return;
+                }
+
+                _showTextShadow = value;
+                Invalidate();
+            }
+        }
+
+        [Category(@"Visuals")]
+        [Description(@"Shadow color for the text; Empty for automatic.")]
+        [DefaultValue(typeof(Color), nameof(Color.Empty))]
+        public Color TextShadowColor
+        {
+            get => _textShadowColor;
+            set
+            {
+                if (_textShadowColor == value)
+                {
+                    return;
+                }
+
+                _textShadowColor = value;
+                Invalidate();
+            }
+        }
+        private bool ShouldSerializeTextShadowColor() => _textShadowColor != Color.Empty;
+        public void ResetTextShadowColor() => TextShadowColor = Color.Empty;
+
+        [Category(@"Visuals")]
+        [Description(@"Draw a rounded backdrop behind the text for readability.")]
+        [DefaultValue(false)]
+        public bool ShowTextBackdrop
+        {
+            get => _showTextBackdrop;
+            set
+            {
+                if (_showTextBackdrop == value)
+                {
+                    return;
+                }
+
+                _showTextBackdrop = value;
+                Invalidate();
+            }
+        }
+
+        [Category(@"Visuals")]
+        [Description(@"Backdrop color for the text; Empty for automatic semi-transparent.")]
+        [DefaultValue(typeof(Color), nameof(Color.Empty))]
+        public Color TextBackdropColor
+        {
+            get => _textBackdropColor;
+            set
+            {
+                if (_textBackdropColor == value)
+                {
+                    return;
+                }
+
+                _textBackdropColor = value;
+                Invalidate();
+            }
+        }
+
+        private bool ShouldSerializeTextBackdropColor() => _textBackdropColor != Color.Empty;
+        public void ResetTextBackdropColor() => TextBackdropColor = Color.Empty;
 
         private bool ShouldSerializeStyle() => Style != ProgressBarStyle.Continuous;
 
@@ -389,7 +519,7 @@ namespace Krypton.Toolkit
         }
 
         /// <summary>
-        /// Gets or sets the text associated with this control. 
+        /// Gets or sets the text associated with this control.
         /// </summary>
         [Editor(typeof(MultilineStringEditor), typeof(UITypeEditor))]
         [RefreshProperties(RefreshProperties.Repaint)]
@@ -556,7 +686,7 @@ namespace Krypton.Toolkit
                 var (barPaletteState, barState) = GetBarPaletteState();
 
                 // Get the renderer associated with this palette
-                IRenderer renderer = _palette.GetRenderer();
+                IRenderer renderer = _palette.GetRenderer()!;
 
                 // Create a layout context used to allow the renderer to layout the content
                 using var viewContext = new ViewLayoutContext(this, renderer);
@@ -576,6 +706,13 @@ namespace Krypton.Toolkit
         /// <inheritdoc />
         protected override void OnPaint(PaintEventArgs e)
         {
+            // If no palette is available, fall back to base painting
+            if (_palette == null)
+            {
+                base.OnPaint(e);
+                return;
+            }
+
             // Get the renderer associated with this palette
             IRenderer renderer = _palette!.GetRenderer();
 
@@ -584,7 +721,7 @@ namespace Krypton.Toolkit
             // Set the style we want picked up from the base palette
             var (barPaletteState, barState) = GetBarPaletteState();
 
-            // Draw the background of the entire control over the entire client area. 
+            // Draw the background of the entire control over the entire client area.
             using (GraphicsPath path = CreateRectGraphicsPath(ClientRectangle))
             {
                 var panelState = !Parent!.Enabled
@@ -619,22 +756,25 @@ namespace Krypton.Toolkit
             // Create a rectangle inset
             Rectangle innerRect = ClientRectangle;
             var maximumRange = (Maximum - Minimum);
-            if (_style == ProgressBarStyle.Marquee)
+
+            switch (Style)
             {
-                float ratio = 1.0f / maximumRange;
-                int half = (int)(3 * ratio);
-                int lower = Math.Max(_marqueeLocation - Minimum - half, Minimum);
-                int higher = Math.Min(lower + half, maximumRange);
-                switch (Orientation)
+                case ProgressBarStyle.Marquee:
                 {
-                    case VisualOrientation.Top:
-                    case VisualOrientation.Bottom:
+                    int bandUnits = Math.Max(1, maximumRange / 10);
+                    int lowerUnits = Math.Max(_marqueeLocation - Minimum, Minimum);
+                    int upperUnits = Math.Min(lowerUnits + bandUnits, maximumRange);
+
+                    switch (Orientation)
+                    {
+                        case VisualOrientation.Top:
+                        case VisualOrientation.Bottom:
                         {
                             int width = innerRect.Width;
+                            float pixelsPerUnit = width / (float)maximumRange;
 
-                            innerRect.X += (int)(ratio * width * lower);
-                            innerRect.Width = (int)(ratio * width * higher);
-                            // Now do special clipping handling for curved borders
+                            innerRect.X += (int)(pixelsPerUnit * lowerUnits);
+                            innerRect.Width = (int)(pixelsPerUnit * (upperUnits - lowerUnits));
                             if (innerRect.Right > ClientRectangle.Right)
                             {
                                 innerRect.Width -= (innerRect.Right - ClientRectangle.Right);
@@ -644,79 +784,290 @@ namespace Krypton.Toolkit
                                 innerRect.X = ClientRectangle.Right;
                             }
                         }
-                        break;
+                            break;
 
-                    case VisualOrientation.Left:
-                    case VisualOrientation.Right:
+                        case VisualOrientation.Left:
+                        case VisualOrientation.Right:
                         {
                             int height = innerRect.Height;
+                            float pixelsPerUnit = height / (float)maximumRange;
 
-                            innerRect.Y += (int)(ratio * height * lower);
-                            innerRect.Height = (int)(ratio * height * higher);
-                            // Now do special clipping handling for curved borders
+                            innerRect.Y += (int)(pixelsPerUnit * lowerUnits);
+                            innerRect.Height = (int)(pixelsPerUnit * (upperUnits - lowerUnits));
                             if (innerRect.Bottom > ClientRectangle.Bottom)
                             {
                                 innerRect.Height -= (innerRect.Bottom - ClientRectangle.Bottom);
                             }
-
                             if (innerRect.Y > ClientRectangle.Bottom)
                             {
                                 innerRect.Y = ClientRectangle.Bottom;
                             }
                         }
-                        break;
+                            break;
+                    }
+
+                    using (GraphicsPath valueLozengePath = renderer.RenderStandardBorder.GetBackPath(renderContext,
+                            innerRect,
+                            barPaletteState.PaletteBorder!,
+                            Orientation,
+                            barState))
+                    {
+                        using var gh = new GraphicsHint(renderContext.Graphics,
+                            barPaletteState.PaletteBorder.GetBorderGraphicsHint(PaletteState.Normal));
+                        _mementoBackProgressValue = renderer.RenderStandardBack.DrawBack(renderContext, innerRect, valueLozengePath, _stateBackValue,
+                            Orientation, barState, _mementoBackProgressValue);
+                    }
+                    break;
                 }
-            }
-            else
-            {
-                // Draw the value offset
-                float v = (Value - Minimum);
-                float ratio = v / maximumRange;
-                switch (Orientation)
+
+                case ProgressBarStyle.Blocks:
                 {
-                    case VisualOrientation.Top:
-                    case VisualOrientation.Bottom:
-                        innerRect.Width = (int)(ratio * innerRect.Width);
-                        if (RightToLeft == RightToLeft.Yes)
+                    float v = (Value - Minimum);
+                    float ratio = maximumRange == 0 ? 0f : v / maximumRange;
+                    int totalBlocks = _blockCount > 0 ? _blockCount : Math.Max(1, maximumRange / 10);
+                    float filledBlocksFloat = ratio * totalBlocks;
+                    int fullBlocks = Math.Max(0, Math.Min(totalBlocks, (int)Math.Floor(filledBlocksFloat)));
+                    float fractional = Math.Max(0f, Math.Min(1f, filledBlocksFloat - fullBlocks));
+                    bool rtl = RightToLeft == RightToLeft.Yes;
+
+                    switch (Orientation)
+                    {
+                        case VisualOrientation.Top:
+                        case VisualOrientation.Bottom:
                         {
-                            innerRect.X = ClientRectangle.Right - innerRect.Width;
+                            Rectangle barRect = ClientRectangle;
+                            int gap = Math.Max(1, Math.Min(3, barRect.Height / 6));
+                            int blockWidth = Math.Max(1, (barRect.Width - ((totalBlocks - 1) * gap)) / totalBlocks);
+                            // Draw full blocks
+                            for (int i = 0; i < fullBlocks; i++)
+                            {
+                                int x = rtl
+                                    ? barRect.Right - ((i + 1) * blockWidth) - (i * gap)
+                                    : barRect.Left + (i * (blockWidth + gap));
+                                Rectangle block = new Rectangle(x, barRect.Y, blockWidth, barRect.Height);
+                                using (GraphicsPath path = renderer.RenderStandardBorder.GetBackPath(renderContext, block,
+                                        barPaletteState.PaletteBorder!, Orientation, barState))
+                                {
+                                    using var gh = new GraphicsHint(renderContext.Graphics,
+                                        barPaletteState.PaletteBorder.GetBorderGraphicsHint(PaletteState.Normal));
+                                    _mementoBackProgressValue = renderer.RenderStandardBack.DrawBack(renderContext, block, path, _stateBackValue,
+                                        Orientation, barState, _mementoBackProgressValue);
+                                }
+                            }
+                            // Draw partial last block if needed
+                            if (fractional > 0f && fullBlocks < totalBlocks)
+                            {
+                                int i = fullBlocks;
+                                int fractionWidth = Math.Max(1, (int)Math.Round(blockWidth * fractional, MidpointRounding.AwayFromZero));
+                                int xBase = rtl
+                                    ? barRect.Right - ((i + 1) * blockWidth) - (i * gap)
+                                    : barRect.Left + (i * (blockWidth + gap));
+                                int x = rtl ? xBase + (blockWidth - fractionWidth) : xBase;
+                                Rectangle block = new Rectangle(x, barRect.Y, fractionWidth, barRect.Height);
+                                using (GraphicsPath path = renderer.RenderStandardBorder.GetBackPath(renderContext, block,
+                                        barPaletteState.PaletteBorder!, Orientation, barState))
+                                {
+                                    using var gh = new GraphicsHint(renderContext.Graphics,
+                                        barPaletteState.PaletteBorder.GetBorderGraphicsHint(PaletteState.Normal));
+                                    _mementoBackProgressValue = renderer.RenderStandardBack.DrawBack(renderContext, block, path, _stateBackValue,
+                                        Orientation, barState, _mementoBackProgressValue);
+                                }
+                            }
                         }
+                            break;
 
-                        break;
-
-                    case VisualOrientation.Left:
-                    case VisualOrientation.Right:
-                        innerRect.Height = (int)(ratio * innerRect.Height);
-                        if (RightToLeft == RightToLeft.Yes)
+                        case VisualOrientation.Left:
+                        case VisualOrientation.Right:
                         {
-                            innerRect.Y = ClientRectangle.Bottom - innerRect.Height;
+                            Rectangle barRect = ClientRectangle;
+                            int gap = Math.Max(1, Math.Min(3, barRect.Width / 6));
+                            int blockHeight = Math.Max(1, (barRect.Height - ((totalBlocks - 1) * gap)) / totalBlocks);
+                            // Draw full blocks
+                            for (int i = 0; i < fullBlocks; i++)
+                            {
+                                int y = rtl
+                                    ? barRect.Bottom - ((i + 1) * blockHeight) - (i * gap)
+                                    : barRect.Top + (i * (blockHeight + gap));
+                                Rectangle block = new Rectangle(barRect.X, y, barRect.Width, blockHeight);
+                                using (GraphicsPath path = renderer.RenderStandardBorder.GetBackPath(renderContext, block,
+                                        barPaletteState.PaletteBorder!, Orientation, barState))
+                                {
+                                    using var gh = new GraphicsHint(renderContext.Graphics,
+                                        barPaletteState.PaletteBorder.GetBorderGraphicsHint(PaletteState.Normal));
+                                    _mementoBackProgressValue = renderer.RenderStandardBack.DrawBack(renderContext, block, path, _stateBackValue,
+                                        Orientation, barState, _mementoBackProgressValue);
+                                }
+                            }
+                            // Draw partial last block if needed
+                            if (fractional > 0f && fullBlocks < totalBlocks)
+                            {
+                                int i = fullBlocks;
+                                int fractionHeight = Math.Max(1, (int)Math.Round(blockHeight * fractional, MidpointRounding.AwayFromZero));
+                                int yBase = rtl
+                                    ? barRect.Bottom - ((i + 1) * blockHeight) - (i * gap)
+                                    : barRect.Top + (i * (blockHeight + gap));
+                                int y = rtl ? yBase + (blockHeight - fractionHeight) : yBase;
+                                Rectangle block = new Rectangle(barRect.X, y, barRect.Width, fractionHeight);
+                                using (GraphicsPath path = renderer.RenderStandardBorder.GetBackPath(renderContext, block,
+                                        barPaletteState.PaletteBorder!, Orientation, barState))
+                                {
+                                    using var gh = new GraphicsHint(renderContext.Graphics,
+                                        barPaletteState.PaletteBorder.GetBorderGraphicsHint(PaletteState.Normal));
+                                    _mementoBackProgressValue = renderer.RenderStandardBack.DrawBack(renderContext, block, path, _stateBackValue,
+                                        Orientation, barState, _mementoBackProgressValue);
+                                }
+                            }
                         }
-
-                        break;
+                            break;
+                    }
+                    break;
                 }
-            }
 
-            using (GraphicsPath valueLozengePath = renderer.RenderStandardBorder.GetBackPath(renderContext,
-                       innerRect,
-                       barPaletteState.PaletteBorder!,
-                       Orientation,
-                       barState))
-            {
-                using var gh = new GraphicsHint(renderContext.Graphics,
-                    barPaletteState.PaletteBorder.GetBorderGraphicsHint(PaletteState.Normal));
-                // Ask renderer to Fill the Progress lozenge
-                _mementoBackProgressValue = renderer.RenderStandardBack.DrawBack(renderContext, innerRect, valueLozengePath, _stateBackValue,
-                    Orientation, barState, _mementoBackProgressValue);
+                default: // Continuous
+                {
+                    float v = (Value - Minimum);
+                    float ratio = maximumRange == 0 ? 0f : v / maximumRange;
+                    switch (Orientation)
+                    {
+                        case VisualOrientation.Top:
+                        case VisualOrientation.Bottom:
+                            innerRect.Width = (int)(ratio * innerRect.Width);
+                            if (RightToLeft == RightToLeft.Yes)
+                            {
+                                innerRect.X = ClientRectangle.Right - innerRect.Width;
+                            }
+                            break;
+
+                        case VisualOrientation.Left:
+                        case VisualOrientation.Right:
+                            innerRect.Height = (int)(ratio * innerRect.Height);
+                            if (RightToLeft == RightToLeft.Yes)
+                            {
+                                innerRect.Y = ClientRectangle.Bottom - innerRect.Height;
+                            }
+                            break;
+                    }
+
+                    using (GraphicsPath valueLozengePath = renderer.RenderStandardBorder.GetBackPath(renderContext,
+                            innerRect,
+                            barPaletteState.PaletteBorder!,
+                            Orientation,
+                            barState))
+                    {
+                        using var gh = new GraphicsHint(renderContext.Graphics,
+                            barPaletteState.PaletteBorder.GetBorderGraphicsHint(PaletteState.Normal));
+                        _mementoBackProgressValue = renderer.RenderStandardBack.DrawBack(renderContext, innerRect, valueLozengePath, _stateBackValue,
+                            Orientation, barState, _mementoBackProgressValue);
+                    }
+                    break;
+                }
             }
 
             // Now we draw the border of the inner area
             renderer.RenderStandardBorder.DrawBorder(renderContext, ClientRectangle, barPaletteState.PaletteBorder,
                 Orientation, barState);
 
-            // Last of all we draw the content over the top of the border and background
+            // Optional text backdrop for readability
+            if (_showTextBackdrop && !string.IsNullOrEmpty(Text))
+            {
+                // Use the exact short-text rectangle from the content memento to match DrawContent
+                var textRect = renderer.RenderStandardContent.GetContentShortTextRectangle(_mementoContent!);
+                var backRect = Rectangle.Inflate(textRect, 6, 2);
+
+                using (GraphicsPath gp = new GraphicsPath())
+                {
+                    int r = Math.Min(backRect.Height, 10);
+                    var arc = new Rectangle(backRect.X, backRect.Y, r, r);
+                    gp.AddArc(arc, 180, 90);
+                    arc.X = backRect.Right - r; gp.AddArc(arc, 270, 90);
+                    arc.Y = backRect.Bottom - r; gp.AddArc(arc, 0, 90);
+                    arc.X = backRect.X; gp.AddArc(arc, 90, 90);
+                    gp.CloseFigure();
+
+                    Color fill = _textBackdropColor != Color.Empty ? _textBackdropColor : Color.FromArgb(150, Color.White);
+                    using (var b = new SolidBrush(fill))
+                    {
+                        renderContext.Graphics.FillPath(b, gp);
+                    }
+                    using (var p = new Pen(Color.FromArgb(100, ControlPaint.Dark(fill)), 1f))
+                    {
+                        renderContext.Graphics.DrawPath(p, gp);
+                    }
+                }
+            }
+
+            // Last of all we draw a shadow underneath the text using the same rect as DrawContent
+            if (_showTextShadow && !string.IsNullOrEmpty(Text))
+            {
+                Rectangle shadowRect = renderer.RenderStandardContent.GetContentShortTextRectangle(_mementoContent!);
+                // Compensate for GDI+ rotation rounding when drawing vertical text shadows
+                if (Orientation == VisualOrientation.Left)
+                {
+                    shadowRect.Offset(1, 0);
+                }
+                else if (Orientation == VisualOrientation.Right)
+                {
+                    shadowRect.Offset(-1, 0);
+                }
+
+                var hAlign = barPaletteState.PaletteContent!.GetContentShortTextH(barState);
+                var vAlign = barPaletteState.PaletteContent!.GetContentShortTextV(barState);
+
+                TextFormatFlags flags = TextFormatFlags.NoPadding | TextFormatFlags.NoClipping;
+                flags |= hAlign switch
+                {
+                    PaletteRelativeAlign.Center => TextFormatFlags.HorizontalCenter,
+                    PaletteRelativeAlign.Far => TextFormatFlags.Right,
+                    _ => TextFormatFlags.Left
+                };
+                flags |= vAlign switch
+                {
+                    PaletteRelativeAlign.Center => TextFormatFlags.VerticalCenter,
+                    PaletteRelativeAlign.Far => TextFormatFlags.Bottom,
+                    _ => TextFormatFlags.Top
+                };
+
+                Color baseText = barPaletteState.PaletteContent!.GetContentShortTextColor1(barState);
+                Color shadow = _textShadowColor != Color.Empty ? _textShadowColor : ControlPaint.Dark(baseText);
+                shadow = Color.FromArgb(160, shadow);
+                var textFont = barPaletteState.PaletteContent!.GetContentShortTextFont(barState) ?? Font;
+
+                using (var brush = new SolidBrush(shadow))
+                {
+                    // Build an AccurateText memento matching the real content draw
+                    var paletteContent = barPaletteState.PaletteContent!;
+                    var hint = paletteContent.GetContentShortTextHint(barState);
+                    var trim = paletteContent.GetContentShortTextTrim(barState);
+                    var prefix = paletteContent.GetContentShortTextPrefix(barState);
+                    var renderingHint = CommonHelper.PaletteTextHintToRenderingHint(hint);
+
+                    using var memento = AccurateText.MeasureString(renderContext.Graphics,
+                        RightToLeft,
+                        Text,
+                        textFont,
+                        trim,
+                        hAlign,
+                        prefix,
+                        renderingHint,
+                        false);
+
+                    // Ensure drawing hint matches the main text draw
+                    using (var drawHint = new GraphicsTextHint(renderContext.Graphics, renderingHint))
+                    {
+                        AccurateText.DrawString(renderContext.Graphics,
+                            brush,
+                            shadowRect,
+                            RightToLeft,
+                            Orientation,
+                            barState,
+                            memento);
+                    }
+                }
+            }
+
             renderer.RenderStandardContent.DrawContent(renderContext, ClientRectangle,
-                    barPaletteState.PaletteContent!, _mementoContent!,
-                    Orientation, barState, false);
+                barPaletteState.PaletteContent!, _mementoContent!,
+                Orientation, barState, false);
 
             base.OnPaint(e);
         }
@@ -743,7 +1094,7 @@ namespace Krypton.Toolkit
             // Unhook events from old palette
             if (_palette != null)
             {
-                _palette.PalettePaint -= OnPalettePaint;
+                _palette.PalettePaint -= OnPalettePaint!;
             }
 
             // Cache the new PaletteBase that is the global palette
@@ -753,7 +1104,7 @@ namespace Krypton.Toolkit
             // Hook into events for the new palette
             if (_palette != null)
             {
-                _palette.PalettePaint += OnPalettePaint;
+                _palette.PalettePaint += OnPalettePaint!;
             }
 
             // Change of palette means we should repaint to show any changes

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonProgressBar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonProgressBar.cs
@@ -836,7 +836,7 @@ namespace Krypton.Toolkit
                         case VisualOrientation.Bottom:
                         {
                             Rectangle barRect = ClientRectangle;
-                            int gap = Math.Max(1, Math.Min(3, barRect.Height / 6));
+                            int gap = 1;//Math.Max(1, Math.Min(2, barRect.Height / 6));
                             int blockWidth = Math.Max(1, (barRect.Width - ((totalBlocks - 1) * gap)) / totalBlocks);
                             // Draw full blocks
                             for (int i = 0; i < fullBlocks; i++)
@@ -845,8 +845,7 @@ namespace Krypton.Toolkit
                                     ? barRect.Right - ((i + 1) * blockWidth) - (i * gap)
                                     : barRect.Left + (i * (blockWidth + gap));
                                 Rectangle block = new Rectangle(x, barRect.Y, blockWidth, barRect.Height);
-                                using (GraphicsPath path = renderer.RenderStandardBorder.GetBackPath(renderContext, block,
-                                        barPaletteState.PaletteBorder!, Orientation, barState))
+                                using (GraphicsPath path = CreateRectGraphicsPath(block))
                                 {
                                     using var gh = new GraphicsHint(renderContext.Graphics,
                                         barPaletteState.PaletteBorder.GetBorderGraphicsHint(PaletteState.Normal));
@@ -864,8 +863,7 @@ namespace Krypton.Toolkit
                                     : barRect.Left + (i * (blockWidth + gap));
                                 int x = rtl ? xBase + (blockWidth - fractionWidth) : xBase;
                                 Rectangle block = new Rectangle(x, barRect.Y, fractionWidth, barRect.Height);
-                                using (GraphicsPath path = renderer.RenderStandardBorder.GetBackPath(renderContext, block,
-                                        barPaletteState.PaletteBorder!, Orientation, barState))
+                                using (GraphicsPath path = CreateRectGraphicsPath(block))
                                 {
                                     using var gh = new GraphicsHint(renderContext.Graphics,
                                         barPaletteState.PaletteBorder.GetBorderGraphicsHint(PaletteState.Normal));
@@ -880,7 +878,7 @@ namespace Krypton.Toolkit
                         case VisualOrientation.Right:
                         {
                             Rectangle barRect = ClientRectangle;
-                            int gap = Math.Max(1, Math.Min(3, barRect.Width / 6));
+                            int gap = 1;//Math.Max(1, Math.Min(2, barRect.Width / 6));
                             int blockHeight = Math.Max(1, (barRect.Height - ((totalBlocks - 1) * gap)) / totalBlocks);
                             // Draw full blocks
                             for (int i = 0; i < fullBlocks; i++)
@@ -889,8 +887,7 @@ namespace Krypton.Toolkit
                                     ? barRect.Bottom - ((i + 1) * blockHeight) - (i * gap)
                                     : barRect.Top + (i * (blockHeight + gap));
                                 Rectangle block = new Rectangle(barRect.X, y, barRect.Width, blockHeight);
-                                using (GraphicsPath path = renderer.RenderStandardBorder.GetBackPath(renderContext, block,
-                                        barPaletteState.PaletteBorder!, Orientation, barState))
+                                using (GraphicsPath path = CreateRectGraphicsPath(block))
                                 {
                                     using var gh = new GraphicsHint(renderContext.Graphics,
                                         barPaletteState.PaletteBorder.GetBorderGraphicsHint(PaletteState.Normal));
@@ -908,8 +905,7 @@ namespace Krypton.Toolkit
                                     : barRect.Top + (i * (blockHeight + gap));
                                 int y = rtl ? yBase + (blockHeight - fractionHeight) : yBase;
                                 Rectangle block = new Rectangle(barRect.X, y, barRect.Width, fractionHeight);
-                                using (GraphicsPath path = renderer.RenderStandardBorder.GetBackPath(renderContext, block,
-                                        barPaletteState.PaletteBorder!, Orientation, barState))
+                                using (GraphicsPath path = CreateRectGraphicsPath(block))
                                 {
                                     using var gh = new GraphicsHint(renderContext.Graphics,
                                         barPaletteState.PaletteBorder.GetBorderGraphicsHint(PaletteState.Normal));
@@ -972,7 +968,7 @@ namespace Krypton.Toolkit
             {
                 // Use the exact short-text rectangle from the content memento to match DrawContent
                 var textRect = renderer.RenderStandardContent.GetContentShortTextRectangle(_mementoContent!);
-                var backRect = Rectangle.Inflate(textRect, 6, 2);
+                var backRect = Rectangle.Inflate(textRect, 2, 2);
 
                 using (GraphicsPath gp = new GraphicsPath())
                 {
@@ -1000,15 +996,6 @@ namespace Krypton.Toolkit
             if (_showTextShadow && !string.IsNullOrEmpty(Text))
             {
                 Rectangle shadowRect = renderer.RenderStandardContent.GetContentShortTextRectangle(_mementoContent!);
-                // Compensate for GDI+ rotation rounding when drawing vertical text shadows
-                if (Orientation == VisualOrientation.Left)
-                {
-                    shadowRect.Offset(1, 0);
-                }
-                else if (Orientation == VisualOrientation.Right)
-                {
-                    shadowRect.Offset(-1, 0);
-                }
 
                 var hAlign = barPaletteState.PaletteContent!.GetContentShortTextH(barState);
                 var vAlign = barPaletteState.PaletteContent!.GetContentShortTextV(barState);

--- a/Source/Krypton Components/TestForm/ProgressBarTest.Designer.cs
+++ b/Source/Krypton Components/TestForm/ProgressBarTest.Designer.cs
@@ -1,9 +1,9 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2024. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -39,30 +39,55 @@ namespace TestForm
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ProgressBarTest));
             this.kryptonPanel1 = new Krypton.Toolkit.KryptonPanel();
+            this.kryptonLabel1 = new Krypton.Toolkit.KryptonLabel();
             this.kcbtnProgressBarColour = new Krypton.Toolkit.KryptonColorButton();
             this.kcmbProgressBarStyle = new Krypton.Toolkit.KryptonComboBox();
+            this.klblColorStyle = new Krypton.Toolkit.KryptonLabel();
+            this.kcmbColorStyle = new Krypton.Toolkit.KryptonComboBox();
+            this.kchkShowTextBackdrop = new Krypton.Toolkit.KryptonCheckBox();
+            this.kcbtnBackdropColor = new Krypton.Toolkit.KryptonColorButton();
             this.kchkUseProgressValueAsText = new Krypton.Toolkit.KryptonCheckBox();
             this.ktrkProgressValues = new Krypton.Toolkit.KryptonTrackBar();
+            this.kryptonProgressBarVert2 = new Krypton.Toolkit.KryptonProgressBar();
+            this.kryptonProgressBarVert1 = new Krypton.Toolkit.KryptonProgressBar();
             this.kryptonProgressBar2 = new Krypton.Toolkit.KryptonProgressBar();
             this.kryptonProgressBar1 = new Krypton.Toolkit.KryptonProgressBar();
+            this.kchkShowTextShadow = new Krypton.Toolkit.KryptonCheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).BeginInit();
             this.kryptonPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.kcmbProgressBarStyle)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kcmbColorStyle)).BeginInit();
             this.SuspendLayout();
             // 
             // kryptonPanel1
             // 
+            this.kryptonPanel1.Controls.Add(this.kchkShowTextShadow);
+            this.kryptonPanel1.Controls.Add(this.kryptonLabel1);
             this.kryptonPanel1.Controls.Add(this.kcbtnProgressBarColour);
             this.kryptonPanel1.Controls.Add(this.kcmbProgressBarStyle);
+            this.kryptonPanel1.Controls.Add(this.klblColorStyle);
+            this.kryptonPanel1.Controls.Add(this.kcmbColorStyle);
+            this.kryptonPanel1.Controls.Add(this.kchkShowTextBackdrop);
+            this.kryptonPanel1.Controls.Add(this.kcbtnBackdropColor);
             this.kryptonPanel1.Controls.Add(this.kchkUseProgressValueAsText);
             this.kryptonPanel1.Controls.Add(this.ktrkProgressValues);
+            this.kryptonPanel1.Controls.Add(this.kryptonProgressBarVert2);
+            this.kryptonPanel1.Controls.Add(this.kryptonProgressBarVert1);
             this.kryptonPanel1.Controls.Add(this.kryptonProgressBar2);
             this.kryptonPanel1.Controls.Add(this.kryptonProgressBar1);
             this.kryptonPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonPanel1.Location = new System.Drawing.Point(0, 0);
             this.kryptonPanel1.Name = "kryptonPanel1";
-            this.kryptonPanel1.Size = new System.Drawing.Size(483, 183);
+            this.kryptonPanel1.Size = new System.Drawing.Size(567, 265);
             this.kryptonPanel1.TabIndex = 0;
+            // 
+            // kryptonLabel1
+            // 
+            this.kryptonLabel1.Location = new System.Drawing.Point(197, 120);
+            this.kryptonLabel1.Name = "kryptonLabel1";
+            this.kryptonLabel1.Size = new System.Drawing.Size(87, 20);
+            this.kryptonLabel1.TabIndex = 21;
+            this.kryptonLabel1.Values.Text = "Progress Style";
             // 
             // kcbtnProgressBarColour
             // 
@@ -82,17 +107,60 @@ namespace TestForm
             this.kcmbProgressBarStyle.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.kcmbProgressBarStyle.DropDownWidth = 261;
             this.kcmbProgressBarStyle.IntegralHeight = false;
-            this.kcmbProgressBarStyle.Location = new System.Drawing.Point(208, 117);
+            this.kcmbProgressBarStyle.Location = new System.Drawing.Point(290, 117);
             this.kcmbProgressBarStyle.Name = "kcmbProgressBarStyle";
-            this.kcmbProgressBarStyle.Size = new System.Drawing.Size(261, 21);
+            this.kcmbProgressBarStyle.Size = new System.Drawing.Size(179, 22);
             this.kcmbProgressBarStyle.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
             this.kcmbProgressBarStyle.TabIndex = 15;
             this.kcmbProgressBarStyle.SelectedIndexChanged += new System.EventHandler(this.kcmbProgressBarStyle_SelectedIndexChanged);
             // 
+            // klblColorStyle
+            // 
+            this.klblColorStyle.Location = new System.Drawing.Point(197, 146);
+            this.klblColorStyle.Name = "klblColorStyle";
+            this.klblColorStyle.Size = new System.Drawing.Size(70, 20);
+            this.klblColorStyle.TabIndex = 17;
+            this.klblColorStyle.Values.Text = "Color Style";
+            // 
+            // kcmbColorStyle
+            // 
+            this.kcmbColorStyle.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.kcmbColorStyle.DropDownWidth = 179;
+            this.kcmbColorStyle.IntegralHeight = false;
+            this.kcmbColorStyle.Location = new System.Drawing.Point(290, 146);
+            this.kcmbColorStyle.Name = "kcmbColorStyle";
+            this.kcmbColorStyle.Size = new System.Drawing.Size(179, 22);
+            this.kcmbColorStyle.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
+            this.kcmbColorStyle.TabIndex = 18;
+            this.kcmbColorStyle.SelectedIndexChanged += new System.EventHandler(this.kcmbColorStyle_SelectedIndexChanged);
+            // 
+            // kchkShowTextBackdrop
+            // 
+            this.kchkShowTextBackdrop.Location = new System.Drawing.Point(17, 191);
+            this.kchkShowTextBackdrop.Name = "kchkShowTextBackdrop";
+            this.kchkShowTextBackdrop.Size = new System.Drawing.Size(132, 20);
+            this.kchkShowTextBackdrop.TabIndex = 19;
+            this.kchkShowTextBackdrop.Values.Text = "Show text backdrop";
+            this.kchkShowTextBackdrop.CheckedChanged += new System.EventHandler(this.kchkShowTextBackdrop_CheckedChanged);
+            // 
+            // kcbtnBackdropColor
+            // 
+            this.kcbtnBackdropColor.CustomColorPreviewShape = Krypton.Toolkit.KryptonColorButtonCustomColorPreviewShape.Circle;
+            this.kcbtnBackdropColor.Location = new System.Drawing.Point(12, 217);
+            this.kcbtnBackdropColor.Name = "kcbtnBackdropColor";
+            this.kcbtnBackdropColor.SelectedColor = System.Drawing.Color.WhiteSmoke;
+            this.kcbtnBackdropColor.Size = new System.Drawing.Size(179, 25);
+            this.kcbtnBackdropColor.TabIndex = 20;
+            this.kcbtnBackdropColor.Values.Image = ((System.Drawing.Image)(resources.GetObject("kcbtnBackdropColor.Values.Image")));
+            this.kcbtnBackdropColor.Values.RoundedCorners = 8;
+            this.kcbtnBackdropColor.Values.Text = "Text Backdrop Colour";
+            this.kcbtnBackdropColor.SelectedColorChanged += new System.EventHandler<Krypton.Toolkit.ColorEventArgs>(this.kcbtnBackdropColor_SelectedColorChanged);
+            // 
             // kchkUseProgressValueAsText
             // 
-            this.kchkUseProgressValueAsText.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.kchkUseProgressValueAsText.Location = new System.Drawing.Point(15, 116);
+            this.kchkUseProgressValueAsText.Checked = true;
+            this.kchkUseProgressValueAsText.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.kchkUseProgressValueAsText.Location = new System.Drawing.Point(17, 116);
             this.kchkUseProgressValueAsText.Name = "kchkUseProgressValueAsText";
             this.kchkUseProgressValueAsText.Size = new System.Drawing.Size(165, 20);
             this.kchkUseProgressValueAsText.TabIndex = 14;
@@ -101,44 +169,108 @@ namespace TestForm
             // 
             // ktrkProgressValues
             // 
-            this.ktrkProgressValues.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.ktrkProgressValues.Location = new System.Drawing.Point(15, 77);
+            this.ktrkProgressValues.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.ktrkProgressValues.Location = new System.Drawing.Point(13, 77);
             this.ktrkProgressValues.Maximum = 100;
             this.ktrkProgressValues.Name = "ktrkProgressValues";
-            this.ktrkProgressValues.Size = new System.Drawing.Size(456, 33);
+            this.ktrkProgressValues.Size = new System.Drawing.Size(468, 33);
             this.ktrkProgressValues.TabIndex = 13;
             this.ktrkProgressValues.TickStyle = System.Windows.Forms.TickStyle.Both;
             this.ktrkProgressValues.ValueChanged += new System.EventHandler(this.ktrkProgressValues_ValueChanged);
             // 
+            // kryptonProgressBarVert2
+            // 
+            this.kryptonProgressBarVert2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.kryptonProgressBarVert2.Enabled = false;
+            this.kryptonProgressBarVert2.Location = new System.Drawing.Point(528, 13);
+            this.kryptonProgressBarVert2.Name = "kryptonProgressBarVert2";
+            this.kryptonProgressBarVert2.Orientation = Krypton.Toolkit.VisualOrientation.Right;
+            this.kryptonProgressBarVert2.Size = new System.Drawing.Size(30, 240);
+            this.kryptonProgressBarVert2.StateCommon.Back.Color1 = System.Drawing.Color.Green;
+            this.kryptonProgressBarVert2.StateDisabled.Back.ColorStyle = Krypton.Toolkit.PaletteColorStyle.OneNote;
+            this.kryptonProgressBarVert2.StateNormal.Back.ColorStyle = Krypton.Toolkit.PaletteColorStyle.OneNote;
+            this.kryptonProgressBarVert2.TabIndex = 23;
+            this.kryptonProgressBarVert2.Text = "75%";
+            this.kryptonProgressBarVert2.TextBackdropColor = System.Drawing.Color.Empty;
+            this.kryptonProgressBarVert2.TextShadowColor = System.Drawing.Color.Empty;
+            this.kryptonProgressBarVert2.UseValueAsText = true;
+            this.kryptonProgressBarVert2.Value = 75;
+            this.kryptonProgressBarVert2.Values.Text = "75%";
+            // 
+            // kryptonProgressBarVert1
+            // 
+            this.kryptonProgressBarVert1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.kryptonProgressBarVert1.Location = new System.Drawing.Point(492, 13);
+            this.kryptonProgressBarVert1.Name = "kryptonProgressBarVert1";
+            this.kryptonProgressBarVert1.Orientation = Krypton.Toolkit.VisualOrientation.Right;
+            this.kryptonProgressBarVert1.Size = new System.Drawing.Size(30, 240);
+            this.kryptonProgressBarVert1.StateCommon.Back.Color1 = System.Drawing.Color.Green;
+            this.kryptonProgressBarVert1.StateDisabled.Back.ColorStyle = Krypton.Toolkit.PaletteColorStyle.OneNote;
+            this.kryptonProgressBarVert1.StateNormal.Back.ColorStyle = Krypton.Toolkit.PaletteColorStyle.OneNote;
+            this.kryptonProgressBarVert1.TabIndex = 22;
+            this.kryptonProgressBarVert1.Text = "75%";
+            this.kryptonProgressBarVert1.TextBackdropColor = System.Drawing.Color.Empty;
+            this.kryptonProgressBarVert1.TextShadowColor = System.Drawing.Color.Empty;
+            this.kryptonProgressBarVert1.UseValueAsText = true;
+            this.kryptonProgressBarVert1.Value = 75;
+            this.kryptonProgressBarVert1.Values.Text = "75%";
+            // 
             // kryptonProgressBar2
             // 
+            this.kryptonProgressBar2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.kryptonProgressBar2.Enabled = false;
             this.kryptonProgressBar2.Location = new System.Drawing.Point(13, 45);
             this.kryptonProgressBar2.Name = "kryptonProgressBar2";
-            this.kryptonProgressBar2.Size = new System.Drawing.Size(456, 26);
+            this.kryptonProgressBar2.Size = new System.Drawing.Size(468, 26);
             this.kryptonProgressBar2.StateCommon.Back.Color1 = System.Drawing.Color.Green;
             this.kryptonProgressBar2.StateDisabled.Back.ColorStyle = Krypton.Toolkit.PaletteColorStyle.OneNote;
             this.kryptonProgressBar2.StateNormal.Back.ColorStyle = Krypton.Toolkit.PaletteColorStyle.OneNote;
             this.kryptonProgressBar2.TabIndex = 1;
-            this.kryptonProgressBar2.Values.Text = "";
+            this.kryptonProgressBar2.Text = "75%";
+            this.kryptonProgressBar2.TextBackdropColor = System.Drawing.Color.Empty;
+            this.kryptonProgressBar2.TextShadowColor = System.Drawing.Color.Empty;
+            this.kryptonProgressBar2.UseValueAsText = true;
+            this.kryptonProgressBar2.Value = 75;
+            this.kryptonProgressBar2.Values.Text = "75%";
             // 
             // kryptonProgressBar1
             // 
+            this.kryptonProgressBar1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.kryptonProgressBar1.Location = new System.Drawing.Point(13, 13);
             this.kryptonProgressBar1.Name = "kryptonProgressBar1";
-            this.kryptonProgressBar1.Size = new System.Drawing.Size(456, 26);
+            this.kryptonProgressBar1.Size = new System.Drawing.Size(468, 26);
             this.kryptonProgressBar1.StateCommon.Back.Color1 = System.Drawing.Color.Green;
             this.kryptonProgressBar1.StateDisabled.Back.ColorStyle = Krypton.Toolkit.PaletteColorStyle.OneNote;
             this.kryptonProgressBar1.StateNormal.Back.ColorStyle = Krypton.Toolkit.PaletteColorStyle.OneNote;
             this.kryptonProgressBar1.TabIndex = 0;
-            this.kryptonProgressBar1.Values.Text = "";
+            this.kryptonProgressBar1.Text = "75%";
+            this.kryptonProgressBar1.TextBackdropColor = System.Drawing.Color.Empty;
+            this.kryptonProgressBar1.TextShadowColor = System.Drawing.Color.Empty;
+            this.kryptonProgressBar1.UseValueAsText = true;
+            this.kryptonProgressBar1.Value = 75;
+            this.kryptonProgressBar1.Values.Text = "75%";
+            // 
+            // kchkShowTextShadow
+            // 
+            this.kchkShowTextShadow.Location = new System.Drawing.Point(197, 191);
+            this.kchkShowTextShadow.Name = "kchkShowTextShadow";
+            this.kchkShowTextShadow.Size = new System.Drawing.Size(122, 20);
+            this.kchkShowTextShadow.TabIndex = 24;
+            this.kchkShowTextShadow.Values.Text = "Show text shadow";
+            this.kchkShowTextShadow.CheckedChanged += new System.EventHandler(this.kchkShowTextShadow_CheckedChanged);
             // 
             // ProgressBarTest
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(483, 183);
+            this.ClientSize = new System.Drawing.Size(567, 265);
             this.Controls.Add(this.kryptonPanel1);
+            this.MinimumSize = new System.Drawing.Size(500, 290);
             this.Name = "ProgressBarTest";
             this.Text = "ProgressBarTest";
             this.Load += new System.EventHandler(this.ProgressBarTest_Load);
@@ -146,6 +278,7 @@ namespace TestForm
             this.kryptonPanel1.ResumeLayout(false);
             this.kryptonPanel1.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.kcmbProgressBarStyle)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kcmbColorStyle)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -159,5 +292,13 @@ namespace TestForm
         private Krypton.Toolkit.KryptonTrackBar ktrkProgressValues;
         private Krypton.Toolkit.KryptonComboBox kcmbProgressBarStyle;
         private Krypton.Toolkit.KryptonColorButton kcbtnProgressBarColour;
+        private Krypton.Toolkit.KryptonLabel klblColorStyle;
+        private Krypton.Toolkit.KryptonComboBox kcmbColorStyle;
+        private Krypton.Toolkit.KryptonCheckBox kchkShowTextBackdrop;
+        private Krypton.Toolkit.KryptonColorButton kcbtnBackdropColor;
+        private KryptonLabel kryptonLabel1;
+        private Krypton.Toolkit.KryptonProgressBar kryptonProgressBarVert1;
+        private Krypton.Toolkit.KryptonProgressBar kryptonProgressBarVert2;
+        private KryptonCheckBox kchkShowTextShadow;
     }
 }

--- a/Source/Krypton Components/TestForm/ProgressBarTest.cs
+++ b/Source/Krypton Components/TestForm/ProgressBarTest.cs
@@ -1,59 +1,125 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2024. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
+ *
  */
 #endregion
 
-namespace TestForm
+namespace TestForm;
+
+public partial class ProgressBarTest : KryptonForm
 {
-    public partial class ProgressBarTest : KryptonForm
+    public ProgressBarTest()
     {
-        public ProgressBarTest()
+        InitializeComponent();
+        ktrkProgressValues.Value = 75;
+    }
+
+    private void ProgressBarTest_Load(object sender, EventArgs e)
+    {
+        foreach (var value in Enum.GetValues(typeof(ProgressBarStyle)))
         {
-            InitializeComponent();
+            kcmbProgressBarStyle.Items.Add(value);
         }
 
-        private void ProgressBarTest_Load(object sender, EventArgs e)
-        {
-            foreach (var value in Enum.GetValues(typeof(ProgressBarStyle)))
-            {
-                kcmbProgressBarStyle.Items.Add(value);
-            }
+        kcmbProgressBarStyle.SelectedIndex = 1;
 
-            kcmbProgressBarStyle.SelectedIndex = 1;
+        foreach (var value in Enum.GetValues(typeof(PaletteColorStyle)))
+        {
+            kcmbColorStyle.Items.Add(value);
         }
 
-        private void ktrkProgressValues_ValueChanged(object sender, EventArgs e)
-        {
-            kryptonProgressBar1.Value = ktrkProgressValues.Value;
+        kcmbColorStyle.SelectedItem = PaletteColorStyle.GlassNormalFull;
+    }
 
-            kryptonProgressBar2.Value = ktrkProgressValues.Value;
-        }
+    private void ktrkProgressValues_ValueChanged(object sender, EventArgs e)
+    {
+        kryptonProgressBar1.Value = ktrkProgressValues.Value;
 
-        private void kchkUseProgressValueAsText_CheckedChanged(object sender, EventArgs e)
-        {
-            kryptonProgressBar1.UseValueAsText = kchkUseProgressValueAsText.Checked;
+        kryptonProgressBar2.Value = ktrkProgressValues.Value;
 
-            kryptonProgressBar2.UseValueAsText = kchkUseProgressValueAsText.Checked;
-        }
+        kryptonProgressBarVert1.Value = ktrkProgressValues.Value;
 
-        private void kcmbProgressBarStyle_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            kryptonProgressBar1.Style =
-                (ProgressBarStyle)Enum.Parse(typeof(ProgressBarStyle), kcmbProgressBarStyle.Text);
+        kryptonProgressBarVert2.Value = ktrkProgressValues.Value;
+    }
 
-            kryptonProgressBar2.Style =
-                (ProgressBarStyle)Enum.Parse(typeof(ProgressBarStyle), kcmbProgressBarStyle.Text);
-        }
+    private void kchkUseProgressValueAsText_CheckedChanged(object sender, EventArgs e)
+    {
+        kryptonProgressBar1.UseValueAsText = kchkUseProgressValueAsText.Checked;
 
-        private void kcbtnProgressBarColour_SelectedColorChanged(object sender, ColorEventArgs e)
-        {
-            kryptonProgressBar1.StateCommon.Back.Color1 = e.Color;
+        kryptonProgressBar2.UseValueAsText = kchkUseProgressValueAsText.Checked;
+    }
 
-            kryptonProgressBar2.StateCommon.Back.Color1 = e.Color;
-        }
+    private void kcmbProgressBarStyle_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        kryptonProgressBar1.Style =
+            (ProgressBarStyle)Enum.Parse(typeof(ProgressBarStyle), kcmbProgressBarStyle.Text);
+
+        kryptonProgressBar2.Style =
+            (ProgressBarStyle)Enum.Parse(typeof(ProgressBarStyle), kcmbProgressBarStyle.Text);
+
+        kryptonProgressBarVert1.Style =
+            (ProgressBarStyle)Enum.Parse(typeof(ProgressBarStyle), kcmbProgressBarStyle.Text);
+
+        kryptonProgressBarVert2.Style =
+            (ProgressBarStyle)Enum.Parse(typeof(ProgressBarStyle), kcmbProgressBarStyle.Text);
+    }
+
+    private void kcbtnProgressBarColour_SelectedColorChanged(object sender, ColorEventArgs e)
+    {
+        kryptonProgressBar1.StateCommon.Back.Color1 = e.Color;
+
+        kryptonProgressBar2.StateCommon.Back.Color1 = e.Color;
+
+        kryptonProgressBarVert1.StateCommon.Back.Color1 = e.Color;
+
+        kryptonProgressBarVert2.StateCommon.Back.Color1 = e.Color;
+    }
+
+    private void kcmbColorStyle_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        var style = (PaletteColorStyle)Enum.Parse(typeof(PaletteColorStyle), kcmbColorStyle.Text);
+        kryptonProgressBar1.ValueBackColorStyle = style;
+
+        kryptonProgressBar2.ValueBackColorStyle = style;
+
+        kryptonProgressBarVert1.ValueBackColorStyle = style;
+
+        kryptonProgressBarVert2.ValueBackColorStyle = style;
+    }
+
+    private void kchkShowTextBackdrop_CheckedChanged(object sender, EventArgs e)
+    {
+        kryptonProgressBar1.ShowTextBackdrop = kchkShowTextBackdrop.Checked;
+
+        kryptonProgressBar2.ShowTextBackdrop = kchkShowTextBackdrop.Checked;
+
+        kryptonProgressBarVert1.ShowTextBackdrop = kchkShowTextBackdrop.Checked;
+
+        kryptonProgressBarVert2.ShowTextBackdrop = kchkShowTextBackdrop.Checked;
+    }
+
+    private void kchkShowTextShadow_CheckedChanged(object sender, EventArgs e)
+    {
+        kryptonProgressBar1.ShowTextShadow = kchkShowTextShadow.Checked;
+
+        kryptonProgressBar2.ShowTextShadow = kchkShowTextShadow.Checked;
+
+        kryptonProgressBarVert1.ShowTextShadow = kchkShowTextShadow.Checked;
+
+        kryptonProgressBarVert2.ShowTextShadow = kchkShowTextShadow.Checked;
+    }
+
+    private void kcbtnBackdropColor_SelectedColorChanged(object sender, ColorEventArgs e)
+    {
+        kryptonProgressBar1.TextBackdropColor = e.Color;
+
+        kryptonProgressBar2.TextBackdropColor = e.Color;
+
+        kryptonProgressBarVert1.TextBackdropColor = e.Color;
+
+        kryptonProgressBarVert2.TextBackdropColor = e.Color;
     }
 }

--- a/Source/Krypton Components/TestForm/ProgressBarTest.resx
+++ b/Source/Krypton Components/TestForm/ProgressBarTest.resx
@@ -121,7 +121,14 @@
   <data name="kcbtnProgressBarColour.Values.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
-        DwAACw8BkvkDpQAAAAd0SU1FB9gBEgI0L+a2mIYAAAATSURBVDhPYxgFo2AUjAIwYGAAAAQQAAGnRHxj
+        DAAACwwBP0AiyAAAAAd0SU1FB9gBEgI0L+a2mIYAAAATSURBVDhPYxgFo2AUjAIwYGAAAAQQAAGnRHxj
+        AAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="kcbtnBackdropColor.Values.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        DAAACwwBP0AiyAAAAAd0SU1FB9gBEgI0L+a2mIYAAAATSURBVDhPYxgFo2AUjAIwYGAAAAQQAAGnRHxj
         AAAAAElFTkSuQmCC
 </value>
   </data>


### PR DESCRIPTION
Fixes #2406 - Sibling of #2413 (V100)

Includes updated progressbar demo page for `TestForm`.

<img width="849" height="308" alt="{66D5352B-169A-4517-A759-81900EC40B31}" src="https://github.com/user-attachments/assets/9391fd8c-ff3c-4e7c-b600-7263fa26923f" />
