### PR TITLE
2442 V100 (feat) Dynamic theme colors in KryptonColorButton (and related components).

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 ====
 
 ## 2025-11-xx - Build 2511 (V10 - alpha) - November 2025
+* Implemented [#2442](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2442), `KryptonColorButton` and related components with `PaletteColors` mode.
 * Implemented [#984](https://github.com/Krypton-Suite/Standard-Toolkit/issues/984), `KryptonForm` using `SizeGripStyle` for grippie.
 	- **Note:** This has a breaking change for custom themes as a new abstract method is introduced in the `PaletteBase` class for sizegrip images!
 * Implemented [#2396](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2396), Added ModernBuild terminal.gui app to solution

--- a/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupClusterColorButton.cs
+++ b/Source/Krypton Components/Krypton.Ribbon/Group Contents/KryptonRibbonGroupClusterColorButton.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
+ *
  *  Modified: Monday 12th April, 2021 @ 18:00 GMT
  *
  */
@@ -56,6 +56,7 @@ public class KryptonRibbonGroupClusterColorButton : KryptonRibbonGroupItem
     private ColorScheme _schemeStandard;
     private int _maxRecentColors;
     private readonly List<Color> _recentColors;
+    private Krypton.Toolkit.ThemeColorSortMode _themeColorSortMode;
 
     // Context menu items
     private readonly KryptonContextMenu? _kryptonContextMenu;
@@ -159,6 +160,9 @@ public class KryptonRibbonGroupClusterColorButton : KryptonRibbonGroupItem
         _maxRecentColors = 10;
         _recentColors = [];
 
+        // Defaults for dynamic theme color mapping
+        _themeColorSortMode = Krypton.Toolkit.ThemeColorSortMode.OKLCH;
+
         // Create the context menu items
         _kryptonContextMenu = new KryptonContextMenu();
         _separatorTheme = new KryptonContextMenuSeparator();
@@ -185,10 +189,36 @@ public class KryptonRibbonGroupClusterColorButton : KryptonRibbonGroupItem
             _separatorNoColor, _itemsNoColor,
             _separatorMoreColors, _itemsMoreColors
         ]);
+
+        // Listen for palette switches so we can refresh dynamic theme colors
+        Krypton.Toolkit.KryptonManager.GlobalPaletteChanged += OnGlobalPaletteChangedForThemeColors;
     }
     #endregion
 
     #region Public
+    /// <summary>
+    /// Sorting used when generating the dynamic Theme Colors map from SchemeColors.
+    /// </summary>
+    [Category(@"Ribbon")]
+    [Description(@"Sorting used for dynamic Theme Colors map from SchemeColors.")]
+    [DefaultValue(Krypton.Toolkit.ThemeColorSortMode.RGB)]
+    public Krypton.Toolkit.ThemeColorSortMode ThemeColorSortMode
+    {
+        get => _themeColorSortMode;
+
+        set
+        {
+            if (_themeColorSortMode != value)
+            {
+                _themeColorSortMode = value;
+                if (_schemeThemes == ColorScheme.PaletteColors)
+                {
+                    RefreshThemeColorsFromActivePalette();
+                }
+                OnPropertyChanged(nameof(ThemeColorSortMode));
+            }
+        }
+    }
     /// <summary>
     /// Gets and sets the selected color.
     /// </summary>
@@ -908,7 +938,7 @@ public class KryptonRibbonGroupClusterColorButton : KryptonRibbonGroupItem
 
                         var contextArgs = new ContextMenuArgs(_kryptonContextMenu);
 
-                        // Generate an event giving a chance for the krypton context menu strip to 
+                        // Generate an event giving a chance for the krypton context menu strip to
                         // be shown to be provided/modified or the action even to be cancelled
                         DropDown?.Invoke(this, contextArgs);
 
@@ -988,7 +1018,7 @@ public class KryptonRibbonGroupClusterColorButton : KryptonRibbonGroupItem
 
     internal override bool ProcessCmdKey(ref Message msg, Keys keyData)
     {
-        // Only interested in key processing if this button definition 
+        // Only interested in key processing if this button definition
         // is enabled and itself and all parents are also visible
         if (Enabled && ChainVisible)
         {
@@ -1070,7 +1100,7 @@ public class KryptonRibbonGroupClusterColorButton : KryptonRibbonGroupItem
         // Do we need to update the recent colors' collection?
         if (AutoRecentColors)
         {
-            // We do not add to recent colors if it is inside another color columns 
+            // We do not add to recent colors if it is inside another color columns
             foreach (var item in _kryptonContextMenu!.Items)
             {
                 // Only interested in the non-recent colors' color columns
@@ -1131,15 +1161,26 @@ public class KryptonRibbonGroupClusterColorButton : KryptonRibbonGroupItem
         _itemsNoColor.Visible = _visibleNoColor;
         _itemsMoreColors.Visible = _visibleMoreColors;
 
+        var usingPaletteColors = _schemeThemes == ColorScheme.PaletteColors;
+
         // Define the display strings
-        _headingTheme.Text = KryptonManager.Strings.RibbonStrings.ThemeColors;
+        _headingTheme.Text = usingPaletteColors
+            ? KryptonManager.Strings.RibbonStrings.PaletteColors
+            : KryptonManager.Strings.RibbonStrings.ThemeColors;
         _headingStandard.Text = KryptonManager.Strings.RibbonStrings.StandardColors;
         _headingRecent.Text = KryptonManager.Strings.RibbonStrings.RecentColors;
         _itemNoColor.Text = KryptonManager.Strings.RibbonStrings.NoColor;
         _itemMoreColors.Text = KryptonManager.Strings.RibbonStrings.MoreColors;
 
         // Define the colors used in the first two color schemes
-        _colorsTheme.ColorScheme = SchemeThemes;
+        if (usingPaletteColors)
+        {
+            RefreshThemeColorsFromActivePalette();
+        }
+        else
+        {
+            _colorsTheme.ColorScheme = SchemeThemes;
+        }
         _colorsStandard.ColorScheme = SchemeStandard;
 
         // Define the recent colors
@@ -1163,6 +1204,33 @@ public class KryptonRibbonGroupClusterColorButton : KryptonRibbonGroupItem
 
         // Should the no color entry be checked?
         _itemNoColor.Checked = _selectedColor.Equals(Color.Empty);
+    }
+
+    /// <summary>
+    /// Handle global palette changes to keep Theme Colors in sync when using SchemeColors.
+    /// </summary>
+    private void OnGlobalPaletteChangedForThemeColors(object? sender, EventArgs e)
+    {
+        if (_schemeThemes == ColorScheme.PaletteColors)
+        {
+            RefreshThemeColorsFromActivePalette();
+        }
+    }
+
+    /// <summary>
+    /// Refresh the Theme Colors grid from the active palette's SchemeColors.
+    /// </summary>
+    private void RefreshThemeColorsFromActivePalette()
+    {
+        var palette = Krypton.Toolkit.KryptonManager.CurrentGlobalPalette;
+        if (palette is null)
+        {
+            return;
+        }
+
+        var custom = Krypton.Toolkit.ThemeColorGridBuilder.BuildThemeColorColumns(palette.GetSchemeColors(), _themeColorSortMode, 16);
+        _colorsTheme.SetCustomColors(custom);
+        _colorsTheme.GroupNonFirstRows = true;
     }
 
     private void DecideOnVisible(KryptonContextMenuItemBase visible, KryptonContextMenuItemBase target)
@@ -1225,6 +1293,13 @@ public class KryptonRibbonGroupClusterColorButton : KryptonRibbonGroupItem
                 SelectedColor = cd.Color;
             }
         }
+    }
+
+    private void OnClickPaletteColors(object? sender, EventArgs e)
+    {
+        _schemeThemes = _schemeThemes == ColorScheme.PaletteColors ? ColorScheme.OfficeThemes : ColorScheme.PaletteColors;
+        _kryptonContextMenu?.Close();
+        Ribbon?.BeginInvoke(new Action(() => PerformDropDown()));
     }
 
     private void OnKryptonContextMenuClosed(object? sender, EventArgs e)

