### PR TITLE
2406 V100 Fix KryptonProgressBar blocks to be squared (regression)

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonProgressBar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonProgressBar.cs
@@ -705,15 +705,15 @@ public class KryptonProgressBar : Control, IContentValues
     /// <inheritdoc />
     protected override void OnPaint(PaintEventArgs e)
     {
-		// If no palette is available, fall back to base painting
-		if (_palette == null)
-		{
-			base.OnPaint(e);
-			return;
-		}
+        // If no palette is available, fall back to base painting
+        if (_palette == null)
+        {
+            base.OnPaint(e);
+            return;
+        }
 
-		// Get the renderer associated with this palette
-		IRenderer renderer = _palette!.GetRenderer();
+        // Get the renderer associated with this palette
+        IRenderer renderer = _palette!.GetRenderer();
 
         // Create the rendering context that is passed into all renderer calls
         using var renderContext = new RenderContext(this, e.Graphics, e.ClipRectangle, renderer);


### PR DESCRIPTION
Fix PR for #2406 (no new changelog entry)

- Small fix to paint blocks as squares and not with rounded corners.
- Smaller gaps between blocks.
- Removed undesirable offset in vertical shadow text.
- Fixed a section of leading tab characters back to spaces.