### PR TITLE
2463-V95-KryptonForm-Titlebar-control-buttons-issues

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -2,8 +2,12 @@
 
 =======
 
-# 2025-08-25 - Build 2508 (Patch 8) - August 2025
+# 2025-10-25 - Build 2508 (Patch 9) - October 2025
 * Resolved [#2463](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2463), `KryptonForm` has incorrect title-bar button behaviour.
+
+=======
+
+# 2025-08-25 - Build 2508 (Patch 8) - August 2025
 * Implemented [#2406](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2406), `KryptonProgressBar` enhancements.
 * Resolved [#413](https://github.com/Krypton-Suite/Standard-Toolkit/issues/413), `KryptonRibbon` controls do not react to MouseWheel scolling.
 * Resolved [#1971](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2416), `KryptonDataGridViewColumn` Drop-down arrow image incorrect for Sparkle themes.

--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2025-08-25 - Build 2508 (Patch 8) - August 2025
+* Resolved [#2463](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2463), `KryptonForm` has incorrect title-bar button behaviour.
 * Implemented [#2406](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2406), `KryptonProgressBar` enhancements.
 * Resolved [#413](https://github.com/Krypton-Suite/Standard-Toolkit/issues/413), `KryptonRibbon` controls do not react to MouseWheel scolling.
 * Resolved [#1971](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2416), `KryptonDataGridViewColumn` Drop-down arrow image incorrect for Sparkle themes.

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecFormWindowClose.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecFormWindowClose.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2024. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
@@ -60,11 +60,8 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibility.</returns>
-        public override bool GetVisible(PaletteBase palette)
-        {
-            // Have all buttons been turned off?
-            return KryptonForm is { ControlBox: true, CloseBox: true };
-        }
+        public override bool GetVisible(PaletteBase palette) =>
+            KryptonForm.CloseBox;
 
         /// <summary>
         /// Gets the button enabled state.

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecFormWindowMax.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecFormWindowMax.cs
@@ -34,25 +34,8 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibility.</returns>
-        public override bool GetVisible(PaletteBase palette)
-        {
-            // The maximize button is never present on tool windows
-            switch (KryptonForm.FormBorderStyle)
-            {
-                case FormBorderStyle.FixedToolWindow:
-                case FormBorderStyle.SizableToolWindow:
-                    return false;
-            }
-
-            // Have all buttons been turned off?
-            if (!KryptonForm.ControlBox)
-            {
-                return false;
-            }
-
-            // Has the minimize/maximize buttons been turned off?
-            return KryptonForm.MaximizeBox || KryptonForm.MinimizeBox;
-        }
+        public override bool GetVisible(PaletteBase palette) =>
+            KryptonForm.MaximizeBox;
 
         /// <summary>
         /// Gets the button enabled state.

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecFormWindowMin.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecFormWindowMin.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2024. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  *  
  */
 #endregion
@@ -34,25 +34,8 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibility.</returns>
-        public override bool GetVisible(PaletteBase palette)
-        {
-            // The minimize button is never present on tool windows
-            switch (KryptonForm.FormBorderStyle)
-            {
-                case FormBorderStyle.FixedToolWindow:
-                case FormBorderStyle.SizableToolWindow:
-                    return false;
-            }
-
-            // Have all buttons been turned off?
-            if (!KryptonForm.ControlBox)
-            {
-                return false;
-            }
-
-            // Has the minimize/maximize buttons been turned off?
-            return KryptonForm.MinimizeBox || KryptonForm.MaximizeBox;
-        }
+        public override bool GetVisible(PaletteBase palette) =>
+            KryptonForm.MinimizeBox;
 
         /// <summary>
         /// Gets the button enabled state.
@@ -61,7 +44,7 @@ namespace Krypton.Toolkit
         /// <returns>Button enabled state.</returns>
         public override ButtonEnabled GetEnabled(PaletteBase palette) =>
             // Has the minimize buttons been turned off?
-            !KryptonForm.MinimizeBox ? ButtonEnabled.False : ButtonEnabled.True;
+            KryptonForm.MinimizeBox ? ButtonEnabled.True : ButtonEnabled.False;
 
         /// <summary>
         /// Gets the button checked state.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2024. All rights reserved.
+ *  Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac & Ahmed Abdelhameed et al. 2017 - 2025. All rights reserved.
  *  
  */
 #endregion

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -244,7 +244,91 @@ namespace Krypton.Toolkit
         }
         #endregion
 
-        #region Public
+        #region Public (New)
+        /// <summary>
+        /// Toggles display of the minimize button.
+        /// </summary>
+        [DefaultValue(true)]
+        [Category("Window Style")]
+        [Description("Toggles display of the minimize button.")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public new bool MinimizeBox 
+        {
+            get => base.MinimizeBox;
+
+            set
+            {
+                if (base.MinimizeBox != value)
+                {
+                    base.MinimizeBox = value;
+                    _buttonManager.PerformNeedPaint(true);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Toggles display of the maximize button.
+        /// </summary>
+        [DefaultValue(true)]
+        [Category("Window Style")]
+        [Description("Toggles display of the maximize button.")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public new bool MaximizeBox 
+        {
+            get => base.MaximizeBox;
+
+            set
+            {
+                if (base.MaximizeBox != value)
+                {
+                    base.MaximizeBox = value;
+                    _buttonManager.PerformNeedPaint(true);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Toggles display of the Close button.
+        /// </summary>
+        [DefaultValue(true)]
+        [Category("Window Style")]
+        [Description("Toggles display of the close button.")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public new bool CloseBox 
+        {
+            get => base.CloseBox;
+
+            set
+            {
+                if (base.CloseBox != value)
+                {
+                    base.CloseBox = value;
+                    _buttonManager.PerformNeedPaint(true);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Indicates the appearance and behavior of the border and title bar of the form.
+        /// </summary>
+        [Category("Appearance")]
+        [DefaultValue(FormBorderStyle.Sizable)]
+        [Description("Indicates the appearance and behavior of the border and title bar of the form.")]
+        public new FormBorderStyle FormBorderStyle 
+        {
+            get => base.FormBorderStyle;
+
+            set
+            {
+                if (base.FormBorderStyle != value)
+                {
+                    base.FormBorderStyle = value;
+                    OnFormBorderStyleChanged();
+                    _buttonManager.PerformNeedPaint(true);
+                }
+            }
+        }
+
         /// <summary>
         /// Gets or sets the extra text associated with the control.
         /// </summary>
@@ -1245,6 +1329,42 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
+        private void OnFormBorderStyleChanged()
+        {
+            // KryptonForm uses ButtonSpecs for Form control buttons.
+            // Those need synchronizing when the FormBorderStyle changes.
+            // Once the style has changed the user can adjust the buttons to the liking.
+            // User configured buttons are changed once the FormBorderStyle changes.
+
+            switch (FormBorderStyle)
+            {
+                case FormBorderStyle.None:
+                    ControlBox = false;
+                    MinimizeBox = false;
+                    MaximizeBox = false;
+                    CloseBox = false;
+                    break;
+
+                case FormBorderStyle.FixedSingle:
+                case FormBorderStyle.Fixed3D:
+                case FormBorderStyle.FixedDialog:
+                case FormBorderStyle.Sizable:
+                    ControlBox = true;
+                    MinimizeBox = true;
+                    MaximizeBox = true;
+                    CloseBox = true;
+                    break;
+
+                case FormBorderStyle.FixedToolWindow:
+                case FormBorderStyle.SizableToolWindow:
+                    ControlBox = true;
+                    MinimizeBox = false;
+                    MaximizeBox = false;
+                    CloseBox = true;
+                    break;
+            }
+        }
+
         private Icon? GetDefinedIcon()
         {
             // Are we allowed to try and show an icon?


### PR DESCRIPTION
- Issue: #2463
- Correct Buttonspecs and FormBorderStyle behaviour
- And the changelog

<img width="290" height="214" alt="compile-results" src="https://github.com/user-attachments/assets/82d337c2-eef3-4c19-b6ce-9fd6a9a1693e" />
