### PR TITLE
2452 V100 Fix: prevent resizing on fixed borders; gate Material hit-band by FormBorderStyle

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 ====
 
 ## 2025-11-xx - Build 2511 (V10 - alpha) - November 2025
+* Resolved [#2452](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2452), Fix: prevent resizing on fixed borders; gate Material hit-band by FormBorderStyle.
 * Resolved [#2448](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2448), `KryptonForm` does not display components without designer source.
 * Implemented [#2444](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2444), Add `AGENTS.md` file.
 * Fix [#1199](https://github.com/Krypton-Suite/Standard-Toolkit/issues/1199), Fix exception in `KryptonDropButton` due to wrong DialogResult.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonDataGridView.cs
@@ -2925,7 +2925,7 @@ public class KryptonDataGridView : DataGridView
     public ToolStripRenderer? CreateToolStripRenderer()
     {
         var palette = GetResolvedPalette() ?? KryptonManager.CurrentGlobalPalette;
-        return Renderer?.RenderToolStrip(palette)!;
+        return Renderer?.RenderToolStrip(palette);
     }
 
     private void OnKryptonContextMenuDisposed(object? sender, EventArgs e) =>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -1640,12 +1640,13 @@ public class KryptonForm : VisualForm,
             }
         }
 
+        bool isResizable = FormBorderStyle == FormBorderStyle.Sizable || FormBorderStyle == FormBorderStyle.SizableToolWindow;
         Padding borders = RealWindowBorders;
 
         // Material: use a wider invisible hit band for easier resize while keeping flat, borderless visuals.
         // RealWindowBorders can be 0 when the palette (e.g., Material) suppresses border width for drawing.
         // Expanding the hit test band preserves resize affordance without adding visible chrome.
-        if (Renderer is RenderMaterial)
+        if (isResizable && Renderer is RenderMaterial)
         {
             const int materialResizeThickness = 6;
             borders = new Padding(
@@ -1682,7 +1683,7 @@ public class KryptonForm : VisualForm,
             }
 
             // Is mouse over one of the borders?
-            if (mouseView == _drawDocker)
+            if (mouseView == _drawDocker && isResizable)
             {
                 // Is point over the left border?
                 if ((borders.Left > 0) && (pt.X <= borders.Left))

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -1640,7 +1640,7 @@ public class KryptonForm : VisualForm,
             }
         }
 
-        bool isResizable = FormBorderStyle == FormBorderStyle.Sizable || FormBorderStyle == FormBorderStyle.SizableToolWindow;
+        bool isResizable = FormBorderStyle is FormBorderStyle.Sizable or FormBorderStyle.SizableToolWindow;
         Padding borders = RealWindowBorders;
 
         // Material: use a wider invisible hit band for easier resize while keeping flat, borderless visuals.
@@ -1683,7 +1683,7 @@ public class KryptonForm : VisualForm,
             }
 
             // Is mouse over one of the borders?
-            if (mouseView == _drawDocker && isResizable)
+            if (isResizable && mouseView == _drawDocker)
             {
                 // Is point over the left border?
                 if ((borders.Left > 0) && (pt.X <= borders.Left))

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonWebBrowser.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonWebBrowser.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
- *  
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed, tobitege et al. 2017 - 2025. All rights reserved.
+ *
  */
 #endregion
 
@@ -186,8 +186,8 @@ public class KryptonWebBrowser : WebBrowser
 
 
     private void OnKryptonContextMenuDisposed(object? sender, EventArgs e) =>
-        // When the current krypton context menu is disposed, we should remove 
-        // it to prevent it being used again, as that would just throw an exception 
+        // When the current krypton context menu is disposed, we should remove
+        // it to prevent it being used again, as that would just throw an exception
         // because it has been disposed.
         KryptonContextMenu = null;
 
@@ -254,7 +254,7 @@ public class KryptonWebBrowser : WebBrowser
     public ToolStripRenderer? CreateToolStripRenderer()
     {
         var palette = GetResolvedPalette() ?? KryptonManager.CurrentGlobalPalette;
-        return Renderer?.RenderToolStrip(palette)!;
+        return _renderer?.RenderToolStrip(palette)!;
     }
 
     /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonWebBrowser.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonWebBrowser.cs
@@ -254,7 +254,7 @@ public class KryptonWebBrowser : WebBrowser
     public ToolStripRenderer? CreateToolStripRenderer()
     {
         var palette = GetResolvedPalette() ?? KryptonManager.CurrentGlobalPalette;
-        return _renderer?.RenderToolStrip(palette)!;
+        return _renderer?.RenderToolStrip(palette);
     }
 
     /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualControlBase.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualControlBase.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
  *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege 2017 - 2025. All rights reserved.
- *  
+ *
  */
 #endregion
 
@@ -289,7 +289,7 @@ public abstract class VisualControlBase : Control,
                 switch (value)
                 {
                     case PaletteMode.Custom:
-                        // Do nothing, you must assign a palette to the 
+                        // Do nothing, you must assign a palette to the
                         // 'Palette' property in order to get the custom mode
                         break;
                     default:
@@ -389,10 +389,10 @@ public abstract class VisualControlBase : Control,
     /// </summary>
     [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Advanced)]
-    public ToolStripRenderer? CreateToolStripRenderer()
+    public ToolStripRenderer CreateToolStripRenderer()
     {
         var palette = GetResolvedPalette() ?? KryptonManager.CurrentGlobalPalette;
-        return Renderer?.RenderToolStrip(palette);
+        return Renderer.RenderToolStrip(palette);
     }
 
     /// <summary>
@@ -523,7 +523,7 @@ public abstract class VisualControlBase : Control,
     /// Gets and sets the ViewManager instance.
     /// </summary>
     [Browsable(false)]  //  Hides the property from the Property Grid in the Visual Studio designer
-    [EditorBrowsable(EditorBrowsableState.Never)]   // Hides the property from IntelliSense and code completion. 
+    [EditorBrowsable(EditorBrowsableState.Never)]   // Hides the property from IntelliSense and code completion.
     [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)] //  Prevents the property from being serialized into the designer code.
     public ViewManager? ViewManager
     {
@@ -880,7 +880,7 @@ public abstract class VisualControlBase : Control,
     }
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     /// <param name="e"></param>
     protected override void OnMouseEnter(EventArgs e)
@@ -1273,8 +1273,8 @@ public abstract class VisualControlBase : Control,
     }
 
     private void OnKryptonContextMenuDisposed(object? sender, EventArgs e) =>
