### PR TITLE
2495-V100-KryptonProgressBar-mementoContent-field-can-be-null

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 ====
 
 ## 2025-11-xx - Build 2511 (V10 - alpha) - November 2025
+* Resolved [#2495](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2495), `KryptonProgressBar` private field `_mementoContent` can be null.
 * Resolved [#2490](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2490), `KryptonComboBox` uses an incorrect Items editor string.
 * Resolved [#2487](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2487), `PaletteBase.PalettePaint` event is not synchronized toward the user.
 * Implemented [#2446](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2446), Add `build.yml` to `.github/workflows`.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonProgressBar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonProgressBar.cs
@@ -131,6 +131,8 @@ public class KryptonProgressBar : Control, IContentValues
         _textShadowColor = Color.Empty;
         _showTextBackdrop = false;
         _textBackdropColor = Color.Empty;
+
+        OnlayoutInternal();
     }
 
     /// <inheritdoc />
@@ -679,26 +681,7 @@ public class KryptonProgressBar : Control, IContentValues
     /// <inheritdoc />
     protected override void OnLayout(LayoutEventArgs e)
     {
-        if (_palette != null)
-        {
-            // We want the inner part of the control to draw like a button.
-            var (barPaletteState, barState) = GetBarPaletteState();
-
-            // Get the renderer associated with this palette
-            IRenderer renderer = _palette.GetRenderer();
-
-            // Create a layout context used to allow the renderer to layout the content
-            using var viewContext = new ViewLayoutContext(this, renderer);
-
-            // Cleanup resources by disposing of old memento instance
-            _mementoContent?.Dispose();
-
-            // Ask the renderer to work out how the Content values will be laid out and
-            // return a memento object that we cache for use when actually performing painting
-            _mementoContent = renderer.RenderStandardContent.LayoutContent(viewContext, ClientRectangle, barPaletteState.PaletteContent!,
-                this, Orientation, barState);
-        }
-
+        OnlayoutInternal(e);
         base.OnLayout(e);
     }
 
@@ -1060,6 +1043,29 @@ public class KryptonProgressBar : Control, IContentValues
     #endregion
 
     #region Implementation
+    private void OnlayoutInternal(LayoutEventArgs? e = null)
+    {
+        if (_palette != null)
+        {
+            // We want the inner part of the control to draw like a button.
+            var (barPaletteState, barState) = GetBarPaletteState();
+
+            // Get the renderer associated with this palette
+            IRenderer renderer = _palette.GetRenderer();
+
+            // Create a layout context used to allow the renderer to layout the content
+            using var viewContext = new ViewLayoutContext(this, renderer);
+
+            // Cleanup resources by disposing of old memento instance
+            _mementoContent?.Dispose();
+
+            // Ask the renderer to work out how the Content values will be laid out and
+            // return a memento object that we cache for use when actually performing painting
+            _mementoContent = renderer.RenderStandardContent.LayoutContent(viewContext, ClientRectangle, barPaletteState.PaletteContent!,
+                this, Orientation, barState);
+        }
+    }
+
     // Find the correct state when getting ProgressBar values
     private (IPaletteTriple barPaletteState, PaletteState barState) GetBarPaletteState()
     {


### PR DESCRIPTION
- Issue: #2495
- Initialise the field from the constructor
- And the changelog

<img width="309" height="228" alt="compile-results" src="https://github.com/user-attachments/assets/b05767ed-43c8-4f5a-b966-72adad8d3507" />
