### PR TITLE
* Update `bug_report.md` template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,7 +26,7 @@ If applicable, add screenshots to help explain your problem.
 **Desktop (please complete the following information):**
  - OS: [e.g. Windows 11]
  - Version: [e.g. 10.0.26200]
- - Framework/.NET Version: [e.g. 4.8.1 or 10] 
+ - Framework/.NET Version: [e.g. 4.7.2 - 4.8.1 or 8 - 10] 
  - Toolkit Version: [e.g. 100.25.12.365]
 
 **Additional context**


### PR DESCRIPTION
* Bumped version `10.0.26100` -> `10.0.26200` to match the build number of 25h2
* No build log or changelog required