-        // When the current krypton context menu is disposed, we should remove 
-        // it to prevent it being used again, as that would just throw an exception 
+        // When the current krypton context menu is disposed, we should remove
+        // it to prevent it being used again, as that would just throw an exception
         // because it has been disposed.
         KryptonContextMenu = null;
 

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualForm.cs
@@ -485,7 +485,11 @@ public abstract class VisualForm : Form,
     /// </summary>
     [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Advanced)]
-    public ToolStripRenderer? CreateToolStripRenderer() => Renderer?.RenderToolStrip(GetResolvedPalette());
+    public ToolStripRenderer CreateToolStripRenderer()
+    {
+        var palette = GetResolvedPalette() ?? KryptonManager.CurrentGlobalPalette;
+        return Renderer.RenderToolStrip(palette);
+    }
 
     /// <summary>
     /// Send the provided system command to the window for processing.

--- a/Source/Krypton Components/Krypton.Toolkit/General/CommonHelper.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/CommonHelper.cs
@@ -30,7 +30,7 @@ public delegate object Operation(object? parameter);
 /// <summary>
 /// Signature of a method that returns a ToolStripRenderer instance.
 /// </summary>
-public delegate ToolStripRenderer GetToolStripRenderer();
+public delegate ToolStripRenderer? GetToolStripRenderer();
 #endregion
 
 /// <summary>


### PR DESCRIPTION
Fixes #2452 (regression from #2436 )

Fix: prevent resizing on fixed borders; gate Material hit-band by FormBorderStyle

- Root cause: `KryptonForm.WindowChromeHitTest(...)` could return resize HT codes even for fixed borders because border hit-tests and the Material “invisible” resize band were not conditioned on resizability, allowing unintended resizing from edges/corners. Introduced with the grippie work in [PR #2436](https://github.com/Krypton-Suite/Standard-Toolkit/pull/2436).

- Change: Gate both border resize hit-tests and Material resize-band expansion behind `FormBorderStyle == Sizable || SizableToolWindow`. The grippie path is already guarded by `ShouldShowSizingGrip()` which respects resizability.

- Result: Forms with `FixedSingle`, `FixedDialog`, `Fixed3D`, etc., no longer respond to resize hit-tests. Sizable forms retain existing behavior (including the sizing grip), RTL and StatusStrip merging remain unchanged.

---

<img width="714" height="256" alt="{61C8FAF7-D374-43D3-AAD9-DC2DAE21429C}" src="https://github.com/user-attachments/assets/4510aa93-6e06-47a5-b5a3-900a4bc0525e" />
