### PR TITLE
1376-V100-Extending-KryptonTaskDialog

### DIFF
--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Elements/KryptonTaskDialogElementContent.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Elements/KryptonTaskDialogElementContent.cs
@@ -7,8 +7,6 @@
  */
 #endregion
 
-using System.Windows.Forms;
-
 namespace Krypton.Toolkit;
 
 public partial class KryptonTaskDialogElementContent : KryptonTaskDialogElementBase,
@@ -83,7 +81,7 @@ public partial class KryptonTaskDialogElementContent : KryptonTaskDialogElementB
         _tlp.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
     }
 
-    private void SetupTextBox()
+    private void SetupControls()
     {
         _textBox.AutoSize = false;
         _textBox.Height = 100;
@@ -96,7 +94,7 @@ public partial class KryptonTaskDialogElementContent : KryptonTaskDialogElementB
     private void SetupPanel()
     {
         SetupPictureBox();
-        SetupTextBox();
+        SetupControls();
         SetupTableLayoutPanel();
             
         // Put it together

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Elements/KryptonTaskDialogElementContent.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Elements/KryptonTaskDialogElementContent.cs
@@ -7,9 +7,11 @@
  */
 #endregion
 
+using System.Windows.Forms;
+
 namespace Krypton.Toolkit;
 
-public class KryptonTaskDialogElementContent : KryptonTaskDialogElementBase,
+public partial class KryptonTaskDialogElementContent : KryptonTaskDialogElementBase,
     IKryptonTaskDialogElementContent,
     IKryptonTaskDialogElementForeColor
 {
@@ -17,33 +19,128 @@ public class KryptonTaskDialogElementContent : KryptonTaskDialogElementBase,
     // default text format flags
     private const TextFormatFlags textFormatFlags = TextFormatFlags.WordBreak | TextFormatFlags.NoPadding | TextFormatFlags.ExpandTabs;
 
-    // Content text
-    KryptonWrapLabel _textControl;
-    // Ttextbox width
-    int _textBoxWidth;
+    private KryptonWrapLabel _textBox;
+    private TableLayoutPanel _tlp;
+    private KryptonPictureBox _pictureBox;
+    private bool _disposed;
     #endregion
 
     #region Identity
     public KryptonTaskDialogElementContent(KryptonTaskDialogDefaults taskDialogDefaults) 
         : base(taskDialogDefaults)
     {
+        _disposed = false;
+
         Panel.Height = 120;
-        _textBoxWidth = Defaults.ClientWidth - Defaults.PanelLeft - Defaults.PanelRight;
+        Panel.Padding = Defaults.PanelPadding1;
 
-        _textControl = new()
+        ContentImage = new ContentImageStorage();
+        ContentImage.PositionedLeft = true;
+        ContentImage.PropertyChanged += OnContentImagePropertyChanged;
+
+        _pictureBox = new();
+        _tlp = new();
+        _textBox = new();
+
+        SetupPanel();
+
+        LayoutDirty = true;
+        OnSizeChanged();
+    }
+    #endregion
+
+    #region Private
+    private void SetupPictureBox()
+    {
+        _pictureBox.Visible = false;
+        _pictureBox.Margin = new Padding(0, 0, Defaults.ComponentSpace, 0);
+        _pictureBox.Padding = Defaults.NullPadding;
+        _pictureBox.BorderStyle = BorderStyle.None;
+        _pictureBox.SizeMode = PictureBoxSizeMode.CenterImage;
+        _pictureBox.Anchor = AnchorStyles.Top | AnchorStyles.Left;
+    }
+
+    private void SetupTableLayoutPanel()
+    {
+        _tlp.Left = Defaults.PanelLeft;
+        _tlp.Top = Defaults.PanelTop;
+        _tlp.AutoSize = true;
+        _tlp.Margin = Defaults.PanelPadding1;
+        _tlp.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+        _tlp.MaximumSize = Defaults.TLP.StdMaxSize;
+        _tlp.MinimumSize = Defaults.TLP.StdMinSize;
+        
+        // Partition the tlp.
+        _tlp.RowStyles.Clear();
+        _tlp.ColumnStyles.Clear();
+        
+        _tlp.RowCount = 1;
+        _tlp.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        
+        _tlp.ColumnCount = 3;
+        _tlp.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+        _tlp.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+        _tlp.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+    }
+
+    private void SetupTextBox()
+    {
+        _textBox.AutoSize = false;
+        _textBox.Height = 100;
+        _textBox.Padding = new Padding(0);
+        _textBox.Margin = new Padding(0, 0, 0, 0);
+        _textBox.Location = new Point(10, 10);
+        _textBox.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
+    }
+
+    private void SetupPanel()
+    {
+        SetupPictureBox();
+        SetupTextBox();
+        SetupTableLayoutPanel();
+            
+        // Put it together
+        _tlp.Controls.Add(_textBox, 1, 0);
+        _tlp.Controls.Add(_pictureBox, 0, 0);
+        Panel.Controls.Add(_tlp);
+    }
+
+    private void OnContentImagePropertyChanged(ContentImageStorageProperties property)
+    {
+        if (property is ContentImageStorageProperties.Image or ContentImageStorageProperties.Size)
         {
-            AutoSize = true,
-            Width = _textBoxWidth,
-            Height = 0,
-            Padding = new Padding(0),
-            Margin = new Padding(3, 0, 0, 0),
-            Location = new Point(10, 10),
-            MaximumSize = new Size(_textBoxWidth, 0),
-            MinimumSize = new Size(_textBoxWidth, 0),
-            Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right,
-        };
+            if (ContentImage.Image is not null)
+            {
+                // If the user has set width or height to zero the raw image size is used, whatever that may be.
+                _pictureBox.Size = (ContentImage.Size.Width == 0 || ContentImage.Size.Height == 0)
+                    ? ContentImage.Image.Size
+                    : ContentImage.Size;
 
-        Panel.Controls.Add(_textControl);
+                _pictureBox.Image = new Bitmap(ContentImage.Image, _pictureBox.Size);
+            }
+            else
+            {
+                ContentImage.Visible = false;
+            }
+        }
+        else if (property == ContentImageStorageProperties.Visible)
+        {
+            _pictureBox.Visible = ContentImage.Image is not null && ContentImage.Visible;
+        }
+        else if (property == ContentImageStorageProperties.Position)
+        {
+            int columnIndex = ContentImage.PositionedLeft ? 0 : 2;
+
+            _tlp.Controls.Remove(_pictureBox);
+            _tlp.Controls.Add(_pictureBox, columnIndex, 0);
+        }
+        else
+        {
+            throw new ArgumentOutOfRangeException($"Unknown ContentImageStorageProperties member: {property}");
+        }
+
+        LayoutDirty = true;
+        OnSizeChanged();
     }
     #endregion
 
@@ -54,16 +151,17 @@ public class KryptonTaskDialogElementContent : KryptonTaskDialogElementBase,
         // Updates / changes are deferred if the element is not visible or until PerformLayout is called
         if (LayoutDirty && (Visible || performLayout))
         {
-            Font font = _textControl.StateCommon.Font
+            Font font = _textBox.StateCommon.Font
                 ?? Palette.GetContentShortTextFont(PaletteContentStyle.LabelNormalControl, PaletteState.Normal)
                 ?? KryptonManager.CurrentGlobalPalette.BaseFont;
 
-            int height = TextRenderer.MeasureText(_textControl.Text, font, new SizeF(_textBoxWidth, float.MaxValue).ToSize(), textFormatFlags).Height;
+            _textBox.Width = _pictureBox.Visible
+                ? _tlp.MaximumSize.Width - _pictureBox.Width - _pictureBox.Margin.Horizontal
+                : _tlp.MaximumSize.Width;
 
-            // Controls seem to need a little help here to stay within the correct bounds
-            Panel.Height = height + Defaults.PanelTop + Defaults.PanelBottom;
-            _textControl.Width = _textBoxWidth - Defaults.PanelLeft - Defaults.PanelRight;
-            _textControl.Height = height;
+            _textBox.Height = TextRenderer.MeasureText(_textBox.Text, font, new SizeF(_textBox.Width, float.MaxValue).ToSize(), textFormatFlags).Height;
+
+            Panel.Height = _tlp.Height + Defaults.PanelTop + Defaults.PanelBottom;
 
             // Tell everybody about it when visible.
             base.OnSizeChanged(performLayout);
@@ -104,19 +202,37 @@ public class KryptonTaskDialogElementContent : KryptonTaskDialogElementBase,
             OnSizeChanged();
         }
     }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (!_disposed && disposing)
+        {
+            ContentImage.PropertyChanged -= OnContentImagePropertyChanged;
+        
+            _disposed = true;
+        }
+
+        base.Dispose(disposing);
+    }
     #endregion
 
     #region Public
