### PR TITLE
2524-V95-ribbontabs-text-not-clipped

### DIFF
--- a/Documents/Changelog/Changelog.md
+++ b/Documents/Changelog/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2025-10-25 - Build 2508 (Patch 9) - October 2025
+* Resolved [#2524](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2524) `KryptonRibbon` tab title malformed when using long strings.
 * Implemented [#648](https://github.com/Krypton-Suite/Standard-Toolkit/issues/648), SystemMenu to be theme related
 * Resolved [#2463](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2463), `KryptonForm` has incorrect title-bar button behaviour.
 


### PR DESCRIPTION
- Issue: #2524
- Updates AccurateText.DrawString method
- And the changelog

<img width="223" height="151" alt="compile-results" src="https://github.com/user-attachments/assets/2ce2551f-1ca7-49fc-ba1c-349f443421e3" />
