### PR TITLE
2436 V100 Fix regression for Pull 2451

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonWebBrowser.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonWebBrowser.cs
@@ -254,7 +254,7 @@ public class KryptonWebBrowser : WebBrowser
     public ToolStripRenderer? CreateToolStripRenderer()
     {
         var palette = GetResolvedPalette() ?? KryptonManager.CurrentGlobalPalette;
-        return Renderer?.RenderToolStrip(palette)!;
+        return _renderer?.RenderToolStrip(palette)!;
     }
 
     /// <summary>

--- a/Source/Krypton Components/Krypton.Toolkit/General/CommonHelper.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/General/CommonHelper.cs
@@ -30,7 +30,7 @@ public delegate object Operation(object? parameter);
 /// <summary>
 /// Signature of a method that returns a ToolStripRenderer instance.
 /// </summary>
-public delegate ToolStripRenderer GetToolStripRenderer();
+public delegate ToolStripRenderer? GetToolStripRenderer();
 #endregion
 
 /// <summary>


### PR DESCRIPTION
Fixes PR #2451 regressions:

- Fix CreateToolStripRenderer to use `_renderer` (compiler error about `Renderer`)
- Change GetToolStripRenderer delegate to nullable to avoid several warnings

<img width="854" height="305" alt="{E5565A33-CA6C-4E79-BB9E-1FE64155B5CC}" src="https://github.com/user-attachments/assets/3d7af39b-8806-4091-a6d8-0d6d6d7b8aac" />