+    /// <summary>
+    /// Image to display together with the content.
+    /// </summary>
+    [TypeConverter(typeof(ExpandableObjectConverter))]
+    public KryptonTaskDialogElementContent.ContentImageStorage ContentImage { get; }
+
     /// <inheritdoc/>
     public string Text 
     {
-        get => _textControl.Text;
+        get => _textBox.Text;
 
         set
         {
-            if (_textControl.Text != value)
+            if (_textBox.Text != value)
             {
-                _textControl.Text = CommonHelper.NormalizeLineBreaks(value) + Environment.NewLine;
+                _textBox.Text = CommonHelper.NormalizeLineBreaks(value) + Environment.NewLine;
                 LayoutDirty = true;
                 OnSizeChanged();
             }
@@ -125,8 +241,8 @@ public class KryptonTaskDialogElementContent : KryptonTaskDialogElementBase,
 
     public Color ForeColor 
     {
-        get => _textControl.StateCommon.TextColor;
-        set => _textControl.StateCommon.TextColor = value;
+        get => _textBox.StateCommon.TextColor;
+        set => _textBox.StateCommon.TextColor = value;
     }
     #endregion
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Elements/KryptonTaskDialogElementContentImageStorage.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Elements/KryptonTaskDialogElementContentImageStorage.cs
@@ -1,0 +1,123 @@
+#region BSD License
+/*
+ *
+ * New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ * Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2025 - 2025. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+public partial class KryptonTaskDialogElementContent
+{
+    /// <summary>
+    /// Used internally by KryptonTaskDialogElementContent
+    /// </summary>
+    public class ContentImageStorage :
+        IKryptonTaskDialogElementContentImage,
+        IKryptonTaskDialogElementPropertyChanged<ContentImageStorageProperties>
+    {
+        #region Events
+        /// <summary>
+        /// Subscribe to be notified when one of the properties changes.
+        /// </summary>
+        public event Action<ContentImageStorageProperties>? PropertyChanged;
+        #endregion
+
+        #region Identity
+        public ContentImageStorage()
+        {
+            Visible = false;
+            Size = new Size(0, 0);
+            Image = null;
+        }
+        #endregion
+
+        #region Private
+        private void OnPropertyChanged(ContentImageStorageProperties property)
+        {
+            PropertyChanged?.Invoke(property);
+        }
+        #endregion
+
+        #region Public
+        /// <summary>
+        /// When true the image display left of the text otherwise on the right side.
+        /// </summary>
+        public bool PositionedLeft
+        {
+            get => field;
+
+            set
+            {
+                if (field != value)
+                {
+                    field = value;
+                    OnPropertyChanged(ContentImageStorageProperties.Position);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Desired size of the image.<br/>
+        /// If the size is left to zero the image will be display using it's own size.
+        /// </summary>
+        public Size Size
+        {
+            get => field;
+
+            set
+            {
+                if (field != value)
+                {
+                    field = value;
+                    OnPropertyChanged(ContentImageStorageProperties.Size);
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        public bool Visible
+        {
+            get => field;
+
+            set
+            {
+                if (field != value)
+                {
+                    field = value;
+                    OnPropertyChanged(ContentImageStorageProperties.Visible);
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        [DefaultValue(null)]
+        public Image? Image
+        {
+            get => field;
+
+            set
+            {
+                if (field != value)
+                {
+                    field = value;
+                    OnPropertyChanged(ContentImageStorageProperties.Image);
+                }
+            }
+        }
+        public void ResetImage() => Image = null;
+
+        /// <summary>
+        /// Not implemented
+        /// </summary>
+        /// <returns>String.Empty</returns>
+        public sealed override string ToString()
+        {
+            return string.Empty;
+        }
+        #endregion
+    }
+}
+

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Elements/KryptonTaskDialogElementContentTest.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Elements/KryptonTaskDialogElementContentTest.cs
@@ -72,7 +72,7 @@ public class KryptonTaskDialogElementContentTest : KryptonTaskDialogElementBase,
 
         Panel.Controls.Add(_tlp);
         //Panel.Controls.Add(_description);
-        //Panel.Controls.Add(_textControl);
+        //Panel.Controls.Add(_textBox);
 
         _tlp.Controls.Add(_description, 0, 0);
         _tlp.Controls.Add(_textControl, 0, 1);

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Elements/KryptonTaskDialogElementFooterBarCommonButtonProperties.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Elements/KryptonTaskDialogElementFooterBarCommonButtonProperties.cs
@@ -12,18 +12,20 @@ namespace Krypton.Toolkit;
 /// <summary>
 /// Used internally by KryptonTaskDialogElementFooterBar
 /// </summary>
-public class KryptonTaskDialogElementFooterBarCommonButtonProperties 
+public class KryptonTaskDialogElementFooterBarCommonButtonProperties :
+        IKryptonTaskDialogElementPropertyChanged<KryptonTaskDialogElementFooterBar.CommonButtonsProperties>
 {
     #region Fields
-    private KryptonTaskDialogElementFooterBar _footerBar;
-    private KryptonTaskDialogCommonButtonTypes _commonButtons;
+    #endregion
+
+    #region Events
+    /// <inheritdoc/>
+    public event Action<KryptonTaskDialogElementFooterBar.CommonButtonsProperties>? PropertyChanged;
     #endregion
 
     #region Identity
-    public KryptonTaskDialogElementFooterBarCommonButtonProperties(KryptonTaskDialogElementFooterBar footerBar)
+    public KryptonTaskDialogElementFooterBarCommonButtonProperties()
     {
-        _footerBar = footerBar;
-        _commonButtons = KryptonTaskDialogCommonButtonTypes.None;
     }
     #endregion
 
@@ -31,14 +33,14 @@ public class KryptonTaskDialogElementFooterBarCommonButtonProperties
     /// <inheritdoc/>
     public KryptonTaskDialogCommonButtonTypes Buttons
     {
-        get => _commonButtons;
+        get => field;
 
         set
         {
-            if (_commonButtons != value)
+            if (field != value)
             {
-                _commonButtons = value;
-                _footerBar.OnCommonButtonsChanged();
+                field = value;
+                OnPropertyChanged(KryptonTaskDialogElementFooterBar.CommonButtonsProperties.Buttons);
             }
         }
     }
@@ -53,7 +55,7 @@ public class KryptonTaskDialogElementFooterBarCommonButtonProperties
             if (field != value)
             {
                 field = value;
-                _footerBar.OnCommonButtonsChanged();
+                OnPropertyChanged(KryptonTaskDialogElementFooterBar.CommonButtonsProperties.AcceptButton);
             }
         }
     }
@@ -68,7 +70,7 @@ public class KryptonTaskDialogElementFooterBarCommonButtonProperties
             if (field != value)
             {
                 field = value;
-                _footerBar.OnCommonButtonsChanged();
+                OnPropertyChanged(KryptonTaskDialogElementFooterBar.CommonButtonsProperties.CancelButton);
             }
         }
     }
@@ -84,4 +86,12 @@ public class KryptonTaskDialogElementFooterBarCommonButtonProperties
         return string.Empty;
     }
     #endregion
+
+    #region Private
+    private void OnPropertyChanged(KryptonTaskDialogElementFooterBar.CommonButtonsProperties property)
+    {
+        PropertyChanged?.Invoke(property);
+    }
+    #endregion
+
 }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Elements/KryptonTaskDialogElementFooterBarFooterProperties.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Elements/KryptonTaskDialogElementFooterBarFooterProperties.cs
@@ -14,43 +14,30 @@ namespace Krypton.Toolkit;
 /// </summary>
 public class KryptonTaskDialogElementFooterBarFooterProperties :
     IKryptonTaskDialogElementFooterBar,
-    IKryptonTaskDialogElementIconType
+    IKryptonTaskDialogElementIconType,
+    IKryptonTaskDialogElementPropertyChanged<KryptonTaskDialogElementFooterBar.FooterBarProperties>
 {
-    #region Fields
-    private KryptonTaskDialogElementFooterBar _footerBar;
-    private KryptonWrapLabel _footNoteText;
-    private string _expanderExpandedText;
-    private string _expanderCollapsedText;
-    private bool _enableExpanderControls;
-    private Action<bool> _onSizeChanged;
-    private Action _updateExpanderText;
-    private Action _updateExpanderEnabledState;
-    private Action _updateFootNoteIcon;
+    #region Events
+    /// <inheritdoc/>
+    public event Action<KryptonTaskDialogElementFooterBar.FooterBarProperties>? PropertyChanged;
     #endregion
 
     #region Identity
     /// <summary>
     /// Default constructor.
     /// </summary>
-    /// <param name="footerBar">FooterBar instance</param>
-    /// <param name="footNoteText">KryptonWarpLabel instance.</param>
-    /// <param name="onSizeChanged">FooterBar OnsizeChanged callback.</param>
-    /// <param name="updateExpanderText">FooterBar updateExpanderText callback.</param>
-    /// <param name="updateExpanderEnabledState">FooterBar updateExpanderEnabledState callback.</param>
-    /// <param name="updateFootNoteIcon">FooterBar updateFootNoteIcon callback.</param>
-    public KryptonTaskDialogElementFooterBarFooterProperties(KryptonTaskDialogElementFooterBar footerBar, KryptonWrapLabel footNoteText, 
-        Action<bool> onSizeChanged, Action updateExpanderText, Action updateExpanderEnabledState, Action updateFootNoteIcon
-        )
+    public KryptonTaskDialogElementFooterBarFooterProperties()
     {
-        _footerBar                  = footerBar;
-        _footNoteText               = footNoteText;
-        _onSizeChanged              = onSizeChanged;
-        _updateExpanderText         = updateExpanderText;
-        _updateExpanderEnabledState = updateExpanderEnabledState;
-        _updateFootNoteIcon         = updateFootNoteIcon;
-        _expanderCollapsedText      = string.Empty;
-        _expanderExpandedText       = string.Empty;
-        _enableExpanderControls     = false;
+        FootNoteText = string.Empty;
+        ExpanderExpandedText = string.Empty;
+        ExpanderCollapsedText = string.Empty;
+    }
+    #endregion
+
+    #region Private
+    private void OnPropertyChanged(KryptonTaskDialogElementFooterBar.FooterBarProperties property)
+    {
+        PropertyChanged?.Invoke(property);
     }
     #endregion
 
@@ -58,16 +45,14 @@ public class KryptonTaskDialogElementFooterBarFooterProperties :
     /// <inheritdoc/>
     public string FootNoteText
     {
-        get => _footNoteText.Text;
+        get => field;
 
         set
         {
-            if (_footNoteText.Text != value)
+            if (field != value)
             {
-                _footNoteText.Text = value;
-                _footNoteText.Invalidate();
-                _footerBar.LayoutDirty = true;
-                _onSizeChanged(false);
+                field = value;
+                OnPropertyChanged(KryptonTaskDialogElementFooterBar.FooterBarProperties.FootNoteText);
             }
         }
     }
@@ -75,15 +60,14 @@ public class KryptonTaskDialogElementFooterBarFooterProperties :
     /// <inheritdoc/>
     public string ExpanderExpandedText
     {
-        get => _expanderExpandedText;
+        get => field;
 
         set
         {
-            if (_expanderExpandedText != value)
+            if (field != value)
             {
-                _expanderExpandedText = value;
-                _footerBar.LayoutDirty = true;
-                _updateExpanderText();
+                field = value;
+                OnPropertyChanged(KryptonTaskDialogElementFooterBar.FooterBarProperties.ExpanderExpandedText);
             }
         }
     }
@@ -91,15 +75,14 @@ public class KryptonTaskDialogElementFooterBarFooterProperties :
     /// <inheritdoc/>
     public string ExpanderCollapsedText
     {
-        get => _expanderCollapsedText;
+        get => field;
 
         set
         {
-            if (_expanderCollapsedText != value)
+            if (field != value)
             {
-                _expanderCollapsedText = value;
-                _footerBar.LayoutDirty = true;
-                _updateExpanderText();
+                field = value;
+                OnPropertyChanged(KryptonTaskDialogElementFooterBar.FooterBarProperties.ExpanderCollapsedText);
             }
         }
     }
@@ -116,8 +99,7 @@ public class KryptonTaskDialogElementFooterBarFooterProperties :
             if (field != value)
             {
                 field = value;
-                _footerBar.LayoutDirty = true;
-                _updateFootNoteIcon();
+                OnPropertyChanged(KryptonTaskDialogElementFooterBar.FooterBarProperties.IconType);
             }
         }
     }
@@ -125,16 +107,14 @@ public class KryptonTaskDialogElementFooterBarFooterProperties :
     /// <inheritdoc/>
     public bool EnableExpanderControls
     {
-        get => _enableExpanderControls;
+        get => field;
 
         set
         {
-            if (_enableExpanderControls != value)
+            if (field != value)
             {
-                _enableExpanderControls = value;
-                _footerBar.LayoutDirty = true;
-                _updateExpanderEnabledState();
-                _onSizeChanged(false);
+                field = value;
+                OnPropertyChanged(KryptonTaskDialogElementFooterBar.FooterBarProperties.EnableExpanderControls);
             }
         }
     }

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Elements/KryptonTaskDialogElementHeading.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Elements/KryptonTaskDialogElementHeading.cs
@@ -17,7 +17,7 @@ public class KryptonTaskDialogElementHeading : KryptonTaskDialogElementBase,
 {
     #region Fields
     private KryptonPictureBox _pictureBox;
-    private KryptonLabel _headingText;
+    private KryptonWrapLabel _headingText;
     private KryptonTaskDialogIconController _iconController;
     private TableLayoutPanel _tlp;
     private int _height;
@@ -25,21 +25,27 @@ public class KryptonTaskDialogElementHeading : KryptonTaskDialogElementBase,
     #endregion
 
     #region Identity
-    public KryptonTaskDialogElementHeading(KryptonTaskDialogDefaults taskDialogDefaults) 
+    public KryptonTaskDialogElementHeading(KryptonTaskDialogDefaults taskDialogDefaults)
         : base(taskDialogDefaults)
     {
         _disposed = false;
-        _height         = 48;
-        Panel.Height    = _height + Defaults.PanelTop + Defaults.PanelBottom;
-        Panel.Width     = Defaults.ClientWidth;
+        _height = 48;
+        Panel.Height = _height + Defaults.PanelTop + Defaults.PanelBottom;
+        Panel.Width = Defaults.ClientWidth;
+
         _iconController = new();
-        IconType        = KryptonTaskDialogIconType.None;
+        _pictureBox = new();
+        _headingText = new();
+        _tlp = new();
 
         SetupPanel();
+
+        IconType = KryptonTaskDialogIconType.None;
+        TextAlignmentHorizontal = PaletteRelativeAlign.Near;
     }
     #endregion
 
-    #region Public properties
+    #region Public
     /// <inheritdoc/>
     public string Text 
     {
@@ -65,15 +71,23 @@ public class KryptonTaskDialogElementHeading : KryptonTaskDialogElementBase,
     /// <inheritdoc/>
     public PaletteRelativeAlign TextAlignmentHorizontal 
     {
-        get => _headingText.StateCommon.ShortText.TextH;
-        set => _headingText.StateCommon.ShortText.TextH = value;
+        get => field;
+
+        set
+        {
+            if (field != value)
+            {
+                field = value;
+                UpdateTextAlignmentHorizontal();
+            }
+        }
     }
 
     /// <inheritdoc/>
     public Color ForeColor 
     {
-        get => _headingText.StateCommon.ShortText.Color1;
-        set => _headingText.StateCommon.ShortText.Color1 = value;
+        get => _headingText.StateCommon.TextColor;
+        set => _headingText.StateCommon.TextColor = value;
     }
     #endregion
 
@@ -85,8 +99,11 @@ public class KryptonTaskDialogElementHeading : KryptonTaskDialogElementBase,
 
         set
         {
-            base.BackColor1 = value;
-            _headingText.Invalidate();
+            if (base.BackColor1 != value)
+            {
+                base.BackColor1 = value;
+                _headingText.Invalidate();
+            }
         }
     }
 
@@ -97,33 +114,48 @@ public class KryptonTaskDialogElementHeading : KryptonTaskDialogElementBase,
         
         set
         {
-            base.BackColor2 = value;
-            _headingText.Invalidate();
+            if (base.BackColor2 != value)
+            {
+                base.BackColor2 = value;
+                _headingText.Invalidate();
+            }
         }
     }
     #endregion
 
     #region Private
+    private void UpdateTextAlignmentHorizontal()
+    {
+        _headingText.TextAlign = TextAlignmentHorizontal switch
+        {
+            PaletteRelativeAlign.Near => System.Drawing.ContentAlignment.MiddleLeft,
+            PaletteRelativeAlign.Center => System.Drawing.ContentAlignment.MiddleCenter,
+            PaletteRelativeAlign.Far => System.Drawing.ContentAlignment.MiddleRight,
+            _ => System.Drawing.ContentAlignment.MiddleLeft
+        };
+    }
+
     private void SetupPanel()
     {
         SetupTableLayoutPanel();
 
-        _pictureBox             = new();
         _pictureBox.Size        = new Size(_height, _height);
         _pictureBox.Padding     = new(0);
         _pictureBox.Margin      = new(0, 0, Defaults.ComponentSpace, 0);
         _pictureBox.BorderStyle = BorderStyle.None;
         _pictureBox.SizeMode    = PictureBoxSizeMode.CenterImage;
-        _pictureBox.Anchor      = AnchorStyles.Top | AnchorStyles.Left;
+        _pictureBox.Visible     = false;
 
-        _headingText = new();
         _headingText.AutoSize = false;
-        _headingText.Margin = new(0);
+        _headingText.Margin = Defaults.NullMargin;
         _headingText.Dock = DockStyle.Fill;
 
         // theme based 
-        _headingText.StateCommon.ShortText.Font = new Font(KryptonManager.CurrentGlobalPalette.BaseFont.FontFamily, 20f, FontStyle.Bold);
-        _headingText.StateCommon.ShortText.TextV = PaletteRelativeAlign.Center;
+        //_headingText.StateCommon.ShortText.Font = new Font(KryptonManager.CurrentGlobalPalette.BaseFont.FontFamily, 20f, FontStyle.Bold);
+        //_headingText.StateCommon.ShortText.TextV = PaletteRelativeAlign.Center;
+
+        _headingText.StateCommon.Font = new Font(KryptonManager.CurrentGlobalPalette.BaseFont.FontFamily, 20f, FontStyle.Bold);
+        _headingText.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
 
         _tlp.Controls.Add(_pictureBox, 0, 0);
         _tlp.Controls.Add(_headingText, 1, 0);
@@ -133,18 +165,22 @@ public class KryptonTaskDialogElementHeading : KryptonTaskDialogElementBase,
 
     private void SetupTableLayoutPanel()
     {
-        _tlp = new()
-        {
-            AutoSize        = false,
-            Height          = _height,
-            Width           = Defaults.ClientWidth - Defaults.PanelLeft - Defaults.PanelRight,
-            Top             = Defaults.PanelTop,
-            Left            = Defaults.PanelLeft,
-            Padding         = new Padding(0),
-            RowCount        = 1,
-            ColumnCount     = 2,
-            CellBorderStyle = TableLayoutPanelCellBorderStyle.None,
-        };
+        _tlp.AutoSize        = false;
+        _tlp.Height          = _height;
+        _tlp.Width           = Defaults.ClientWidth - Defaults.PanelLeft - Defaults.PanelRight;
+        
+        _tlp.MinimumSize     = 
+        _tlp.MaximumSize     = new Size(_tlp.Width, _height);
+
+        _tlp.Top             = Defaults.PanelTop;
+        _tlp.Left            = Defaults.PanelLeft;
+        _tlp.Padding         = Defaults.NullPadding;
+        _tlp.Margin          = Defaults.NullMargin;          
+        
+        _tlp.RowCount        = 1;
+        _tlp.ColumnCount     = 2;
+        _tlp.CellBorderStyle = TableLayoutPanelCellBorderStyle.None;
+        _tlp.BackColor       = Color.Transparent;
 
         _tlp.RowStyles.Clear();
         _tlp.ColumnStyles.Clear();
@@ -152,7 +188,6 @@ public class KryptonTaskDialogElementHeading : KryptonTaskDialogElementBase,
         _tlp.RowStyles.Add(new RowStyle(SizeType.Absolute, _height));
         _tlp.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
         _tlp.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
-
     }
 
     private void UpdateHeaderIcon()

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Enums/KryptonTaskDialogElementContent.ContentImageStorageProperties.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Enums/KryptonTaskDialogElementContent.ContentImageStorageProperties.cs
@@ -1,0 +1,23 @@
+#region BSD License
+/*
+ *
+ * New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ * Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2025 - 2025. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+public partial class KryptonTaskDialogElementContent
+{
+    public enum ContentImageStorageProperties
+    {
+        None = 0,
+        Size,
+        Image,
+        Visible,
+        Position
+    }
+}
+

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Enums/KryptonTaskDialogElementFooterBar.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Enums/KryptonTaskDialogElementFooterBar.cs
@@ -1,0 +1,31 @@
+#region BSD License
+/*
+ *
+ * New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ * Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2025 - 2025. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+public partial class KryptonTaskDialogElementFooterBar
+{
+    public enum CommonButtonsProperties
+    {
+        None = 0,
+        Buttons,
+        AcceptButton,
+        CancelButton,
+    }
+
+    public enum FooterBarProperties
+    {
+        None = 0,
+        FootNoteText,
+        ExpanderExpandedText,
+        ExpanderCollapsedText,
+        IconType,
+        EnableExpanderControls
+    }
+}

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Interfaces/IKryptonTaskDialogElementImage.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Interfaces/IKryptonTaskDialogElementImage.cs
@@ -1,0 +1,28 @@
+#region BSD License
+/*
+ *
+ * New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ * Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2025 - 2025. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+public interface IKryptonTaskDialogElementContentImage
+{
+    /// <summary>
+    /// Image to display
+    /// </summary>
+    public Image? Image { get; set; }
+
+    /// <summary>
+    /// Size of the image to display
+    /// </summary>
+    public Size Size { get; set; }
+
+    /// <summary>
+    /// If the image is to be displayed.
+    /// </summary>
+    public bool Visible { get; set; }
+}

--- a/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Interfaces/IKryptonTaskDialogElementPropertyChanged.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/Controls Toolkit/KryptonTaskDialog/Interfaces/IKryptonTaskDialogElementPropertyChanged.cs
@@ -1,0 +1,18 @@
+#region BSD License
+/*
+ *
+ * New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
+ * Modifications by Peter Wagner (aka Wagnerp), Simon Coghlan (aka Smurf-IV), Giduac, Ahmed Abdelhameed, tobitege et al. 2025 - 2025. All rights reserved.
+ *
+ */
+#endregion
+
+namespace Krypton.Toolkit;
+
+public interface IKryptonTaskDialogElementPropertyChanged<T> where T : Enum
+{
+    /// <summary>
+    /// Subscribe to be notfied when a property has changed.
+    /// </summary>
+    public event Action<T>? PropertyChanged;
+}


### PR DESCRIPTION
- Issue: #1376
- Refactoring of property sub classes and made those event based leaving the logic in the parent class.
- Fixed Header element alignment and label positioning
- Added an optional image to the Content and Expander elements.
- Some housekeeping
- For details see #1376

https://github.com/user-attachments/assets/67560dd4-3865-4255-b7d6-f6d45e3f89a4

Warnings are from another PR.

<img width="318" height="157" alt="compile-results" src="https://github.com/user-attachments/assets/d4d8cc8e-bb0c-499e-8c34-e71450bc89cf" />