--- a/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuColorColumns.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ContextMenu/KryptonContextMenuColorColumns.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -55,7 +55,7 @@ public class KryptonContextMenuColorColumns : KryptonContextMenuItemBase
         [Color.Cyan,    Color.Teal],
         [Color.Blue,    Color.Navy],
         [Color.Fuchsia, Color.Purple]
-    ]; 
+    ];
 
     private static readonly Color[][] _officeStandardScheme =
     [
@@ -70,7 +70,7 @@ public class KryptonContextMenuColorColumns : KryptonContextMenuItemBase
         [Color.FromArgb(  0,  32,  96)],
         [Color.FromArgb(112,  48, 160)]
     ];
-    
+
     private static readonly Color[][] _officeThemeScheme =
     [
         [Color.White,                   Color.FromArgb(242, 242, 242), Color.FromArgb(216, 216, 216), Color.FromArgb(191, 191, 191), Color.FromArgb(165, 165, 165), Color.Gray
@@ -203,7 +203,7 @@ public class KryptonContextMenuColorColumns : KryptonContextMenuItemBase
     {
         get => _autoClose;
 
-        set 
+        set
         {
             if (_autoClose != value)
             {
@@ -267,7 +267,7 @@ public class KryptonContextMenuColorColumns : KryptonContextMenuItemBase
     {
         get => _blockSize;
 
-        set 
+        set
         {
             if (_blockSize != value)
             {
@@ -288,7 +288,7 @@ public class KryptonContextMenuColorColumns : KryptonContextMenuItemBase
     {
         get => _groupNonFirstRows;
 
-        set 
+        set
         {
             if (_groupNonFirstRows != value)
             {
@@ -390,8 +390,20 @@ public class KryptonContextMenuColorColumns : KryptonContextMenuItemBase
             ColorScheme.Basic16 => _basic16Scheme,
             ColorScheme.OfficeStandard => _officeStandardScheme,
             ColorScheme.OfficeThemes => _officeThemeScheme,
+            ColorScheme.PaletteColors => BuildPaletteColorsFallback(),
             _ => Colors
         };
+    }
+
+    private static Color[][] BuildPaletteColorsFallback()
+    {
+        var palette = KryptonManager.CurrentGlobalPalette;
+        if (palette == null)
+        {
+            return _officeStandardScheme;
+        }
+        var custom = ThemeColorGridBuilder.BuildThemeColorColumns(palette.GetSchemeColors(), ThemeColorSortMode.OKLCH, 16);
+        return custom.Length == 0 ? _noneScheme : custom;
     }
     #endregion
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonColorDialog.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonColorDialog.cs
@@ -1,8 +1,8 @@
 ﻿#region BSD License
 /*
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2021 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2021 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -74,7 +74,8 @@ public class KryptonColorDialog : ColorDialog
         _alphaUpdateTimer = new System.Windows.Forms.Timer();
         _alphaUpdateTimer.Enabled = false;
         _alphaUpdateTimer.Tick += Timer1OnTick;
-        _commonDialogHandler = new CommonDialogHandler(true)
+        // No embedding or dialog will stall!
+        _commonDialogHandler = new CommonDialogHandler(false)
         {
             ClickCallback = ClickCallback,
             Icon = DialogImageResources.Colour_V10,
@@ -123,7 +124,7 @@ public class KryptonColorDialog : ColorDialog
     private bool _showAlphaSlider;
 
     /// <summary>
-    /// Allows an alpha slider to be displayed 
+    /// Allows an alpha slider to be displayed
     /// </summary>
     /// <remarks>
     /// Will force FullOpen to be true if set.
@@ -274,7 +275,7 @@ public class KryptonColorDialog : ColorDialog
                     //_commonDialogHandler._wrapperForm.ClientSize
                     _alphaSlider.Size = new Size(_commonDialogHandler._wrapperForm.ClientSize.Width - _alphaSlider.Location.X + 4, _blueEdit.ClientLocation.Y - _redEdit.ClientLocation.Y + _blueEdit.Size.Height);
                     _commonDialogHandler._wrapperForm.Controls[0].Controls.Add(_alphaSlider);
-                    // Find the Add button 
+                    // Find the Add button
                     var btnAdd = _commonDialogHandler.Controls.First(static ctl => ctl.DlgCtrlId == 0x00002C8);
                     btnAdd.Button!.Parent!.Width -= 16;
 

--- a/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/Definitions.cs
@@ -2,9 +2,9 @@
 /*
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Gidua, Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
  */
 #endregion
 
@@ -1635,7 +1635,24 @@ public enum ColorScheme
     /// <summary>
     /// Specifies the Office set of 10 color themes.
     /// </summary>
-    OfficeThemes
+    OfficeThemes,
+
+    /// <summary>
+    /// Specifies dynamic colors sourced from the active palette's SchemeColors.
+    /// </summary>
+    PaletteColors
+}
+#endregion
+
+#region Enum ThemeColorSortMode
+/// <summary>
+/// Sorting options for dynamic Theme Colors generated from the active palette SchemeColors.
+/// </summary>
+public enum ThemeColorSortMode
+{
+    OKLCH,
+    HSB,
+    RGB
 }
 #endregion
 
@@ -1698,7 +1715,7 @@ public enum KryptonTaskDialogResult
     Yes = KryptonMessageBoxResult.Yes,
     /// <summary>The "No" button was selected.</summary>
     No = KryptonMessageBoxResult.No,
-    /// <summary>The "Retry" button was selected.</summary>b
+    /// <summary>The "Retry" button was selected.</summary>
     Retry = KryptonMessageBoxResult.Retry,
     /// <summary>The "Abort" button was selected.</summary>
     Abort = KryptonMessageBoxResult.Abort,
@@ -1856,7 +1873,7 @@ public enum PlacementMode
 }
 #endregion Enum PlacementMode
 
-#region MessageBox Definitions 
+#region MessageBox Definitions
 
 #region Enum MessageBoxContentAreaType
 
@@ -2514,7 +2531,7 @@ public enum InformationBoxDefaultButton
     Button1,
 
     /// <summary>
-    /// The second button on the message box is the default button. 
+    /// The second button on the message box is the default button.
     /// </summary>
     Button2,
 

--- a/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteColorButtonStrings.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Palette Controls/PaletteColorButtonStrings.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -24,6 +24,7 @@ public class PaletteColorButtonStrings : Storage
     private const string DEFAULT_RECENT_COLORS = "Recent Colors";
     private const string DEFAULT_STANDARD_COLORS = "Standard Colors";
     private const string DEFAULT_THEME_COLORS = "Theme Colors";
+    private const string DEFAULT_PALETTE_COLORS = "Palette Colors";
 
     #endregion
 
@@ -39,6 +40,7 @@ public class PaletteColorButtonStrings : Storage
         RecentColors = DEFAULT_RECENT_COLORS;
         StandardColors = DEFAULT_STANDARD_COLORS;
         ThemeColors = DEFAULT_THEME_COLORS;
+        PaletteColors = DEFAULT_PALETTE_COLORS;
     }
     #endregion
 
@@ -52,7 +54,8 @@ public class PaletteColorButtonStrings : Storage
                                       NoColor.Equals(DEFAULT_NO_COLOR) &&
                                       RecentColors.Equals(DEFAULT_RECENT_COLORS) &&
                                       StandardColors.Equals(DEFAULT_STANDARD_COLORS) &&
-                                      ThemeColors.Equals(DEFAULT_THEME_COLORS);
+                                      ThemeColors.Equals(DEFAULT_THEME_COLORS) &&
+                                      PaletteColors.Equals(DEFAULT_PALETTE_COLORS);
 
     #endregion
 
@@ -118,6 +121,19 @@ public class PaletteColorButtonStrings : Storage
     [DefaultValue("Theme Colors")]
     [RefreshProperties(RefreshProperties.All)]
     public string ThemeColors { get; set; }
+
+    #endregion
+
+    #region PaletteColors
+    /// <summary>
+    /// Gets and sets the title for the palette colors section of the color button menu.
+    /// </summary>
+    [Localizable(true)]
+    [Category(@"Visuals")]
+    [Description(@"Title for palette colors section of the color button menu.")]
+    [DefaultValue("Palette Colors")]
+    [RefreshProperties(RefreshProperties.All)]
+    public string PaletteColors { get; set; }
 
     #endregion
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Translations/Colours/GlobalColorStrings.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Translations/Colours/GlobalColorStrings.cs
@@ -1,9 +1,9 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2023 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2023 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -23,6 +23,7 @@ public class GlobalColorStrings : GlobalId
     private const string DEFAULT_COLORS = @"Colors";
     private const string DEFAULT_MORE_COLORS = @"More Colors ...";
     private const string DEFAULT_THEME_COLORS = @"Theme Colors";
+    private const string DEFAULT_PALETTE_COLORS = @"Palette Colors";
     private const string DEFAULT_STANDARD_COLORS = @"Standard Colors";
     private const string DEFAULT_RECENT_COLORS = @"Recent Colors";
     private const string DEFAULT_NO_COLOR = @"No Color";
@@ -54,6 +55,7 @@ public class GlobalColorStrings : GlobalId
                              Colors.Equals(DEFAULT_COLORS) &&
                              MoreColors.Equals(DEFAULT_MORE_COLORS) &&
                              ThemeColors.Equals(DEFAULT_THEME_COLORS) &&
+                             PaletteColors.Equals(DEFAULT_PALETTE_COLORS) &&
                              StandardColors.Equals(DEFAULT_STANDARD_COLORS) &&
                              RecentColors.Equals(DEFAULT_RECENT_COLORS) &&
                              NoColor.Equals(DEFAULT_NO_COLOR);
@@ -67,6 +69,7 @@ public class GlobalColorStrings : GlobalId
         Colors = DEFAULT_COLORS;
         MoreColors = DEFAULT_MORE_COLORS;
         ThemeColors = DEFAULT_THEME_COLORS;
+        PaletteColors = DEFAULT_PALETTE_COLORS;
         StandardColors = DEFAULT_STANDARD_COLORS;
         RecentColors = DEFAULT_RECENT_COLORS;
         NoColor = DEFAULT_NO_COLOR;
@@ -127,6 +130,14 @@ public class GlobalColorStrings : GlobalId
     [DefaultValue(DEFAULT_NO_COLOR)]
     [RefreshProperties(RefreshProperties.All)]
     public string NoColor { get; set; }
+
+    /// <summary>Gets or sets the palette colors string.</summary>
+    [Localizable(true)]
+    [Category(@"Visuals")]
+    [Description(@"Localised palette colors string.")]
+    [DefaultValue(DEFAULT_PALETTE_COLORS)]
+    [RefreshProperties(RefreshProperties.All)]
+    public string PaletteColors { get; set; }
 
     #endregion
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Translations/General/GeneralRibbonStrings.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Translations/General/GeneralRibbonStrings.cs
@@ -2,7 +2,7 @@
 /*
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
  *
  */
 #endregion
@@ -30,6 +30,7 @@ public class GeneralRibbonStrings : GlobalId
     private const string DEFAULT_SHOW_BELOW_RIBBON = @"&Show Below the Ribbon";
     private const string DEFAULT_STANDARD_COLORS = @"Standard Colors";
     private const string DEFAULT_THEME_COLORS = @"Theme Colors";
+    private const string DEFAULT_PALETTE_COLORS = @"Palette Colors";
 
     #endregion
 
@@ -73,6 +74,7 @@ public class GeneralRibbonStrings : GlobalId
                              ShowQATBelowRibbon.Equals(DEFAULT_SHOW_QAT_BELOW_RIBBON) &&
                              StandardColors.Equals(DEFAULT_STANDARD_COLORS) &&
                              ThemeColors.Equals(DEFAULT_THEME_COLORS) &&
+                             PaletteColors.Equals(DEFAULT_PALETTE_COLORS) &&
                              AppButtonText.Equals(DEFAULT_APPLICATION_BUTTON_TEXT);
 
     #endregion
@@ -222,6 +224,16 @@ public class GeneralRibbonStrings : GlobalId
     public string ThemeColors { get; set; }
 
     /// <summary>
+    /// Gets and sets the title for the palette colors section of the color button menu.
+    /// </summary>
+    [Localizable(true)]
+    [Category(@"Visuals")]
+    [Description(@"Title for palette colors section of the color button menu.")]
+    [DefaultValue(DEFAULT_PALETTE_COLORS)]
+    [RefreshProperties(RefreshProperties.All)]
+    public string PaletteColors { get; set; }
+
+    /// <summary>
     /// Gets and sets the button text for the app button.
     /// </summary>
     [Localizable(true)]
@@ -265,6 +277,8 @@ public class GeneralRibbonStrings : GlobalId
         StandardColors = DEFAULT_STANDARD_COLORS;
 
         ThemeColors = DEFAULT_THEME_COLORS;
+
+        PaletteColors = DEFAULT_PALETTE_COLORS;
     }
 
     #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Utilities/ThemeColorGridBuilder.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Utilities/ThemeColorGridBuilder.cs
@@ -1,0 +1,234 @@
+#region BSD License
+/*
+ *
+ *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), tobitege et al. 2025 - 2025. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+public static class ThemeColorGridBuilder
+{
+    public static Color[][] BuildThemeColorColumns(Color[]? schemeColors, ThemeColorSortMode sortMode, int columns = 16)
+    {
+        if ((schemeColors == null) || (schemeColors.Length == 0))
+        {
+            return Array.Empty<Color[]>();
+        }
+
+        var filtered = schemeColors.Where(static c => !c.IsEmpty && (c.A == 255))
+                                   .GroupBy(static c => c.ToArgb())
+                                   .Select(static g => g.First())
+                                   .ToArray();
+
+        var columnsList = new List<Color>[columns];
+
+        if (sortMode == ThemeColorSortMode.HSB)
+        {
+            const double neutralSatThreshold = 0.18;
+            const int greyDeltaThreshold = 28;
+
+            static bool IsNeutral(Color c)
+            {
+                var max = Math.Max(c.R, Math.Max(c.G, c.B));
+                var min = Math.Min(c.R, Math.Min(c.G, c.B));
+                var spreadIsGrey = (max - min) <= greyDeltaThreshold;
+                var sat = c.GetSaturation();
+                var bri = c.GetBrightness();
+                var isLowSat = sat <= neutralSatThreshold;
+                var isNearWhiteTint = (bri >= 0.92f) && (sat <= 0.35f);
+                return isLowSat || spreadIsGrey || isNearWhiteTint;
+            }
+
+            var neutrals = filtered.Where(IsNeutral)
+                                   .OrderBy(static c => c.GetBrightness())
+                                   .ToList();
+
+            var chroma = filtered.Where(static c => !IsNeutral(c)).ToList();
+
+            var hueBins = new List<Color>[columns];
+            for (var i = 0; i < columns; i++) hueBins[i] = new List<Color>();
+
+            foreach (var color in chroma)
+            {
+                var hue = color.GetHue();
+                var bin = (int)Math.Min(columns - 1, Math.Floor(hue / (360.0 / columns)));
+                hueBins[bin].Add(color);
+            }
+
+            for (var i = 0; i < columns; i++)
+            {
+                hueBins[i] = hueBins[i]
+                    .OrderByDescending(static c => c.GetBrightness())
+                    .ThenBy(static c => c.GetSaturation())
+                    .ToList();
+            }
+
+            var orderedChroma = new List<Color>(filtered.Length);
+            for (var i = 0; i < columns; i++) orderedChroma.AddRange(hueBins[i]);
+
+            var total = orderedChroma.Count + neutrals.Count;
+            var rowsTarget = (int)Math.Ceiling(total / (double)columns);
+
+            var neutralsColumns = (int)Math.Ceiling(neutrals.Count / (double)rowsTarget);
+            var chromaColumns = columns - neutralsColumns;
+            var minChromaCols = (int)Math.Ceiling(orderedChroma.Count / (double)rowsTarget);
+            if (chromaColumns < minChromaCols)
+            {
+                chromaColumns = Math.Min(columns, minChromaCols);
+                neutralsColumns = Math.Max(0, columns - chromaColumns);
+            }
+
+            var offsetChroma = 0;
+            for (var c = 0; c < chromaColumns; c++)
+            {
+                var remaining = orderedChroma.Count - offsetChroma;
+                var take = Math.Min(rowsTarget, Math.Max(remaining, 0));
+                columnsList[c] = take > 0 ? orderedChroma.Skip(offsetChroma).Take(take).ToList() : new List<Color>();
+                offsetChroma += take;
+            }
+
+            var offsetNeutral = 0;
+            for (var c = chromaColumns; c < columns; c++)
+            {
+                var remaining = neutrals.Count - offsetNeutral;
+                var take = Math.Min(rowsTarget, Math.Max(remaining, 0));
+                columnsList[c] = take > 0 ? neutrals.Skip(offsetNeutral).Take(take).ToList() : new List<Color>();
+                offsetNeutral += take;
+            }
+        }
+        else if (sortMode == ThemeColorSortMode.OKLCH)
+        {
+            const double neutralCThreshold = 0.04;
+
+            var lchList = filtered.Select(static c => new { Color = c, Lch = ToOkLch(c) }).ToList();
+
+            var neutrals = lchList.Where(static x => x.Lch.C <= neutralCThreshold)
+                                   .OrderBy(static x => x.Lch.L)
+                                   .Select(static x => x.Color)
+                                   .ToList();
+
+            var chroma = lchList.Where(static x => x.Lch.C > neutralCThreshold).ToList();
+
+            var hueBins = new List<(Color Color, OkLch Lch)>[columns];
+            for (var i = 0; i < columns; i++) hueBins[i] = new List<(Color, OkLch)>();
+
+            foreach (var entry in chroma)
+            {
+                var bin = (int)Math.Min(columns - 1, Math.Floor(entry.Lch.H / (360.0 / columns)));
+                hueBins[bin].Add((entry.Color, entry.Lch));
+            }
+
+            for (var i = 0; i < columns; i++)
+            {
+                hueBins[i] = hueBins[i]
+                    .OrderByDescending(static t => t.Lch.L)
+                    .ThenByDescending(static t => t.Lch.C)
+                    .ToList();
+            }
+
+            var orderedChroma = new List<Color>(filtered.Length);
+            for (var i = 0; i < columns; i++) orderedChroma.AddRange(hueBins[i].Select(static t => t.Color));
+
+            var total = orderedChroma.Count + neutrals.Count;
+            var rowsTarget = (int)Math.Ceiling(total / (double)columns);
+
+            var neutralsColumns = (int)Math.Ceiling(neutrals.Count / (double)rowsTarget);
+            var chromaColumns = columns - neutralsColumns;
+            var minChromaCols = (int)Math.Ceiling(orderedChroma.Count / (double)rowsTarget);
+            if (chromaColumns < minChromaCols)
+            {
+                chromaColumns = Math.Min(columns, minChromaCols);
+                neutralsColumns = Math.Max(0, columns - chromaColumns);
+            }
+
+            var offsetChroma = 0;
+            for (var c = 0; c < chromaColumns; c++)
+            {
+                var remaining = orderedChroma.Count - offsetChroma;
+                var take = Math.Min(rowsTarget, Math.Max(remaining, 0));
+                columnsList[c] = take > 0 ? orderedChroma.Skip(offsetChroma).Take(take).ToList() : new List<Color>();
+                offsetChroma += take;
+            }
+
+            var offsetNeutral = 0;
+            for (var c = chromaColumns; c < columns; c++)
+            {
+                var remaining = neutrals.Count - offsetNeutral;
+                var take = Math.Min(rowsTarget, Math.Max(remaining, 0));
+                columnsList[c] = take > 0 ? neutrals.Skip(offsetNeutral).Take(take).ToList() : new List<Color>();
+                offsetNeutral += take;
+            }
+        }
+        else
+        {
+            var ordered = filtered.OrderBy(static c => c.R)
+                                  .ThenBy(static c => c.G)
+                                  .ThenBy(static c => c.B)
+                                  .ToArray();
+
+            var total = ordered.Length;
+            var rowsTarget = (int)Math.Ceiling(total / (double)columns);
+            var offset = 0;
+            for (var c = 0; c < columns; c++)
+            {
+                var remaining = total - offset;
+                var take = Math.Min(rowsTarget, Math.Max(remaining, 0));
+                columnsList[c] = take > 0 ? ordered.Skip(offset).Take(take).ToList() : new List<Color>();
+                offset += take;
+            }
+        }
+
+        var rows = columnsList.Max(static list => list?.Count ?? 0);
+        var custom = new Color[columns][];
+        for (var c = 0; c < columns; c++)
+        {
+            var colList = columnsList[c] ?? new List<Color>();
+            custom[c] = new Color[rows];
+            for (var r = 0; r < rows; r++)
+            {
+                custom[c][r] = r < colList.Count ? colList[r] : Color.Empty;
+            }
+        }
+
+        return custom;
+    }
+
+    private struct OkLch
+    {
+        public double L;
+        public double C;
+        public double H;
+    }
+
+    private static OkLch ToOkLch(Color color)
+    {
+        double sr = color.R / 255.0;
+        double sg = color.G / 255.0;
+        double sb = color.B / 255.0;
+
+        double r = sr <= 0.04045 ? sr / 12.92 : Math.Pow((sr + 0.055) / 1.055, 2.4);
+        double g = sg <= 0.04045 ? sg / 12.92 : Math.Pow((sg + 0.055) / 1.055, 2.4);
+        double b = sb <= 0.04045 ? sb / 12.92 : Math.Pow((sb + 0.055) / 1.055, 2.4);
+
+        double l = 0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b;
+        double m = 0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b;
+        double s = 0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b;
+
+        double l_ = l > 0 ? Math.Pow(l, 1.0 / 3.0) : 0;
+        double m_ = m > 0 ? Math.Pow(m, 1.0 / 3.0) : 0;
+        double s_ = s > 0 ? Math.Pow(s, 1.0 / 3.0) : 0;
+
+        double L = 0.2104542553 * l_ + 0.7936177850 * m_ - 0.0040720468 * s_;
+        double A = 1.9779984951 * l_ - 2.4285922050 * m_ + 0.4505937099 * s_;
+        double B = 0.0259040371 * l_ + 0.7827717662 * m_ - 0.8086757660 * s_;
+
+        double C = Math.Sqrt(A * A + B * B);
+        double H = Math.Atan2(B, A) * (180.0 / Math.PI);
+        if (H < 0) H += 360.0;
+
+        return new OkLch { L = L, C = C, H = H };
+    }
+}

--- a/Source/Krypton Components/TestForm/ButtonsTest.Designer.cs
+++ b/Source/Krypton Components/TestForm/ButtonsTest.Designer.cs
@@ -1,9 +1,9 @@
 ﻿#region BSD License
 /*
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2024 - 2025. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2024 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -39,6 +39,10 @@ namespace TestForm
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ButtonsTest));
             this.kryptonPanel1 = new Krypton.Toolkit.KryptonPanel();
+            this.kryptonLabel2 = new Krypton.Toolkit.KryptonLabel();
+            this.kcbColorScheme = new Krypton.Toolkit.KryptonComboBox();
+            this.kryptonLabel1 = new Krypton.Toolkit.KryptonLabel();
+            this.kcbSortMode = new Krypton.Toolkit.KryptonComboBox();
             this.kbtnButtonStyles = new Krypton.Toolkit.KryptonButton();
             this.kryptonThemeComboBox1 = new Krypton.Toolkit.KryptonThemeComboBox();
             this.kryptonColorButton1 = new Krypton.Toolkit.KryptonColorButton();
@@ -49,8 +53,8 @@ namespace TestForm
             this.kryptonContextMenuItem1 = new Krypton.Toolkit.KryptonContextMenuItem();
             this.kryptonCommand1 = new Krypton.Toolkit.KryptonCommand();
             this.kryptonContextMenuItem2 = new Krypton.Toolkit.KryptonContextMenuItem();
-            this.kryptonCommand2 = new Krypton.Toolkit.KryptonCommand();
             this.kryptonContextMenuItem3 = new Krypton.Toolkit.KryptonContextMenuItem();
+            this.kryptonCommand2 = new Krypton.Toolkit.KryptonCommand();
             this.kryptonButton6 = new Krypton.Toolkit.KryptonButton();
             this.kryptonButton7 = new Krypton.Toolkit.KryptonButton();
             this.kryptonButton8 = new Krypton.Toolkit.KryptonButton();
@@ -61,11 +65,17 @@ namespace TestForm
             this.buttonSpecAny1 = new Krypton.Toolkit.ButtonSpecAny();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).BeginInit();
             this.kryptonPanel1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.kcbColorScheme)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kcbSortMode)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonThemeComboBox1)).BeginInit();
             this.SuspendLayout();
             // 
             // kryptonPanel1
             // 
+            this.kryptonPanel1.Controls.Add(this.kryptonLabel2);
+            this.kryptonPanel1.Controls.Add(this.kcbColorScheme);
+            this.kryptonPanel1.Controls.Add(this.kryptonLabel1);
+            this.kryptonPanel1.Controls.Add(this.kcbSortMode);
             this.kryptonPanel1.Controls.Add(this.kbtnButtonStyles);
             this.kryptonPanel1.Controls.Add(this.kryptonThemeComboBox1);
             this.kryptonPanel1.Controls.Add(this.kryptonColorButton1);
@@ -81,12 +91,63 @@ namespace TestForm
             this.kryptonPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonPanel1.Location = new System.Drawing.Point(0, 0);
             this.kryptonPanel1.Name = "kryptonPanel1";
-            this.kryptonPanel1.Size = new System.Drawing.Size(542, 233);
+            this.kryptonPanel1.Size = new System.Drawing.Size(559, 305);
             this.kryptonPanel1.TabIndex = 0;
+            // 
+            // kryptonLabel2
+            // 
+            this.kryptonLabel2.Location = new System.Drawing.Point(18, 173);
+            this.kryptonLabel2.Name = "kryptonLabel2";
+            this.kryptonLabel2.Size = new System.Drawing.Size(88, 20);
+            this.kryptonLabel2.TabIndex = 6;
+            this.kryptonLabel2.Values.Text = "Color scheme:";
+            // 
+            // kcbColorScheme
+            // 
+            this.kcbColorScheme.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.kcbColorScheme.DropDownWidth = 150;
+            this.kcbColorScheme.Items.AddRange(new object[] {
+            "None",
+            "Mono2",
+            "Mono8",
+            "Basic16",
+            "OfficeStandard",
+            "OfficeThemes",
+            "PaletteColors"});
+            this.kcbColorScheme.Location = new System.Drawing.Point(135, 171);
+            this.kcbColorScheme.Name = "kcbColorScheme";
+            this.kcbColorScheme.Size = new System.Drawing.Size(126, 22);
+            this.kcbColorScheme.TabIndex = 7;
+            this.kcbColorScheme.Text = "OfficeThemes";
+            this.kcbColorScheme.SelectedIndexChanged += new System.EventHandler(this.kcbColorScheme_SelectedIndexChanged);
+            // 
+            // kryptonLabel1
+            // 
+            this.kryptonLabel1.Location = new System.Drawing.Point(18, 201);
+            this.kryptonLabel1.Name = "kryptonLabel1";
+            this.kryptonLabel1.Size = new System.Drawing.Size(149, 20);
+            this.kryptonLabel1.TabIndex = 8;
+            this.kryptonLabel1.Values.Text = "`PaletteColors` sort order:";
+            // 
+            // kcbSortMode
+            // 
+            this.kcbSortMode.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.kcbSortMode.DropDownWidth = 130;
+            this.kcbSortMode.Enabled = false;
+            this.kcbSortMode.Items.AddRange(new object[] {
+            "OKLCH",
+            "HSB",
+            "RGB"});
+            this.kcbSortMode.Location = new System.Drawing.Point(182, 199);
+            this.kcbSortMode.Name = "kcbSortMode";
+            this.kcbSortMode.Size = new System.Drawing.Size(79, 22);
+            this.kcbSortMode.TabIndex = 9;
+            this.kcbSortMode.Text = "OKLCH";
+            this.kcbSortMode.SelectedIndexChanged += new System.EventHandler(this.kcbSortMode_SelectedIndexChanged);
             // 
             // kbtnButtonStyles
             // 
-            this.kbtnButtonStyles.Location = new System.Drawing.Point(140, 196);
+            this.kbtnButtonStyles.Location = new System.Drawing.Point(278, 270);
             this.kbtnButtonStyles.Name = "kbtnButtonStyles";
             this.kbtnButtonStyles.Size = new System.Drawing.Size(243, 25);
             this.kbtnButtonStyles.TabIndex = 10;
@@ -96,25 +157,22 @@ namespace TestForm
             // 
             // kryptonThemeComboBox1
             // 
-            this.kryptonThemeComboBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.kryptonThemeComboBox1.DefaultPalette = Krypton.Toolkit.PaletteMode.Global;
             this.kryptonThemeComboBox1.DropDownWidth = 492;
             this.kryptonThemeComboBox1.IntegralHeight = false;
             this.kryptonThemeComboBox1.Location = new System.Drawing.Point(18, 13);
             this.kryptonThemeComboBox1.Name = "kryptonThemeComboBox1";
-            this.kryptonThemeComboBox1.Size = new System.Drawing.Size(504, 22);
+            this.kryptonThemeComboBox1.Size = new System.Drawing.Size(503, 22);
             this.kryptonThemeComboBox1.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
-            this.kryptonThemeComboBox1.TabIndex = 9;
+            this.kryptonThemeComboBox1.TabIndex = 0;
             // 
             // kryptonColorButton1
             // 
             this.kryptonColorButton1.CustomColorPreviewShape = Krypton.Toolkit.KryptonColorButtonCustomColorPreviewShape.Circle;
             this.kryptonColorButton1.Enabled = false;
-            this.kryptonColorButton1.Location = new System.Drawing.Point(267, 165);
+            this.kryptonColorButton1.Location = new System.Drawing.Point(278, 227);
             this.kryptonColorButton1.Name = "kryptonColorButton1";
             this.kryptonColorButton1.Size = new System.Drawing.Size(243, 25);
-            this.kryptonColorButton1.TabIndex = 8;
+            this.kryptonColorButton1.TabIndex = 15;
             this.kryptonColorButton1.Values.Image = ((System.Drawing.Image)(resources.GetObject("kryptonColorButton1.Values.Image")));
             this.kryptonColorButton1.Values.RoundedCorners = 8;
             this.kryptonColorButton1.Values.Text = "Disabled Drop Down Color";
@@ -122,10 +180,11 @@ namespace TestForm
             // kcbtnDropDown
             // 
             this.kcbtnDropDown.CustomColorPreviewShape = Krypton.Toolkit.KryptonColorButtonCustomColorPreviewShape.Circle;
-            this.kcbtnDropDown.Location = new System.Drawing.Point(18, 165);
+            this.kcbtnDropDown.Location = new System.Drawing.Point(18, 227);
             this.kcbtnDropDown.Name = "kcbtnDropDown";
+            this.kcbtnDropDown.SchemeStandard = Krypton.Toolkit.ColorScheme.OfficeThemes;
             this.kcbtnDropDown.Size = new System.Drawing.Size(243, 25);
-            this.kcbtnDropDown.TabIndex = 7;
+            this.kcbtnDropDown.TabIndex = 5;
             this.kcbtnDropDown.Values.Image = ((System.Drawing.Image)(resources.GetObject("kcbtnDropDown.Values.Image")));
             this.kcbtnDropDown.Values.RoundedCorners = 8;
             this.kcbtnDropDown.Values.Text = "Drop Down Color";
@@ -135,11 +194,11 @@ namespace TestForm
             // 
             this.kryptonButton5.Enabled = false;
             this.kryptonButton5.KryptonContextMenu = this.kryptonContextMenu1;
-            this.kryptonButton5.Location = new System.Drawing.Point(267, 134);
+            this.kryptonButton5.Location = new System.Drawing.Point(278, 134);
             this.kryptonButton5.Name = "kryptonButton5";
             this.kryptonButton5.ShowSplitOption = true;
             this.kryptonButton5.Size = new System.Drawing.Size(243, 25);
-            this.kryptonButton5.TabIndex = 6;
+            this.kryptonButton5.TabIndex = 14;
             this.kryptonButton5.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton5.Values.Image = ((System.Drawing.Image)(resources.GetObject("kryptonButton5.Values.Image")));
             this.kryptonButton5.Values.ShowSplitOption = true;
@@ -149,14 +208,14 @@ namespace TestForm
             // kryptonContextMenu1
             // 
             this.kryptonContextMenu1.Items.AddRange(new Krypton.Toolkit.KryptonContextMenuItemBase[] {
-            ((Krypton.Toolkit.KryptonContextMenuItemBase)(this.kryptonContextMenuItems1))});
+            this.kryptonContextMenuItems1});
             // 
             // kryptonContextMenuItems1
             // 
             this.kryptonContextMenuItems1.Items.AddRange(new Krypton.Toolkit.KryptonContextMenuItemBase[] {
-            ((Krypton.Toolkit.KryptonContextMenuItemBase)(this.kryptonContextMenuItem1)),
-            ((Krypton.Toolkit.KryptonContextMenuItemBase)(this.kryptonContextMenuItem2)),
-            ((Krypton.Toolkit.KryptonContextMenuItemBase)(this.kryptonContextMenuItem3))});
+            this.kryptonContextMenuItem1,
+            this.kryptonContextMenuItem2,
+            this.kryptonContextMenuItem3});
             // 
             // kryptonContextMenuItem1
             // 
@@ -174,23 +233,23 @@ namespace TestForm
             this.kryptonContextMenuItem2.KryptonCommand = this.kryptonCommand1;
             this.kryptonContextMenuItem2.Text = "Choice 2 (Command 1)";
             // 
-            // kryptonCommand2
-            // 
-            this.kryptonCommand2.Execute += new System.EventHandler(this.kryptonCommand1_Execute);
-            // 
             // kryptonContextMenuItem3
             // 
             this.kryptonContextMenuItem3.CommandParameter = "ThisIsCmd2";
             this.kryptonContextMenuItem3.KryptonCommand = this.kryptonCommand2;
             this.kryptonContextMenuItem3.Text = "Choice 3 (Command 2)";
             // 
+            // kryptonCommand2
+            // 
+            this.kryptonCommand2.Execute += new System.EventHandler(this.kryptonCommand1_Execute);
+            // 
             // kryptonButton6
             // 
             this.kryptonButton6.Enabled = false;
-            this.kryptonButton6.Location = new System.Drawing.Point(267, 103);
+            this.kryptonButton6.Location = new System.Drawing.Point(278, 103);
             this.kryptonButton6.Name = "kryptonButton6";
             this.kryptonButton6.Size = new System.Drawing.Size(243, 25);
-            this.kryptonButton6.TabIndex = 4;
+            this.kryptonButton6.TabIndex = 13;
             this.kryptonButton6.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton6.Values.Image = ((System.Drawing.Image)(resources.GetObject("kryptonButton6.Values.Image")));
             this.kryptonButton6.Values.Text = "Disabled UAC Button";
@@ -203,7 +262,7 @@ namespace TestForm
             this.kryptonButton7.Name = "kryptonButton7";
             this.kryptonButton7.ShowSplitOption = true;
             this.kryptonButton7.Size = new System.Drawing.Size(243, 25);
-            this.kryptonButton7.TabIndex = 5;
+            this.kryptonButton7.TabIndex = 4;
             this.kryptonButton7.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton7.Values.Image = ((System.Drawing.Image)(resources.GetObject("kryptonButton7.Values.Image")));
             this.kryptonButton7.Values.ShowSplitOption = true;
@@ -225,10 +284,10 @@ namespace TestForm
             // 
             this.kryptonButton4.Enabled = false;
             this.kryptonButton4.KryptonContextMenu = this.kryptonContextMenu1;
-            this.kryptonButton4.Location = new System.Drawing.Point(267, 72);
+            this.kryptonButton4.Location = new System.Drawing.Point(278, 72);
             this.kryptonButton4.Name = "kryptonButton4";
             this.kryptonButton4.Size = new System.Drawing.Size(243, 25);
-            this.kryptonButton4.TabIndex = 2;
+            this.kryptonButton4.TabIndex = 12;
             this.kryptonButton4.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton4.Values.ShowSplitOption = true;
             this.kryptonButton4.Values.Text = "Disabled Drop Down";
@@ -236,10 +295,10 @@ namespace TestForm
             // kryptonButton2
             // 
             this.kryptonButton2.Enabled = false;
-            this.kryptonButton2.Location = new System.Drawing.Point(267, 41);
+            this.kryptonButton2.Location = new System.Drawing.Point(278, 41);
             this.kryptonButton2.Name = "kryptonButton2";
             this.kryptonButton2.Size = new System.Drawing.Size(243, 25);
-            this.kryptonButton2.TabIndex = 1;
+            this.kryptonButton2.TabIndex = 11;
             this.kryptonButton2.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton2.Values.Text = "Disabled Button";
             // 
@@ -249,7 +308,7 @@ namespace TestForm
             this.kryptonButton3.Location = new System.Drawing.Point(18, 72);
             this.kryptonButton3.Name = "kryptonButton3";
             this.kryptonButton3.Size = new System.Drawing.Size(243, 25);
-            this.kryptonButton3.TabIndex = 1;
+            this.kryptonButton3.TabIndex = 2;
             this.kryptonButton3.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton3.Values.ShowSplitOption = true;
             this.kryptonButton3.Values.Text = "Normal Drop Down";
@@ -259,7 +318,7 @@ namespace TestForm
             this.kryptonButton1.Location = new System.Drawing.Point(18, 41);
             this.kryptonButton1.Name = "kryptonButton1";
             this.kryptonButton1.Size = new System.Drawing.Size(243, 25);
-            this.kryptonButton1.TabIndex = 0;
+            this.kryptonButton1.TabIndex = 1;
             this.kryptonButton1.Values.DropDownArrowColor = System.Drawing.Color.Empty;
             this.kryptonButton1.Values.Text = "Normal Button";
             // 
@@ -273,7 +332,7 @@ namespace TestForm
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ButtonSpecs.Add(this.buttonSpecAny1);
-            this.ClientSize = new System.Drawing.Size(542, 233);
+            this.ClientSize = new System.Drawing.Size(559, 305);
             this.Controls.Add(this.kryptonPanel1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.Fixed3D;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
@@ -281,12 +340,13 @@ namespace TestForm
             this.MinimizeBox = false;
             this.MinimumSize = new System.Drawing.Size(544, 280);
             this.Name = "ButtonsTest";
-            this.ShowIcon = false;
-            this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Buttons Test";
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).EndInit();
             this.kryptonPanel1.ResumeLayout(false);
+            this.kryptonPanel1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.kcbColorScheme)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kcbSortMode)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonThemeComboBox1)).EndInit();
             this.ResumeLayout(false);
 
@@ -309,11 +369,15 @@ namespace TestForm
         private Krypton.Toolkit.KryptonContextMenuItem kryptonContextMenuItem1;
         private Krypton.Toolkit.KryptonContextMenuItem kryptonContextMenuItem2;
         private Krypton.Toolkit.KryptonContextMenuItem kryptonContextMenuItem3;
-        private KryptonColorButton kryptonColorButton1;
-        private ButtonSpecAny buttonSpecAny1;
-        private KryptonThemeComboBox kryptonThemeComboBox1;
-        private KryptonButton kbtnButtonStyles;
-        private KryptonCommand kryptonCommand1;
-        private KryptonCommand kryptonCommand2;
+        private Krypton.Toolkit.KryptonColorButton kryptonColorButton1;
+        private Krypton.Toolkit.ButtonSpecAny buttonSpecAny1;
+        private Krypton.Toolkit.KryptonThemeComboBox kryptonThemeComboBox1;
+        private Krypton.Toolkit.KryptonButton kbtnButtonStyles;
+        private Krypton.Toolkit.KryptonCommand kryptonCommand1;
+        private Krypton.Toolkit.KryptonCommand kryptonCommand2;
+        private Krypton.Toolkit.KryptonComboBox kcbSortMode;
+        private Krypton.Toolkit.KryptonLabel kryptonLabel1;
+        private Krypton.Toolkit.KryptonComboBox kcbColorScheme;
+        private Krypton.Toolkit.KryptonLabel kryptonLabel2;
     }
 }

--- a/Source/Krypton Components/TestForm/ButtonsTest.cs
+++ b/Source/Krypton Components/TestForm/ButtonsTest.cs
@@ -14,6 +14,8 @@ public partial class ButtonsTest : KryptonForm
     public ButtonsTest()
     {
         InitializeComponent();
+        kcbColorScheme.SelectedItem = "OfficeThemes";
+        kcbSortMode.Enabled = false;
     }
 
     private void kcbtnDropDown_SelectedColorChanged(object sender, ColorEventArgs e)
@@ -39,5 +41,27 @@ public partial class ButtonsTest : KryptonForm
         var paramText = item?.CommandParameter is string s ? s : "<no param>";
 
         KryptonMessageBox.Show($"Command executed by:\nType: {typeName}\nParam: {paramText}", "Context Item Called");
+    }
+
+    private void kcbSortMode_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        var text = kcbSortMode.SelectedItem?.ToString();
+        if (!Enum.TryParse<Krypton.Toolkit.ThemeColorSortMode>(text, true, out var mode))
+        {
+            mode = Krypton.Toolkit.ThemeColorSortMode.OKLCH;
+        }
+        kcbtnDropDown.ThemeColorSortMode = mode;
+    }
+
+    private void kcbColorScheme_SelectedIndexChanged(object sender, EventArgs e)
+    {
+        var text = kcbColorScheme.SelectedItem?.ToString();
+        if (!Enum.TryParse<Krypton.Toolkit.ColorScheme>(text, true, out var scheme))
+        {
+            scheme = Krypton.Toolkit.ColorScheme.OfficeThemes;
+        }
+
+        kcbtnDropDown.SchemeThemes = scheme;
+        kcbSortMode.Enabled = scheme == Krypton.Toolkit.ColorScheme.PaletteColors;
     }
 }

--- a/Source/Krypton Components/TestForm/ButtonsTest.resx
+++ b/Source/Krypton Components/TestForm/ButtonsTest.resx
@@ -135,12 +135,6 @@
   <metadata name="kryptonContextMenu1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="kryptonCommand1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>245, 17</value>
-  </metadata>
-  <metadata name="kryptonCommand2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>449, 17</value>
-  </metadata>
   <data name="kryptonButton5.Values.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
@@ -213,6 +207,12 @@
         6bPzse3/DSHfAf2EqkKNe37BAAAAAElFTkSuQmCC
 </value>
   </data>
+  <metadata name="kryptonCommand1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>245, 17</value>
+  </metadata>
+  <metadata name="kryptonCommand2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>449, 17</value>
+  </metadata>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAUAMDAAAAEAIACoJQAAVgAAACAgAAABACAAqBAAAP4lAAAgIAAAAQAIAKgIAACmNgAAEBAAAAEA


### PR DESCRIPTION
Implements #2442 

### Integrate “Palette Colors” into ColorScheme and unify across color pickers

#### Summary
- Added `ColorScheme.PaletteColors` and integrated it into all color button surfaces (WinForms and Ribbon).
- Removed the separate “Palette Colors” toggle path; selection is now driven by the existing `ColorScheme` property.
- When `PaletteColors` is active, color grids are generated dynamically from the active palette’s SchemeColors and auto-refresh on palette change.
- Updated the ButtonsTest form to select the scheme via a combobox and enable sort-mode only for `PaletteColors`.
- Minor cleanup and a small doc fix.

#### Why
The previous “Palette Colors” mode was bolted-on and not aligned with how other schemes are selected. Moving it into `ColorScheme` makes the feature feel native, simplifies configuration, and reduces UI clutter.

#### What changed
- New enum value:
  - `ColorScheme.PaletteColors` (in `Definitions.cs`)
- Context menu color columns:
  - `KryptonContextMenuColorColumns` now understands `PaletteColors` and builds columns from the active palette (via `ThemeColorGridBuilder`), with a safe fallback when no palette is available.
- Color buttons:
  - `KryptonColorButton`, `KryptonRibbonGroupColorButton`, `KryptonRibbonGroupClusterColorButton` integrate `PaletteColors` into `SchemeThemes`.
  - Headings change to localized “Palette Colors” when appropriate.
  - Dynamic refresh occurs on global palette changes when `SchemeThemes == PaletteColors`.

- `TestForm` app -> `Buttons`:
  - Added `kcbColorScheme` combobox to select color scheme.
  - Added `kcbSortMode` specifically only enabled for when `PaletteColors` is selected.
- Misc:
  - Fixed a stray character in XML docs for `KryptonTaskDialogResult` that could break builds.

- **FIX** in `KryptonColorDialog` to disable embedding, which hangs the app!

<img width="361" height="670" alt="image" src="https://github.com/user-attachments/assets/ac3a5ff0-58a9-43e1-bffd-0a2734c8f9af" />
