### PR TITLE
2436 V100 Guard GetResolvedPalette nulls; use CurrentGlobalPalette fallback (followup)

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 ====
 
 ## 2025-11-xx - Build 2511 (V10 - alpha) - November 2025
+* Resolved [#2436](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2436), Guard GetResolvedPalette nulls; use CurrentGlobalPalette fallback.
 * Resolved [#2448](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2448), `KryptonForm` does not display components without designer source.
 * Implemented [#2444](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2444), Add `AGENTS.md` file.
 * Fix [#1199](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1199), Fix exception in `KryptonDropButton` due to wrong DialogResult.

--- a/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderBase.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderBase.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Gidua, Ahmed Abdelhameed, tobitege 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
@@ -341,11 +341,12 @@ internal abstract class ViewBuilderBase
         var handled = false;
 
         // Check for shortcut key combinations
+        var palette = Navigator.GetResolvedPalette() ?? KryptonManager.CurrentGlobalPalette;
         if (keyData == Navigator.Button.CloseButtonShortcut)
         {
             // Can only invoke action if there is a close button that is enabled
-            if (Navigator.Button.CloseButton.GetVisible(Navigator.GetResolvedPalette()) &&
-                (Navigator.Button.CloseButton.GetEnabled(Navigator.GetResolvedPalette()) == ButtonEnabled.True))
+            if (Navigator.Button.CloseButton.GetVisible(palette) &&
+                (Navigator.Button.CloseButton.GetEnabled(palette) == ButtonEnabled.True))
             {
                 Navigator.PerformCloseAction();
                 handled = true;
@@ -354,8 +355,8 @@ internal abstract class ViewBuilderBase
         else if (keyData == Navigator.Button.ContextButtonShortcut)
         {
             // Can only invoke action if there is a context button that is enabled
-            if (Navigator.Button.ContextButton.GetVisible(Navigator.GetResolvedPalette()) &&
-                (Navigator.Button.ContextButton.GetEnabled(Navigator.GetResolvedPalette()) == ButtonEnabled.True))
+            if (Navigator.Button.ContextButton.GetVisible(palette) &&
+                (Navigator.Button.ContextButton.GetEnabled(palette) == ButtonEnabled.True))
             {
                 Navigator.PerformContextAction();
                 handled = true;
@@ -364,8 +365,8 @@ internal abstract class ViewBuilderBase
         else if (keyData == Navigator.Button.PreviousButtonShortcut)
         {
             // Can only invoke action if there is a previous button that is enabled
-            if (Navigator.Button.PreviousButton.GetVisible(Navigator.GetResolvedPalette()) &&
-                (Navigator.Button.PreviousButton.GetEnabled(Navigator.GetResolvedPalette()) == ButtonEnabled.True))
+            if (Navigator.Button.PreviousButton.GetVisible(palette) &&
+                (Navigator.Button.PreviousButton.GetEnabled(palette) == ButtonEnabled.True))
             {
                 Navigator.PerformPreviousAction();
                 handled = true;
@@ -374,8 +375,8 @@ internal abstract class ViewBuilderBase
         else if (keyData == Navigator.Button.NextButtonShortcut)
         {
             // Can only invoke action if there is a next button that is enabled
-            if (Navigator.Button.NextButton.GetVisible(Navigator.GetResolvedPalette()) &&
-                (Navigator.Button.NextButton.GetEnabled(Navigator.GetResolvedPalette()) == ButtonEnabled.True))
+            if (Navigator.Button.NextButton.GetVisible(palette) &&
+                (Navigator.Button.NextButton.GetEnabled(palette) == ButtonEnabled.True))
             {
                 Navigator.PerformNextAction();
                 handled = true;

--- a/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderBase.cs
+++ b/Source/Krypton Components/Krypton.Navigator/View Builder/ViewBuilderBase.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Gidua, Ahmed Abdelhameed, tobitege 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege 2017 - 2025. All rights reserved.
  *  
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -2912,7 +2912,7 @@ public class KryptonDataGridView : DataGridView
     /// </summary>
     [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Advanced)]
-    public ToolStripRenderer CreateToolStripRenderer()
+    public ToolStripRenderer? CreateToolStripRenderer()
     {
         var palette = GetResolvedPalette() ?? KryptonManager.CurrentGlobalPalette;
         return Renderer?.RenderToolStrip(palette)!;

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -2912,7 +2912,11 @@ public class KryptonDataGridView : DataGridView
     /// </summary>
     [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Advanced)]
-    public ToolStripRenderer CreateToolStripRenderer() => Renderer?.RenderToolStrip(GetResolvedPalette()!)!;
+    public ToolStripRenderer CreateToolStripRenderer()
+    {
+        var palette = GetResolvedPalette() ?? KryptonManager.CurrentGlobalPalette;
+        return Renderer?.RenderToolStrip(palette)!;
+    }
 
     private void OnKryptonContextMenuDisposed(object? sender, EventArgs e) =>
         // When the current krypton context menu is disposed, we should remove

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -340,7 +340,7 @@ public class KryptonForm : VisualForm,
 
     private Color GetGripDotColor()
     {
-        var palette = GetResolvedPalette();
+        var palette = GetResolvedPalette() ?? KryptonManager.CurrentGlobalPalette;
         Color back = palette.GetBackColor1(PaletteBackStyle.FormMain, PaletteState.Normal);
         if (back == GlobalStaticValues.EMPTY_COLOR || back.IsEmpty)
         {
@@ -391,7 +391,7 @@ public class KryptonForm : VisualForm,
     {
         // First, ask the palette for a themed sizing grip image (RTL-aware)
         var isRtl = RightToLeftLayout ? RightToLeft.Yes : RightToLeft.No;
-        Image? themedGrip = GetResolvedPalette().GetSizeGripImage(isRtl);
+        Image? themedGrip = (GetResolvedPalette() ?? KryptonManager.CurrentGlobalPalette).GetSizeGripImage(isRtl);
         if (themedGrip is null)
         {
             return false;
@@ -1195,7 +1195,7 @@ public class KryptonForm : VisualForm,
     /// Create the redirector instance.
     /// </summary>
     /// <returns>PaletteRedirect derived class.</returns>
-    protected override PaletteRedirect CreateRedirector() => new FormPaletteRedirect(GetResolvedPalette(), this);
+    protected override PaletteRedirect CreateRedirector() => new FormPaletteRedirect(GetResolvedPalette() ?? KryptonManager.CurrentGlobalPalette, this);
 
     internal class FormPaletteRedirect : PaletteRedirect
     {
@@ -2134,7 +2134,7 @@ public class KryptonForm : VisualForm,
             // Decide if we should have custom chrome applied
             var needChrome = UseThemeFormChromeBorderWidth &&
                              KryptonManager.UseThemeFormChromeBorderWidth &&
-                             (GetResolvedPalette().UseThemeFormChromeBorderWidth == InheritBool.True);
+                             ((GetResolvedPalette() ?? KryptonManager.CurrentGlobalPalette).UseThemeFormChromeBorderWidth == InheritBool.True);
 
             // Is there a change in custom chrome requirement?
             if (UseThemeFormChromeBorderWidth != needChrome

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonWebBrowser.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonWebBrowser.cs
@@ -251,7 +251,11 @@ public class KryptonWebBrowser : WebBrowser
     /// </summary>
     [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Advanced)]
-    public ToolStripRenderer CreateToolStripRenderer() => _renderer.RenderToolStrip(GetResolvedPalette());
+    public ToolStripRenderer? CreateToolStripRenderer()
+    {
+        var palette = GetResolvedPalette() ?? KryptonManager.CurrentGlobalPalette;
+        return Renderer?.RenderToolStrip(palette)!;
+    }
 
     /// <summary>
     /// Gets the resolved palette to actually use when drawing.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonWrapLabel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonWrapLabel.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobiteg 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
@@ -433,7 +433,11 @@ public class KryptonWrapLabel : Label
     /// </summary>
     [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Advanced)]
-    public ToolStripRenderer? CreateToolStripRenderer() => Renderer?.RenderToolStrip(GetResolvedPalette()!);
+    public ToolStripRenderer? CreateToolStripRenderer()
+    {
+        var palette = GetResolvedPalette() ?? KryptonManager.CurrentGlobalPalette;
+        return Renderer?.RenderToolStrip(palette);
+    }
 
     /// <summary>
     /// Update the font property.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContainerControlBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContainerControlBase.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
@@ -385,7 +385,11 @@ public abstract class VisualContainerControlBase : ContainerControl,
     /// </summary>
     [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Advanced)]
-    public ToolStripRenderer? CreateToolStripRenderer() => Renderer.RenderToolStrip(GetResolvedPalette());
+    public ToolStripRenderer? CreateToolStripRenderer()
+    {
+        var palette = GetResolvedPalette() ?? KryptonManager.CurrentGlobalPalette;
+        return Renderer.RenderToolStrip(palette);
+    }
 
     /// <summary>
     /// Gets or sets the background image displayed in the control.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContainerControlBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualContainerControlBase.cs
@@ -388,7 +388,7 @@ public abstract class VisualContainerControlBase : ContainerControl,
     public ToolStripRenderer? CreateToolStripRenderer()
     {
         var palette = GetResolvedPalette() ?? KryptonManager.CurrentGlobalPalette;
-        return Renderer.RenderToolStrip(palette);
+        return Renderer?.RenderToolStrip(palette);
     }
 
     /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualControlBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualControlBase.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
@@ -389,7 +389,11 @@ public abstract class VisualControlBase : Control,
     /// </summary>
     [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Advanced)]
-    public ToolStripRenderer CreateToolStripRenderer() => Renderer.RenderToolStrip(GetResolvedPalette());
+    public ToolStripRenderer CreateToolStripRenderer()
+    {
+        var palette = GetResolvedPalette() ?? KryptonManager.CurrentGlobalPalette;
+        return Renderer.RenderToolStrip(palette);
+    }
 
     /// <summary>
     /// Gets or sets the background image displayed in the control.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualControlBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualControlBase.cs
@@ -389,10 +389,10 @@ public abstract class VisualControlBase : Control,
     /// </summary>
     [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Advanced)]
-    public ToolStripRenderer CreateToolStripRenderer()
+    public ToolStripRenderer? CreateToolStripRenderer()
     {
         var palette = GetResolvedPalette() ?? KryptonManager.CurrentGlobalPalette;
-        return Renderer.RenderToolStrip(palette);
+        return Renderer?.RenderToolStrip(palette);
     }
 
     /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
@@ -485,7 +485,7 @@ public abstract class VisualForm : Form,
     /// </summary>
     [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Advanced)]
-    public ToolStripRenderer CreateToolStripRenderer() => Renderer.RenderToolStrip(GetResolvedPalette());
+    public ToolStripRenderer? CreateToolStripRenderer() => Renderer?.RenderToolStrip(GetResolvedPalette());
 
     /// <summary>
     /// Send the provided system command to the window for processing.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPanel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPanel.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
@@ -422,7 +422,11 @@ public abstract class VisualPanel : Panel,
     /// </summary>
     [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Advanced)]
-    public ToolStripRenderer CreateToolStripRenderer() => Renderer!.RenderToolStrip(GetResolvedPalette());
+    public ToolStripRenderer CreateToolStripRenderer()
+    {
+        var palette = GetResolvedPalette() ?? KryptonManager.CurrentGlobalPalette;
+        return Renderer!.RenderToolStrip(palette);
+    }
 
     /// <summary>
     /// Gets or sets the background image displayed in the control.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPopup.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPopup.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
@@ -285,7 +285,11 @@ public class VisualPopup : ContainerControl
     /// </summary>
     [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Advanced)]
-    public ToolStripRenderer CreateToolStripRenderer() => Renderer.RenderToolStrip(GetResolvedPalette()!);
+    public ToolStripRenderer CreateToolStripRenderer()
+    {
+        var palette = GetResolvedPalette() ?? KryptonManager.CurrentGlobalPalette;
+        return Renderer.RenderToolStrip(palette);
+    }
 
     /// <summary>
     /// Gets the resolved palette to actually use when drawing.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPopup.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPopup.cs
@@ -285,10 +285,10 @@ public class VisualPopup : ContainerControl
     /// </summary>
     [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Advanced)]
-    public ToolStripRenderer CreateToolStripRenderer()
+    public ToolStripRenderer? CreateToolStripRenderer()
     {
         var palette = GetResolvedPalette() ?? KryptonManager.CurrentGlobalPalette;
-        return Renderer.RenderToolStrip(palette);
+        return Renderer?.RenderToolStrip(palette);
     }
 
     /// <summary>


### PR DESCRIPTION
Followup fix for #2436 

### Summary
Ensure all calls to `GetResolvedPalette()` handle `null` by falling back to the global palette, preventing null-ref errors and ensuring consistent rendering.

### Changes
- Guarded palette resolution with `KryptonManager.CurrentGlobalPalette` in:
  - VisualPopup, VisualPanel, VisualControlBase, VisualContainerControlBase: CreateToolStripRenderer
  - KryptonDataGridView, KryptonWrapLabel: CreateToolStripRenderer
  - KryptonForm: GetGripDotColor, TryDrawResourceGrip, CreateRedirector, UpdateUseThemeFormChromeBorderWidthDecision

### Why
- Some `GetResolvedPalette()` implementations can return null; callers must handle that to avoid exceptions and inconsistent theme behavior.

### Impact
- No breaking changes. When a local palette is absent, controls now render using the global palette.
- Did not alter nullable `GetResolvedPalette()` overrides where null indicates “no palette” (e.g., base VisualPopup). Only call sites and non-null-returning implementations were adjusted.

---

<img width="713" height="260" alt="{0E8BD693-5AF0-42FE-8989-E7F6DA963695}" src="https://github.com/user-attachments/assets/b00a2da4-cf5b-401b-a32f-6a1cbbb438b0" />
