### PR TITLE
2514-V100-KryptonPanel-OnPaint-does-not-call-base

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 ====
 
 ## 2025-11-xx - Build 2511 (V10 - alpha) - November 2025
+* Resolved [#2514](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2514), `KryptonPanel.OnPaint` does not call base.
 * Resolved [#2508](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2508), Add internal `InDesignMode()` extension methods to both `Control` and `Component` classes.
 * Resolved [#2492](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2492), `KryptonForm` does not display '(Administrator)' when elevated
 * Resolved [#2502](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2502), **[Breaking Change]** `KryptonCommandLinkButton` updates several properties and their behaviour. See issue for full details.

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPanel.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Visuals/VisualPanel.cs
@@ -869,11 +869,14 @@ public abstract class VisualPanel : Panel,
     /// Raises the Paint event.
     /// </summary>
     /// <param name="e">A PaintEventArgs that contains the event data.</param>
-    protected override void OnPaint(PaintEventArgs? e)
+    protected override void OnPaint(PaintEventArgs e)
     {
         // Cannot process a message for a disposed control
         if (!IsDisposed)
         {
+            // Call base first
+            base.OnPaint(e);
+
             // Do we have a manager to use for painting?
             if (ViewManager is not null)
             {


### PR DESCRIPTION
- Issue: #2514
- Restore behaviour
- And the changelog

Warnings do not stem from this PR.

<img width="294" height="220" alt="compile-results" src="https://github.com/user-attachments/assets/fb6193d8-8f48-4cb0-8637-42f748d943d5" />

