### PR TITLE
2448-V100-KryptonForm-does-not-display-components

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 ====
 
 ## 2025-11-xx - Build 2511 (V10 - alpha) - November 2025
+* Resolved [#2448](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2448), `KryptonForm` does not display components without designer source.
 * Implemented [#2444](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2444), Add `AGENTS.md` file.
 * Fix [#1199](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1199), Fix exception in `KryptonDropButton` due to wrong DialogResult.
 * Implemented [#2442](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2442), `KryptonColorButton` and related components with `PaletteColors` mode.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -1524,11 +1524,12 @@ public class KryptonForm : VisualForm,
                 }
             }
         }
-        else if (_internalPanelState == InheritBool.Inherit)
+        else if (_internalPanelState == InheritBool.Inherit && !DesignMode)
         {
             // #2448 | Work-around / fix | Only runs on non mdi containers
             // This happens when KForm is instantiated manually without designer source,
             // which runs the layout methods through InitializeComponent.
+            // This block is only to be executed at runtime.
             SuspendLayout();
             ResumeLayout(false);
         }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -1509,16 +1509,28 @@ public class KryptonForm : VisualForm,
     {
         base.OnHandleCreated(e);
 
-        if (IsMdiContainer && !_mdiTransferred)
+        // Differ on MdiContainer first
+        if (IsMdiContainer)
         {
-            SetInheritedControlOverride();
-
-            Control.ControlCollection checkForRibbon = _internalKryptonPanel.Controls;
-
-            for (var i = checkForRibbon.Count - 1; i >= 0; i--)
+            if (!_mdiTransferred)
             {
-                base.Controls.Add(checkForRibbon[i]);
+                SetInheritedControlOverride();
+
+                Control.ControlCollection checkForRibbon = _internalKryptonPanel.Controls;
+
+                for (var i = checkForRibbon.Count - 1; i >= 0; i--)
+                {
+                    base.Controls.Add(checkForRibbon[i]);
+                }
             }
+        }
+        else if (_internalPanelState == InheritBool.Inherit)
+        {
+            // #2448 | Work-around / fix | Only runs on non mdi containers
+            // This happens when KForm is instantiated manually without designer source,
+            // which runs the layout methods through InitializeComponent.
+            SuspendLayout();
+            ResumeLayout(false);
         }
 
         // Register with the ActiveFormTracker


### PR DESCRIPTION
- Issue: #2448
- Small update to 2448 & PR #2449
- Adds a condition so that the code block is excuted only at runtime.