### PR TITLE
2524-V85-ribbontabs-text-not-clipped

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -3,6 +3,7 @@
 =======
 
 # 2025-10-25 - Build 2508 (Patch 9) - October 2025
+* Resolved [#2524](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2524) `KryptonRibbon` tab title malformed when using long strings.
 * Implemented [#648](https://github.com/Krypton-Suite/Standard-Toolkit/issues/648), SystemMenu to be theme related
 * Resolved [#2463](https://github.com/Krypton-Suite/Standard-Toolkit/issues/2463), `KryptonForm` has incorrect title-bar button behaviour.
 

--- a/Source/Krypton Components/Krypton.Toolkit/AccurateText/AccurateText.cs
+++ b/Source/Krypton Components/Krypton.Toolkit/AccurateText/AccurateText.cs
@@ -316,12 +316,47 @@ namespace Krypton.Toolkit
                                     // Convert from StringFormat to TextFormatFlags
                                     var tff = StringFormatToFlags(memento.Format);
 
-                                    // End line ellipsis don't work well with DrawText and tend to cut off words when not needed
-                                    // DrawString seems to do this better
-                                    tff &= ~(TextFormatFlags.EndEllipsis | TextFormatFlags.WordEllipsis | TextFormatFlags.PathEllipsis);
+                                    // Precompute overflow once for both ellipsis and NoClipping logic
+                                    const TextFormatFlags ellipsisFlags = TextFormatFlags.EndEllipsis |
+                                                                          TextFormatFlags.WordEllipsis |
+                                                                          TextFormatFlags.PathEllipsis;
+                                    bool textOverflows = memento.Size.Width > rect.Width;
 
-                                    // Whatever happens, NoClipping is on
-                                    tff |= TextFormatFlags.NoClipping;
+                                    if (textOverflows)
+                                    {
+                                        // If NoClipping is requested but text would overflow, enable clipping
+                                        if ((tff & TextFormatFlags.NoClipping) != 0)
+                                        {
+                                            tff &= ~TextFormatFlags.NoClipping;
+                                        }
+                                    }
+                                    else
+                                    {
+                                        // If ellipsis requested but text fits, remove ellipsis
+                                        if ((tff & ellipsisFlags) != 0)
+                                        {
+                                            tff &= ~ellipsisFlags;
+                                        }
+
+                                        // Only inspect Graphics.Clip if NoClipping is still set and we did not
+                                        // already decide to clip due to text overflow.
+                                        if (((tff & TextFormatFlags.NoClipping) != 0))
+                                        {
+                                            // If the caller set a finite clip region, and the text would exceed
+                                            // that clip width, clear NoClipping to respect upstream clipping.
+                                            using (Region clip = g.Clip)
+                                            {
+                                                if (!clip.IsInfinite(g))
+                                                {
+                                                    var cb = g.ClipBounds;
+                                                    if (memento.Size.Width > cb.Width - 0.5f)
+                                                    {
+                                                        tff &= ~TextFormatFlags.NoClipping;
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
 
                                     TextRenderer.DrawText(g, memento.Text, memento.Font!, rect, color, tff);
                                 }


### PR DESCRIPTION
- Issue: #2524
- Updates AccurateText.DrawString method
- And the changelog

<img width="300" height="166" alt="compile-results" src="https://github.com/user-attachments/assets/836b2c56-5bb3-44aa-8dc3-24bcc63da292" />
