### PR TITLE
2463-V85-KryptonForm-Titlebar-control-buttons-issues

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -2,7 +2,7 @@
 
 =======
 
-# 2025-08-25 - Build 2508 (Patch 8) - November 2025
+# 2025-10-25 - Build 2508 (Patch 9) - October 2025
 * Resolved [#2463](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2463), `KryptonForm` has incorrect title-bar button behaviour.
 
 * =======

--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -2,8 +2,12 @@
 
 =======
 
-# 2025-08-25 - Build 2508 (Patch 8) - August 2025
+# 2025-08-25 - Build 2508 (Patch 8) - November 2025
 * Resolved [#2463](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2463), `KryptonForm` has incorrect title-bar button behaviour.
+
+* =======
+
+# 2025-08-25 - Build 2508 (Patch 8) - August 2025
 * Resolved [#413](https://github.com/Krypton-Suite/Standard-Toolkit/issues/413), `KryptonRibbon` controls do not react to MouseWheel scolling.
 * Resolved [#1971](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2416), `KryptonDataGridViewColumn` Drop-down arrow image incorrect for Sparkle themes.
 * Implemented [#2406](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2406), `KryptonProgressBar` enhancements.

--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2025-08-25 - Build 2508 (Patch 8) - August 2025
+* Resolved [#2463](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2463), `KryptonForm` has incorrect title-bar button behaviour.
 * Resolved [#413](https://github.com/Krypton-Suite/Standard-Toolkit/issues/413), `KryptonRibbon` controls do not react to MouseWheel scolling.
 * Resolved [#1971](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2416), `KryptonDataGridViewColumn` Drop-down arrow image incorrect for Sparkle themes.
 * Implemented [#2406](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2406), `KryptonProgressBar` enhancements.

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecFormWindowClose.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecFormWindowClose.cs
@@ -60,18 +60,8 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibility.</returns>
-        public override bool GetVisible(PaletteBase? palette)
-        {
-            // We do not show if the custom chrome is combined with composition,
-            // in which case the form buttons are handled by the composition
-            if (KryptonForm is { ApplyComposition: true, ApplyCustomChrome: true })
-            {
-                return false;
-            }
-
-            // Have all buttons been turned off?
-            return KryptonForm is { ControlBox: true, CloseBox: true };
-        }
+        public override bool GetVisible(PaletteBase? palette) =>
+            KryptonForm.CloseBox;
 
         /// <summary>
         /// Gets the button enabled state.

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecFormWindowMax.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecFormWindowMax.cs
@@ -34,32 +34,8 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibility.</returns>
-        public override bool GetVisible(PaletteBase? palette)
-        {
-            // We do not show if the custom chrome is combined with composition,
-            // in which case the form buttons are handled by the composition
-            if (KryptonForm is { ApplyComposition: true, ApplyCustomChrome: true })
-            {
-                return false;
-            }
-
-            // The maximize button is never present on tool windows
-            switch (KryptonForm.FormBorderStyle)
-            {
-                case FormBorderStyle.FixedToolWindow:
-                case FormBorderStyle.SizableToolWindow:
-                    return false;
-            }
-
-            // Have all buttons been turned off?
-            if (!KryptonForm.ControlBox)
-            {
-                return false;
-            }
-
-            // Has the minimize/maximize buttons been turned off?
-            return KryptonForm.MinimizeBox || KryptonForm.MaximizeBox;
-        }
+        public override bool GetVisible(PaletteBase? palette) =>
+            KryptonForm.MaximizeBox;
 
         /// <summary>
         /// Gets the button enabled state.

--- a/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecFormWindowMin.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/ButtonSpec/ButtonSpecFormWindowMin.cs
@@ -34,32 +34,8 @@ namespace Krypton.Toolkit
         /// </summary>
         /// <param name="palette">Palette to use for inheriting values.</param>
         /// <returns>Button visibility.</returns>
-        public override bool GetVisible(PaletteBase? palette)
-        {
-            // We do not show if the custom chrome is combined with composition,
-            // in which case the form buttons are handled by the composition
-            if (KryptonForm is { ApplyComposition: true, ApplyCustomChrome: true })
-            {
-                return false;
-            }
-
-            // The minimize button is never present on tool windows
-            switch (KryptonForm.FormBorderStyle)
-            {
-                case FormBorderStyle.FixedToolWindow:
-                case FormBorderStyle.SizableToolWindow:
-                    return false;
-            }
-
-            // Have all buttons been turned off?
-            if (!KryptonForm.ControlBox)
-            {
-                return false;
-            }
-
-            // Has the minimize/maximize buttons been turned off?
-            return KryptonForm.MinimizeBox || KryptonForm.MaximizeBox;
-        }
+        public override bool GetVisible(PaletteBase? palette) =>
+            KryptonForm.MinimizeBox;
 
         /// <summary>
         /// Gets the button enabled state.
@@ -68,7 +44,7 @@ namespace Krypton.Toolkit
         /// <returns>Button enabled state.</returns>
         public override ButtonEnabled GetEnabled(PaletteBase? palette) =>
             // Has the minimize buttons been turned off?
-            !KryptonForm.MinimizeBox ? ButtonEnabled.False : ButtonEnabled.True;
+            KryptonForm.MinimizeBox ? ButtonEnabled.True : ButtonEnabled.False;
 
         /// <summary>
         /// Gets the button checked state.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonForm.cs
@@ -246,7 +246,92 @@ namespace Krypton.Toolkit
         }
         #endregion
 
-        #region Public
+        #region Public (New)
+        /// <summary>
+        /// Toggles display of the minimize button.
+        /// </summary>
+        [DefaultValue(true)]
+        [Category("Window Style")]
+        [Description("Toggles display of the minimize button.")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public new bool MinimizeBox 
+        {
+            get => base.MinimizeBox;
+
+            set
+            {
+                if (base.MinimizeBox != value)
+                {
+                    base.MinimizeBox = value;
+                    _buttonManager.PerformNeedPaint(true);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Toggles display of the maximize button.
+        /// </summary>
+        [DefaultValue(true)]
+        [Category("Window Style")]
+        [Description("Toggles display of the maximize button.")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public new bool MaximizeBox 
+        {
+            get => base.MaximizeBox;
+
+            set
+            {
+                if (base.MaximizeBox != value)
+                {
+                    base.MaximizeBox = value;
+                    _buttonManager.PerformNeedPaint(true);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Toggles display of the Close button.
+        /// </summary>
+        [DefaultValue(true)]
+        [Category("Window Style")]
+        [Description("Toggles display of the close button.")]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Visible)]
+        public new bool CloseBox 
+        {
+            get => base.CloseBox;
+
+            set
+            {
+                if (base.CloseBox != value)
+                {
+                    base.CloseBox = value;
+                    _buttonManager.PerformNeedPaint(true);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Indicates the appearance and behavior of the border and title bar of the form.
+        /// </summary>
+        [Category("Appearance")]
+        [DefaultValue(FormBorderStyle.Sizable)]
+        [Description("Indicates the appearance and behavior of the border and title bar of the form.")]
+        public new FormBorderStyle FormBorderStyle 
+        {
+            get => base.FormBorderStyle;
+
+            set
+            {
+                if (base.FormBorderStyle != value)
+                {
+                    base.FormBorderStyle = value;
+                    OnFormBorderStyleChanged();
+                    _buttonManager.PerformNeedPaint(true);
+                }
+            }
+        }
+
+
         /// <summary>
         /// Gets or sets the extra text associated with the control.
         /// </summary>
@@ -1269,6 +1354,42 @@ namespace Krypton.Toolkit
         #endregion
 
         #region Implementation
+        private void OnFormBorderStyleChanged()
+        {
+            // KryptonForm uses ButtonSpecs for Form control buttons.
+            // Those need synchronizing when the FormBorderStyle changes.
+            // Once the style has change the user can adjust the buttons to the liking.
+            // User configured buttons are changed once the FormBorderStyle changes.
+
+            switch (FormBorderStyle)
+            {
+                case FormBorderStyle.None:
+                    ControlBox = false;
+                    MinimizeBox = false;
+                    MaximizeBox = false;
+                    CloseBox = false;
+                    break;
+
+                case FormBorderStyle.FixedSingle:
+                case FormBorderStyle.Fixed3D:
+                case FormBorderStyle.FixedDialog:
+                case FormBorderStyle.Sizable:
+                    ControlBox = true;
+                    MinimizeBox = true;
+                    MaximizeBox = true;
+                    CloseBox = true;
+                    break;
+
+                case FormBorderStyle.FixedToolWindow:
+                case FormBorderStyle.SizableToolWindow:
+                    ControlBox = false;
+                    MinimizeBox = false;
+                    MaximizeBox = false;
+                    CloseBox = true;
+                    break;
+            }
+        }
+
         private Icon? GetDefinedIcon()
         {
             // Are we allowed to try and show an icon?


### PR DESCRIPTION
- Issue: #2463
- Correct Buttonspecs and FormBorderStyle behaviour
- And the changelog

<img width="270" height="174" alt="compile-results" src="https://github.com/user-attachments/assets/1fd57f9d-adcf-4011-a32d-c1ef2ced58b0" />
